### PR TITLE
Remove special DOCTYPE treatment in relativize_paths filter

### DIFF
--- a/lib/nanoc/filters/relativize_paths.rb
+++ b/lib/nanoc/filters/relativize_paths.rb
@@ -90,14 +90,7 @@ module Nanoc::Filters
           end
         end
       end
-      result = doc.send("to_#{type}")
-
-      # FIXME cleanup because it is ugly
-      # # Because using the `Nokogiri::XML::DocumentFragment` class DOCTYPE 
-      # pseudonodes becomes even more creepy than usual.
-      result.sub!(/(!DOCTYPE.+?)(&gt;)/, '<\1>')
-
-      result
+      doc.send("to_#{type}")
     end
 
     def path_is_relativizable?(s)

--- a/test/filters/test_relativize_paths.rb
+++ b/test/filters/test_relativize_paths.rb
@@ -750,5 +750,28 @@ XML
     end
   end
 
+  def test_filter_html_doctype
+    # Create filter with mock item
+    filter = Nanoc::Filters::RelativizePaths.new
+
+    # Mock item
+    filter.instance_eval do
+      @item_rep = Nanoc::ItemRep.new(
+        Nanoc::Item.new(
+          'content',
+          {},
+          '/foo/bar/baz/'),
+        :blah)
+      @item_rep.path = '/foo/bar/baz/'
+    end
+
+    # Set content
+    raw_content      = %[&lt;!DOCTYPE html>]
+    expected_content = %[&lt;!DOCTYPE html&gt;]
+
+    # Test
+    actual_content = filter.setup_and_run(raw_content, :type => :html)
+    assert_equal(expected_content, actual_content)
+  end
 
 end


### PR DESCRIPTION
The `relativize_paths` filter has odd behavior that filters out `DOCTYPE`s in the body of the content. This should not happen, because the `relativize_paths` filter can only realistically be run on the entire document, and not on document fragments.

See also #291, the original pull request with a test case. (This pull request replaces the original pull request.)
