### PR TITLE
Add Asciidoctor filter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
+gem 'asciidoctor'
 gem 'adsf'
 gem 'bluecloth', :platforms => :ruby
 gem 'builder'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,7 @@ GEM
     RedCloth (4.2.9)
     adsf (1.2.0)
       rack (>= 1.0.0)
+    asciidoctor (0.1.4)
     ast (1.1.0)
     bluecloth (2.2.0)
     builder (3.2.2)
@@ -160,6 +161,7 @@ PLATFORMS
 DEPENDENCIES
   RedCloth
   adsf
+  asciidoctor
   bluecloth
   builder
   coderay

--- a/lib/nanoc/filters.rb
+++ b/lib/nanoc/filters.rb
@@ -3,6 +3,7 @@
 module Nanoc::Filters
 
   autoload 'AsciiDoc',        'nanoc/filters/asciidoc'
+  autoload 'Asciidoctor',     'nanoc/filters/asciidoctor'
   autoload 'BlueCloth',       'nanoc/filters/bluecloth'
   autoload 'CodeRay',         'nanoc/filters/coderay'
   autoload 'ColorizeSyntax',  'nanoc/filters/colorize_syntax'
@@ -32,6 +33,7 @@ module Nanoc::Filters
   autoload 'YUICompressor',   'nanoc/filters/yui_compressor'
 
   Nanoc::Filter.register '::Nanoc::Filters::AsciiDoc',        :asciidoc
+  Nanoc::Filter.register '::Nanoc::Filters::Asciidoctor',     :asciidoctor
   Nanoc::Filter.register '::Nanoc::Filters::BlueCloth',       :bluecloth
   Nanoc::Filter.register '::Nanoc::Filters::CodeRay',         :coderay
   Nanoc::Filter.register '::Nanoc::Filters::ColorizeSyntax',  :colorize_syntax

--- a/lib/nanoc/filters/asciidoctor.rb
+++ b/lib/nanoc/filters/asciidoctor.rb
@@ -1,0 +1,21 @@
+# encoding: utf-8
+
+module Nanoc::Filters
+
+  class Asciidoctor < Nanoc::Filter
+
+    requires 'asciidoctor'
+
+    # Runs the content through [Asciidoctor](http://asciidoctor.org/).
+    # Parameters passed to this filter will be passed on to `Asciidoctor.render`.
+    #
+    # @param [String] content The content to filter
+    #
+    # @return [String] The filtered content
+    def run(content, params = {})
+      Asciidoctor.render(content, params)
+    end
+
+  end
+
+end

--- a/test/filters/test_asciidoctor.rb
+++ b/test/filters/test_asciidoctor.rb
@@ -1,0 +1,16 @@
+# encoding: utf-8
+
+class Nanoc::Filters::AsciidoctorTest < Nanoc::TestCase
+
+  def test_filter
+    if_have 'asciidoctor' do
+      # Create filter
+      filter = ::Nanoc::Filters::AsciiDoc.new
+
+      # Run filter
+      result = filter.setup_and_run("== Blah blah")
+      assert_match %r{<h2 id="_blah_blah">Blah blah</h2>}, result
+    end
+  end
+
+end


### PR DESCRIPTION
This adds a filter for [Asciidoctor](http://asciidoctor.org/), which is a nice and flexible Ruby implementation of [AsciiDoc](http://www.methods.co.nz/asciidoc/).
### Neat stuff you can do with it

You can extract AsciiDoc metadata into items during preprocessing:

``` ruby
preprocess do
  @items.each do |item|
    case item[:extension]
    when 'adoc', 'asciidoc'
      Asciidoctor::Document.new(item.raw_content).attributes.each_pair do |k,v|
        item[k.to_sym] = v
      end
    end
  end
end
```
### Why no `nanoc-asciidoctor` gem?

nanoc 4.0 will have a much more modular architecture where each filter and helper lives in its own repository and gem. Unfortunately, nanoc 4.0 is a long way off, and I believe it is better to continue with the current approach and add new features directly into the nanoc repository/gem itself.

This right here unfortunately contradicts what I’ve been saying in #385, #386 and #388. (Sorry.) I feel this needs more discussion. We have two choices:
- Include this change, as well as the other three ones mentioned above, in nanoc 3.7. The advantage of this is that we don’t change our policy.
- Create separate repositories and gems for each filter/helper/etc. The disadvantage is that some things are very hard to extract (e.g. commands). Extracting them without letting `nanoc` depend on them will break backwards compatibility, but letting `nanoc` depend on 30 other gems is also ridiculous.
