### PR TITLE
Permit included rules files to define their own preprocess block

### DIFF
--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -190,12 +190,13 @@ module Nanoc
     end
     memoize :dependency_tracker
 
-    # Runs the preprocessor.
+    # Runs the preprocessors.
     #
     # @api private
     def preprocess
-      return if rules_collection.preprocessor.nil?
-      preprocessor_context.instance_eval(&rules_collection.preprocessor)
+      rules_collection.preprocessors.each_value do |preprocessor|
+        preprocessor_context.instance_eval(&preprocessor)
+      end
     end
 
     # Returns all objects managed by the site (items, layouts, code snippets,

--- a/lib/nanoc/base/compilation/compiler_dsl.rb
+++ b/lib/nanoc/base/compilation/compiler_dsl.rb
@@ -5,6 +5,11 @@ module Nanoc
   # Contains methods that will be executed by the site’s `Rules` file.
   class CompilerDSL
 
+    # The current rules filename.
+    #
+    # @return [String] The current rules filename.
+    attr_accessor :rules_filename
+
     # Creates a new compiler DSL for the given collection of rules.
     #
     # @api private
@@ -25,12 +30,11 @@ module Nanoc
     #
     # @return [void]
     def preprocess(&block)
-      if @rules_collection.preprocessor
+      if @rules_collection.preprocessors[rules_filename]
         warn 'WARNING: A preprocess block is already defined. Defining ' \
           'another preprocess block overrides the previously one.'
       end
-
-      @rules_collection.preprocessor = block
+      @rules_collection.preprocessors[rules_filename] = block
     end
 
     # Creates a compilation rule for all items whose identifier match the
@@ -246,7 +250,7 @@ module Nanoc
       filename = [ "#{name}", "#{name}.rb", "./#{name}", "./#{name}.rb" ].find { |f| File.file?(f) }
       raise Nanoc::Errors::NoRulesFileFound.new if filename.nil?
 
-      instance_eval(File.read(filename), filename)
+      @rules_collection.parse(filename)
     end
 
   private

--- a/lib/nanoc/base/compilation/rules_collection.rb
+++ b/lib/nanoc/base/compilation/rules_collection.rb
@@ -23,17 +23,21 @@ module Nanoc
     # @return [Hash] The layout-to-filter mapping rules
     attr_reader :layout_filter_mapping
 
-    # @return [Proc] The code block that will be executed after all data is
-    #   loaded but before the site is compiled
-    attr_accessor :preprocessor
+    # The hash containing preprocessor code blocks that will be executed after
+    #   all data is loaded but before the site is compiled.
+    #
+    # @return [Hash] The hash containing the preprocessor code blocks that will
+    #   be executed after all data is loaded but before the site is compiled
+    attr_accessor :preprocessors
 
     # @param [Nanoc::Compiler] compiler The site’s compiler
     def initialize(compiler)
       @compiler = compiler
 
-      @item_compilation_rules  = []
-      @item_routing_rules      = []
-      @layout_filter_mapping   = OrderedHash.new
+      @item_compilation_rules = []
+      @item_routing_rules     = []
+      @layout_filter_mapping  = OrderedHash.new
+      @preprocessors          = OrderedHash.new
     end
 
     # Add the given rule to the list of item compilation rules.
@@ -71,20 +75,29 @@ module Nanoc
       rules_filename = rules_filenames.find { |f| File.file?(f) }
       raise Nanoc::Errors::NoRulesFileFound.new if rules_filename.nil?
 
+      parse(rules_filename)
+    end
+
+    def parse(rules_filename)
+      rules_filename = File.absolute_path(rules_filename)
+
       # Get rule data
       @data = File.read(rules_filename)
 
-      # Load DSL
-      dsl.instance_eval(@data, "./#{rules_filename}")
+      old_rules_filename = dsl.rules_filename
+      dsl.rules_filename = rules_filename
+      dsl.instance_eval(@data, rules_filename)
+      dsl.rules_filename = old_rules_filename
     end
 
     # Unloads this site’s rules.
     #
     # @return [void]
     def unload
-      @item_compilation_rules  = []
-      @item_routing_rules      = []
-      @layout_filter_mapping   = OrderedHash.new
+      @item_compilation_rules = []
+      @item_routing_rules     = []
+      @layout_filter_mapping  = OrderedHash.new
+      @preprocessors          = OrderedHash.new
     end
 
     # Finds the first matching compilation rule for the given item

--- a/test/base/test_compiler_dsl.rb
+++ b/test/base/test_compiler_dsl.rb
@@ -33,6 +33,40 @@ class Nanoc::CompilerDSLTest < Nanoc::TestCase
     assert_match(/WARNING: A preprocess block is already defined./, io[:stderr])
   end
 
+  def test_per_rules_file_preprocessor
+    # Create site
+    Nanoc::CLI.run %w( create_site per-rules-file-preprocessor )
+    FileUtils.cd('per-rules-file-preprocessor') do
+      # Create rep
+      item = Nanoc::Item.new('foo', { :extension => 'bar' }, '/foo/')
+
+      # Create a bonus rules file
+      File.open('more_rules.rb', 'w') { |io| io.write "preprocess { @items['/foo/'][:preprocessed] = true }" }
+
+      # Create other necessary stuff
+      site = Nanoc::Site.new('.')
+      site.items << item
+      dsl = site.compiler.rules_collection.dsl
+      io = capturing_stdio do
+        dsl.preprocess {}
+      end
+      assert_empty io[:stdout]
+      assert_empty io[:stderr]
+
+      # Include rules
+      dsl.include_rules 'more_rules'
+
+      # Check that the two preprocess blocks have been added
+      assert_equal 2, site.compiler.rules_collection.preprocessors.size
+      refute_nil site.compiler.rules_collection.preprocessors.first
+      refute_nil site.compiler.rules_collection.preprocessors.last
+
+      # Apply preprocess blocks
+      site.compiler.preprocess
+      assert item[:preprocessed]
+    end
+  end
+
   def test_include_rules
     # Create site
     Nanoc::CLI.run %w( create_site with_bonus_rules )

--- a/test/base/test_site.rb
+++ b/test/base/test_site.rb
@@ -36,11 +36,13 @@ class Nanoc::SiteTest < Nanoc::TestCase
   def test_load_rules_with_existing_rules_file
     # Mock DSL
     dsl = mock
+    dsl.stubs(:rules_filename)
+    dsl.stubs(:rules_filename=)
     dsl.expects(:compile).with('*')
 
     # Create site
     site = Nanoc::Site.new({})
-    site.compiler.rules_collection.expects(:dsl).returns(dsl)
+    site.compiler.rules_collection.stubs(:dsl).returns(dsl)
 
     # Create rules file
     File.open('Rules', 'w') do |io|


### PR DESCRIPTION
Within a rules file, behavior when defining two preprocessor blocks is unchanged: defining another processor block overrides the previous one.

This follows up on #413.
