### PR TITLE
Ensure layouts are truely textual

### DIFF
--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -93,6 +93,8 @@ module Nanoc::DataSources
         if is_binary && klass == Nanoc::Item
           meta                = (meta_filename && YAML.load_file(meta_filename)) || {}
           content_or_filename = content_filename
+        elsif is_binary && klass == Nanoc::Layout
+          raise "The layout file '#{content_filename}' is a binary file, but layouts can only be textual"
         else
           meta, content_or_filename = parse(content_filename, meta_filename, kind)
         end

--- a/test/data_sources/test_filesystem_unified.rb
+++ b/test/data_sources/test_filesystem_unified.rb
@@ -135,11 +135,9 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
     File.open('foo/stuff.dat', 'w') { |io| io.write("random binary data") }
 
     # Load
-    items = data_source.send(:load_objects, 'foo', 'item', Nanoc::Layout)
-
-    # Check
-    assert_equal 1, items.size
-    assert_equal 'random binary data', items[0].raw_content
+    assert_raises(RuntimeError) do
+      data_source.send(:load_objects, 'foo', 'item', Nanoc::Layout)
+    end
   end
 
   def test_identifier_for_filename_allowing_periods_in_identifiers

--- a/test/data_sources/test_filesystem_verbose.rb
+++ b/test/data_sources/test_filesystem_verbose.rb
@@ -138,7 +138,7 @@ class Nanoc::DataSources::FilesystemVerboseTest < Nanoc::TestCase
       io.write("---\n")
       io.write("filter: erb\n")
     end
-    File.open('layouts/foo/foo.rhtml', 'w') do |io|
+    File.open('layouts/foo/foo.html', 'w') do |io|
       io.write('Lorem ipsum dolor sit amet...')
     end
 
@@ -148,8 +148,8 @@ class Nanoc::DataSources::FilesystemVerboseTest < Nanoc::TestCase
     # Check layouts
     assert_equal(1,                       layouts.size)
     assert_equal('erb',                   layouts[0][:filter])
-    assert_equal('rhtml',                 layouts[0][:extension])
-    assert_equal('layouts/foo/foo.rhtml', layouts[0][:content_filename])
+    assert_equal('html',                  layouts[0][:extension])
+    assert_equal('layouts/foo/foo.html',  layouts[0][:content_filename])
     assert_equal('layouts/foo/foo.yaml',  layouts[0][:meta_filename])
   end
 

--- a/test/helpers/test_rendering.rb
+++ b/test/helpers/test_rendering.rb
@@ -12,7 +12,7 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
         io.write("layout '/foo/', :erb\n")
       end
 
-      File.open('layouts/foo.xyz', 'w') do |io|
+      File.open('layouts/foo.erb', 'w') do |io|
         io.write 'This is the <%= @layout.identifier %> layout.'
       end
 
@@ -38,7 +38,7 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
         io.write("layout '/foo/', nil\n")
       end
 
-      File.open('layouts/foo.xyz', 'w').close()
+      File.open('layouts/foo.erb', 'w').close()
 
       assert_raises(Nanoc::Errors::CannotDetermineFilter) do
         render '/foo/'
@@ -54,7 +54,7 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
         io.write("layout '/foo/', :asdf\n")
       end
 
-      File.open('layouts/foo.xyz', 'w').close()
+      File.open('layouts/foo.erb', 'w').close()
 
       assert_raises(Nanoc::Errors::UnknownFilter) do
         render '/foo/'
@@ -70,7 +70,7 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
         io.write("layout '/foo/', :erb\n")
       end
 
-      File.open('layouts/foo.xyz', 'w') do |io|
+      File.open('layouts/foo.erb', 'w') do |io|
         io.write '[partial-before]<%= yield %>[partial-after]'
       end
 


### PR DESCRIPTION
Raise a `RuntimeError` when binary files are found in the `layouts/` directory. Addresses #457.
