### PR TITLE
Don't enforce symbols for keys.

### DIFF
--- a/lib/nanoc/base/core_ext/hash.rb
+++ b/lib/nanoc/base/core_ext/hash.rb
@@ -8,8 +8,8 @@ module Nanoc::HashExtensions
   #
   # @return [Hash] The converted hash
   def symbolize_keys_recursively
-    inject({}) do |hash, (key, value)|
-      hash.merge(key.to_sym => value.respond_to?(:symbolize_keys_recursively) ? value.symbolize_keys_recursively : value)
+    inject({}) do |h, (k, v)|
+      h.merge((k.to_sym rescue k) => v.respond_to?(__method__) ? v.send(__method__) : v)
     end
   end
 


### PR DESCRIPTION
Symbolize keys assumes that people will be using string keys
which can result in problems for people who do not use
string keys in their config.yml.  Since config.yaml can be
used for global data for templates and such non-string keys
should be supported.
