### PR TITLE
Revert "Fix support for dotfiles in data-sources"

### DIFF
--- a/lib/nanoc/extra/filesystem_tools.rb
+++ b/lib/nanoc/extra/filesystem_tools.rb
@@ -60,7 +60,7 @@ module Nanoc::Extra
     # @raise [UnsupportedFileTypeError] if a file of an unsupported type is
     #   detected (something other than file, directory or link)
     def all_files_in(dir_name, recursion_limit = 10)
-      Dir.glob(dir_name + '/**/*', File::FNM_DOTMATCH).map do |fn|
+      Dir[dir_name + '/**/*'].map do |fn|
         case File.ftype(fn)
         when 'link'
           if 0 == recursion_limit

--- a/test/extra/test_filesystem_tools.rb
+++ b/test/extra/test_filesystem_tools.rb
@@ -101,13 +101,4 @@ class Nanoc::Extra::FilesystemToolsTest < Nanoc::TestCase
     end
   end
 
-  def test_dotfiles_are_valid_items
-    # Write sample files
-    FileUtils.mkdir_p('dir')
-    File.open('dir/.htaccess', 'w') { |io| io.write('o hai') }
-    
-    actual_files = Nanoc::Extra::FilesystemTools.all_files_in('dir').sort
-    assert_equal ['dir/.htaccess'], actual_files
-  end
-
 end


### PR DESCRIPTION
#492 adds support for dotfiles in data sources, but unfortunately introduces a backwards incompatibility issue: sites likely currently rely on dotfiles being ignored, and this change would break their sites. A common dotfile is `.DS_Store`, which few sites (if any at all!) take into account.

This PR reverts the change. Having support for dotfiles is good, but in order to keep backwards compatibility, it should be optional, and opt-in.

Also see [this and later comments on #496](https://github.com/nanoc/nanoc/pull/496#issuecomment-63274338).

CC @andydrop 
