### PR TITLE
Fix supposedly NTFS-related "races" for the `tmp` directory

### DIFF
--- a/test/base/test_context.rb
+++ b/test/base/test_context.rb
@@ -20,7 +20,7 @@ class Nanoc::ContextTest < Nanoc::TestCase
 
   def test_example
     # Parse
-    YARD.parse('../lib/nanoc/base/context.rb')
+    YARD.parse(LIB_DIR + '/nanoc/base/context.rb')
 
     # Run
     assert_examples_correct 'Nanoc::Context#initialize'

--- a/test/base/test_directed_graph.rb
+++ b/test/base/test_directed_graph.rb
@@ -282,7 +282,7 @@ class Nanoc::DirectedGraphTest < Nanoc::TestCase
   end
 
   def test_example
-    YARD.parse('../lib/nanoc/base/directed_graph.rb')
+    YARD.parse(LIB_DIR + '/nanoc/base/directed_graph.rb')
     assert_examples_correct 'Nanoc::DirectedGraph'
   end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -21,9 +21,12 @@ require 'nanoc/cli'
 require 'nanoc/tasks'
 
 # Load miscellaneous requirements
+require 'tmpdir'
 require 'stringio'
 
 module Nanoc::TestHelpers
+
+  LIB_DIR = File.expand_path(File.dirname(__FILE__) + '/../lib')
 
   def if_have(*libs)
     libs.each do |lib|
@@ -121,9 +124,9 @@ EOS
     end
 
     # Enter tmp
-    FileUtils.mkdir_p('tmp')
+    @tmp_dir = Dir.mktmpdir('nanoc-test')
     @orig_wd = FileUtils.pwd
-    FileUtils.cd('tmp')
+    FileUtils.cd(@tmp_dir)
 
     # Let us get to the raw errors
     Nanoc::CLI::ErrorHandler.disable
@@ -135,7 +138,7 @@ EOS
 
     # Exit tmp
     FileUtils.cd(@orig_wd)
-    FileUtils.rm_rf('tmp')
+    FileUtils.rm_rf(@tmp_dir)
 
     # Go unquiet
     unless ENV['QUIET'] == 'false'

--- a/test/helpers/test_link_to.rb
+++ b/test/helpers/test_link_to.rb
@@ -207,7 +207,7 @@ class Nanoc::Helpers::LinkToTest < Nanoc::TestCase
 
   def test_examples_link_to
     # Parse
-    YARD.parse('../lib/nanoc/helpers/link_to.rb')
+    YARD.parse(LIB_DIR + '/nanoc/helpers/link_to.rb')
 
     # Mock
     @items = [ mock, mock, mock ]
@@ -227,7 +227,7 @@ class Nanoc::Helpers::LinkToTest < Nanoc::TestCase
 
   def test_examples_link_to_unless_current
     # Parse
-    YARD.parse('../lib/nanoc/helpers/link_to.rb')
+    YARD.parse(LIB_DIR + '/nanoc/helpers/link_to.rb')
 
     # Mock
     @item_rep = mock
@@ -241,7 +241,7 @@ class Nanoc::Helpers::LinkToTest < Nanoc::TestCase
 
   def test_examples_relative_path_to
     # Parse
-    YARD.parse('../lib/nanoc/helpers/link_to.rb')
+    YARD.parse(LIB_DIR + '/nanoc/helpers/link_to.rb')
 
     # Mock
     @item_rep = mock


### PR DESCRIPTION
This addresses #366 by using a different directory in the system's temporary directory for every test. It can still occur that the temp dirs are not correctly deleted after the test finishes but it causes no follow-up tests to fail anymore. I'd say that the occasional stray temp dir when running tests is an acceptable drawback.

Introduced a constant `Nanoc::TestHelpers::LIB_DIR` since some tests using `YARD.parse` relied on the relative position of the temp dir to the lib dir.
