### PR TITLE
Account for sparse vertex lists

### DIFF
--- a/lib/nanoc/base/directed_graph.rb
+++ b/lib/nanoc/base/directed_graph.rb
@@ -200,7 +200,13 @@ module Nanoc
 
     # @return [Array] The list of all vertices in this graph.
     def vertices
-      @vertices.keys.sort_by { |v| @vertices[v] }
+      vertex_list = []
+
+      @vertices.each_pair do |v, i|
+        vertex_list[i] = v
+      end
+
+      vertex_list
     end
 
     # Returns an array of tuples representing the edges. The result of this

--- a/test/base/test_directed_graph.rb
+++ b/test/base/test_directed_graph.rb
@@ -190,6 +190,12 @@ class Nanoc::DirectedGraphTest < Nanoc::TestCase
     assert_equal [ 1 ], graph.direct_predecessors_of(3).sort
     assert_equal [ 1 ], graph.direct_successors_of(3).sort
     assert_equal Set.new([]), graph.roots
+    edges = graph.edges
+    vertices = graph.vertices
+    assert_equal 1, vertices[edges[0][0]]
+    assert_equal 3, vertices[edges[0][1]]
+    assert_equal 3, vertices[edges[1][0]]
+    assert_equal 1, vertices[edges[1][1]]
   end
 
   def test_delete_vertex_resulting_roots


### PR DESCRIPTION
Because any vertex may be removed from the graph at any time, the array
that describes the vertex-to-index mapping may be sparse. Generate an
array with nil values in place of removed vertices.
