### PR TITLE
Add :items param to xml_sitemap helper

### DIFF
--- a/lib/nanoc3/helpers/xml_sitemap.rb
+++ b/lib/nanoc3/helpers/xml_sitemap.rb
@@ -29,9 +29,18 @@ module Nanoc3::Helpers
     #   if the site is at "http://example.com/", the `base_url` would be
     #   "http://example.com".
     #
+    # @example Excluding binary items from the sitemap
+    #
+    #   <%= xml_sitemap :items => @items.reject{ |i| i[:is_hidden] || i[:binary] } %>
+    #
+    # @option params [Array] :items A list of items to include in the sitemap
+    #
     # @return [String] The XML sitemap
-    def xml_sitemap
+    def xml_sitemap(params={})
       require 'builder'
+
+      # Extract parameters
+      items = params[:items] || @items.reject { |i| i[:is_hidden] }
 
       # Create builder
       buffer = ''
@@ -46,7 +55,7 @@ module Nanoc3::Helpers
       xml.instruct!
       xml.urlset(:xmlns => 'http://www.google.com/schemas/sitemap/0.84') do
         # Add item
-        @items.reject { |i| i[:is_hidden] }.each do |item|
+        items.each do |item|
           item.reps.reject { |r| r.raw_path.nil? }.each do |rep|
             xml.url do
               xml.loc         @site.config[:base_url] + rep.path

--- a/test/helpers/test_xml_sitemap.rb
+++ b/test/helpers/test_xml_sitemap.rb
@@ -66,4 +66,42 @@ class Nanoc3::Helpers::XMLSitemapTest < MiniTest::Unit::TestCase
     @site  = nil
   end
 
+  def test_sitemap_with_items_as_param
+    if_have 'builder' do
+      # Create items
+      @items = [ mock, mock, mock ]
+
+      # Create item 0
+      @items[0].expects(:[]).never
+
+      # Create item 1
+      @items[1].expects(:[]).never
+
+      # Create item 2
+      @items[2].expects(:mtime).times(2).returns(nil)
+      @items[2].expects(:[]).times(2).with(:changefreq).returns(nil)
+      @items[2].expects(:[]).times(2).with(:priority).returns(nil)
+      item_reps = [ mock, mock ]
+      item_reps[0].expects(:path).returns('/kkk/')
+      item_reps[0].expects(:raw_path).returns('output/kkk/index.html')
+      item_reps[1].expects(:path).returns('/lll/')
+      item_reps[1].expects(:raw_path).returns('output/lll/index.html')
+      @items[2].expects(:reps).returns(item_reps)
+
+      # Create sitemap item
+      @item = mock
+
+      # Create site
+      config = mock
+      config.expects(:[]).with(:base_url).at_least_once.returns('http://example.com')
+      @site = mock
+      @site.expects(:config).at_least_once.returns(config)
+
+      # Check
+      xml_sitemap(
+        :items => [@items[2]]
+      )
+    end
+  end
+
 end


### PR DESCRIPTION
As discussed in IRC, this allows users to explicitly set (or remove) sitemap items:

```
<%= xml_sitemap :items => @items.reject{ |i| i[:is_hidden] || i[:binary] } %>
```
