### PR TITLE
Allow for passing arbitrary options to pygmentize.

### DIFF
--- a/lib/nanoc3/filters/colorize_syntax.rb
+++ b/lib/nanoc3/filters/colorize_syntax.rb
@@ -177,10 +177,8 @@ module Nanoc3::Filters
     #
     # @return [String] The colorized output
     def pygmentize(code, language, params={})
-      enc = ""
-      enc = "-O encoding=" + params[:encoding] if params[:encoding]
-
-      IO.popen("pygmentize -l #{language} -f html #{enc}", "r+") do |io|
+      opts = "-O #{params.map {|k,v| "#{k}=#{v}"} * ','}" unless params.empty?
+      IO.popen("pygmentize #{opts} -l #{language} -f html", "r+") do |io|
         io.write(code)
         io.close_write
         highlighted_code = io.read


### PR DESCRIPTION
The only option that could be passed to the pygmentize command line tool was
encoding. However, there is a wealth of other options that users might want to
provide to the command line of pygmentize. For example, this patch allows users
to do so in the following way:

```
filter :colorize_syntax,
    :colorizers => { :c => :pygmentize },
    :pygmentize => { :linenos => 'noclasses' }
```
