### PR TITLE
Unescape URLs when checking internal links

### DIFF
--- a/lib/nanoc/extra/checking/checks/internal_links.rb
+++ b/lib/nanoc/extra/checking/checks/internal_links.rb
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+require 'uri'
+
 module Nanoc::Extra::Checking::Checks
 
   # A check that verifies that all internal links point to a location that exists.
@@ -37,6 +39,9 @@ module Nanoc::Extra::Checking::Checks
       # Remove query string
       path = path.sub(/\?.*$/, '')
       return true if path.empty?
+
+      # Decode URL (e.g. '%20' -> ' ')
+      path = URI.unescape(path)
 
       # Make absolute
       if path[0, 1] == '/'

--- a/test/extra/checking/checks/test_internal_links.rb
+++ b/test/extra/checking/checks/test_internal_links.rb
@@ -53,4 +53,15 @@ class Nanoc::Extra::Checking::Checks::InternalLinksTest < Nanoc::TestCase
     end
   end
 
+  def test_unescape_url
+    with_site do |site|
+      FileUtils.mkdir_p('output/stuff')
+      File.open('output/stuff/right foo', 'w') { |io| io.write('hi') }
+
+      check = Nanoc::Extra::Checking::Checks::InternalLinks.new(site)
+
+      assert check.send(:valid?, 'stuff/right%20foo', 'output/origin')
+      refute check.send(:valid?, 'stuff/wrong%20foo', 'output/origin')
+    end
+  end
 end


### PR DESCRIPTION
When checking internal links, URL containing encoded characters (e.g. `%20`) are not decoded, and thus incorrectly result in failed checks. This simple fix uses `URI.unescape` to decode link paths prior to checking their existence in the output directory.
