### PR TITLE
`relativize_paths` with Nokogiri

### DIFF
--- a/lib/nanoc/filters/relativize_paths.rb
+++ b/lib/nanoc/filters/relativize_paths.rb
@@ -48,6 +48,10 @@ module Nanoc::Filters
       when :xhtml
         selectors = params[:select] || ['//a/@href | a/@href', '//img/@src | img/@src', '//script/@src | script/@src', '//link/@href | link/@href']
         namespaces = params[:namespaces] || {}
+        # FIXME cleans the XHTML namespace to process fragments and full
+        # documents in the same way. At least, Nokogiri adds this namespace if
+        # detects the `html` element.
+        content.sub!(%r{(<html[^>]+)xmlns="http://www.w3.org/1999/xhtml"}, '\1')
         nokogiri_process(content, selectors, namespaces, params[:type])
       else
         raise RuntimeError.new(

--- a/test/filters/test_relativize_paths.rb
+++ b/test/filters/test_relativize_paths.rb
@@ -413,7 +413,7 @@ XML
       # Set content
       raw_content = <<-XML
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html>
+<html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <link rel="stylesheet" href="/css"/>
     <script src="/js"></script>


### PR DESCRIPTION
This patch adds two new types: `:xml` and `:xhtml`. These new types uses the `Nokogiri::XML::DocumentFragment` class to deal with the input string (`content`). The output content is generated through the methods `#to_xml` or `#to_xhtml` matching the given params[:type].

I avoided using `Nokogiri::XML::Document` and `Nokogiri::HTML` because it adds extras to the output and could be annoying. For example, with `Nokogiri::XML::Document` and `#to_xml` adds the XML prolog and with the `#to_xhtml` adds a DOCTYPE and the Content-Type meta. I think having or not a prolog, DOCTYPE or the meta is out of the scope of this filter.

Because this issues and some other related to de magic inside `Nokogiri::HTML` I avoided using Nokogiri with the `:html` type.  For this type I made just a tiny modification to the regex to allow self-closing tags without the space before de `/`. So now you can use:

```
<img alt="" src="/foo" />
```

and

```
<img alt="" src="/foo"/>
```

with the same path modification.
