### PR TITLE
allow ERB in config file

### DIFF
--- a/lib/nanoc/base/source_data/site.rb
+++ b/lib/nanoc/base/source_data/site.rb
@@ -363,7 +363,8 @@ module Nanoc
           end
           File.join(dir_or_config_hash, filename)
         end
-        @config = DEFAULT_CONFIG.merge(YAML.load_file(config_path).symbolize_keys_recursively)
+        require 'erb'
+        @config = DEFAULT_CONFIG.merge(YAML.load(ERB.new(IO.read(config_path, :encoding => 'UTF-8')).result).symbolize_keys_recursively)
         @config[:data_sources].map! { |ds| ds.symbolize_keys_recursively }
       else
         # Use passed config hash


### PR DESCRIPTION
This commits sends the config file through ERB before parsing it as YAML.

Despite not being panacea, this works around the lack of include directive in YAML.
