### PR TITLE
Add a shortcut notation to rules dsl

### DIFF
--- a/lib/nanoc/base/compilation/compiler_dsl.rb
+++ b/lib/nanoc/base/compilation/compiler_dsl.rb
@@ -61,8 +61,16 @@ module Nanoc
     #       # do nothing
     #     end
     def compile(identifier, params={}, &block)
-      # Require block
-      raise ArgumentError.new("#compile requires a block") unless block_given?
+      unless block_given?
+        if params.nil?
+          # Allow shortcut notation
+          params = {}
+          block = Proc.new {}
+        else
+          # Require block
+          raise ArgumentError.new("#compile requires a block")
+        end
+      end
 
       # Get rep name
       rep_name = params[:rep] || :default
@@ -105,8 +113,16 @@ module Nanoc
     #       '/raw' + item.identifier + 'index.txt'
     #     end
     def route(identifier, params={}, &block)
-      # Require block
-      raise ArgumentError.new("#route requires a block") unless block_given?
+      unless block_given?
+        if params.nil?
+          # Allow shortcut notation
+          params = {}
+          block = Proc.new {}
+        else
+          # Require block
+          raise ArgumentError.new("#route requires a block")
+        end
+      end
 
       # Get rep name
       rep_name      = params[:rep] || :default


### PR DESCRIPTION
This allows creating null routes or empty compiler rules with the following notation:

``` ruby
compile '/foo/', nil
route '/foo/', nil
```

As it currently stands, the shortest way to do these is this:

``` ruby
compile('/foo/') {}
route('/foo/') {}
```

or this:

``` ruby
compile '/foo/' do
  nil
end
route '/foo/' do
  # nothing
end
```

.. Neither of which feels as clean as the shortcut notation.
