### PR TITLE
logger: Be bold or colourful - not both

### DIFF
--- a/lib/nanoc/cli/logger.rb
+++ b/lib/nanoc/cli/logger.rb
@@ -11,11 +11,11 @@ module Nanoc::CLI
     # Maps actions (`:create`, `:update`, `:identical`, `:skip` and `:delete`)
     # onto their ANSI color codes.
     ACTION_COLORS = {
-      :create         => "\e[1m" + "\e[32m", # bold + green
-      :update         => "\e[1m" + "\e[33m", # bold + yellow
-      :identical      => "\e[1m",            # bold
-      :skip           => "\e[1m",            # bold
-      :delete         => "\e[1m" + "\e[31m"  # bold + red
+      :create         => "\e[32m", # green
+      :update         => "\e[33m", # yellow
+      :identical      => "\e[1m",  # bold
+      :skip           => "\e[1m",  # bold
+      :delete         => "\e[31m"  # red
     }
 
     include Singleton


### PR DESCRIPTION
Output that is both colourful and bold confuses 16-bit colourschemes
such as Solarized.  It also makes filtering typescripts more awkward.

(In Solarized, bold+green is the same as regular output, so things
that should stand out, in fact don't stand out at all!)
