### PR TITLE
Unwrap pygmentize output if necessary

### DIFF
--- a/lib/nanoc/filters/colorize_syntax.rb
+++ b/lib/nanoc/filters/colorize_syntax.rb
@@ -177,7 +177,7 @@ module Nanoc::Filters
     #
     # By default the pygmentize highlighter is invoked with the parameters
     # `:nowrap => 'True'` and `:encoding => 'utf-8'`. Note that using `nowrap`
-    # disables some of other parameters of pygmentize i.e. line numbering.
+    # disables some other options of pygmentize i.e. line numbering.
     #
     # @api private
     #
@@ -289,7 +289,7 @@ module Nanoc::Filters
       s.lines.drop_while { |line| line.strip.empty? }.join.rstrip
     end
 
-    # Determine if the specified value is a 'falsy' value
+    # Determine if the specified value/parameter is a 'falsy' value
     def falsy(v)
         [false, 'false', 'False', '0', 0].include?(v)
     end


### PR DESCRIPTION
Hi,

using these changes the output of the `pygmentize` command will be unwrapped of the additional `div`, `pre` tags generated by the highlighter if you enable _wrapping_ by specifying the `:unwrap => 0` parameter. This is especially useful if you want to use options like _line numbering_.

Example usage:

```
filter :colorize_syntax,
    :default_colorizer => :pygmentize,
    :pygmentize => { :linenos => 'inline', :linenospecial => 5, :nowrap => 0 }
```

I am fairly new to ruby - so please bear with me in case the code style is not as desired :-)

Cheers,
Gregor
