### PR TITLE
Support filtering Items Arrays by Regex

### DIFF
--- a/lib/nanoc/base/source_data/item_array.rb
+++ b/lib/nanoc/base/source_data/item_array.rb
@@ -34,6 +34,8 @@ module Nanoc
     def [](*args)
       if 1 == args.size && args.first.is_a?(String)
         item_with_identifier(args.first)
+      elsif 1 == args.size && args.first.is_a?(Regexp)
+        @items.select { |i| i.identifier =~ args.first }
       else
         @items[*args]
       end

--- a/test/base/test_item_array.rb
+++ b/test/base/test_item_array.rb
@@ -97,6 +97,14 @@ class Nanoc::ItemArrayTest < Nanoc::TestCase
     assert_nil @items.at('/tenthousand/')
   end
 
+  def test_regex
+    foo = Nanoc::Item.new('Item Foo', {}, '/foo/')
+    @items << foo
+
+    assert_equal [@one], @items[/n/]
+    assert_equal [@two, foo], @items[%r{o/}]
+  end
+
   def test_less_than_less_than
     assert_nil @items[2]
     assert_nil @items['/foo/']


### PR DESCRIPTION
This is a convenience API for working with the `@items` array in nanoc's
`preprocess` block. In that context, it is common to manipulate items
according to a shared part of their identifier.

For example, with this change in place, users could succinctly create a
collection of all authors for a given site's weblog:

```
@items[%r{^/weblog/authors/}].each { |author|
  # etc...
}
```
