### PR TITLE
Fix default stylesheet link

### DIFF
--- a/lib/nanoc/cli/commands/create-site.rb
+++ b/lib/nanoc/cli/commands/create-site.rb
@@ -252,7 +252,7 @@ EOS
   <head>
     <meta charset="utf-8">
     <title>A Brand New nanoc Site - <%= @item[:title] %></title>
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="<%= @items['/stylesheet/'].path %>">
 
     <!-- you don't need to keep this, but it's cool for stats! -->
     <meta name="generator" content="nanoc <%= Nanoc::VERSION %>">

--- a/test/cli/commands/test_create_site.rb
+++ b/test/cli/commands/test_create_site.rb
@@ -19,4 +19,14 @@ class Nanoc::CLI::Commands::CreateSiteTest < Nanoc::TestCase
     end
   end
 
+  def test_new_site_has_correct_stylesheets
+    Nanoc::CLI.run %w( create_site foo )
+    FileUtils.cd('foo') do
+      Nanoc::CLI.run %w( compile )
+
+      assert File.file?('content/stylesheet.css')
+      assert_match(/\/stylesheet.css/, File.read('output/index.html'))
+    end
+  end
+
 end


### PR DESCRIPTION
Potential fix for #410.

I am not sure whether I prefer `<%= @items['/stylesheet/'].path %>` over `/stylesheet.css`. Maybe the latter is better.
