### PR TITLE
Lazily define SassFilesystemImporter

### DIFF
--- a/lib/nanoc/filters/sass.rb
+++ b/lib/nanoc/filters/sass.rb
@@ -3,7 +3,7 @@
 module Nanoc::Filters
   class Sass < Nanoc::Filter
 
-    requires 'sass', 'nanoc/filters/sass_filesystem_importer'
+    requires 'sass', 'nanoc/filters/sass/sass_filesystem_importer'
 
     class << self
       # The current filter. This is definitely going to bite me if I ever get

--- a/lib/nanoc/filters/sass/sass_filesystem_importer.rb
+++ b/lib/nanoc/filters/sass/sass_filesystem_importer.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 module Nanoc::Filters
   class Sass
 


### PR DESCRIPTION
Without it I'm getting [this error](https://gist.github.com/cdlm/7b690075a8dabdda65be)
