### PR TITLE
Do not strip whitespaces and newlines when separating content from metadata

### DIFF
--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -255,7 +255,7 @@ module Nanoc::DataSources
       end
 
       # Split data
-      pieces = data.split(/^(-{5}|-{3})\s*$/)
+      pieces = data.split(/^(-{5}|-{3})[ \t]*\n/)
       if pieces.size < 4
         raise RuntimeError.new(
           "The file '#{content_filename}' appears to start with a metadata section (three or five dashes at the top) but it does not seem to be in the correct format."
@@ -268,7 +268,7 @@ module Nanoc::DataSources
       rescue Exception => e
         raise "Could not parse YAML for #{content_filename}: #{e.message}"
       end
-      content = pieces[4..-1].join.strip
+      content = pieces[4..-1].join
 
       # Done
       [ meta, content ]

--- a/lib/nanoc/data_sources/filesystem_unified.rb
+++ b/lib/nanoc/data_sources/filesystem_unified.rb
@@ -94,7 +94,7 @@ module Nanoc::DataSources
         meta = attributes.stringify_keys_recursively
         unless meta == {}
           io.write(YAML.dump(meta).strip + "\n")
-          io.write("---\n\n")
+          io.write("---\n")
         end
         io.write(content)
       end

--- a/test/data_sources/test_filesystem.rb
+++ b/test/data_sources/test_filesystem.rb
@@ -316,7 +316,7 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
       io.write "-----\n"
       io.write "foo: bar\n"
       io.write "-----\n"
-      io.write "blah blah\n"
+      io.write "  \t\n  blah blah\n"
     end
 
     # Create data source
@@ -325,7 +325,7 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
     # Parse it
     result = data_source.instance_eval { parse('test.html', nil, 'foobar') }
     assert_equal({ 'foo' => 'bar' }, result[0])
-    assert_equal('blah blah', result[1])
+    assert_equal("  \t\n  blah blah\n", result[1])
   end
 
   def test_parse_embedded_with_extra_spaces
@@ -334,7 +334,7 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
       io.write "-----             \n"
       io.write "foo: bar\n"
       io.write "-----\t\t\t\t\t\n"
-      io.write "blah blah\n"
+      io.write "  blah blah\n"
     end
 
     # Create data source
@@ -343,7 +343,7 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
     # Parse it
     result = data_source.instance_eval { parse('test.html', nil, 'foobar') }
     assert_equal({ 'foo' => 'bar' }, result[0])
-    assert_equal('blah blah', result[1])
+    assert_equal("  blah blah\n", result[1])
   end
 
   def test_parse_embedded_empty_meta
@@ -351,7 +351,7 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
     File.open('test.html', 'w') do |io|
       io.write "-----\n"
       io.write "-----\n"
-      io.write "blah blah\n"
+      io.write "\nblah blah\n"
     end
 
     # Create data source
@@ -360,7 +360,7 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
     # Parse it
     result = data_source.instance_eval { parse('test.html', nil, 'foobar') }
     assert_equal({}, result[0])
-    assert_equal('blah blah', result[1])
+    assert_equal("\nblah blah\n", result[1])
   end
 
   def test_parse_utf8_bom
@@ -376,7 +376,7 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
 
     result = data_source.instance_eval { parse('test.html', nil, 'foobar') }
     assert_equal({ 'utf8bomawareness' => 'high' }, result[0])
-    assert_equal('content goes here', result[1])
+    assert_equal("content goes here\n", result[1])
   end
 
   def test_parse_embedded_no_meta

--- a/test/data_sources/test_filesystem_unified.rb
+++ b/test/data_sources/test_filesystem_unified.rb
@@ -25,7 +25,7 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
     assert File.file?('foobar/asdf.html')
 
     # Check file content
-    expected = /^--- ?\nfoo: bar\n---\n\ncontent here$/
+    expected = /^--- ?\nfoo: bar\n---\ncontent here$/
     assert_match expected, File.read('foobar/asdf.html')
   end
 
@@ -41,7 +41,7 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
     assert File.file?('foobar/index.html')
 
     # Check file content
-    expected = /^--- ?\nfoo: bar\n---\n\ncontent here$/
+    expected = /^--- ?\nfoo: bar\n---\ncontent here$/
     assert_match expected, File.read('foobar/index.html')
   end
 


### PR DESCRIPTION
When parsing items and separating content from metadata, Nanoc strips the content: https://github.com/nanoc/nanoc/blob/3.7.1/lib/nanoc/data_sources/filesystem.rb#L271

This is bogus and prevents the following Markdown from being correctly compiled:

```
----
title: I start with a code block
----
    this is a code block
    this is a code block
```

Calling `#strip` removes the leading spaces and breaks the code block.
