### PR TITLE
Add support and tests for Redcarpet Markdown

### DIFF
--- a/lib/nanoc3/filters.rb
+++ b/lib/nanoc3/filters.rb
@@ -17,6 +17,7 @@ module Nanoc3::Filters
   autoload 'Rainpress',       'nanoc3/filters/rainpress'
   autoload 'RDiscount',       'nanoc3/filters/rdiscount'
   autoload 'RDoc',            'nanoc3/filters/rdoc'
+  autoload 'Redcarpet',       'nanoc3/filters/redcarpet'
   autoload 'RedCloth',        'nanoc3/filters/redcloth'
   autoload 'RelativizePaths', 'nanoc3/filters/relativize_paths'
   autoload 'RubyPants',       'nanoc3/filters/rubypants'
@@ -39,6 +40,7 @@ module Nanoc3::Filters
   Nanoc3::Filter.register '::Nanoc3::Filters::Rainpress',       :rainpress
   Nanoc3::Filter.register '::Nanoc3::Filters::RDiscount',       :rdiscount
   Nanoc3::Filter.register '::Nanoc3::Filters::RDoc',            :rdoc
+  Nanoc3::Filter.register '::Nanoc3::Filters::RedCarpet',       :redcarpet
   Nanoc3::Filter.register '::Nanoc3::Filters::RedCloth',        :redcloth
   Nanoc3::Filter.register '::Nanoc3::Filters::RelativizePaths', :relativize_paths
   Nanoc3::Filter.register '::Nanoc3::Filters::RubyPants',       :rubypants

--- a/lib/nanoc3/filters/redcarpet.rb
+++ b/lib/nanoc3/filters/redcarpet.rb
@@ -1,0 +1,23 @@
+# encoding: utf-8
+
+module Nanoc3::Filters
+  class Redcarpet < Nanoc3::Filter
+
+    # Runs the content through [Redcarpet](https://github.com/tanoku/redcarpet/).
+    # This method optionally takes processing options to pass on to Redcarpet.
+    #
+    # @content [String] content The content to filter
+    #
+    # @params [Hash{Symbol => Array<Symbol>}]
+    #
+    # @return [String] The filtered content
+    def run(content, params={})
+      require 'redcarpet'
+
+      options = params[:options] || []
+
+      ::Redcarpet.new(content, *options).to_html
+    end
+
+  end
+end

--- a/test/filters/test_redcarpet.rb
+++ b/test/filters/test_redcarpet.rb
@@ -1,0 +1,59 @@
+# encoding: utf-8
+
+require 'test/helper'
+
+class Nanoc3::Filters::RedcarpetTest < MiniTest::Unit::TestCase
+
+  include Nanoc3::TestHelpers
+
+  def test_filter
+    if_have 'redcarpet' do
+      # Create filter
+      filter = ::Nanoc3::Filters::Redcarpet.new
+
+      # Run filter
+      result = filter.run("> Quote")
+      assert_match(/<blockquote>\s*<p>Quote<\/p>\s*<\/blockquote>/, result)
+    end
+  end
+
+  def test_with_extensions
+    if_have 'redcarpet' do
+      # Create filter
+      filter = ::Nanoc3::Filters::Redcarpet.new
+
+      # Run filter
+      input           = "The quotation 'marks' sure make this look sarcastic!"
+      output_expected = /The quotation &lsquo;marks&rsquo; sure make this look sarcastic!/
+      output_actual   = filter.run(input, :options => [ :smart ])
+      assert_match(output_expected, output_actual)
+    end
+  end
+
+  def test_html_by_default
+    if_have 'redcarpet' do
+      # Create filter
+      filter = ::Nanoc3::Filters::Redcarpet.new
+
+      # Run filter
+      input           = "![Alt](/path/to/img 'Title')"
+      output_expected = %r{<img src="/path/to/img" alt="Alt" title="Title">}
+      output_actual   = filter.run(input)
+      assert_match(output_expected, output_actual)
+    end
+  end
+
+  def test_xhtml_if_requested
+    if_have 'redcarpet' do
+      # Create filter
+      filter = ::Nanoc3::Filters::Redcarpet.new
+
+      # Run filter
+      input           = "![Alt](/path/to/img 'Title')"
+      output_expected = %r{<img src="/path/to/img" alt="Alt" title="Title"/>}
+      output_actual   = filter.run(input, :options => [ :xhtml ])
+      assert_match(output_expected, output_actual)
+    end
+  end
+
+end


### PR DESCRIPTION
This is based entirely on the existing Rdiscount filter. But I did add
two tests to confirm that (1) Redcarpet outputs HTML style tags by default
and (2) can output strict XHTML style on request.
