### PR TITLE
Do not show multiple preprocessor warning for first definition

### DIFF
--- a/lib/nanoc/base/compilation/compiler_dsl.rb
+++ b/lib/nanoc/base/compilation/compiler_dsl.rb
@@ -25,8 +25,11 @@ module Nanoc
     #
     # @return [void]
     def preprocess(&block)
-      warn 'WARNING: A preprocess block is already defined. Defining ' \
-        'another preprocess block overrides the previously one.'
+      if @rules_collection.preprocessor
+        warn 'WARNING: A preprocess block is already defined. Defining ' \
+          'another preprocess block overrides the previously one.'
+      end
+
       @rules_collection.preprocessor = block
     end
 

--- a/test/base/test_compiler_dsl.rb
+++ b/test/base/test_compiler_dsl.rb
@@ -18,8 +18,14 @@ class Nanoc::CompilerDSLTest < Nanoc::TestCase
     rules_collection = Nanoc::RulesCollection.new(nil)
     compiler_dsl = Nanoc::CompilerDSL.new(rules_collection, {})
 
-    compiler_dsl.preprocess {}
+    # first time
+    io = capturing_stdio do
+      compiler_dsl.preprocess {}
+    end
+    assert_empty io[:stdout]
+    assert_empty io[:stderr]
 
+    # second time
     io = capturing_stdio do
       compiler_dsl.preprocess {}
     end


### PR DESCRIPTION
I am sorry.
