### PR TITLE
Call forget_dependencies_if_outdated in run instead of load

### DIFF
--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -81,6 +81,10 @@ module Nanoc
       # Compile reps
       load
       @site.freeze
+
+      # Determine which reps need to be recompiled
+      forget_dependencies_if_outdated(items)
+
       dependency_tracker.start
       compile_reps(reps)
       dependency_tracker.stop
@@ -120,9 +124,6 @@ module Nanoc
 
       # Load auxiliary stores
       stores.each { |s| s.load }
-
-      # Determine which reps need to be recompiled
-      forget_dependencies_if_outdated(items)
 
       @loaded = true
     rescue => e


### PR DESCRIPTION
This helps to track down the dependency that leads to outdated objects.

If the dependencies are cleared in load, nanoc show-data just
will show empty dependencies for all outdated objects.
