### PR TITLE
Support Atom icon and logo

### DIFF
--- a/lib/nanoc/helpers/blogging.rb
+++ b/lib/nanoc/helpers/blogging.rb
@@ -56,6 +56,7 @@ module Nanoc::Helpers
       attr_accessor :author_name
       attr_accessor :author_uri
       attr_accessor :icon
+      attr_accessor :logo
 
       def initialize(site, item)
         @site = site
@@ -136,8 +137,9 @@ module Nanoc::Helpers
             xml.uri   author_uri
           end
 
-          # Add icon
+          # Add icon and logo
           xml.icon icon if icon
+          xml.logo logo if logo
 
           # Add articles
           sorted_relevant_articles.each do |a|
@@ -281,6 +283,8 @@ module Nanoc::Helpers
     #
     # @option params [String] :icon The URI of the feed's icon.
     #
+    # @option params [String] :logo The URI of the feed's logo.
+    #
     # @return [String] The generated feed content
     def atom_feed(params={})
       require 'builder'
@@ -297,6 +301,7 @@ module Nanoc::Helpers
       builder.author_name       = params[:author_name] || @item[:author_name] || @site.config[:author_name]
       builder.author_uri        = params[:author_uri] || @item[:author_uri] || @site.config[:author_uri]
       builder.icon              = params[:icon]
+      builder.logo              = params[:logo]
 
       # Run
       builder.validate

--- a/test/helpers/test_blogging.rb
+++ b/test/helpers/test_blogging.rb
@@ -572,6 +572,28 @@ class Nanoc::Helpers::BloggingTest < MiniTest::Unit::TestCase
     end
   end
 
+  def test_atom_feed_with_logo_param
+    if_have 'builder' do
+      # Mock article
+      @items = [ mock_article ]
+
+      # Mock site
+      @site = mock
+      @site.stubs(:config).returns({ :base_url => 'http://example.com' })
+
+      # Create feed item
+      @item = mock
+      @item.stubs(:[]).with(:title).returns('My Blog Or Something')
+      @item.stubs(:[]).with(:author_name).returns('J. Doe')
+      @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
+      @item.stubs(:[]).with(:feed_url).returns('http://example.com/feed')
+
+      # Check
+      result = atom_feed :logo => 'http://example.com/logo.png'
+      assert_match '<logo>http://example.com/logo.png</logo>', result
+    end
+  end
+
   def test_atom_feed_with_item_without_path
     if_have 'builder' do
       # Create items


### PR DESCRIPTION
These commits add support to the Atom feed generator for [icon](http://tools.ietf.org/html/rfc4287#section-4.2.5) and [logo](http://tools.ietf.org/html/rfc4287#section-4.2.8).
