### PR TITLE
Silence "INFO: Could not find files for the given pattern(s)" message

### DIFF
--- a/lib/nanoc/cli/commands/watch.rb
+++ b/lib/nanoc/cli/commands/watch.rb
@@ -98,9 +98,6 @@ module Nanoc::CLI::Commands
       # A list of commandline tool names that can be used to send notifications
       TOOLS = %w( growlnotify notify-send ) unless defined? TOOLS
 
-      # The tool to use for discovering binaries' locations
-      FIND_BINARY_COMMAND = RUBY_PLATFORM =~ /mingw|mswin/ ? "where" : "which" unless defined? FIND_BINARY_COMMAND
-
       # Send a notification. If no notifier is found, no notification will be
       # created.
       #
@@ -110,22 +107,38 @@ module Nanoc::CLI::Commands
         send(tool.tr('-', '_'), message)
       end
 
-    private
+    protected
+
+      def on_windows?
+        @_on_windows ||= RUBY_PLATFORM =~ /mingw|mswin/
+      end
+
+      def have_tool_nix?(tool)
+        !`which #{tool}`.empty?
+      rescue Errno::ENOENT
+        false
+      end
+
+      def have_tool_windows?(tool)
+        !`where #{tool} 2> nul`.empty?
+      rescue Errno::ENOENT
+        false
+      end
+
+      def have_tool?(tool)
+        if self.on_windows?
+          self.have_tool_windows?(tool)
+        else
+          self.have_tool_nix?(tool)
+        end
+      end
 
       def tool
         @tool ||= begin
           require 'terminal-notifier'
           'terminal-notify'
         rescue LoadError
-          begin
-            old_stderr = $stderr
-            $stderr = StringIO.new
-            TOOLS.find { |t| !`#{FIND_BINARY_COMMAND} #{t}`.empty? }
-          rescue Errno::ENOENT
-            nil
-          ensure
-            $stderr = old_stderr
-          end
+          TOOLS.find { |t| have_tool?(t) }
         end
       end
 


### PR DESCRIPTION
This gets rid of the "INFO: Could not find files for the given pattern(s)" message that is spewed out by the `watch` command on Windows.

Fixes #82.
