### PR TITLE
reload items after precompilation

### DIFF
--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -120,6 +120,7 @@ module Nanoc
       # Preprocess
       rules_collection.load
       preprocess
+      site.reload_items
       site.setup_child_parent_links
       build_reps
       route_reps

--- a/lib/nanoc/base/source_data/site.rb
+++ b/lib/nanoc/base/source_data/site.rb
@@ -241,10 +241,10 @@ module Nanoc
 
       # Load all data
       load_code_snippets
-      data_sources.each { |ds| ds.use }
-      load_items
-      load_layouts
-      data_sources.each { |ds| ds.unuse }
+      with_datasources do
+        load_items
+        load_layouts
+      end
       setup_child_parent_links
 
       # Ensure unique
@@ -261,6 +261,17 @@ module Nanoc
       raise e
     ensure
       @loading = false
+    end
+
+    # Reloads the site items data. It is not necessary to call this method explicitly;
+    # it will be called after preprocessing.
+    #
+    # @api private
+    #
+    # @return [void]
+    def reload_items
+      @items_loaded = false
+      with_datasources { load_items }
     end
 
     # Undoes the effects of {#load}. Used when {#load} raises an exception.
@@ -299,6 +310,14 @@ module Nanoc
     end
 
   private
+
+    # make sure datasources are unloaded properly even on trouble
+    def with_datasources(&block)
+      data_sources.each { |ds| ds.use }
+      yield
+    ensure
+      data_sources.each { |ds| ds.unuse }
+    end
 
     # Loads this site’s code and executes it.
     def load_code_snippets


### PR DESCRIPTION
use case:

``` ruby
preprocess do
  AutoHelper.new(File.dirname(__FILE__), self).auto # do some automated content genration

  # force reload of items
  self.site.instance_variable_set(:@loaded, false)
  self.site.instance_variable_set(:@items_loaded, false)
  self.site.load
end
```

the code above does generate warning:

> WARNING: A preprocess block is already defined. Defining another preprocess block overrides the previously one.

the proposed fix is free of this warning

no tests yet, please let me know if you like it and I can think of something
