### PR TITLE
CDN support

### DIFF
--- a/lib/nanoc/extra/deployers/fog.rb
+++ b/lib/nanoc/extra/deployers/fog.rb
@@ -9,6 +9,10 @@ module Nanoc::Extra::Deployers
   #   deploy:
   #     public:
   #       kind:       fog
+  #       bucket:     nanoc-site
+  #       cdn_id:     XXXXXX
+  #     preprod:
+  #       kind:       fog
   #       provider:   local
   #       local_root: ~/myCloud
   #       bucket:     nanoc-site
@@ -27,6 +31,7 @@ module Nanoc::Extra::Deployers
       src      = File.expand_path(source_path)
       bucket   = config.delete(:bucket) || config.delete(:bucket_name)
       path     = config.delete(:path)
+      cdn_id   = config.delete(:cdn_id)
 
       config.delete(:kind)
 
@@ -35,6 +40,7 @@ module Nanoc::Extra::Deployers
 
       # Mock if necessary
       if self.dry_run?
+        puts 'Dry run - simulation'
         ::Fog.mock!
       end
 
@@ -53,6 +59,7 @@ module Nanoc::Extra::Deployers
 
       # Create bucket if necessary
       if should_create_bucket
+        puts 'Creating bucket'
         directory = connection.directories.create(:key => bucket, :prefix => path)
       end
 
@@ -65,6 +72,7 @@ module Nanoc::Extra::Deployers
         files = files + set
       end
       keys_to_destroy = files.all.map { |file| file.key }
+      keys_to_invalidate = []
 
       # Upload all the files in the output folder to the clouds
       puts 'Uploading local files'
@@ -77,6 +85,7 @@ module Nanoc::Extra::Deployers
             :body => File.open(file_path),
             :public => true)
           keys_to_destroy.delete(key)
+          keys_to_invalidate.push(key)
         end
       end
 
@@ -84,6 +93,21 @@ module Nanoc::Extra::Deployers
       puts 'Removing remote files'
       keys_to_destroy.each do |key|
         directory.files.get(key).destroy
+      end
+
+      # invalidate CDN objects
+      if cdn_id 
+        puts 'Invalidating CDN distribution'
+        keys_to_invalidate.concat(keys_to_destroy)
+        cdn = ::Fog::CDN.new(config)
+        # fog cannot mock CDN requests
+        unless self.dry_run?
+          distribution = cdn.get_distribution(cdn_id)
+          # usual limit per invalidation: 1000 objects
+          keys_to_invalidate.each_slice(1000) do |paths|
+            resp = cdn.post_invalidation(distribution, paths)
+          end
+        end
       end
 
       puts 'Done!'

--- a/test/extra/deployers/test_fog.rb
+++ b/test/extra/deployers/test_fog.rb
@@ -62,6 +62,38 @@ class Nanoc::Extra::Deployers::FogTest < Nanoc::TestCase
     end
   end
 
+  def test_run_cdn_with_dry_run
+    if_have 'fog' do
+      begin
+	# Create deployer
+	fog = Nanoc::Extra::Deployers::Fog.new(
+	  'output/',
+	  {
+	    :provider              => 'aws',
+            :cdn_id                => 'id-cdn',
+	    # FIXME bucket is necessary for deployer but fog doesn't like it
+	    :bucket_name           => 'doesntmatter',
+	    :aws_access_key_id     => 'meh',
+	    :aws_secret_access_key => 'dontcare'},
+	  :dry_run => true)
+
+	# Create site
+	FileUtils.mkdir_p('output')
+	File.open('output/meow', 'w') { |io| io.write "I am a cat!" }
+	File.open('output/bark', 'w') { |io| io.write "I am a dog!" }
+
+	# Create local cloud (but not bucket)
+	FileUtils.mkdir_p('mylocalcloud')
+
+	# Run
+	fog.run
+      ensure
+	# Hack :(
+	::Fog.instance_eval { @mocking = false }
+      end
+    end
+  end
+
   def test_run_delete_stray
     if_have 'fog' do
       # Create deployer


### PR DESCRIPTION
Implemented support for CDN

if cdn_id is specified, it will invalidate objects on CDN.

Implemented fixes as Fog does not support dry run. Also, basic test is implemented.
