### PR TITLE
adding a test for html doctype embeded in a <pre><code>

### DIFF
--- a/test/filters/test_relativize_paths.rb
+++ b/test/filters/test_relativize_paths.rb
@@ -328,6 +328,29 @@ EOS
     assert_equal(expected_content, actual_content)
   end
 
+  def test_filter_html_doctype
+    # Create filter with mock item
+    filter = Nanoc::Filters::RelativizePaths.new
+
+    # Mock item
+    filter.instance_eval do
+      @item_rep = Nanoc::ItemRep.new(
+        Nanoc::Item.new(
+          'content',
+          {},
+          '/foo/bar/baz/'),
+        :blah)
+      @item_rep.path = '/foo/bar/baz/'
+    end
+
+    # Set content
+    raw_content      = %[&lt;!DOCTYPE html>]
+    expected_content = %[&lt;!DOCTYPE html&gt;]
+
+    # Test
+    actual_content = filter.setup_and_run(raw_content, :type => :html)
+    assert_equal(expected_content, actual_content)
+  end
 
   def test_filter_implicit
     # Create filter with mock item


### PR DESCRIPTION
When an item contains: 

```
<pre><code>
#!html
&lt;!DOCTYPE html>
</code></pre>
```

with the relativize_paths filter, the result is messed up by the [following code](https://github.com/nanoc/nanoc/blob/release-3.6.x/lib/nanoc/filters/relativize_paths.rb#L98):

```
# FIXME cleanup because it is ugly
# # Because using the `Nokogiri::XML::DocumentFragment` class DOCTYPE 
# pseudonodes becomes even more creepy than usual.
result.sub!(/(!DOCTYPE.+?)(&gt;)/, '<\1>')
```

Is that still usefull?
