### PR TITLE
Prevent crash while compiling extension-less files.

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -64,7 +64,7 @@ end
 
 route '*' do
   if item.binary?
-    item.identifier.chop + '.' + item[:extension]
+    item.identifier.chop + (item[:extension] ? '.' + item[:extension] : '')
   else
     item.identifier + 'index.html'
   end


### PR DESCRIPTION
The default Rules file doesn't check if a file has an extension before attempting to append '.' to it. If you have an extension-less file in the content directory, it crashes.
