### PR TITLE
fixed 'passthrough' rule routing

### DIFF
--- a/lib/nanoc/base/compilation/compiler_dsl.rb
+++ b/lib/nanoc/base/compilation/compiler_dsl.rb
@@ -186,7 +186,7 @@ module Nanoc
       routing_block = proc do
         item[:extension].nil? ? item.identifier.chop : item.identifier.chop + '.' + item[:extension]
       end
-      routing_rule = Rule.new(identifier_to_regex(identifier), rep_name, routing_block)
+      routing_rule = Rule.new(identifier_to_regex(identifier), rep_name, routing_block, :snapshot_name => :last)
       @rules_collection.add_item_routing_rule(routing_rule, :before)
     end
 


### PR DESCRIPTION
Without that fix, `passthrough` rules don't route items properly.

steps to reproduce:
1. nanoc create_site foo
2. add foo/content/robots.txt
3. add passthrough '/robots/' at the beginning of the Rules file

without the fix
- nanoc creates output/robots/index.html

with the fix
- nanoc creates output/robots.txt
