### PR TITLE
Permit included rules files to define their own preprocess block

### DIFF
--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -190,12 +190,15 @@ module Nanoc
     end
     memoize :dependency_tracker
 
-    # Runs the preprocessor.
+    # Runs the preprocessors.
     #
     # @api private
     def preprocess
-      return if rules_collection.preprocessor.nil?
-      preprocessor_context.instance_eval(&rules_collection.preprocessor)
+      rules_collection.preprocessor_stack.each do |preprocessor|
+        if !preprocessor.nil?
+          preprocessor_context.instance_eval(&preprocessor)
+        end
+      end
     end
 
     # Returns all objects managed by the site (items, layouts, code snippets,

--- a/lib/nanoc/base/compilation/compiler_dsl.rb
+++ b/lib/nanoc/base/compilation/compiler_dsl.rb
@@ -25,12 +25,11 @@ module Nanoc
     #
     # @return [void]
     def preprocess(&block)
-      if @rules_collection.preprocessor
+      if @rules_collection.preprocessor_stack.last
         warn 'WARNING: A preprocess block is already defined. Defining ' \
           'another preprocess block overrides the previously one.'
       end
-
-      @rules_collection.preprocessor = block
+      @rules_collection.preprocessor_stack[-1] = block
     end
 
     # Creates a compilation rule for all items whose identifier match the
@@ -246,6 +245,7 @@ module Nanoc
       filename = [ "#{name}", "#{name}.rb", "./#{name}", "./#{name}.rb" ].find { |f| File.file?(f) }
       raise Nanoc::Errors::NoRulesFileFound.new if filename.nil?
 
+      @rules_collection.preprocessor_stack << nil
       instance_eval(File.read(filename), filename)
     end
 

--- a/lib/nanoc/base/compilation/rules_collection.rb
+++ b/lib/nanoc/base/compilation/rules_collection.rb
@@ -25,7 +25,7 @@ module Nanoc
 
     # @return [Proc] The code block that will be executed after all data is
     #   loaded but before the site is compiled
-    attr_accessor :preprocessor
+    attr_accessor :preprocessor_stack
 
     # @param [Nanoc::Compiler] compiler The site’s compiler
     def initialize(compiler)
@@ -34,6 +34,8 @@ module Nanoc
       @item_compilation_rules  = []
       @item_routing_rules      = []
       @layout_filter_mapping   = OrderedHash.new
+
+      @preprocessor_stack = [ nil ]
     end
 
     # Add the given rule to the list of item compilation rules.


### PR DESCRIPTION
Permit included rules files to define their own preprocess block.

Preprocess blocks are stacked and executed in sequence.
Within a rules file, behavior when defining two preprocessor blocks is unchanged: the latest preprocess block wins.
