### PR TITLE
Sass filter

### DIFF
--- a/lib/nanoc3/filters/sass.rb
+++ b/lib/nanoc3/filters/sass.rb
@@ -35,13 +35,15 @@ module Nanoc3::Filters
       pathname = Pathname.new(filename)
       item = @items.find { |i| i[:content_filename] && Pathname.new(i[:content_filename]).realpath == pathname.realpath }
 
-      # Notify
-      Nanoc3::NotificationCenter.post(:visit_started, item)
-      Nanoc3::NotificationCenter.post(:visit_ended,   item)
+      unless item.nil?
+        # Notify
+        Nanoc3::NotificationCenter.post(:visit_started, item)
+        Nanoc3::NotificationCenter.post(:visit_ended,   item)
 
-      # Raise unmet dependency error if item is not yet compiled
-      # any_uncompiled_rep = item.reps.find { |r| !r.compiled? }
-      # raise Nanoc3::Errors::UnmetDependency.new(any_uncompiled_rep) if any_uncompiled_rep
+        # Raise unmet dependency error if item is not yet compiled
+        any_uncompiled_rep = item.reps.find { |r| !r.compiled? }
+        raise Nanoc3::Errors::UnmetDependency.new(any_uncompiled_rep) if any_uncompiled_rep
+      end
     end
 
   end


### PR DESCRIPTION
Since Sass 3.1 the sass filter is not working at all. This change uses the new `Sass::Importer` API to track files under `Nanoc3::NotificationCenter`.

Therefore now you can change the Importer used using the parameter `:filesystem_importer` so:

```
filter :sass,
       :filesystem_importer => My::Importers::Foo
```

will use the importer `My::Importers::Foo` instead of the default `Nanoc3::Importers::Nanoc`.
