### PR TITLE
Adjust documentation for Rdiscount

### DIFF
--- a/lib/nanoc3/filters/rdiscount.rb
+++ b/lib/nanoc3/filters/rdiscount.rb
@@ -4,9 +4,11 @@ module Nanoc3::Filters
   class RDiscount < Nanoc3::Filter
 
     # Runs the content through [RDiscount](http://github.com/rtomayko/rdiscount).
-    # This method takes no options.
+    # This method takes optional parameters to pass along to Rdiscount.
     #
-    # @param [String] content The content to filter
+    # @content [String] content The content to filter
+    #
+    # @params [Hash{Symbol => Array<Symbol>}]
     #
     # @return [String] The filtered content
     def run(content, params={})


### PR DESCRIPTION
The description of how Rdiscount is called was slightly off. There is
a parameter for the content that wasn't mentioned by name. And, contrary,
to the docs, the method does take optional parameters to change how
Rdiscount processes the markup.
