### PR TITLE
fix single url check for external links, add increasing timeout for slow connection

### DIFF
--- a/lib/nanoc/extra/checking/checks/external_links.rb
+++ b/lib/nanoc/extra/checking/checks/external_links.rb
@@ -99,22 +99,23 @@ module ::Nanoc::Extra::Checking::Checks
 
       # Get status
       res = nil
+      last_err = nil
+      timeouts = [3, 5, 10, 30, 60]
       5.times do |i|
         begin
-          Timeout.timeout(10) do
+          Timeout.timeout(timeouts[i]) do
             res = request_url_once(url)
             if res.code == '405'
               res = request_url_once(url, Net::HTTP::Get)
             end
           end
         rescue => e
-          return Result.new(href, e.message)
+          last_err = e
+          next # can not allow
         end
 
         if res.code =~ /^3..$/
-          if i == 4
-            return Result.new(href, 'too many redirects')
-          end
+          return Result.new(href, 'too many redirects') if i == 4
 
           # Find proper location
           location = res['Location']
@@ -133,7 +134,13 @@ module ::Nanoc::Extra::Checking::Checks
           return Result.new(href, res.code)
         end
       end
-      raise 'should not have gotten here'
+      if
+        last_err
+      then
+        return Result.new(href, last_err.message)
+      else
+        raise 'should not have gotten here'
+      end
     end
 
     def path_for_url(url)


### PR DESCRIPTION
addressing two problems:
1. `5.times do` was executed only once in case of `#<Timeout::Error: execution expired>` - this is fixed with preserving the error in `last_err` and calling `next` to skip rest of the code for this itteration
2. `10` seconds timeout could be to small in rare cases, only today I hit this `timeout` like 5 of 50 times, added a table with `[3, 5, 10, 30, 60]` so first check will `timeout` quite fast on slow connection, but the `timeout` will be increased, ending in `60` which might be even enough for such disasters as remote site restart. also the high timeouts should be compensated with the 10 thread pool above.

did not add any tests yet - but I could think of something if you like this change
