### PR TITLE
Created_at is immutable we need to dup object for it to work in 1.8.7

### DIFF
--- a/lib/nanoc/helpers/blogging.rb
+++ b/lib/nanoc/helpers/blogging.rb
@@ -309,6 +309,9 @@ module Nanoc::Helpers
     #
     # @return [Time] The Time instance corresponding to the given input
     def attribute_to_time(time)
+      if time.is_a?(Date)
+        time = time.dup
+      end
       time = Time.local(time.year, time.month, time.day) if time.is_a?(Date)
       time = Time.parse(time) if time.is_a?(String)
       time


### PR DESCRIPTION
There seems to be a problem with immutable variables and Ruby 1.8.7. So to bypass this in the blogging helper we duplicate the Date object to be able to convert it into a Time object.
