### PR TITLE
Excluded files are still deleted when auto_prune is enabled

### DIFF
--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -79,7 +79,7 @@ module Nanoc::CLI::Commands
 
       # Prune
       if self.site.config[:prune][:auto_prune]
-        Nanoc::Extra::Pruner.new(self.site).run
+        Nanoc::Extra::Pruner.new(self.site, :exclude => self.prune_config_exclude).run
       end
 
       # Give general feedback
@@ -307,6 +307,16 @@ module Nanoc::CLI::Commands
         filter_name = format("%#{max_filter_name_length}s", filter_name)
         puts "#{filter_name} |  #{count}  #{min}s  #{avg}s  #{max}s  #{tot}s"
       end
+    end
+
+  protected
+
+    def prune_config
+      self.site.config[:prune] || {}
+    end
+
+    def prune_config_exclude
+      self.prune_config[:exclude] || {}
     end
 
   end

--- a/test/cli/commands/test_compile.rb
+++ b/test/cli/commands/test_compile.rb
@@ -71,4 +71,49 @@ class Nanoc::CLI::Commands::CompileTest < MiniTest::Unit::TestCase
     end
   end
 
+  def test_auto_prune_with_exclude
+    with_site do |site|
+      Nanoc::CLI.run %w( create_item foo )
+      Nanoc::CLI.run %w( create_item bar )
+      Nanoc::CLI.run %w( create_item baz )
+
+      File.open('Rules', 'w') do |io|
+        io.write "compile '*' do\n"
+        io.write "  filter :erb\n"
+        io.write "end\n"
+        io.write "\n"
+        io.write "route '*' do\n"
+        io.write "  if item.binary?\n"
+        io.write "    item.identifier.chop + '.' + item[:extension]\n"
+        io.write "  else\n"
+        io.write "    item.identifier + 'index.html'\n"
+        io.write "  end\n"
+        io.write "end\n"
+        io.write "\n"
+        io.write "layout '*', :erb\n"
+      end
+
+      Dir.mkdir('output/excluded_dir')
+
+      File.open('output/stray.html', 'w') do |io|
+        io.write 'I am a stray file and I am about to be deleted!'
+      end
+
+      assert File.file?('output/stray.html')
+      Nanoc::CLI.run %w( compile )
+      assert File.file?('output/stray.html')
+
+      File.open('config.yaml', 'w') do |io|
+        io.write "prune:\n"
+        io.write "  auto_prune: true\n"
+        io.write "  exclude: [ 'excluded_dir' ]\n"
+      end
+
+      assert File.file?('output/stray.html')
+      Nanoc::CLI.run %w( compile )
+      refute File.file?('output/stray.html')
+      assert File.directory?('output/excluded_dir'),
+             'excluded_dir should still be there'
+    end
+  end
 end


### PR DESCRIPTION
The `[:prune][:exclude]` config section is ignored when compiling with
the `auto_prune` option.

This pull request adds an extra test case and reads the exclude list
from the config file.
