### PR TITLE
Improve internal/external link check summary

### DIFF
--- a/lib/nanoc/extra/checking/checks/external_links.rb
+++ b/lib/nanoc/extra/checking/checks/external_links.rb
@@ -25,7 +25,7 @@ module ::Nanoc::Extra::Checking::Checks
         filenames = hrefs_with_filenames[res.href]
         filenames.each do |filename|
           add_issue(
-            "reference to #{res.href}: #{res.explanation}",
+            "broken reference to #{res.href}: #{res.explanation}",
             :subject => filename)
         end
       end

--- a/lib/nanoc/extra/checking/checks/internal_links.rb
+++ b/lib/nanoc/extra/checking/checks/internal_links.rb
@@ -18,7 +18,7 @@ module Nanoc::Extra::Checking::Checks
         fns.each do |filename|
           unless valid?(href, filename)
           add_issue(
-            "reference to #{href}",
+            "broken reference to #{href}",
             :subject  => filename)
           end
         end


### PR DESCRIPTION
The message “reference to blah” is not quite clear. This PR changes the message to “broken reference to blah”.
