### PR TITLE
Added :commands_dirs (Array<String>) support to configuration file.

### DIFF
--- a/lib/nanoc/base/source_data/site.rb
+++ b/lib/nanoc/base/source_data/site.rb
@@ -34,6 +34,7 @@ module Nanoc
     DEFAULT_CONFIG = {
       :text_extensions    => %w( css erb haml htm html js less markdown md php rb sass scss txt xhtml xml coffee hb handlebars mustache ms slim ).sort,
       :lib_dirs           => %w( lib ),
+      :commands_dirs      => %w( commands ),
       :output_dir         => 'output',
       :data_sources       => [ {} ],
       :index_filenames    => [ 'index.html' ],

--- a/lib/nanoc/cli.rb
+++ b/lib/nanoc/cli.rb
@@ -118,16 +118,25 @@ protected
     end
   end
 
-  # Loads site-specific commands in `commands/`.
+  # Loads site-specific commands.
   #
   # @return [void]
   def self.load_custom_commands
-    recursive_contents_of('commands').each do |filename|
+    if Nanoc::Site.cwd_is_nanoc_site?
+      site = Nanoc::Site.new('.')
+      site.config[:commands_dirs].each do |path|
+        load_commands_at(path)
+      end
+    end
+  end
+
+  def self.load_commands_at(path)
+    recursive_contents_of(path).each do |filename|
       # Create command
       command = Nanoc::CLI.load_command_at(filename)
 
       # Get supercommand
-      pieces = filename.gsub(/^commands\/|\.rb$/, '').split('/')
+      pieces = filename.gsub(/^#{path}\/|\.rb$/, '').split('/')
       pieces = pieces[0, pieces.size - 1] || []
       root = Nanoc::CLI.root_command
       supercommand = pieces.reduce(root) do |cmd, piece|

--- a/test/cli/test_cli.rb
+++ b/test/cli/test_cli.rb
@@ -75,6 +75,36 @@ EOS
     end
   end
 
+  def test_load_custom_commands_non_default_commands_dirs
+    Nanoc::CLI.run %w( create_site foo )
+    FileUtils.cd('foo') do
+      File.open('nanoc.yaml', 'w') { |io| io.write('commands_dirs: [commands, commands_alt]') }
+
+      # Create command
+      FileUtils.mkdir_p('commands_alt')
+      File.open('commands_alt/_test.rb', 'w') do |io|
+        io.write(COMMAND_CODE)
+      end
+
+      # Create subcommand
+      FileUtils.mkdir_p('commands_alt/_test')
+      File.open('commands_alt/_test/_sub.rb', 'w') do |io|
+        io.write(SUBCOMMAND_CODE)
+      end
+
+      # Run command
+      begin
+        Nanoc::CLI.run %w( _test _sub )
+      rescue SystemExit
+        assert false, 'Running _test sub should not cause system exit'
+      end
+
+      # Check
+      assert File.file?('_test_sub.out')
+      assert_equal 'It works sub!', File.read('_test_sub.out')
+    end
+  end
+
   def test_load_custom_commands_broken
     Nanoc::CLI.run %w( create_site foo )
 


### PR DESCRIPTION
Makes nanoc load commands from configurable directories.

This replaces the hardcoded `commands` path by `@config[:commands_dirs]`.
