### PR TITLE
Fixed watch command on Windows platform.

### DIFF
--- a/lib/nanoc/cli/commands/watch.rb
+++ b/lib/nanoc/cli/commands/watch.rb
@@ -91,6 +91,7 @@ module Nanoc::CLI::Commands
 
       # A list of commandline tool names that can be used to send notifications
       TOOLS = %w( growlnotify notify-send )
+      FIND_BINARY_COMMAND = RUBY_PLATFORM =~ /mingw|mswin/ ? "where" : "which"
 
       # Send a notification. If no notifier is found, no notification will be
       # created.
@@ -104,7 +105,7 @@ module Nanoc::CLI::Commands
     private
 
       def tool
-        @tool ||= TOOLS.find { |t| !`which #{t}`.empty? }
+        @tool ||= TOOLS.find { |t| !`#{FIND_BINARY_COMMAND} #{t}`.empty? }
       end
 
       def growlnotify(message)


### PR DESCRIPTION
Windows equivalent of 'which' is 'where', so just used the appropriate command. I haven't tested this fix except on Windows, but I'll trust you can double-check it :) I had problems getting tests to run; they just seemed to die without message after a few tests, so I haven't added an appropriate test for the fix. I have only used rspec/riot for testing and life is too short to try to work out what is wrong - Sorry!
