### PR TITLE
Fix deploy command on Ruby 1.8

### DIFF
--- a/lib/nanoc/cli/commands/deploy.rb
+++ b/lib/nanoc/cli/commands/deploy.rb
@@ -4,7 +4,7 @@
 registry       = Nanoc::PluginRegistry.instance
 deployer_class = Nanoc::Extra::Deployer
 deployers      = registry.find_all(deployer_class)
-deployer_names = deployers.keys.sort
+deployer_names = deployers.keys.sort_by { |k| k.to_s }
 
 usage       'deploy [options]'
 summary     'deploy the compiled site'


### PR DESCRIPTION
In Ruby 1.8, Symbol does not have #<=> method.
