### PR TITLE
Do not catch USR1 on JRuby

### DIFF
--- a/lib/nanoc/cli/error_handler.rb
+++ b/lib/nanoc/cli/error_handler.rb
@@ -58,12 +58,16 @@ module Nanoc::CLI
           exit!(0)
         end
       end
-      begin
-        Signal.trap('USR1') do
-          puts 'Caught USR1; dumping a stack trace'
-          puts caller.map { |i| "  #{i}" }.join("\n")
+
+      # Set stack trace dump handler
+      if !defined?(RUBY_ENGINE) || RUBY_ENGINE != 'jruby'
+        begin
+          Signal.trap('USR1') do
+            puts 'Caught USR1; dumping a stack trace'
+            puts caller.map { |i| "  #{i}" }.join("\n")
+          end
+        rescue ArgumentError
         end
-      rescue ArgumentError
       end
 
       # Run


### PR DESCRIPTION
Attempting to catch USR1 on the JVM raises the following message:

> The signal USR1 is in use by the JVM and will not work correctly on this platform

Potential fix for #425.

There are no tests for this change; I don’t think it’s possible to write a reasonable test for this.
