### PR TITLE
Rules backwards-compatibility for Redcarpet 1/2

### DIFF
--- a/lib/nanoc/filters/redcarpet.rb
+++ b/lib/nanoc/filters/redcarpet.rb
@@ -45,6 +45,13 @@ module Nanoc::Filters
         renderer_class   = params[:renderer]         || ::Redcarpet::Render::HTML
         renderer_options = params[:renderer_options] || {}
 
+		# Redcarpet 2 requires the options to be in the form of a hash
+		if options.is_a? Array
+			hash = {}
+			options.each { |opt| hash[opt] = true }
+			options = hash
+		end
+
         renderer = renderer_class.new(renderer_options)
         ::Redcarpet::Markdown.new(renderer, options).render(content)
       else


### PR DESCRIPTION
This is a simple patch to redcarpet.rb - my site compilation was breaking with Redcarpet 2 because I had an array of options to the :redcarpet filter in my Rules file. Redcarpet 2, of course, requires a hash - this just provides compatibility for unconverted Rules files so they don't break. 
