### PR TITLE
Fix item rep compilation duration recording

### DIFF
--- a/test/cli/commands/test_compile.rb
+++ b/test/cli/commands/test_compile.rb
@@ -140,4 +140,65 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
     end
   end
 
+  def test_file_action_printer_normal
+    # Create data
+    item = Nanoc::Item.new('content', {}, '/')
+    rep = Nanoc::ItemRep.new(item, :default)
+    rep.raw_path = 'output/foo.txt'
+
+    # Listen
+    listener = new_file_action_printer([ rep ])
+    listener.start
+    Nanoc::NotificationCenter.post(:compilation_started, rep)
+    Nanoc::NotificationCenter.post(:compilation_ended, rep)
+    listener.stop
+
+    # Check
+    assert_equal 1, listener.events.size
+    assert_equal :low,             listener.events[0][:level]
+    assert_equal :skip,            listener.events[0][:action]
+    assert_equal 'output/foo.txt', listener.events[0][:path]
+    assert_in_delta 0.0,           listener.events[0][:duration], 1.0
+  end
+
+  def test_file_action_printer_skip
+    # Create data
+    item = Nanoc::Item.new('content', {}, '/')
+    rep = Nanoc::ItemRep.new(item, :default)
+    rep.raw_path = 'output/foo.txt'
+
+    # Listen
+    listener = new_file_action_printer([ rep ])
+    listener.start
+    Nanoc::NotificationCenter.post(:compilation_started, rep)
+    listener.stop
+
+    # Check
+    assert_equal 1, listener.events.size
+    assert_equal :low,             listener.events[0][:level]
+    assert_equal :skip,            listener.events[0][:action]
+    assert_equal 'output/foo.txt', listener.events[0][:path]
+    assert_nil listener.events[0][:duration]
+  end
+
+  def new_file_action_printer(reps)
+    listener = Nanoc::CLI::Commands::Compile::FileActionPrinter.new(:reps => reps)
+
+    def listener.log(level, action, path, duration)
+      @events ||= []
+      @events << {
+        :level    => level,
+        :action   => action,
+        :path     => path,
+        :duration => duration
+      }
+    end
+
+    def listener.events
+      @events
+    end
+
+    listener
+  end
+
 end


### PR DESCRIPTION
This prevents “skip” from being shown with a ridiculously large value.

Instead of using `@rep_times` to store either the start date or the duration, I’m now using `@start_times` and `@end_times`, which is a much better solution.

Fixes #360.
