### PR TITLE
Add new selectors to relativize_paths filters covering all HTML cases.

### DIFF
--- a/lib/nanoc/filters/relativize_paths.rb
+++ b/lib/nanoc/filters/relativize_paths.rb
@@ -6,7 +6,7 @@ module Nanoc::Filters
     require 'nanoc/helpers/link_to'
     include Nanoc::Helpers::LinkTo
 
-    SELECTORS = [ 'a/@href', 'img/@src', 'script/@src', 'link/@href', 'input/@src', 'iframe/@src', 'frame/@src', 'area/@href', 'base/@href' ]
+    SELECTORS = [ '*/@href', '*/@src', 'object/@data', 'param[@name="movie"]/@content' ]
 
     # Relativizes all paths in the given content, which can be HTML, XHTML, XML
     # or CSS. This filter is quite useful if a site needs to be hosted in a

--- a/test/filters/test_relativize_paths.rb
+++ b/test/filters/test_relativize_paths.rb
@@ -305,6 +305,32 @@ EOS
     assert_equal(expected_content, actual_content)
   end
 
+
+  def test_filter_html_object_with_relative_path
+    # Create filter with mock item
+    filter = Nanoc::Filters::RelativizePaths.new
+
+    # Mock item
+    filter.instance_eval do
+      @item_rep = Nanoc::ItemRep.new(
+        Nanoc::Item.new(
+          'content',
+          {},
+          '/foo/bar/baz/'),
+        :blah)
+      @item_rep.path = '/woof/meow/'
+    end
+
+    # Set content
+    raw_content      = %[<object data="/example"><param name="movie" content="/example"></object>]
+    expected_content = %[<object data="../../example"><param name="movie" content="../../example"></object>]
+
+    # Test
+    actual_content = filter.run(raw_content, :type => :html)
+    assert_equal(expected_content, actual_content)
+  end
+
+
   def test_filter_implicit
     # Create filter with mock item
     filter = Nanoc::Filters::RelativizePaths.new


### PR DESCRIPTION
The missing selectors were 'input/@src', 'frame/@src', 'iframe/@src', 'base/@href' and 'area/@href'.
