### PR TITLE
add access to regular expressions group matches used in route

### DIFF
--- a/lib/nanoc/base/compilation/rule.rb
+++ b/lib/nanoc/base/compilation/rule.rb
@@ -67,7 +67,26 @@ module Nanoc
         raise ArgumentError, 'Required :compiler option is missing'
       end
       rep = Nanoc::ItemRepProxy.new(rep, compiler) unless rep.proxy?
-      Nanoc::RuleContext.new(:rep => rep, :compiler => compiler).instance_eval(&@block)
+      Nanoc::RuleContext.new(
+        :rep      => rep,
+        :compiler => compiler
+      ).instance_exec(
+        matches(rep.item.identifier),
+        &@block
+      )
+    end
+
+  protected
+
+    # Matches the rule regexp against items identifier and gives back group
+    # captures if any
+    #
+    # @param String items identifier to check
+    #
+    # @return [nil, Array] array of group captures if any
+    def matches(identifier)
+      matches = @identifier_regex.match(identifier)
+      matches && matches.captures
     end
 
   end

--- a/test/base/test_rule.rb
+++ b/test/base/test_rule.rb
@@ -14,4 +14,14 @@ class Nanoc::RuleTest < Nanoc::TestCase
     # TODO implement
   end
 
+  def test_matches
+    regexp     = %r</(.*)/(.*)/>
+    identifier = '/anything/else/'
+    expected   = ['anything', 'else']
+
+    rule = Nanoc::Rule.new(regexp, :string, Proc.new {})
+
+    assert_equal expected, rule.send(:matches, identifier)
+  end
+
 end


### PR DESCRIPTION
``` bash
$ nanoc --version
nanoc 3.7.3 © 2007-2014 Denis Defreyne.
Running ruby 2.0.0 (2014-05-08) on x86_64-linux with RubyGems 2.2.2.
```

my current example:

``` ruby
blog_regexp = %r</blog/([0-9]+)\-([0-9]+)\-([0-9]+)\-([^\/]+)>
route blog_regexp do
  y,m,d,slug = blog_regexp.match(item.identifier)[1..-1]
  "/blog/#{y}/#{m}/#{slug}/index.html"
end
```

would be nice if t could be reduced to:

``` ruby
route %r</blog/([0-9]+)\-([0-9]+)\-([0-9]+)\-([^\/]+)> do |y, m, d, slug|
  "/blog/#{y}/#{m}/#{slug}/index.html"
end
```

although adding `matches` for simplicity would be fine with me too:

``` ruby
route %r</blog/([0-9]+)\-([0-9]+)\-([0-9]+)\-([^\/]+)> do
  y, m, d, slug = matches
  "/blog/#{y}/#{m}/#{slug}/index.html"
end
```

I did not looked in to the code yet, wanted to make sure such change would be welcome
