### PR TITLE
Swallow broken pipe errors

### DIFF
--- a/lib/nanoc/cli/cleaning_stream.rb
+++ b/lib/nanoc/cli/cleaning_stream.rb
@@ -41,12 +41,16 @@ module Nanoc::CLI
 
     # @see IO#write
     def write(s)
-      @stream.write(self.clean(s))
+      self._nanoc_swallow_broken_pipe_errors_while do
+        @stream.write(self._nanoc_clean(s))
+      end
     end
 
     # @see IO#<<
     def <<(s)
-      @stream.<<(self.clean(s))
+      self._nanoc_swallow_broken_pipe_errors_while do
+        @stream.<<(self._nanoc_clean(s))
+      end
     end
 
     # @see IO#tty?
@@ -56,7 +60,9 @@ module Nanoc::CLI
 
     # @see IO#flush
     def flush
-      @stream.flush
+      self._nanoc_swallow_broken_pipe_errors_while do
+        @stream.flush
+      end
     end
 
     # @see IO#tell
@@ -66,12 +72,16 @@ module Nanoc::CLI
 
     # @see IO#print
     def print(s)
-      @stream.print(self.clean(s))
+      self._nanoc_swallow_broken_pipe_errors_while do
+        @stream.print(self._nanoc_clean(s))
+      end
     end
 
     # @see IO#puts
     def puts(*s)
-      @stream.puts(*s.map { |ss| self.clean(ss) })
+      self._nanoc_swallow_broken_pipe_errors_while do
+        @stream.puts(*s.map { |ss| self._nanoc_clean(ss) })
+      end
     end
 
     # @see StringIO#string
@@ -111,8 +121,13 @@ module Nanoc::CLI
 
   protected
 
-    def clean(s)
+    def _nanoc_clean(s)
       @stream_cleaners.inject(s) { |m,c| c.clean(m) }
+    end
+
+    def _nanoc_swallow_broken_pipe_errors_while
+      yield
+    rescue Errno::EPIPE
     end
 
   end

--- a/test/cli/test_cleaning_stream.rb
+++ b/test/cli/test_cleaning_stream.rb
@@ -9,7 +9,7 @@ class Nanoc::CLI::CleaningStreamTest < Nanoc::TestCase
     def initialize
       @called_methods = Set.new
     end
-    
+
     def method_missing(symbol, *args)
       @called_methods << symbol
     end
@@ -47,6 +47,14 @@ class Nanoc::CLI::CleaningStreamTest < Nanoc::TestCase
     logger = Logger.new(cleaning_stream)
     logger.info("Some info")
     logger.warn("Something could start going wrong!")
+  end
+
+  def test_broken_pipe
+    stream = StringIO.new
+    def stream.write(s) ; raise Errno::EPIPE.new ; end
+
+    cleaning_stream = Nanoc::CLI::CleaningStream.new(stream)
+    cleaning_stream.write('lol')
   end
 
 end


### PR DESCRIPTION
This fix makes sure broken pipe errors are swallowed.

These errors sometimes occur when piping a large amount of data into another process that exist prematurely, e.g. `nanoc show-data | less` and pressing `q` to exit `less` before scrolling.

Fixes #318.
