### PR TITLE
Detect PHP delimiter for colorize syntax filter

### DIFF
--- a/lib/nanoc/filters/colorize_syntax.rb
+++ b/lib/nanoc/filters/colorize_syntax.rb
@@ -116,10 +116,15 @@ module Nanoc::Filters
           language = match[2] if match
           has_class = true if language
         else
-          # Get language from comment line
-          match = element.inner_text.match(/^#!([^\/][^\n]*)$/)
-          language = match[1] if match
-          element.content = element.content.sub(/^#!([^\/][^\n]*)$\n/, '') if language
+          # Get language from delimiter
+          if element.inner_text.match(/<\?php$/)
+            language = 'php'
+          else
+            # Get language from comment line
+            match = element.inner_text.match(/^#!([^\/][^\n]*)$/)
+            language = match[1] if match
+            element.content = element.content.sub(/^#!([^\/][^\n]*)$\n/, '') if language
+          end
         end
 
         # Give up if there is no hope left

--- a/test/filters/test_colorize_syntax.rb
+++ b/test/filters/test_colorize_syntax.rb
@@ -85,6 +85,21 @@ EOS
     end
   end
 
+  def test_coderay_with_delimiter
+    if_have 'coderay', 'nokogiri' do
+      # Create filter
+      filter = ::Nanoc::Filters::ColorizeSyntax.new
+
+      # Get input and expected output
+      input = %[<pre title="moo"><code>&lt;?php\n// comment</code></pre>]
+      expected_output = %[<pre title="moo"><code class="language-php"><span class="inline-delimiter">&lt;?php</span>\n<span class="comment">// comment</span></code></pre>]
+
+      # Run filter
+      actual_output = filter.run(input)
+      assert_equal(expected_output, actual_output)
+    end
+  end
+
   def test_coderay_with_comment_and_class
     if_have 'coderay', 'nokogiri' do
       # Create filter


### PR DESCRIPTION
This probably isn't the best way to do this, and I'm sure there are other languages which would benefit from a similar approach, but it's entirely possible to detect PHP code blocks by delimiter. This is super handy with markdown, for the same reason as the `#!php` comments.
