### PR TITLE
Fixing "Uninitialized constant Nanoc::CLI" error in rsync task

### DIFF
--- a/lib/nanoc/tasks/deploy/rsync.rake
+++ b/lib/nanoc/tasks/deploy/rsync.rake
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require 'nanoc/cli'
 
 namespace :deploy do
 


### PR DESCRIPTION
When I run `rake deploy:rsync` I get an `Uninitialized constant Nanoc::CLI` error. This patch fixes this issue.

I'm using nanoc 3.3.1 with Ruby 1.8.7
