### PR TITLE
Removed each require 'test/helper' 

### DIFF
--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -11,6 +11,9 @@ test = namespace :test do
 
     $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__) + '/..'))
 
+    # require our test helper so we don't have to in each individual test
+    require 'test/helper'
+
     MiniTest::Unit.autorun
 
     test_files = Dir['test/**/*_spec.rb'] + Dir['test/**/test_*.rb']
@@ -24,6 +27,9 @@ test = namespace :test do
       ENV['QUIET'] ||= 'true'
 
       $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__) + '/..'))
+
+      # require our test helper so we don't have to in each individual test
+      require 'test/helper'
 
       MiniTest::Unit.autorun
 

--- a/test/base/core_ext/array_spec.rb
+++ b/test/base/core_ext/array_spec.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 describe 'Array#symbolize_keys' do
 
   it 'should convert keys to symbols' do

--- a/test/base/core_ext/hash_spec.rb
+++ b/test/base/core_ext/hash_spec.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 describe 'Hash#symbolize_keys' do
 
   it 'should convert keys to symbols' do

--- a/test/base/core_ext/pathname_spec.rb
+++ b/test/base/core_ext/pathname_spec.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 describe 'Pathname#checksum' do
 
   it 'should work on empty files' do

--- a/test/base/core_ext/string_spec.rb
+++ b/test/base/core_ext/string_spec.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 describe 'String#cleaned_identifier' do
 
   it 'should not convert already clean paths' do

--- a/test/base/test_checksum_store.rb
+++ b/test/base/test_checksum_store.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::ChecksumStoreTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/base/test_code_snippet.rb
+++ b/test/base/test_code_snippet.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::CodeSnippetTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/base/test_compiler.rb
+++ b/test/base/test_compiler.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::CompilerTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/base/test_compiler_dsl.rb
+++ b/test/base/test_compiler_dsl.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::CompilerDSLTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/base/test_context.rb
+++ b/test/base/test_context.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::ContextTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/base/test_data_source.rb
+++ b/test/base/test_data_source.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::DataSourceTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/base/test_dependency_tracker.rb
+++ b/test/base/test_dependency_tracker.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::DependencyTrackerTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/base/test_directed_graph.rb
+++ b/test/base/test_directed_graph.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::DirectedGraphTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/base/test_filter.rb
+++ b/test/base/test_filter.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::FilterTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/base/test_item.rb
+++ b/test/base/test_item.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::ItemTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/base/test_item_rep.rb
+++ b/test/base/test_item_rep.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::ItemRepTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/base/test_layout.rb
+++ b/test/base/test_layout.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::LayoutTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/base/test_memoization.rb
+++ b/test/base/test_memoization.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::MemoizationTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/base/test_notification_center.rb
+++ b/test/base/test_notification_center.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::NotificationCenterTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/base/test_outdatedness_checker.rb
+++ b/test/base/test_outdatedness_checker.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::OutdatednessCheckerTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/base/test_plugin.rb
+++ b/test/base/test_plugin.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::PluginTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/base/test_rule.rb
+++ b/test/base/test_rule.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::RuleTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/base/test_rule_context.rb
+++ b/test/base/test_rule_context.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::RuleContextTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/base/test_site.rb
+++ b/test/base/test_site.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::SiteTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/cli/commands/test_compile.rb
+++ b/test/cli/commands/test_compile.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::CLI::Commands::CompileTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/cli/commands/test_create_item.rb
+++ b/test/cli/commands/test_create_item.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::CLI::Commands::CreateItemTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/cli/commands/test_create_layout.rb
+++ b/test/cli/commands/test_create_layout.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::CLI::Commands::CreateLayoutTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/cli/commands/test_create_site.rb
+++ b/test/cli/commands/test_create_site.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::CLI::Commands::CreateSiteTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/cli/commands/test_help.rb
+++ b/test/cli/commands/test_help.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::CLI::Commands::HelpTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/cli/commands/test_info.rb
+++ b/test/cli/commands/test_info.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::CLI::Commands::InfoTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/cli/commands/test_update.rb
+++ b/test/cli/commands/test_update.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::CLI::Commands::UpdateTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/cli/test_logger.rb
+++ b/test/cli/test_logger.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::CLI::LoggerTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/data_sources/test_filesystem.rb
+++ b/test/data_sources/test_filesystem.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::DataSources::FilesystemTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/data_sources/test_filesystem_unified.rb
+++ b/test/data_sources/test_filesystem_unified.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::DataSources::FilesystemUnifiedTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/data_sources/test_filesystem_verbose.rb
+++ b/test/data_sources/test_filesystem_verbose.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::DataSources::FilesystemVerboseTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/extra/core_ext/test_enumerable.rb
+++ b/test/extra/core_ext/test_enumerable.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::ExtraCoreExtEnumerableTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/extra/core_ext/test_time.rb
+++ b/test/extra/core_ext/test_time.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::ExtraCoreExtTimeTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/extra/deployers/test_rsync.rb
+++ b/test/extra/deployers/test_rsync.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Extra::Deployers::RsyncTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/extra/test_auto_compiler.rb
+++ b/test/extra/test_auto_compiler.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Extra::AutoCompilerTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/extra/test_file_proxy.rb
+++ b/test/extra/test_file_proxy.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Extra::FileProxyTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/extra/test_vcs.rb
+++ b/test/extra/test_vcs.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Extra::VCSTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/extra/validators/test_links.rb
+++ b/test/extra/validators/test_links.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Extra::Validators::LinksTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/extra/validators/test_w3c.rb
+++ b/test/extra/validators/test_w3c.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Extra::Validators::W3CTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/filters/test_asciidoc.rb
+++ b/test/filters/test_asciidoc.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Filters::AsciiDocTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/filters/test_bluecloth.rb
+++ b/test/filters/test_bluecloth.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Filters::BlueClothTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/filters/test_coderay.rb
+++ b/test/filters/test_coderay.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Filters::CodeRayTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/filters/test_colorize_syntax.rb
+++ b/test/filters/test_colorize_syntax.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Filters::ColorizeSyntaxTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/filters/test_erb.rb
+++ b/test/filters/test_erb.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Filters::ERBTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/filters/test_erubis.rb
+++ b/test/filters/test_erubis.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Filters::ErubisTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/filters/test_haml.rb
+++ b/test/filters/test_haml.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Filters::HamlTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/filters/test_kramdown.rb
+++ b/test/filters/test_kramdown.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Filters::KramdownTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/filters/test_less.rb
+++ b/test/filters/test_less.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Filters::LessTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/filters/test_markaby.rb
+++ b/test/filters/test_markaby.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Filters::MarkabyTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/filters/test_maruku.rb
+++ b/test/filters/test_maruku.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Filters::MarukuTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/filters/test_mustache.rb
+++ b/test/filters/test_mustache.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Filters::MustacheTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/filters/test_rainpress.rb
+++ b/test/filters/test_rainpress.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Filters::RainpressTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/filters/test_rdiscount.rb
+++ b/test/filters/test_rdiscount.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Filters::RDiscountTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/filters/test_rdoc.rb
+++ b/test/filters/test_rdoc.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Filters::RDocTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/filters/test_redcarpet.rb
+++ b/test/filters/test_redcarpet.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Filters::RedcarpetTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/filters/test_redcloth.rb
+++ b/test/filters/test_redcloth.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Filters::RedClothTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/filters/test_relativize_paths.rb
+++ b/test/filters/test_relativize_paths.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Filters::RelativizePathsTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/filters/test_rubypants.rb
+++ b/test/filters/test_rubypants.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Filters::RubyPantsTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/filters/test_sass.rb
+++ b/test/filters/test_sass.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Filters::SassTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/filters/test_slim.rb
+++ b/test/filters/test_slim.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Filters::SlimTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/filters/test_typogruby.rb
+++ b/test/filters/test_typogruby.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Filters::TypogrubyTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/helpers/test_blogging.rb
+++ b/test/helpers/test_blogging.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Helpers::BloggingTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/helpers/test_breadcrumbs.rb
+++ b/test/helpers/test_breadcrumbs.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Helpers::BreadcrumbsTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/helpers/test_capturing.rb
+++ b/test/helpers/test_capturing.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Helpers::CapturingTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/helpers/test_filtering.rb
+++ b/test/helpers/test_filtering.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Helpers::FilteringTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/helpers/test_html_escape.rb
+++ b/test/helpers/test_html_escape.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Helpers::HTMLEscapeTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/helpers/test_link_to.rb
+++ b/test/helpers/test_link_to.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Helpers::LinkToTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/helpers/test_rendering.rb
+++ b/test/helpers/test_rendering.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Helpers::RenderingTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/helpers/test_tagging.rb
+++ b/test/helpers/test_tagging.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Helpers::TaggingTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/helpers/test_text.rb
+++ b/test/helpers/test_text.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Helpers::TextTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/helpers/test_xml_sitemap.rb
+++ b/test/helpers/test_xml_sitemap.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Helpers::XMLSitemapTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers

--- a/test/tasks/test_clean.rb
+++ b/test/tasks/test_clean.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'test/helper'
-
 class Nanoc3::Tasks::CleanTest < MiniTest::Unit::TestCase
 
   include Nanoc3::TestHelpers


### PR DESCRIPTION
It is now in test.rake, although it still is there twice (has to be)
