### PR TITLE
Fix handlebars crash when used outside layout

### DIFF
--- a/lib/nanoc/filters/handlebars.rb
+++ b/lib/nanoc/filters/handlebars.rb
@@ -18,9 +18,11 @@ module Nanoc::Filters
     def run(content, params={})
       context = item.attributes.dup
       context[:item]   = assigns[:item].attributes
-      context[:layout] = assigns[:layout].attributes
       context[:config] = assigns[:config]
       context[:yield]  = assigns[:content]
+      if assigns.has_key?(:layout)
+        context[:layout] = assigns[:layout].attributes
+      end
 
       handlebars = ::Handlebars::Context.new
       template = handlebars.compile(content)

--- a/test/filters/test_handlebars.rb
+++ b/test/filters/test_handlebars.rb
@@ -34,4 +34,25 @@ class Nanoc::Filters::HandlebarsTest < Nanoc::TestCase
     end
   end
 
+  def test_filter_without_layout
+    if_have 'handlebars' do
+      # Create data
+      item = Nanoc::Item.new(
+        'content',
+        { :title => 'Max Payne', :protagonist => 'Max Payne', :location => 'here' },
+        '/games/max-payne/')
+
+      # Create filter
+      assigns = {
+        :item    => item,
+        :content => 'No Payne No Gayne'
+      }
+      filter = ::Nanoc::Filters::Handlebars.new(assigns)
+
+      # Run filter
+      result = filter.setup_and_run('{{protagonist}} says: {{yield}}.')
+      assert_equal('Max Payne says: No Payne No Gayne.', result)
+    end
+  end
+
 end


### PR DESCRIPTION
The `handlebars` filter assumes the presence of `attributes[:layout]`, which is not the case when used outside a layout.

This fixes #346.
