### PR TITLE
Colorize all <code> tags, not just those nested in <pre>. 

### DIFF
--- a/lib/nanoc/filters/colorize_syntax.rb
+++ b/lib/nanoc/filters/colorize_syntax.rb
@@ -70,6 +70,9 @@ module Nanoc::Filters
     #   a mapping of programming languages (symbols, not strings) onto
     #   colorizers (symbols).
     #
+    # @option params [String] :colorize_selector ('code') The CSS selector used
+    #   to find page elements to colorize.
+    #
     # @return [String] The filtered content
     def run(content, params={})
       # Take colorizers from parameters
@@ -91,7 +94,7 @@ module Nanoc::Filters
 
       # Colorize
       doc = klass.fragment(content)
-      doc.css('code').each do |element|
+      doc.css(params[:colorize_selector] || 'code').each do |element|
         # Get language
         has_class = false
         language = nil


### PR DESCRIPTION
This makes highlighting short snippets within Markdown much easier, since you're not allowed to have `<pre>` nested within `<p>` tags.
