### PR TITLE
The relativize_paths filter fails with network-paths (//*).

### DIFF
--- a/lib/nanoc/filters/relativize_paths.rb
+++ b/lib/nanoc/filters/relativize_paths.rb
@@ -41,7 +41,7 @@ module Nanoc::Filters
         end
       when :css
         # FIXME parse CSS the proper way using csspool or something
-        content.gsub(/url\((['"]?)(\/.*?)\1\)/) do
+        content.gsub(/url\((['"]?)(\/(?:[^\/].*?)?)\1\)/) do
           'url(' + $1 + relative_path_to($2) + $1 + ')'
         end
       when :xml, :xhtml

--- a/test/filters/test_relativize_paths.rb
+++ b/test/filters/test_relativize_paths.rb
@@ -306,6 +306,29 @@ class Nanoc::Filters::RelativizePathsTest < MiniTest::Unit::TestCase
     assert_equal(expected_content, actual_content)
   end
 
+  def test_filter_css_network_path
+    # Create filter with mock item
+    filter = Nanoc::Filters::RelativizePaths.new
+
+    # Mock item
+    filter.instance_eval do
+      @item_rep = Nanoc::ItemRep.new(
+        Nanoc::Item.new(
+          'content',
+          {},
+          '/foo/bar/baz/'),
+        :blah)
+      @item_rep.path = '/woof/meow/'
+    end
+
+    # Set content
+    raw_content      = %[background: url(//example.com);]
+    expected_content = %[background: url(//example.com);]
+
+    # Test
+    actual_content = filter.run(raw_content, :type => :css)
+    assert_equal(expected_content, actual_content)
+  end
 
   def test_filter_xml
     if_have 'nokogiri' do


### PR DESCRIPTION
The relativize_paths filter deforms URIs starting with two slashes (so-called "network-path references").

Given a base URI `http://www.github.com/foo`, [RFC 3986](http://tools.ietf.org/html/rfc3986#section-5.4.1) tells us that `//example.com/bar` should be interpreted as `http://example.com/bar`.

However, relativize_paths currently transforms these URIs, instead of leaving them as-is. As a result, they no longer refer to the intended resource.

These commits address the problem for HTML and CSS, as demonstrated in the tests.
