### PR TITLE
Failing test for relativize_paths filter.

### DIFF
--- a/test/filters/test_relativize_paths.rb
+++ b/test/filters/test_relativize_paths.rb
@@ -101,6 +101,30 @@ class Nanoc::Filters::RelativizePathsTest < MiniTest::Unit::TestCase
     assert_equal(expected_content, actual_content)
   end
 
+  def test_filter_html_nested
+    # Create filter with mock item
+    filter = Nanoc::Filters::RelativizePaths.new
+
+    # Mock item
+    filter.instance_eval do
+      @item_rep = Nanoc::ItemRep.new(
+        Nanoc::Item.new(
+          'content',
+          {},
+          '/foo/bar/baz/'),
+        :blah)
+      @item_rep.path = '/foo/bar/baz/'
+    end
+
+    # Set content
+    raw_content      = %[<a href="/"><img src="/bar.png" /></a>]
+    expected_content = %[<a href="../../../"><img src="../../../bar.png" /></a>]
+
+    # Test
+    actual_content = filter.run(raw_content, :type => :html)
+    assert_equal(expected_content, actual_content)
+  end
+
   def test_filter_html_outside_tag
     # Create filter with mock item
     filter = Nanoc::Filters::RelativizePaths.new


### PR DESCRIPTION
This fails only when the `<a>` and `<img>` are on the same line, and seems to only fail when the `href` attribute of the `<a>` is `"/"`.
