### PR TITLE
Set explicit UTF-8 encoding in nanoc.yaml by default

### DIFF
--- a/lib/nanoc/cli/commands/create-site.rb
+++ b/lib/nanoc/cli/commands/create-site.rb
@@ -85,6 +85,10 @@ data_sources:
     # it will become “/about.html/” instead.
     allow_periods_in_identifiers: false
 
+    # The encoding to use for input files. If your input files are not in
+    # UTF-8 (which they should be!), change this.
+    encoding: utf-8
+
 # Configuration for the “watch” command, which watches a site for changes and
 # recompiles if necessary.
 watcher:

--- a/test/cli/commands/test_create_site.rb
+++ b/test/cli/commands/test_create_site.rb
@@ -21,4 +21,30 @@ class Nanoc::CLI::Commands::CreateSiteTest < MiniTest::Unit::TestCase
     end
   end
 
+  def test_default_encoding
+    original_encoding = Encoding.default_external
+    Encoding.default_external = 'ISO-8859-1' # ew!
+
+    Nanoc::CLI.run %w( create_site foo )
+
+    FileUtils.cd('foo') do
+
+      # Try with encoding = default encoding = utf-8
+      File.open('content/index.html', 'w') { |io| io.write("Hello <\xD6>!\n") }
+      site = Nanoc::Site.new('.')
+      exception = assert_raises(RuntimeError) do
+        site.compile
+      end
+      assert_equal "Could not read content/index.html because the file is not valid UTF-8.", exception.message
+
+      # Try with encoding = specific
+      File.open('nanoc.yaml', 'w') { |io| io.write("meh: true\n") }
+      site = Nanoc::Site.new('.')
+      site.compile
+    end
+    FileUtils
+  ensure
+    Encoding.default_external = original_encoding
+  end
+
 end


### PR DESCRIPTION
This fixes #239.

The `encoding: utf-8` needs to be explicitly defined in `create-site.rb` and cannot be in the default configuration specified in `site.rb`, because defining it in `site.rb` would override the encoding for existing sites also.
