### PR TITLE
Use #rm_rf rather than #remove_entry_secure

### DIFF
--- a/lib/nanoc/base/temp_filename_factory.rb
+++ b/lib/nanoc/base/temp_filename_factory.rb
@@ -42,13 +42,13 @@ module Nanoc
     def cleanup(prefix)
       path = File.join(@root_dir, prefix)
       if File.exist?(path)
-        FileUtils.remove_entry_secure(path)
+        FileUtils.rm_rf(path)
       end
 
       @counts.delete(prefix)
 
       if @counts.empty? && File.directory?(@root_dir)
-        FileUtils.remove_entry_secure(@root_dir)
+        FileUtils.rm_rf(@root_dir)
       end
     end
 


### PR DESCRIPTION
On some systems, `FileUtils#remove_entry_secure` fails to work because
it fails the [TOCTTOU vulnerability check](http://www.ruby-doc.org/stdlib-2.1.2/libdoc/fileutils/rdoc/FileUtils.html#method-c-remove_entry_secure), even for `/tmp`. In the
case of nanoc, the vulnerability check has little use, since it deletes
the directories that it creates itself, so using `FileUtils#rm_rf`
instead of `FileUtils#remove_entry_secure` is fine.

Also see nanoc/nanoc#465
