### PR TITLE
Missing gem 'redcloth' needs camelcase for 'gem install RedCloth'

### DIFF
--- a/lib/nanoc/cli/error_handler.rb
+++ b/lib/nanoc/cli/error_handler.rb
@@ -160,7 +160,7 @@ module Nanoc::CLI
       'rainpress'      => 'rainpress',
       'rdiscount'      => 'rdiscount',
       'redcarpet'      => 'redcarpet',
-      'redcloth'       => 'redcloth',
+      'redcloth'       => 'RedCloth',
       'rubypants'      => 'rubypants',
       'sass'           => 'sass',
       'systemu'        => 'systemu',


### PR DESCRIPTION
RedCloth is camel case - changed value for 'redcloth' in hash
