### PR TITLE
Minor tweak to create-site.rb’s HTML output: omit optional `@type` attribute, and remove `@media`

### DIFF
--- a/lib/nanoc/cli/commands/create-site.rb
+++ b/lib/nanoc/cli/commands/create-site.rb
@@ -273,7 +273,7 @@ EOS
   <head>
     <meta charset="utf-8">
     <title>A Brand New nanoc Site - <%= @item[:title] %></title>
-    <link rel="stylesheet" type="text/css" href="/style.css" media="screen">
+    <link rel="stylesheet" href="/style.css">
 
     <!-- you don't need to keep this, but it's cool for stats! -->
     <meta name="generator" content="nanoc <%= Nanoc::VERSION %>"> 


### PR DESCRIPTION
The `type=text/css` attribute/value pair for `<link rel=stylesheet>` is optional as per HTML5, as it’s the default/implied value. http://mathiasbynens.be/notes/html5-levels#level-1

Removing the `media=screen` attribute/value pair allows specifying the styles for various types of media in a single CSS file.
