### PR TITLE
Fix Sass imports outside of filter

### DIFF
--- a/lib/nanoc/filters/sass/sass_filesystem_importer.rb
+++ b/lib/nanoc/filters/sass/sass_filesystem_importer.rb
@@ -11,8 +11,10 @@ class ::Sass::Importers::Filesystem
 
     # Create dependency
     filter = options[:nanoc_current_filter]
-    item = filter.imported_filename_to_item(full_filename)
-    filter.depend_on([ item ]) unless item.nil?
+    if filter
+      item = filter.imported_filename_to_item(full_filename)
+      filter.depend_on([ item ]) unless item.nil?
+    end
 
     # Call original _find
     _orig_find(dir, name, options)

--- a/test/filters/test_sass.rb
+++ b/test/filters/test_sass.rb
@@ -271,6 +271,17 @@ class Nanoc::Filters::SassTest < Nanoc::TestCase
     end
   end
 
+  def test_sass_without_filter
+    if_have 'sass' do
+      File.open('_morestuff.sass', 'w') do |io|
+        io.write("p\n  color: blue")
+      end
+
+      options = { :filename => File.join(Dir.getwd, 'test.sass') }
+      ::Sass::Engine.new('@import "morestuff"', options).render
+    end
+  end
+
 private
 
   def create_filter(params={})


### PR DESCRIPTION
Identical to #445, but on release-3.7.x instead of release-3.6.x.
