### PR TITLE
Hide deprecated watch and autocompile commands

### DIFF
--- a/lib/nanoc/cli/commands/autocompile.rb
+++ b/lib/nanoc/cli/commands/autocompile.rb
@@ -2,6 +2,7 @@
 
 usage       'autocompile [options]'
 summary     'start the autocompiler'
+be_hidden
 aliases     :aco
 description <<-EOS
 Start the autocompiler web server. Unless overridden with commandline options

--- a/lib/nanoc/cli/commands/watch.rb
+++ b/lib/nanoc/cli/commands/watch.rb
@@ -2,6 +2,7 @@
 
 usage       'watch [options]'
 summary     'start the watcher'
+be_hidden
 description <<-EOS
 Start the watcher. When a change is detected, the site will be recompiled.
 EOS


### PR DESCRIPTION
Since `watch` and `autocompile` are deprecated, it makes sense to hide them in the list of commands shown by `nanoc help`.
