### PR TITLE
Allow excluding links from the internal_links checker

### DIFF
--- a/lib/nanoc/cli/commands/create-site.rb
+++ b/lib/nanoc/cli/commands/create-site.rb
@@ -102,6 +102,17 @@ watcher:
   # When to send notifications (using Growl or notify-send).
   notify_on_compilation_success: true
   notify_on_compilation_failure: true
+
+# Configuration for the “check” command, which run unit tests on the site.
+checks:
+  # Configuration for the “internal_links” checker, which checks whether all
+  # internal links are valid.
+  internal_links:
+    # A list of patterns, specified as regular expressions, to exclude from the check.
+    # If an internal link matches this pattern, the validity check will be skipped.
+    # E.g.:
+    #   exclude: ['^/server_status']
+    exclude: []
 EOS
 
     DEFAULT_RULES = <<EOS unless defined? DEFAULT_RULES

--- a/lib/nanoc/extra/checking/checks/internal_links.rb
+++ b/lib/nanoc/extra/checking/checks/internal_links.rb
@@ -7,6 +7,9 @@ module Nanoc::Extra::Checking::Checks
 
     # Starts the validator. The results will be printed to stdout.
     #
+    # Internal links that match a regexp pattern in `@config[:checks][:internal_links][:exclude]` will
+    # be skipped.
+    #
     # @return [void]
     def run
       # TODO de-duplicate this (duplicated in external links check)
@@ -29,6 +32,9 @@ module Nanoc::Extra::Checking::Checks
       # Skip hrefs that point to self
       # FIXME this is ugly and won’t always be correct
       return true if href == '.'
+
+      # Skip hrefs that are specified in the exclude configuration
+      return true if self.excluded?(href)
 
       # Remove target
       path = href.sub(/#.*$/, '')
@@ -53,6 +59,11 @@ module Nanoc::Extra::Checking::Checks
 
       # Nope :(
       return false
+    end
+
+    def excluded?(href)
+      excludes =  @site.config.fetch(:checks, {}).fetch(:internal_links, {}).fetch(:exclude, [])
+      excludes.any? { |pattern| Regexp.new(pattern).match(href) }
     end
 
   end

--- a/test/extra/checking/checks/test_internal_links.rb
+++ b/test/extra/checking/checks/test_internal_links.rb
@@ -55,4 +55,17 @@ class Nanoc::Extra::Checking::Checks::InternalLinksTest < MiniTest::Unit::TestCa
     end
   end
 
+  def test_exclude
+    with_site do |site|
+      # Create check
+      check = Nanoc::Extra::Checking::Checks::InternalLinks.new(site)
+      site.config.update({ :checks => { :internal_links => { :exclude => ['^/excluded\d+'] } } })
+
+      # Test
+      assert check.send(:valid?, '/excluded1', 'output/origin')
+      assert check.send(:valid?, '/excluded2', 'output/origin')
+      assert !check.send(:valid?, '/excluded_not', 'output/origin')
+    end
+  end
+
 end


### PR DESCRIPTION
Links to be excluded can be specified as a list of regular
expressions in config[:checks][:internal_links][:exclude].
