### PR TITLE
Replace rubyforge.org URLs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -465,7 +465,7 @@ New:
 * A new “+” wildcard in rule patterns that matches one or more characters
 * A `view` command that starts a web server in the output directory
 * A `debug` command that shows information about the items, reps and layouts
-* A `kramdown` filter ([kramdown site](http://kramdown.rubyforge.org/))
+* A `kramdown` filter ([kramdown site](http://kramdown.gettalong.org/))
 * A diff between the previously compiled content and the last compiled content is now written to `output.diff` if the `enable_output_diff` site configuration attribute is true
 * Assigns, such as `@items`, `@layouts`, `@item`, … are accessible without `@`
 * Support for binary items
@@ -653,7 +653,7 @@ updated manual will be useful.
 New:
 
 * New `rdiscount` filter ([RDiscount site](http://github.com/rtomayko/rdiscount))
-* New `maruku` filter ([Maruku site](http://maruku.rubyforge.org/))
+* New `maruku` filter ([Maruku site](https://github.com/bhollis/maruku/))
 * New `erubis` filter ([Erubis site](http://www.kuwata-lab.com/erubis/))
 * A better commandline frontend
 * A new filesystem data source named `filesystem_combined`

--- a/lib/nanoc/extra/auto_compiler.rb
+++ b/lib/nanoc/extra/auto_compiler.rb
@@ -25,7 +25,7 @@ module Nanoc::Extra
     end
 
     # Calls the autocompiler. The behaviour of this method is defined by the
-    # [Rack specification](http://rack.rubyforge.org/doc/SPEC.html).
+    # [Rack specification](http://rubydoc.info/github/rack/rack/master/file/SPEC).
     #
     # @param [Hash] env The environment, as defined by the Rack specification
     #

--- a/lib/nanoc/extra/chick.rb
+++ b/lib/nanoc/extra/chick.rb
@@ -8,12 +8,12 @@ module Nanoc::Extra
 
   # @deprecated Use a HTTP library such as
   #   [Net::HTTP](http://ruby-doc.org/stdlib/libdoc/net/http/rdoc/) or
-  #   [Curb](http://curb.rubyforge.org/) instead.
+  #   [Curb](https://github.com/taf2/curb) instead.
   module CHiCk
 
     # @deprecated Use a HTTP library such as
     #   [Net::HTTP](http://ruby-doc.org/stdlib/libdoc/net/http/rdoc/) or
-    #   [Curb](http://curb.rubyforge.org/) instead.
+    #   [Curb](https://github.com/taf2/curb) instead.
     class Client
 
       DEFAULT_OPTIONS = {
@@ -62,7 +62,7 @@ module Nanoc::Extra
 
     # @deprecated Use a HTTP library such as
     #   [Net::HTTP](http://ruby-doc.org/stdlib/libdoc/net/http/rdoc/) or
-    #   [Curb](http://curb.rubyforge.org/) instead.
+    #   [Curb](https://github.com/taf2/curb) instead.
     class CacheController
 
       def initialize(app, options = {})
@@ -82,7 +82,7 @@ module Nanoc::Extra
 
     # @deprecated Use a HTTP library such as
     #   [Net::HTTP](http://ruby-doc.org/stdlib/libdoc/net/http/rdoc/) or
-    #   [Curb](http://curb.rubyforge.org/) instead.
+    #   [Curb](https://github.com/taf2/curb) instead.
     class RackClient
 
       METHOD_TO_CLASS_MAPPING = {

--- a/lib/nanoc/filters/kramdown.rb
+++ b/lib/nanoc/filters/kramdown.rb
@@ -5,7 +5,7 @@ module Nanoc::Filters
 
     requires 'kramdown'
 
-    # Runs the content through [Kramdown](http://kramdown.rubyforge.org/).
+    # Runs the content through [Kramdown](http://kramdown.gettalong.org/).
     # Parameters passed to this filter will be passed on to Kramdown.
     #
     # @param [String] content The content to filter

--- a/lib/nanoc/filters/markaby.rb
+++ b/lib/nanoc/filters/markaby.rb
@@ -5,7 +5,7 @@ module Nanoc::Filters
 
     requires 'markaby'
 
-    # Runs the content through [Markaby](http://markaby.rubyforge.org/).
+    # Runs the content through [Markaby](http://markaby.github.io/).
     # This method takes no options.
     #
     # @param [String] content The content to filter

--- a/lib/nanoc/filters/maruku.rb
+++ b/lib/nanoc/filters/maruku.rb
@@ -5,7 +5,7 @@ module Nanoc::Filters
 
     requires 'maruku'
 
-    # Runs the content through [Maruku](http://maruku.rubyforge.org/).
+    # Runs the content through [Maruku](https://github.com/bhollis/maruku/).
     # Parameters passed to this filter will be passed on to Maruku.
     #
     # @param [String] content The content to filter

--- a/lib/nanoc/filters/rdoc.rb
+++ b/lib/nanoc/filters/rdoc.rb
@@ -10,7 +10,7 @@ module Nanoc::Filters
       super
     end
 
-    # Runs the content through [RDoc::Markup](http://rdoc.rubyforge.org/RDoc/Markup.html).
+    # Runs the content through [RDoc::Markup](http://docs.seattlerb.org/rdoc/RDoc/Markup.html).
     # This method takes no options.
     #
     # @param [String] content The content to filter


### PR DESCRIPTION
A fix for #454.

CC @grv87
