### PR TITLE
Take CR/LF into account when separating content from YAML metadata

### DIFF
--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -257,7 +257,7 @@ module Nanoc::DataSources
       end
 
       # Split data
-      pieces = data.split(/^(-{5}|-{3})[ \t]*\n/)
+      pieces = data.split(/^(-{5}|-{3})[ \t]*\r?\n?/, 3)
       if pieces.size < 4
         raise RuntimeError.new(
           "The file '#{content_filename}' appears to start with a metadata section (three or five dashes at the top) but it does not seem to be in the correct format."
@@ -270,7 +270,7 @@ module Nanoc::DataSources
       rescue Exception => e
         raise "Could not parse YAML for #{content_filename}: #{e.message}"
       end
-      content = pieces[4..-1].join
+      content = pieces[4]
 
       # Done
       [ meta, content ]

--- a/test/data_sources/test_filesystem.rb
+++ b/test/data_sources/test_filesystem.rb
@@ -277,6 +277,57 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
     end
   end
 
+  def test_parse_embedded_meta_only_1
+    # Create a file
+    File.open('test.html', 'w') do |io|
+      io.write "-----\r\n"
+      io.write "foo: bar\n"
+      io.write "-----\n"
+    end
+
+    # Create data source
+    data_source = Nanoc::DataSources::FilesystemCombined.new(nil, nil, nil, nil)
+
+    # Parse it
+    result = data_source.instance_eval { parse('test.html', nil, 'foobar') }
+    assert_equal({ 'foo' => 'bar' }, result[0])
+    assert_equal("", result[1])
+  end
+
+  def test_parse_embedded_meta_only_2
+    # Create a file
+    File.open('test.html', 'w') do |io|
+      io.write "-----\n"
+      io.write "foo: bar\r\n"
+      io.write "-----\r"
+    end
+
+    # Create data source
+    data_source = Nanoc::DataSources::FilesystemCombined.new(nil, nil, nil, nil)
+
+    # Parse it
+    result = data_source.instance_eval { parse('test.html', nil, 'foobar') }
+    assert_equal({ 'foo' => 'bar' }, result[0])
+    assert_equal("", result[1])
+  end
+
+  def test_parse_embedded_meta_only_3
+    # Create a file
+    File.open('test.html', 'w') do |io|
+      io.write "-----\r\n"
+      io.write "foo: bar\n"
+      io.write "-----"
+    end
+
+    # Create data source
+    data_source = Nanoc::DataSources::FilesystemCombined.new(nil, nil, nil, nil)
+
+    # Parse it
+    result = data_source.instance_eval { parse('test.html', nil, 'foobar') }
+    assert_equal({ 'foo' => 'bar' }, result[0])
+    assert_equal("", result[1])
+  end
+
   def test_parse_embedded_invalid_2
     # Create a file
     File.open('test.html', 'w') do |io|
@@ -313,7 +364,7 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
   def test_parse_embedded_full_meta
     # Create a file
     File.open('test.html', 'w') do |io|
-      io.write "-----\n"
+      io.write "-----\r\n"
       io.write "foo: bar\n"
       io.write "-----\n"
       io.write "  \t\n  blah blah\n"
@@ -352,6 +403,7 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
       io.write "-----\n"
       io.write "-----\n"
       io.write "\nblah blah\n"
+      io.write "-----"
     end
 
     # Create data source
@@ -360,7 +412,7 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
     # Parse it
     result = data_source.instance_eval { parse('test.html', nil, 'foobar') }
     assert_equal({}, result[0])
-    assert_equal("\nblah blah\n", result[1])
+    assert_equal("\nblah blah\n-----", result[1])
   end
 
   def test_parse_utf8_bom


### PR DESCRIPTION
Fixes issue #470. 
