### PR TITLE
Use long options in rsync deployer default options instead of short options

### DIFF
--- a/lib/nanoc/extra/deployers/rsync.rb
+++ b/lib/nanoc/extra/deployers/rsync.rb
@@ -23,7 +23,15 @@ module Nanoc::Extra::Deployers
 
     # Default rsync options
     DEFAULT_OPTIONS = [
-      '-glpPrtvz',
+      '--group',
+      '--links',
+      '--perms',
+      '--partial',
+      '--progress',
+      '--recursive',
+      '--times',
+      '--verbose',
+      '--compress',
       '--exclude=".hg"',
       '--exclude=".svn"',
       '--exclude=".git"'


### PR DESCRIPTION
It's usually a good habit to use long switches inside scripts for the purpose of self-documentation. But what about deployers for nanoc, like rsync for example? 
