### PR TITLE
Add support for params to LESS filter

### DIFF
--- a/lib/nanoc/filters/less.rb
+++ b/lib/nanoc/filters/less.rb
@@ -46,7 +46,7 @@ module Nanoc::Filters
       # Add filename to load path
       paths = [ File.dirname(@item[:content_filename]) ]
       parser = ::Less::Parser.new(:paths => paths)
-      parser.parse(content).to_css
+      parser.parse(content).to_css params
     end
 
   end

--- a/test/filters/test_less.rb
+++ b/test/filters/test_less.rb
@@ -110,4 +110,18 @@ class Nanoc::Filters::LessTest < MiniTest::Unit::TestCase
     end
   end
 
+  def test_compression
+    if_have 'less' do
+      # Create item
+      @item = Nanoc::Item.new("blah", { :content_filename => 'content/foo/bar.txt' }, '/foo/bar/')
+
+      # Create filter
+      filter = ::Nanoc::Filters::Less.new(:item => @item, :items => [ @item ])
+
+      # Run filter with compress option
+      result = filter.run('.foo { bar: a; } .bar { foo: b; }', :compress => true)
+      assert_match /^\.foo{bar:a;}\n\.bar{foo:b;}/, result
+    end
+  end
+
 end


### PR DESCRIPTION
This pull request adds support for parameters to the LESS filter, like so:

``` ruby
filter = ::Nanoc::Filters::Less.new(:item => @item, :items => [ @item ])
result = filter.run('.foo { bar: a; } .bar { foo: b; }', :compress => true)
```
