### PR TITLE
Made #make_rule_memory_serializable() use Nanoc::Checksummer

### DIFF
--- a/lib/nanoc/base/compilation/rules_collection.rb
+++ b/lib/nanoc/base/compilation/rules_collection.rb
@@ -198,9 +198,9 @@ module Nanoc
     end
     memoize :new_rule_memory_for_rep
 
-    # Makes the given rule memory serializable by calling `#inspect` on the
-    # filter arguments, so that objects such as classes and filenames can be
-    # serialized.
+    # Makes the given rule memory serializable by calling
+    # `Nanoc::Checksummer#calc` on the filter arguments, so that objects such as
+    # classes and filenames can be serialized.
     #
     # @param [Array] rs The rule memory for a certain item rep
     #
@@ -208,7 +208,7 @@ module Nanoc
     def make_rule_memory_serializable(rs)
       rs.map do |r|
         if r[0] == :filter
-          [ r[0], r[1], r[2].to_a.map { |a| a.inspect }  ]
+          [ r[0], r[1], r[2].to_a.map { |a| Nanoc::Checksummer.calc(a) }  ]
         else
           r
         end


### PR DESCRIPTION
This should fix #310 once and for all.

When integrating with Compass, one would typically use the `:sass` filter the following way:

```
filter :sass, Compass.sass_engine_options
```

However, upon each call to `Compass.sass_engine_options` new instances of `Sass::Importers::Filesystem` and `Compass::SpriteImporter` populate the `:load_paths` array. Those classes don't implement `#inspect` and ultimately the default `#inspect` implementation returns a string containing a different memory address upon each invocation.

This confuses Nanoc which believes rules have changed since the item was last compiled:

```
/foo/ is outdated: The rules file has been modified since the last time the site was compiled.
```
