### PR TITLE
Add ability to specify host and/or port options for the autocompile command in config.yaml

### DIFF
--- a/lib/nanoc/cli/commands/autocompile.rb
+++ b/lib/nanoc/cli/commands/autocompile.rb
@@ -8,7 +8,8 @@ Start the autocompiler web server. Unless overridden with commandline options
 or configuration entries, the web server will run on port 3000 and listen on all
 IP addresses. Running the autocompiler requires the 'mime/types' and 'rack' gems.
 
-To specify the host and/or port options in config.yaml, you can add the following:
+To specify the host and/or port options in config.yaml, you can add either (or
+both) of the following:
 
   autocompile:
     host: '10.0.2.0'  # override the default host


### PR DESCRIPTION
When using nanoc's autocompile command, I often have another web service running on my machine (in development) on port 3000, and I always forget to pass `-p <port>`. I wanted a way to specify this as a configuration option, so I've added configurable entries for the `autocompile` command, which read either (or both) of these settings from `config.yaml`:

```
autocompile:
  host: '10.0.2.0'  # override the default host
  port: 4000        # override the default port
```
