### PR TITLE
Add new html test for relativize_paths

### DIFF
--- a/test/filters/test_relativize_paths.rb
+++ b/test/filters/test_relativize_paths.rb
@@ -626,7 +626,7 @@ XML
       raw_content = <<-XML
 <a href="/foo">bar</a>
 <p>
-  <img src="/img"/>
+  <img src="/img">
 </p>
 XML
 
@@ -663,7 +663,7 @@ XML
       raw_content = <<-XML
 <p><a href="/foo">bar</a>
 <p>
-  <img src="/img"/>
+  <img src="/img">
 </p>
 XML
 


### PR DESCRIPTION
These new tests should pass.

Because nokogiri (or libxml2) behave when deals with not closed tags the html result is a mess.
