### PR TITLE
Reset corrupted PStore (fixes #409)

### DIFF
--- a/lib/nanoc/base/store.rb
+++ b/lib/nanoc/base/store.rb
@@ -87,7 +87,7 @@ module Nanoc
           @loaded = true
         end
       rescue
-        File.file?(filename)
+        FileUtils.rm_f(filename)
         load
       end
     end

--- a/test/base/test_store.rb
+++ b/test/base/test_store.rb
@@ -1,0 +1,41 @@
+# encoding: utf-8
+
+class Nanoc::StoreTest < Nanoc::TestCase
+
+  class TestStore < Nanoc::Store
+
+    def data
+      @data
+    end
+
+    def data=(new_data)
+      @data = new_data
+    end
+
+  end
+
+  def test_delete_and_reload_on_error
+    store = TestStore.new('test.db', 1)
+
+    # Create
+    store.load
+    store.data = { :fun => 'sure' }
+    store.store
+
+    # Test stored values
+    store = TestStore.new('test.db', 1)
+    store.load
+    assert_equal({ :fun => 'sure' }, store.data)
+
+    # Mess up
+    File.open('test.db', 'w') do |io|
+      io << 'Damn {}#}%@}$^)@&$&*^#@ broken stores!!!'
+    end
+
+    # Reload
+    store = TestStore.new('test.db', 1)
+    store.load
+    assert_equal(nil, store.data)
+  end
+
+end


### PR DESCRIPTION
This PR makes a store reset itself when corruption is detected. This is fine, because the stores only contain data to speed up site compilation.

Fix for #409.
