### PR TITLE
Add #include_rules to the nanoc compiler DSL

### DIFF
--- a/lib/nanoc/base/compilation/compiler_dsl.rb
+++ b/lib/nanoc/base/compilation/compiler_dsl.rb
@@ -190,6 +190,25 @@ module Nanoc
       @rules_collection.add_item_routing_rule(routing_rule, :before)
     end
 
+    # Includes an additional rules file in the current rules collection.
+    #
+    # @param [String] name The name of the rules file — an ".rb" extension is
+    #   implied if not explicitly given
+    #
+    # @return [void]
+    #
+    # @example Including two additional rules files, 'rules/assets.rb' and
+    #   'rules/content.rb'
+    #
+    #     include_rules 'rules/assets'
+    #     include_rules 'rules/content'
+    def include_rules(name)
+      filename = [ "#{name}", "#{name}.rb", "./#{name}", "./#{name}.rb" ].find { |f| File.file?(f) }
+      raise Nanoc::Errors::NoRulesFileFound.new if filename.nil?
+
+      self.instance_eval(File.read(filename), filename)
+    end
+
   private
 
     # Converts the given identifier, which can contain the '*' or '+'

--- a/test/base/test_compiler_dsl.rb
+++ b/test/base/test_compiler_dsl.rb
@@ -16,6 +16,30 @@ class Nanoc::CompilerDSLTest < MiniTest::Unit::TestCase
     # TODO implement
   end
 
+  def test_include_rules
+    # Create site
+    Nanoc::CLI.run %w( create_site with_bonus_rules )
+    FileUtils.cd('with_bonus_rules') do
+      # Create rep
+      item = Nanoc::Item.new('foo', { :extension => 'bar' }, '/foo/')
+      rep  = Nanoc::ItemRep.new(item, :default)
+
+      # Create a bonus rules file
+      File.open('more_rules.rb', 'w') { |io| io.write "passthrough '/foo/'" }
+
+      # Create other necessary stuff
+      site = Nanoc::Site.new('.')
+      site.items << item
+      dsl = site.compiler.rules_collection.dsl
+
+      # Include rules
+      dsl.include_rules 'more_rules'
+
+      # Check that the rule made it into the collection
+      refute_nil site.compiler.rules_collection.routing_rule_for(rep)
+    end
+  end
+
   def test_passthrough
     # Create site
     Nanoc::CLI.run %w( create_site bar)


### PR DESCRIPTION
I have two additional rules files: `rules/assets.rb` and `rules/content.rb`. To include them in my site's main rules collection, I add two lines to the top of `rules.rb`:

``` rb
# encoding: utf-8

include_rules 'rules/assets'
include_rules 'rules/content'

# ...
```

Sweet!
