### PR TITLE
Guard against stubbed items in Sass filter

### DIFF
--- a/lib/nanoc/filters/sass.rb
+++ b/lib/nanoc/filters/sass.rb
@@ -30,8 +30,8 @@ module Nanoc::Filters
       item_dirglob = Pathname.new(sass_filename).dirname.realpath.to_s + '**'
       clean_items = @items.reject { |i| i[:content_filename].nil? }
       @scoped_items, @rest_items = clean_items.partition do |i|
-        i[:content_filename] &&
-          Pathname.new(i[:content_filename]).realpath.fnmatch(item_dirglob)
+        path = Pathname.new(i[:content_filename])
+        path.exist? && path.realpath.fnmatch(item_dirglob)
       end
       
       # Render
@@ -42,8 +42,8 @@ module Nanoc::Filters
 
     def imported_filename_to_item(filename)
       filematch = lambda do |i|
-        i[:content_filename] &&
-          Pathname.new(i[:content_filename]).realpath == Pathname.new(filename).realpath
+        pathname = Pathname.new(i[:content_filename])
+        pathname.exist? && pathname.realpath == Pathname.new(filename).realpath
       end
       @scoped_items.find(&filematch) || @rest_items.find(&filematch)
     end

--- a/test/filters/test_sass.rb
+++ b/test/filters/test_sass.rb
@@ -88,6 +88,22 @@ class Nanoc::Filters::SassTest < MiniTest::Unit::TestCase
     end
   end
 
+  def test_filter_will_skip_items_without_file
+    if_have 'sass' do
+      items = [ Nanoc::Item.new(
+        'blah',
+        { :content_filename => 'content/not-a-real-file.sass' },
+        '/blah/') ]
+      filter = create_filter({ :item => items[0], :items => items })
+
+      # Create sample file
+      File.open('moo.sass', 'w') { |io| io.write "body\n  color: red" }
+
+      # Run filter
+      filter.setup_and_run('@import moo')
+    end
+  end
+
   def test_css_imports_work
     if_have 'sass' do
       # Create filter


### PR DESCRIPTION
Because the items collection may contain items without a matching
content file, the Sass filter should first ensure that the item has a
file before attempting to expand its name.
