### PR TITLE
Added optional block parameter to select the items to be included in the

### DIFF
--- a/lib/nanoc3/helpers/xml_sitemap.rb
+++ b/lib/nanoc3/helpers/xml_sitemap.rb
@@ -29,8 +29,17 @@ module Nanoc3::Helpers
     #   if the site is at "http://example.com/", the `base_url` would be
     #   "http://example.com".
     #
+    # @param [Proc] block An optional block accepting an item. When given, the block will
+    #   be evaluated to determine whether to include the item in the sitemap.
+    #   Note: If the block evaluates to true, the item's `:is_hidden` attribute will be ignored
+    #
+    # @example Include items in the sitemap only if they meet a certain criteria
+    #
+    #    xml_sitemap { |item| item[:include_in_sitemap] && item[:extension] =~ /haml|pdf/ }
+    #
+    #
     # @return [String] The XML sitemap
-    def xml_sitemap
+    def xml_sitemap(&block)
       require 'builder'
 
       # Create builder
@@ -46,7 +55,7 @@ module Nanoc3::Helpers
       xml.instruct!
       xml.urlset(:xmlns => 'http://www.google.com/schemas/sitemap/0.84') do
         # Add item
-        @items.reject { |i| i[:is_hidden] }.each do |item|
+        @items.reject { |i| (block_given? && !(yield i)) || i[:is_hidden] }.each do |item|
           item.reps.reject { |r| r.raw_path.nil? }.each do |rep|
             xml.url do
               xml.loc         @site.config[:base_url] + rep.path

--- a/test/helpers/test_xml_sitemap.rb
+++ b/test/helpers/test_xml_sitemap.rb
@@ -12,55 +12,92 @@ class Nanoc3::Helpers::XMLSitemapTest < MiniTest::Unit::TestCase
     if_have 'builder' do
       require 'time'
 
-      # Create items
-      @items = [ mock, mock, mock, mock ]
-
-      # Create item 0
-      @items[0].expects(:[]).with(:is_hidden).returns(false)
-      @items[0].expects(:mtime).times(2).returns(nil)
-      @items[0].expects(:[]).times(2).with(:changefreq).returns(nil)
-      @items[0].expects(:[]).times(2).with(:priority).returns(nil)
-      item_reps = [ mock, mock ]
-      item_reps[0].expects(:path).returns('/kkk/')
-      item_reps[0].expects(:raw_path).returns('output/kkk/index.html')
-      item_reps[1].expects(:path).returns('/lll/')
-      item_reps[1].expects(:raw_path).returns('output/lll/index.html')
-      @items[0].expects(:reps).returns(item_reps)
-
-      # Create item 1
-      @items[1].expects(:[]).with(:is_hidden).returns(true)
-
-      # Create item 2
-      @items[2].expects(:[]).with(:is_hidden).returns(false)
-      @items[2].expects(:mtime).times(4).returns(Time.parse('12/07/2004'))
-      @items[2].expects(:[]).with(:changefreq).times(4).returns('daily')
-      @items[2].expects(:[]).with(:priority).times(4).returns(0.5)
-      item_reps = [ mock, mock ]
-      item_reps[0].expects(:path).returns('/aaa/')
-      item_reps[0].expects(:raw_path).returns('output/aaa/index.html')
-      item_reps[1].expects(:path).returns('/bbb/')
-      item_reps[1].expects(:raw_path).returns('output/bbb/index.html')
-      @items[2].expects(:reps).returns(item_reps)
-
-      # Create item 3
-      @items[3].expects(:[]).with(:is_hidden).returns(false)
-      item_rep = mock
-      item_rep.expects(:raw_path).returns(nil)
-      @items[3].expects(:reps).returns([ item_rep ])
-
-      # Create sitemap item
-      @item = mock
-
-      # Create site
-      config = mock
-      config.expects(:[]).with(:base_url).at_least_once.returns('http://example.com')
-      @site = mock
-      @site.expects(:config).at_least_once.returns(config)
-
+      setup_sitemap_test
+ 
       # Check
       xml_sitemap
+      
     end
   ensure
+    teardown_sitemap_test
+  end
+  
+  def test_xml_sitemap_with_block
+    if_have 'builder' do
+      require 'time'
+
+      setup_sitemap_test
+      
+      # Include these items in the sitemap
+      @items[0].expects(:[]).with(:accepted_by_the_block).returns(true)
+      @items[1].expects(:[]).with(:accepted_by_the_block).returns(true)
+      @items[2].expects(:[]).with(:accepted_by_the_block).returns(true)
+      @items[3].expects(:[]).with(:accepted_by_the_block).returns(true)
+      
+      # Create item 4 to be rejected by the block
+      @items << mock
+      @items[4].expects(:[]).with(:accepted_by_the_block).returns(false)
+
+      # Check
+      xml_sitemap { |item| item[:accepted_by_the_block] }
+      
+    end
+  ensure
+    teardown_sitemap_test
+  end
+  
+  protected
+  
+  def setup_sitemap_test
+    
+    # Create items
+     @items = [ mock, mock, mock, mock]
+
+     # Create item 0
+     @items[0].expects(:[]).with(:is_hidden).returns(false)
+     @items[0].expects(:mtime).times(2).returns(nil)
+     @items[0].expects(:[]).times(2).with(:changefreq).returns(nil)
+     @items[0].expects(:[]).times(2).with(:priority).returns(nil)
+     item_reps = [ mock, mock ]
+     item_reps[0].expects(:path).returns('/kkk/')
+     item_reps[0].expects(:raw_path).returns('output/kkk/index.html')
+     item_reps[1].expects(:path).returns('/lll/')
+     item_reps[1].expects(:raw_path).returns('output/lll/index.html')
+     @items[0].expects(:reps).returns(item_reps)
+
+     # Create item 1
+     @items[1].expects(:[]).with(:is_hidden).returns(true)
+
+     # Create item 2
+     @items[2].expects(:[]).with(:is_hidden).returns(false)
+     @items[2].expects(:mtime).times(4).returns(Time.parse('12/07/2004'))
+     @items[2].expects(:[]).with(:changefreq).times(4).returns('daily')
+     @items[2].expects(:[]).with(:priority).times(4).returns(0.5)
+     item_reps = [ mock, mock ]
+     item_reps[0].expects(:path).returns('/aaa/')
+     item_reps[0].expects(:raw_path).returns('output/aaa/index.html')
+     item_reps[1].expects(:path).returns('/bbb/')
+     item_reps[1].expects(:raw_path).returns('output/bbb/index.html')
+     @items[2].expects(:reps).returns(item_reps)
+
+     # Create item 3
+     @items[3].expects(:[]).with(:is_hidden).returns(false)
+     item_rep = mock
+     item_rep.expects(:raw_path).returns(nil)
+     @items[3].expects(:reps).returns([ item_rep ])
+
+     # Create sitemap item
+     @item = mock
+     
+     # Create site
+     config = mock
+     config.expects(:[]).with(:base_url).at_least_once.returns('http://example.com')
+     @site = mock
+     @site.expects(:config).at_least_once.returns(config)
+    
+  end
+  
+  def teardown_sitemap_test
     @items = nil
     @item  = nil
     @site  = nil


### PR DESCRIPTION
Nanoc's xml_sitemap helper added all CSS, JS, images files, etc to the sitemap when only URLs with actual content should be included.  Passing a block allows for simple and flexible filtering of the items to publish.

Cheers,
