### PR TITLE
Add `auto_remove_stale_items` config option.

### DIFF
--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -75,6 +75,12 @@ module Nanoc::CLI::Commands
       # Stop diffing
       teardown_diffs
 
+      # Auto-remove stale items
+      if self.site.config[:auto_remove_stale_items]
+        puts "Removing stale items..."
+        Nanoc3::CLI.run %w( clean_strays )
+      end
+
       # Give general feedback
       puts
       puts "Site compiled in #{format('%.2f', Time.now - time_before)}s."


### PR DESCRIPTION
This allows the `/output` directory to act as a build directory, as all stale files are removed after compilation (fixes issue #1) …

It's prob'ly not the most efficient way to accomplish this, and I'm positive the way I invoked the `clean_strays` command is wrong, but it does the trick. @ddfreyne, what's the right way to do this?

Note that this pull request depends on pull request #61 for the `clean_strays` command.
