### PR TITLE
Do not move files out of `content/` (fixes #271)

### DIFF
--- a/lib/nanoc/base/result_data/item_rep.rb
+++ b/lib/nanoc/base/result_data/item_rep.rb
@@ -143,7 +143,7 @@ module Nanoc
         is_modified = is_created || !FileUtils.identical?(raw_path, temp_path)
 
         # Write
-        FileUtils.mv(temp_path, raw_path) if is_modified
+        FileUtils.cp(temp_path, raw_path) if is_modified
 
         # Notify
         Nanoc::NotificationCenter.post(:rep_written, self, raw_path, is_created, is_modified)

--- a/test/base/test_compiler.rb
+++ b/test/base/test_compiler.rb
@@ -519,4 +519,27 @@ class Nanoc::CompilerTest < MiniTest::Unit::TestCase
     end
   end
 
+  def test_unfiltered_binary_item_should_not_be_moved_outside_content
+    with_site do
+      File.open('content/blah.dat', 'w') { |io| io.write('o hello') }
+
+      File.open('Rules', 'w') do |io|
+        io.write "compile '*' do\n"
+        io.write "end\n"
+        io.write "\n"
+        io.write "route '*' do\n"
+        io.write "  item.identifier.chop + '.' + item[:extension]\n"
+        io.write "end\n"
+        io.write "\n"
+        io.write "layout '*', :erb\n"
+      end
+
+      site = Nanoc::Site.new('.')
+      site.compile
+
+      assert_equal Set.new(%w( content/blah.dat )), Set.new(Dir['content/*'])
+      assert_equal Set.new(%w( output/blah.dat )), Set.new(Dir['output/*'])
+    end
+  end
+
 end


### PR DESCRIPTION
This is not as efficient as it could be, because moving files out of the temporary directory into `output/` is perfectly fine. Copying binary items into the temporary directory just so they can be safely moved is also not efficient either, though.

And yes, @bobthecow was right all along.
