### PR TITLE
NEP-40: Watcher notifications on Mountain Lion

### DIFF
--- a/lib/nanoc/cli/commands/watch.rb
+++ b/lib/nanoc/cli/commands/watch.rb
@@ -104,7 +104,16 @@ module Nanoc::CLI::Commands
     private
 
       def tool
-        @tool ||= TOOLS.find { |t| !`#{FIND_BINARY_COMMAND} #{t}`.empty? }
+        @tool ||= begin
+          require 'terminal-notifier'
+          'terminal-notify'
+        rescue LoadError
+          TOOLS.find { |t| !`#{FIND_BINARY_COMMAND} #{t}`.empty? }
+        end
+      end
+
+      def terminal_notify(message)
+        TerminalNotifier.notify(message, :title => "nanoc")
       end
 
       def growlnotify(message)


### PR DESCRIPTION
if `terminal-notifier` gem is present, it will use Notification Center, otherwise it'll try the usual `which growlnotify` type stuffs.
