### PR TITLE
Update rdoc filter to use RDoc 4.x

### DIFF
--- a/lib/nanoc/filters/rdoc.rb
+++ b/lib/nanoc/filters/rdoc.rb
@@ -3,7 +3,12 @@
 module Nanoc::Filters
   class RDoc < Nanoc::Filter
 
-    requires 'rdoc/markup', 'rdoc/markup/to_html'
+    requires 'rdoc'
+
+    def self.setup
+      gem 'rdoc', '~> 4.0'
+      super
+    end
 
     # Runs the content through [RDoc::Markup](http://rdoc.rubyforge.org/RDoc/Markup.html).
     # This method takes no options.
@@ -12,7 +17,9 @@ module Nanoc::Filters
     #
     # @return [String] The filtered content
     def run(content, params={})
-      ::RDoc::Markup.new.convert(content, ::RDoc::Markup::ToHtml.new)
+      options = ::RDoc::Options.new
+      to_html = ::RDoc::Markup::ToHtml.new(options)
+      ::RDoc::Markup.new.convert(content, to_html)
     end
 
   end

--- a/test/filters/test_rdoc.rb
+++ b/test/filters/test_rdoc.rb
@@ -5,14 +5,12 @@ class Nanoc::Filters::RDocTest < MiniTest::Unit::TestCase
   include Nanoc::TestHelpers
 
   def test_filter
-    if_have 'rdoc' do
-      # Get filter
-      filter = ::Nanoc::Filters::RDoc.new
+    # Get filter
+    filter = ::Nanoc::Filters::RDoc.new
 
-      # Run filter
-      result = filter.setup_and_run("= Foo")
-      assert_match(%r{<h1( id="label-Foo")?>Foo</h1>\Z}, result)
-    end
+    # Run filter
+    result = filter.setup_and_run("= Foo")
+    assert_match(%r{\A\s*<h1( id="label-Foo")?>Foo(<span>.*</span>)?</h1>\s*\Z}, result)
   end
 
 end


### PR DESCRIPTION
This change lets the RDoc filter use the `rdoc` gem, version 4.x, which is the latest released RDoc version.
### Compatibility with RDoc 3.x

As much as I would like to be compatible with both RDoc 3.x and 4.x, I do not believe this is possible here. There is no clean way to load RDoc 4.x if available, and fall back to RDoc 3.x if it is not. This is because RDoc is bundled with Ruby.

One solution to the compatibility problem would be to rescue the exception that the `gem` call raises. Afterwards, the filter code can base itself on the value of `RDoc::VERSION` to decide whether to take the 3.x or the 4.x path.

However, should people who use RDoc not simply upgrade to 4.x?
