### PR TITLE
Require bundler so that Bundler::GemfileNotFound becomes available

### DIFF
--- a/bin/nanoc
+++ b/bin/nanoc
@@ -3,6 +3,7 @@
 
 # Try loading bundler if it's possible
 begin
+  require 'bundler'
   require 'bundler/setup'
   begin
     Bundler.require(:default)


### PR DESCRIPTION
Without requiring `bundler`, `Bundler::GemfileNotFound` does not exist.

Sorry for the delay in fixing this. :(

CC @bobthecow @gpakosz @jugglinmike - :+1: if you like (picking some random people to review)
