### PR TITLE
enable validation of HTTPS links via Nanoc::Extra::Validators::Links

### DIFF
--- a/lib/nanoc/extra/validators/links.rb
+++ b/lib/nanoc/extra/validators/links.rb
@@ -234,10 +234,16 @@ module Nanoc::Extra::Validators
     end
 
     def request_url_once(url)
+      require 'net/https'
+
       path = (url.path.nil? || url.path.empty? ? '/' : url.path)
       req = Net::HTTP::Head.new(path)
-      res = Net::HTTP.start(url.host, url.port) { |h| h.request(req) }
-      res
+      http=Net::HTTP.new(url.host, url.port)
+      if url.instance_of? URI::HTTPS
+        http.use_ssl = true
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      end
+      res = http.request(req)
     end
 
     def external_href_validated(href, is_valid)

--- a/test/extra/validators/test_links.rb
+++ b/test/extra/validators/test_links.rb
@@ -48,4 +48,15 @@ class Nanoc::Extra::Validators::LinksTest < MiniTest::Unit::TestCase
     refute validator.send(:is_valid_external_href?, 'http://example.com/">')
   end
 
+  def test_fetch_http_status_for
+    # Create validator
+    validator = Nanoc::Extra::Validators::Links.new('output', [ 'index.html' ])
+
+    # Test
+    assert validator.send(:fetch_http_status_for, URI.parse('http://heise.de/'), 200)
+    assert validator.send(:fetch_http_status_for, URI.parse('https://www.google.com/'), 200)
+    assert validator.send(:fetch_http_status_for, URI.parse('https://google.com/'), 200)
+    assert validator.send(:fetch_http_status_for, URI.parse('http://google.com/foo/bar'), 404)
+  end
+
 end


### PR DESCRIPTION
- this includes an integration test that might be better replaced by a unit test but demonstrates that https links currently don't work
