### PR TITLE
Delete root temp directory eventually

### DIFF
--- a/lib/nanoc/base/temp_filename_factory.rb
+++ b/lib/nanoc/base/temp_filename_factory.rb
@@ -46,6 +46,10 @@ module Nanoc
       end
 
       @counts.delete(prefix)
+
+      if @counts.empty? && File.directory?(@root_dir)
+        FileUtils.remove_entry_secure(@root_dir)
+      end
     end
 
   end

--- a/test/base/temp_filename_factory_spec.rb
+++ b/test/base/temp_filename_factory_spec.rb
@@ -53,6 +53,14 @@ describe Nanoc::TempFilenameFactory do
       File.file?(path_a).wont_equal(true)
     end
 
+    it 'should eventually delete the root directory' do
+      subject.create(prefix)
+      File.directory?(subject.root_dir).must_equal(true)
+
+      subject.cleanup(prefix)
+      File.directory?(subject.root_dir).wont_equal(true)
+    end
+
   end
 
   describe 'other instance' do


### PR DESCRIPTION
This is a potential for #440.

`#cleanup` will now delete the root directory if the temp filename factory is no longer being used.
