### PR TITLE
Handle Bundler::GemfileNotFound

### DIFF
--- a/bin/nanoc
+++ b/bin/nanoc
@@ -4,7 +4,11 @@
 # Try loading bundler if it's possible
 begin
   require 'bundler/setup'
-  Bundler.require(:default)
+  begin
+    Bundler.require(:default)
+  rescue Bundler::GemfileNotFound
+    # no problem
+  end
 rescue LoadError
   # no problem
 end


### PR DESCRIPTION
A fix for #447 and an alternative to the fix proposed in #448.

This causes `bin/nanoc` to ignore `Bundler::GemfileNotFound`.

CC @bobthecow @mpapis
