### PR TITLE
Add a 'static' data source to Nanoc core.

### DIFF
--- a/lib/nanoc/cli/commands/create_site.rb
+++ b/lib/nanoc/cli/commands/create_site.rb
@@ -79,6 +79,24 @@ data_sources:
     # it will become “/about.html/” instead.
     allow_periods_in_identifiers: false
 
+# Create a directory named “assets/” in the site directory and uncomment the
+# following to enable a static data source for assets:
+#  -
+#    # The static data source provides items from a single directory. Unlike the
+#    # filesystem data sources, static provides no additional item metadata.  As
+#    # such, it is most useful for simple assets, not for standard content.
+#    type: static
+#
+#    # The path where static assets should be mounted. This should be different
+#    # from items_root in the `filesystem_unified` data source above to prevent
+#    # item identifier collisions.
+#    items_root: /assets/
+#
+#    # By default, the `static` data source will read items from the “static/”
+#    # directory of your site. This may be overridden by changing the `prefix`
+#    # configuration option
+#    prefix: assets
+
 # Configuration for the “watch” command, which watches a site for changes and
 # recompiles if necessary.
 watcher:
@@ -113,10 +131,17 @@ EOS
 #   “content/about.html”). To select all children, grandchildren, … of an
 #   item, use the pattern “/about/*/”; “/about/*” will also select the parent,
 #   because “*” matches zero or more characters.
+#
+# * A set of rules is provided—but not enabled—for static assets. Uncomment the
+#   rules below if you are using a static data source.
 
 compile '/stylesheet/' do
   # don’t filter or layout
 end
+
+# compile '/assets/*' do
+#   # nothing at all
+# end
 
 compile '*' do
   if item.binary?
@@ -130,6 +155,11 @@ end
 route '/stylesheet/' do
   '/style.css'
 end
+
+# route '/assets/*' do
+#   # /assets/foo.css/ → /foo.css
+#   item.identifier[7..-2]
+# end
 
 route '*' do
   if item.binary?
@@ -202,9 +232,9 @@ a:hover {
 
 #main p {
   margin: 20px 0;
-  
+
   font-size: 15px;
-  
+
   line-height: 20px;
 }
 
@@ -214,7 +244,7 @@ a:hover {
 
 #main li {
   font-size: 15px;
-  
+
   line-height: 20px;
 }
 

--- a/lib/nanoc/data_sources.rb
+++ b/lib/nanoc/data_sources.rb
@@ -9,6 +9,10 @@ module Nanoc::DataSources
   Nanoc::DataSource.register '::Nanoc::DataSources::FilesystemVerbose',  :filesystem_verbose
   Nanoc::DataSource.register '::Nanoc::DataSources::FilesystemUnified',  :filesystem_unified
 
+  autoload 'Static', 'nanoc/data_sources/static'
+
+  Nanoc::DataSource.register '::Nanoc::DataSources::Static',             :static
+
   # Deprecated; fetch data from online data sources manually instead
   # TODO [in nanoc 4.0] remove me
   autoload 'Delicious', 'nanoc/data_sources/deprecated/delicious'

--- a/lib/nanoc/data_sources/static.rb
+++ b/lib/nanoc/data_sources/static.rb
@@ -1,0 +1,77 @@
+# encoding: utf-8
+
+module Nanoc3::DataSources
+
+  # The static data source provides items from a single directory. Unlike the
+  # filesystem data sources, static provides no additional item metadata. In
+  # addition, all items are treated as 'binary', regardless of their extension
+  # or content. As such, it is most useful for simple assets, not for normal
+  # content.
+  #
+  # The identifier for static items is the full item path. For example, if your
+  # static data source item_root is `static`, an item named `foo.css` would have
+  # the identifier `/static/foo.css/`. Note that, unlike the filesystem data
+  # sources, `foo/index.html` and `foo.yaml` receive no special treatment. They
+  # are simple static items, just like `foo.css`.
+  #
+  # The default data source directory is `static/`, but this can be overridden
+  # in the data source configuration:
+  #
+  #    data_sources:
+  #      - type:         static
+  #        config:
+  #          prefix:     assets
+  #
+  # Unless the `hide_items` configuration attribute is false, items from static
+  # data sources will have the :is_hidden attribute set by default, which will
+  # exclude them from the Blogging helper's atom feed generator, among other
+  # things.
+  class Static < Nanoc3::DataSource
+    identifier :static
+
+    def items
+      # Get prefix
+      prefix = config[:prefix] || 'static'
+
+      # Get all files under prefix dir
+      filenames = Dir[prefix + '/**/*'].select { |f| File.file?(f) }
+
+      # Convert filenames to items
+      filenames.map do |filename|
+        attributes = {
+          :extension => File.extname(filename)[1..-1],
+          :filename  => filename,
+        }
+        attributes[:is_hidden] = true unless config[:hide_items] == false
+        identifier = filename[(prefix.length+1)..-1] + '/'
+
+        mtime      = File.mtime(filename)
+        checksum   = checksum_for(filename)
+
+        Nanoc3::Item.new(
+          filename,
+          attributes,
+          identifier,
+          :binary => true, :mtime => mtime, :checksum => checksum
+        )
+      end
+    end
+
+  private
+
+    # Returns a checksum of the given filenames
+    # TODO un-duplicate this somewhere
+    def checksum_for(*filenames)
+      filenames.flatten.map do |filename|
+        digest = Digest::SHA1.new
+        File.open(filename, 'r') do |io|
+          until io.eof
+            data = io.readpartial(2**10)
+            digest.update(data)
+          end
+        end
+        digest.hexdigest
+      end.join('-')
+    end
+  end
+end

--- a/test/data_sources/test_static.rb
+++ b/test/data_sources/test_static.rb
@@ -1,0 +1,66 @@
+# encoding: utf-8
+
+class Nanoc::DataSources::StaticTest < MiniTest::Unit::TestCase
+
+  include Nanoc::TestHelpers
+
+  def new_data_source(params=nil)
+    # Mock site
+    site = Nanoc::Site.new({})
+
+    # Create data source
+    data_source = Nanoc::DataSources::Static.new(site, nil, nil, params)
+
+    # Done
+    data_source
+  end
+
+  def test_items
+    # Create data source
+    data_source = new_data_source(:prefix => 'foo')
+
+    # Create sample files
+    FileUtils.mkdir_p('foo')
+    FileUtils.mkdir_p('foo/a/b')
+    File.open('foo/bar.png',   'w') { |io| io.write("random binary data") }
+    File.open('foo/b.c.css',   'w') { |io| io.write("more binary data") }
+    File.open('foo/a/b/c.gif', 'w') { |io| io.write("yet more binary data") }
+
+    # Get expected and actual output
+    expected_out = [
+      Nanoc::Item.new(
+        'foo/bar.png',
+        { :extension => 'png', :filename => 'foo/bar.png' },
+        '/bar.png/',
+        :binary => true,
+        :mtime => File.mtime('foo/bar.png'),
+        :checksum => data_source.send(:checksum_for, 'foo/bar.png')
+      ),
+      Nanoc::Item.new(
+        'foo/b.c.css',
+        { :extension => 'css', :filename => 'foo/b.c.css' },
+        '/b.c.css/',
+        :binary => true,
+        :mtime => File.mtime('foo/b.c.css'),
+        :checksum => data_source.send(:checksum_for, 'foo/b.c.css')
+      ),
+      Nanoc::Item.new(
+        'foo/a/b/c.gif',
+        { :extension => 'gif', :filename => 'foo/a/b/c.gif' },
+        '/a/b/c.gif/',
+        :binary => true,
+        :mtime => File.mtime('foo/a/b/c.gif'),
+        :checksum => data_source.send(:checksum_for, 'foo/a/b/c.gif')
+      )
+    ].sort_by { |i| i.identifier }
+
+    actual_out = data_source.send(:items).sort_by { |i| i.identifier }
+
+    (0..expected_out.size-1).each do |i|
+      assert_equal expected_out[i].raw_content, actual_out[i].raw_content, 'content must match'
+      assert_equal expected_out[i].identifier, actual_out[i].identifier, 'identifier must match'
+      assert_equal expected_out[i].mtime, actual_out[i].mtime, 'mtime must match'
+      assert_equal expected_out[i].raw_filename, actual_out[i].raw_filename, 'file paths must match'
+    end
+  end
+end


### PR DESCRIPTION
The static data source fills a common need for Nanoc sites. Hopefully it'll reduce the amount of n00b questions in IRC and on the mailing list :)

The original author of this data source appears to be @ddfreyne. Data source code [from here](http://pastie.textmate.org/914015).

I also updated `create_site` command to include a stub configuration, routing rule and compilation rule for the static data source. This doesn't change the defaults, but it adds commented out configuration to make it easier to get going.
