### PR TITLE
Add `nanoc sync` command.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # nanoc news
 
+## 3.6 (???)
+
+Improvements:
+
+ * Added `sync` command, allowing data sources to update local caches of
+   external data [Justin Hileman]
+
 ## 3.5 (???)
 
 Major changes:

--- a/lib/nanoc/base/source_data/data_source.rb
+++ b/lib/nanoc/base/source_data/data_source.rb
@@ -148,6 +148,18 @@ module Nanoc
     def update
     end
 
+    # Sync the content for this data source with an external source.
+    # This method is called by the `nanoc sync` command so that data sources may
+    # update local caches of external data, such as items fetched from
+    # third-party APIs.
+    #
+    # Subclasses may override this method, but are not required to do so; the
+    # default implementation simply does nothing.
+    #
+    # @return [void]
+    def sync
+    end
+
     # Returns the list of items (represented by {Nanoc::Item}) in this site.
     # The default implementation simply returns an empty array.
     #

--- a/lib/nanoc/cli/commands/sync.rb
+++ b/lib/nanoc/cli/commands/sync.rb
@@ -1,0 +1,34 @@
+usage   'sync'
+summary 'sync data sources'
+description <<-EOS
+Sync data source data. This command is useful for updating local item caches
+for data sources which rely on slow external APIs.
+EOS
+
+module Nanoc::CLI::Commands
+
+  class Sync < ::Nanoc::CLI::CommandRunner
+
+    def run
+      # Check arguments
+      if arguments.size != 0
+        raise Nanoc::Errors::GenericTrivial, "usage: #{command.usage}"
+      end
+
+      # Make sure we are in a nanoc site directory
+      self.require_site
+
+      # Update all syncable data sources
+      self.site.data_sources.each do |data_source|
+        unless data_source.method(:sync).owner == Nanoc::DataSource
+          puts "Syncing #{data_source.config[:type]} data source: #{data_source.items_root}"
+          data_source.sync
+        end
+      end
+    end
+
+  end
+
+end
+
+runner Nanoc::CLI::Commands::Sync

--- a/test/cli/commands/test_sync.rb
+++ b/test/cli/commands/test_sync.rb
@@ -1,0 +1,31 @@
+class Nanoc::CLI::Commands::SyncTest < MiniTest::Unit::TestCase
+
+  include Nanoc::TestHelpers
+
+  def test_run
+    with_site do
+      File.open('lib/foo_data_source.rb', 'w') do |io|
+        io.write "class FooDataSource < Nanoc::DataSource\n"
+        io.write "  identifier :sync_test_foo\n"
+        io.write "  def sync\n"
+        io.write "    File.open('foo_source_data.yaml', 'w') do |io|\n"
+        io.write "      io.write 'sync: true'\n"
+        io.write "    end\n"
+        io.write "  end\n"
+        io.write "end\n"
+      end
+
+      File.open('config.yaml', 'w') do |io|
+        io.write "data_sources:\n"
+        io.write "  - type: sync_test_foo\n"
+        io.write "    items_root: /"
+      end
+
+      Nanoc::CLI.run %w( sync )
+
+      assert File.file?('foo_source_data.yaml')
+      assert_equal File.read('foo_source_data.yaml'), 'sync: true'
+    end
+  end
+
+end


### PR DESCRIPTION
This command calls #sync on all data sources which implement it, which allows data sources to keep local caches of expensive calculations or external API calls.
