### PR TITLE
More style fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,13 @@ RegexpLiteral:
 RescueException:
   Enabled: false
 
+# This is used in tests, to verify the effect of state-changing functions.
+Style/GlobalVars:
+  Enabled: false
+
+ClassAndModuleChildren:
+  Enabled: false
+
 
 
 # ----- DISABLED (hard) -----
@@ -56,9 +63,25 @@ FileName:
 AccessorMethodName:
   Enabled: false
 
+# This trips up on a piece of code that handles URI fragments.
+LeadingCommentSpace:
+  Enabled: false
+
+# We use _erbout.
+Lint/UnderscorePrefixedVariableName:
+  Enabled: false
+
 
 
 # ----- DISABLED (opinionated) -----
+
+# This can lead to massive indentation.
+Style/AlignHash:
+  Enabled: false
+
+# It’s difficult to rework existing code to handle this well.
+Metrics/AbcSize:
+  Enabled: false
 
 # Parameters are indented one soft tab instead.
 AlignParameters:
@@ -67,10 +90,6 @@ AlignParameters:
 # We should embrace UTF-8, not avoid it. Since the Encoding cop is enabled,
 # there’s no point in enforcing ASCII comments.
 AsciiComments:
-  Enabled: false
-
-# Personal convention is to use “memo” and an appropriate name for the element.
-SingleLineBlockParams:
   Enabled: false
 
 # Mostly long hardcoded strings which I’d rather not break up (yet).
@@ -93,10 +112,6 @@ ClassLength:
 PerceivedComplexity:
   Enabled: false
 
-# Personal convention is to use colon-less annotations.
-CommentAnnotation:
-  Enabled: false
-
 # Other tools exist for checking code quality. This cop is probably good to
 # have, but nanoc 3.x will not get any major refactorings anymore anyway.
 #
@@ -108,25 +123,12 @@ CyclomaticComplexity:
 Documentation:
   Enabled: false
 
-# Personal preference is to have symmetric blank lines inside module and class
-# definitions.
-EmptyLinesAroundBody:
-  Enabled: false
-
-# No personal preference over how to format strings.
-FormatString:
-  Enabled: false
-
 # nanoc suppresses exceptions for valid reasons in a few cases.
 HandleExceptions:
   Enabled: false
 
 # if/unless at the end of the line makes it too easy to oversee.
 IfUnlessModifier:
-  Enabled: false
-
-# Inconsistent AccessModifierIndentation:EnforcedStyle set to `outdent`
-IndentationWidth:
   Enabled: false
 
 # This causes the hashes to be ridiculously indented.
@@ -154,10 +156,6 @@ SignalException:
 # single value) should still not be considered to be accessors. This is a purely
 # semantic difference.
 TrivialAccessors:
-  Enabled: false
-
-# Used to be personal preference. Can remove soon.
-ClassAndModuleChildren:
   Enabled: false
 
 # Trailing commas improve diffs. One could argue that diff algorithms should be

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 gemspec
 
-# FIXME we may be missing some mswin dependencies here
+# FIXME: we may be missing some mswin dependencies here
 all_rubies = Bundler::Dependency::PLATFORM_MAP.keys
 ruby_19_plus               = [:ruby_19, :ruby_20, :ruby_21, :jruby] & all_rubies
 ruby_19_plus_without_jruby = [:ruby_19, :ruby_20, :ruby_21]         & all_rubies

--- a/doc/yardoc_handlers/identifier.rb
+++ b/doc/yardoc_handlers/identifier.rb
@@ -1,5 +1,4 @@
 class NanocIdentifierHandler < ::YARD::Handlers::Ruby::AttributeHandler
-
   # e.g. identifier :foo, :bar
 
   handles method_call(:identifier), method_call(:identifiers)
@@ -9,11 +8,9 @@ class NanocIdentifierHandler < ::YARD::Handlers::Ruby::AttributeHandler
     identifiers = statement.parameters(false).map { |param| param.jump(:ident)[0] }
     namespace['nanoc_identifiers'] = identifiers
   end
-
 end
 
 class NanocRegisterFilterHandler < ::YARD::Handlers::Ruby::AttributeHandler
-
   # e.g. Nanoc::Filter.register '::Nanoc::Filters::AsciiDoc', :asciidoc
 
   handles method_call(:register)
@@ -21,7 +18,7 @@ class NanocRegisterFilterHandler < ::YARD::Handlers::Ruby::AttributeHandler
 
   def process
     target = statement.jump(:const_path_ref)
-    return if target != s(:const_path_ref, s(:var_ref, s(:const, "Nanoc")), s(:const, "Filter"))
+    return if target != s(:const_path_ref, s(:var_ref, s(:const, 'Nanoc')), s(:const, 'Filter'))
 
     class_name = statement.jump(:string_literal).jump(:tstring_content)[0]
     identifier = statement.jump(:symbol_literal).jump(:ident)[0]
@@ -30,5 +27,4 @@ class NanocRegisterFilterHandler < ::YARD::Handlers::Ruby::AttributeHandler
     obj['nanoc_identifiers'] ||= []
     obj['nanoc_identifiers'] << identifier
   end
-
 end

--- a/lib/nanoc.rb
+++ b/lib/nanoc.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc
-
   # @return [String] A string containing information about this nanoc version
   #   and its environment (Ruby engine and version, Rubygems version if any).
   def self.version_information
@@ -17,7 +16,6 @@ module Nanoc
   def self.on_windows?
     RUBY_PLATFORM =~ /windows|bccwin|cygwin|djgpp|mingw|mswin|wince/i
   end
-
 end
 
 Nanoc3 = Nanoc

--- a/lib/nanoc/base.rb
+++ b/lib/nanoc/base.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc
-
   require 'nanoc/base/core_ext'
   require 'nanoc/base/ordered_hash'
 
@@ -46,7 +45,6 @@ module Nanoc
   autoload 'RulesCollection',      'nanoc/base/compilation/rules_collection'
 
   # Deprecated; use PluginRepository instead
-  # TODO [in nanoc 4.0] remove me
+  # TODO: [in nanoc 4.0] remove me
   autoload 'Plugin',               'nanoc/base/plugin_registry'
-
 end

--- a/lib/nanoc/base/checksummer.rb
+++ b/lib/nanoc/base/checksummer.rb
@@ -1,15 +1,12 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Creates checksums for given objects.
   #
   # A checksum is a string, such as “mL+TaqNsEeiPkWloPgCtAofT1yg=”, that is used
   # to determine whether a piece of data has changed.
   class Checksummer
-
     class << self
-
       # @param obj The object to create a checksum for
       #
       # @return [String] The digest
@@ -72,11 +69,7 @@ module Nanoc
 
           digest.update(data)
         end
-
       end
-
     end
-
   end
-
 end

--- a/lib/nanoc/base/compilation/checksum_store.rb
+++ b/lib/nanoc/base/compilation/checksum_store.rb
@@ -1,13 +1,11 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Stores checksums for objects in order to be able to detect whether a file
   # has changed since the last site compilation.
   #
   # @api private
   class ChecksumStore < ::Nanoc::Store
-
     # @option params [Nanoc::Site] site The site where this checksum store
     #   belongs to
     def initialize(params = {})
@@ -51,7 +49,5 @@ module Nanoc
     def data=(new_data)
       @checksums = new_data
     end
-
   end
-
 end

--- a/lib/nanoc/base/compilation/compiled_content_cache.rb
+++ b/lib/nanoc/base/compilation/compiled_content_cache.rb
@@ -1,13 +1,11 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Represents a cache than can be used to store already compiled content,
   # to prevent it from being needlessly recompiled.
   #
   # @api private
   class CompiledContentCache < ::Nanoc::Store
-
     def initialize
       super('tmp/compiled_content', 1)
 
@@ -56,7 +54,5 @@ module Nanoc
     def data=(new_data)
       @cache = new_data
     end
-
   end
-
 end

--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Responsible for compiling a site’s item representations.
   #
   # The compilation process makes use of notifications (see
@@ -39,7 +38,6 @@ module Nanoc
   # * `processing_ended` — indicates that the compiler has finished processing
   #   the specified object.
   class Compiler
-
     extend Nanoc::Memoization
 
     # @group Accessors
@@ -461,7 +459,5 @@ module Nanoc
         rule_memory_store
       ]
     end
-
   end
-
 end

--- a/lib/nanoc/base/compilation/compiler_dsl.rb
+++ b/lib/nanoc/base/compilation/compiler_dsl.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Contains methods that will be executed by the site’s `Rules` file.
   class CompilerDSL
-
     # The current rules filename.
     #
     # @return [String] The current rules filename.
@@ -271,7 +269,5 @@ module Nanoc
         identifier
       end
     end
-
   end
-
 end

--- a/lib/nanoc/base/compilation/dependency_tracker.rb
+++ b/lib/nanoc/base/compilation/dependency_tracker.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Responsible for remembering dependencies between items and layouts. It is
   # used to speed up compilation by only letting an item be recompiled when it
   # is outdated or any of its dependencies (or dependencies’ dependencies,
@@ -20,7 +19,6 @@ module Nanoc
   #
   # @api private
   class DependencyTracker < ::Nanoc::Store
-
     # @return [Array<Nanoc::Item, Nanoc::Layout>] The list of items and
     #   layouts that are being tracked by the dependency tracker
     attr_reader :objects
@@ -207,7 +205,5 @@ module Nanoc
         end
       end
     end
-
   end
-
 end

--- a/lib/nanoc/base/compilation/filter.rb
+++ b/lib/nanoc/base/compilation/filter.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Nanoc::Filter is responsible for filtering items. It is the superclass
   # for all textual filters.
   #
@@ -27,7 +26,6 @@ module Nanoc
   #
   # @abstract Subclass and override {#run} to implement a custom filter.
   class Filter < Context
-
     TMP_BINARY_ITEMS_DIR = 'binary_items'
 
     # A hash containing variables that will be made available during
@@ -39,7 +37,6 @@ module Nanoc
     extend Nanoc::PluginRegistry::PluginMethods
 
     class << self
-
       # Sets the new type for the filter. The type can be `:binary` (default)
       # or `:text`. The given argument can either be a symbol indicating both
       # “from” and “to” types, or a hash where the only key is the “from” type
@@ -100,7 +97,6 @@ module Nanoc
           true
         end
       end
-
     end
 
     # Creates a new filter that has access to the given assigns.
@@ -186,7 +182,5 @@ module Nanoc
         raise Nanoc::Errors::UnmetDependency.new(rep) if rep
       end
     end
-
   end
-
 end

--- a/lib/nanoc/base/compilation/item_rep_proxy.rb
+++ b/lib/nanoc/base/compilation/item_rep_proxy.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Represents an item representation, but provides an interface that is
   # easier to use when writing compilation and routing rules. It is also
   # responsible for fetching the necessary information from the compiler, such
@@ -10,7 +9,6 @@ module Nanoc
   # The API provided by item representation proxies allows layout identifiers
   # to be given as literals instead of as references to {Nanoc::Layout}.
   class ItemRepProxy
-
     extend Forwardable
 
     def_delegators :@item_rep, :item, :name, :binary, :binary?, :compiled_content, :has_snapshot?, :raw_path, :path
@@ -98,7 +96,5 @@ module Nanoc
       raise Nanoc::Errors::UnknownLayout.new(layout_identifier) if layout.nil?
       layout
     end
-
   end
-
 end

--- a/lib/nanoc/base/compilation/item_rep_recorder_proxy.rb
+++ b/lib/nanoc/base/compilation/item_rep_recorder_proxy.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Represents a fake iem representation that does not actually perform any
   # actual filtering, layouting or snapshotting, but instead keeps track of
   # what would happen if a real item representation would have been used
@@ -15,7 +14,6 @@ module Nanoc
   #
   # @api private
   class ItemRepRecorderProxy
-
     extend Forwardable
 
     def_delegators :@item_rep, :item, :name, :binary, :binary?, :compiled_content, :has_snapshot?, :raw_path, :path, :assigns, :assigns=
@@ -97,7 +95,5 @@ module Nanoc
       true
     end
     alias_method :is_proxy?, :proxy?
-
   end
-
 end

--- a/lib/nanoc/base/compilation/outdatedness_checker.rb
+++ b/lib/nanoc/base/compilation/outdatedness_checker.rb
@@ -1,12 +1,10 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Responsible for determining whether an item or a layout is outdated.
   #
   # @api private
   class OutdatednessChecker
-
     extend Nanoc::Memoization
 
     # @option params [Nanoc::Site] :site (nil) The site this outdatedness
@@ -220,7 +218,5 @@ module Nanoc
     def site
       @site
     end
-
   end
-
 end

--- a/lib/nanoc/base/compilation/outdatedness_reasons.rb
+++ b/lib/nanoc/base/compilation/outdatedness_reasons.rb
@@ -1,14 +1,11 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Module that contains all outdatedness reasons.
   module OutdatednessReasons
-
     # A generic outdatedness reason. An outdatedness reason is basically a
     # descriptive message that explains why a given object is outdated.
     class Generic
-
       # @return [String] A descriptive message for this outdatedness reason
       attr_reader :message
 
@@ -17,7 +14,6 @@ module Nanoc
       def initialize(message)
         @message = message
       end
-
     end
 
     CodeSnippetsModified = Generic.new(
@@ -40,7 +36,5 @@ module Nanoc
 
     SourceModified = Generic.new(
       'The source file of this item has been modified since the last time the site was compiled.')
-
   end
-
 end

--- a/lib/nanoc/base/compilation/rule.rb
+++ b/lib/nanoc/base/compilation/rule.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Contains the processing information for a item.
   class Rule
-
     # @return [Regexp] The regex that determines which items this rule can be
     #   applied to. This rule can be applied to items with a identifier
     #   matching this regex.
@@ -69,7 +67,5 @@ module Nanoc
       rep = Nanoc::ItemRepProxy.new(rep, compiler) unless rep.proxy?
       Nanoc::RuleContext.new(:rep => rep, :compiler => compiler).instance_eval(&@block)
     end
-
   end
-
 end

--- a/lib/nanoc/base/compilation/rule_context.rb
+++ b/lib/nanoc/base/compilation/rule_context.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Provides a context in which compilation and routing rules can be executed.
   # It provides access to the item representation that is being compiled or
   # routed.
@@ -17,7 +16,6 @@ module Nanoc
   #
   # @api private
   class RuleContext < Context
-
     # @option params [Nanoc::ItemRep] :rep The item representation that will
     #   be processed in this rule context
     #
@@ -85,7 +83,5 @@ module Nanoc
     def snapshot(snapshot_name)
       rep.snapshot(snapshot_name)
     end
-
   end
-
 end

--- a/lib/nanoc/base/compilation/rule_memory_calculator.rb
+++ b/lib/nanoc/base/compilation/rule_memory_calculator.rb
@@ -1,13 +1,11 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Calculates rule memories for objects that can be run through a rule (item
   # representations and layouts).
   #
   # @api private
   class RuleMemoryCalculator
-
     extend Nanoc::Memoization
 
     # @option params [Nanoc::RulesCollection] rules_collection The rules
@@ -35,7 +33,5 @@ module Nanoc
       result
     end
     memoize :[]
-
   end
-
 end

--- a/lib/nanoc/base/compilation/rule_memory_store.rb
+++ b/lib/nanoc/base/compilation/rule_memory_store.rb
@@ -1,13 +1,11 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Stores rule memories for objects that can be run through a rule (item
   # representations and layouts).
   #
   # @api private
   class RuleMemoryStore < ::Nanoc::Store
-
     # @option params [Nanoc::Site] site The site where this rule memory store
     #   belongs to
     def initialize(params = {})
@@ -47,7 +45,5 @@ module Nanoc
     def data=(new_data)
       @rule_memories = new_data
     end
-
   end
-
 end

--- a/lib/nanoc/base/compilation/rules_collection.rb
+++ b/lib/nanoc/base/compilation/rules_collection.rb
@@ -1,12 +1,10 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Keeps track of the rules in a site.
   #
   # @api private
   class RulesCollection
-
     # @return [String] the contents of the Rules file
     #
     # @api private
@@ -253,7 +251,5 @@ module Nanoc
     def rule_memory_calculator
       @compiler.rule_memory_calculator
     end
-
   end
-
 end

--- a/lib/nanoc/base/context.rb
+++ b/lib/nanoc/base/context.rb
@@ -1,11 +1,9 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Provides a context and a binding for use in filters such as the ERB and
   # Haml ones.
   class Context
-
     # Creates a new context based off the contents of the hash.
     #
     # Each pair in the hash will be converted to an instance variable and an
@@ -42,6 +40,5 @@ module Nanoc
     def get_binding
       binding
     end
-
   end
 end

--- a/lib/nanoc/base/core_ext/array.rb
+++ b/lib/nanoc/base/core_ext/array.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc::ArrayExtensions
-
   # Returns a new array where all items' keys are recursively converted to
   # symbols by calling {Nanoc::ArrayExtensions#symbolize_keys_recursively} or
   # {Nanoc::HashExtensions#symbolize_keys_recursively}.
@@ -66,7 +65,6 @@ module Nanoc::ArrayExtensions
   def checksum
     Nanoc::Checksummer.calc(self)
   end
-
 end
 
 class Array

--- a/lib/nanoc/base/core_ext/date.rb
+++ b/lib/nanoc/base/core_ext/date.rb
@@ -14,7 +14,6 @@ end
 if needs_patch
 
   class ::Date
-
     [:amjd, :jd, :day_fraction, :mjd, :ld, :civil, :ordinal, :commercial, :weeknum0, :weeknum1, :time, :wday, :julian?, :gregorian?, :leap?].each do |m|
       module_eval <<EOS
         alias_method :__orig_#{m}, :#{m}
@@ -23,7 +22,6 @@ if needs_patch
         end
 EOS
     end
-
   end
 
 end

--- a/lib/nanoc/base/core_ext/hash.rb
+++ b/lib/nanoc/base/core_ext/hash.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc::HashExtensions
-
   # Returns a new hash where all keys are recursively converted to symbols by
   # calling {Nanoc::ArrayExtensions#symbolize_keys_recursively} or
   # {Nanoc::HashExtensions#symbolize_keys_recursively}.
@@ -68,7 +67,6 @@ module Nanoc::HashExtensions
   def checksum
     Nanoc::Checksummer.calc(self)
   end
-
 end
 
 class Hash

--- a/lib/nanoc/base/core_ext/pathname.rb
+++ b/lib/nanoc/base/core_ext/pathname.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc::PathnameExtensions
-
   # Calculates the checksum for the file referenced to by this pathname. Any
   # change to the file contents will result in a different checksum.
   #
@@ -11,7 +10,6 @@ module Nanoc::PathnameExtensions
   def checksum
     Nanoc::Checksummer.calc(self)
   end
-
 end
 
 class Pathname

--- a/lib/nanoc/base/core_ext/string.rb
+++ b/lib/nanoc/base/core_ext/string.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc::StringExtensions
-
   # Transforms string into an actual identifier
   #
   # @return [String] The identifier generated from the receiver
@@ -18,7 +17,6 @@ module Nanoc::StringExtensions
   def checksum
     Nanoc::Checksummer.calc(self)
   end
-
 end
 
 class String

--- a/lib/nanoc/base/directed_graph.rb
+++ b/lib/nanoc/base/directed_graph.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Represents a directed graph. It is used by the dependency tracker for
   # storing and querying dependencies between items.
   #
@@ -30,7 +29,6 @@ module Nanoc
   #   graph.predecessors_of('d').sort
   #     # => %w( b c )
   class DirectedGraph
-
     # @group Creating a graph
 
     # Creates a new directed graph with the given vertices.
@@ -266,7 +264,5 @@ module Nanoc
 
       all_vertices.to_a
     end
-
   end
-
 end

--- a/lib/nanoc/base/errors.rb
+++ b/lib/nanoc/base/errors.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Module that contains all nanoc-specific errors.
   module Errors
-
     # Generic error. Superclass for all nanoc-specific errors.
     class Generic < ::StandardError
     end
@@ -17,103 +15,86 @@ module Nanoc
     # Error that is raised when a site is loaded that uses a data source with
     # an unknown identifier.
     class UnknownDataSource < Generic
-
       # @param [String] data_source_name The data source name for which no
       #   data source could be found
       def initialize(data_source_name)
         super("The data source specified in the site’s configuration file, “#{data_source_name}”, does not exist.")
       end
-
     end
 
     # Error that is raised during site compilation when an item uses a layout
     # that is not present in the site.
     class UnknownLayout < Generic
-
       # @param [String] layout_identifier The layout identifier for which no
       #   layout could be found
       def initialize(layout_identifier)
         super("The site does not have a layout with identifier “#{layout_identifier}”.")
       end
-
     end
 
     # Error that is raised during site compilation when an item uses a filter
     # that is not known.
     class UnknownFilter < Generic
-
       # @param [Symbol] filter_name The filter name for which no filter could
       #   be found
       def initialize(filter_name)
         super("The requested filter, “#{filter_name}”, does not exist.")
       end
-
     end
 
     # Error that is raised during site compilation when a layout is compiled
     # for which the filter cannot be determined. This is similar to the
     # {UnknownFilter} error, but specific for filters for layouts.
     class CannotDetermineFilter < Generic
-
       # @param [String] layout_identifier The identifier of the layout for
       #   which the filter could not be determined
       def initialize(layout_identifier)
         super("The filter to be used for the “#{layout_identifier}” layout could not be determined. Make sure the layout does have a filter.")
       end
-
     end
 
     # Error that is raised during site compilation when an item (directly or
     # indirectly) includes its own item content, leading to endless recursion.
     class RecursiveCompilation < Generic
-
       # @param [Array<Nanoc::ItemRep>] reps A list of item representations
       #   that mutually depend on each other
       def initialize(reps)
         list = reps.map { |r| r.inspect }.join("\n")
         super("The site cannot be compiled because the following items mutually depend on each other:\n#{list}.")
       end
-
     end
 
     # Error that is raised when no rules file can be found in the current
     # working directory.
     class NoRulesFileFound < Generic
-
       def initialize
         super('This site does not have a rules file, which is required for nanoc sites.')
       end
-
     end
 
     # Error that is raised when no compilation rule that can be applied to the
     # current item can be found.
     class NoMatchingCompilationRuleFound < Generic
-
       # @param [Nanoc::Item] item The item for which no compilation rule
       #   could be found
       def initialize(item)
         super("No compilation rules were found for the “#{item.identifier}” item.")
       end
-
     end
 
     # Error that is raised when no routing rule that can be applied to the
     # current item can be found.
     class NoMatchingRoutingRuleFound < Generic
-
       # @param [Nanoc::ItemRep] rep The item repiresentation for which no
       #   routing rule could be found
       def initialize(rep)
         super("No routing rules were found for the “#{rep.item.identifier}” item (rep “#{rep.name}”).")
       end
-
     end
 
     # Error that is raised when an rep cannot be compiled because it depends
     # on other representations.
     class UnmetDependency < Generic
-
       # @return [Nanoc::ItemRep] The item representation that cannot yet be
       #   compiled
       attr_reader :rep
@@ -124,24 +105,20 @@ module Nanoc
         @rep = rep
         super("The current item cannot be compiled yet because of an unmet dependency on the “#{rep.item.identifier}” item (rep “#{rep.name}”).")
       end
-
     end
 
     # Error that is raised when a binary item is attempted to be laid out.
     class CannotLayoutBinaryItem < Generic
-
       # @param [Nanoc::ItemRep] rep The item representation that was attempted
       #   to be laid out
       def initialize(rep)
         super("The “{rep.item.identifier}” item (rep “#{rep.name}”) cannot be laid out because it is a binary item. If you are getting this error for an item that should be textual instead of binary, make sure that its extension is included in the text_extensions array in the site configuration.")
       end
-
     end
 
     # Error that is raised when a textual filter is attempted to be applied to
     # a binary item representation.
     class CannotUseTextualFilter < Generic
-
       # @param [Nanoc::ItemRep] rep The item representation that was
       #   attempted to be filtered
       #
@@ -149,13 +126,11 @@ module Nanoc
       def initialize(rep, filter_class)
         super("The “#{filter_class.inspect}” filter cannot be used to filter the “#{rep.item.identifier}” item (rep “#{rep.name}”), because textual filters cannot be used on binary items.")
       end
-
     end
 
     # Error that is raised when a binary filter is attempted to be applied to
     # a textual item representation.
     class CannotUseBinaryFilter < Generic
-
       # @param [Nanoc::ItemRep] rep The item representation that was
       #   attempted to be filtered
       #
@@ -163,13 +138,11 @@ module Nanoc
       def initialize(rep, filter_class)
         super("The “#{filter_class.inspect}” filter cannot be used to filter the “#{rep.item.identifier}” item (rep “#{rep.name}”), because binary filters cannot be used on textual items. If you are getting this error for an item that should be textual instead of binary, make sure that its extension is included in the text_extensions array in the site configuration.")
       end
-
     end
 
     # Error that is raised when the compiled content at a non-existing snapshot
     # is requested.
     class NoSuchSnapshot < Generic
-
       # @return [Nanoc::ItemRep] The item rep from which the compiled content
       #   was requested
       attr_reader :item_rep
@@ -185,12 +158,10 @@ module Nanoc
         @item_rep, @snapshot = item_rep, snapshot
         super("The “#{item_rep.inspect}” item rep does not have a snapshot “#{snapshot.inspect}”")
       end
-
     end
 
     # Error that is raised when a snapshot with an existing name is made.
     class CannotCreateMultipleSnapshotsWithSameName < Generic
-
       # @param [Nanoc::ItemRep] rep The item representation for which a
       #   snapshot was attempted to be made
       #
@@ -199,37 +170,28 @@ module Nanoc
       def initialize(rep, snapshot)
         super("Attempted to create a snapshot with a duplicate name #{snapshot.inspect} for the item rep “#{rep.inspect}”")
       end
-
     end
 
     # Error that is raised when the compiled content of a binary item is attempted to be accessed.
     class CannotGetCompiledContentOfBinaryItem < Generic
-
       # @param [Nanoc::ItemRep] rep The binary item representation whose compiled content was attempted to be accessed
       def initialize(rep)
         super("You cannot access the compiled content of a binary item representation (but you can access the path). The offending item rep is #{rep.inspect}.")
       end
-
     end
 
     # @deprecated No longer necessary, but kept for backwards compatibility.
     class DataNotYetAvailable < Generic
-
       def initialize(type, plural)
         super("#{type} #{plural ? 'are' : 'is'} not available yet. You may be missing a Nanoc::Site#load_data call.")
       end
-
     end
 
     # Error that is raised when multiple items or layouts with the same identifier exist.
     class DuplicateIdentifier < Generic
-
       def initialize(identifier, type)
         super("There are multiple #{type}s with the #{identifier} identifier.")
       end
-
     end
-
   end
-
 end

--- a/lib/nanoc/base/memoization.rb
+++ b/lib/nanoc/base/memoization.rb
@@ -1,12 +1,10 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Adds support for memoizing functions.
   #
   # @since 3.2.0
   module Memoization
-
     # Memoizes the method with the given name. The modified method will cache
     # the results of the original method, so that calling a method twice with
     # the same arguments will short-circuit and return the cached results
@@ -61,7 +59,5 @@ module Nanoc
         @__memoization_cache[method_name][args]
       end
     end
-
   end
-
 end

--- a/lib/nanoc/base/notification_center.rb
+++ b/lib/nanoc/base/notification_center.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Provides a way to send notifications between objects. It allows blocks
   # associated with a certain notification name to be registered; these blocks
   # will be called when the notification with the given name is posted.
@@ -10,9 +9,7 @@ module Nanoc
   # table of subscribers is not stored in the observable object itself, but in
   # the notification center.
   class NotificationCenter
-
     class << self
-
       # Adds the given block to the list of blocks that should be called when
       # the notification with the given name is received.
       #
@@ -76,9 +73,6 @@ module Nanoc
         @notifications ||= {}       # name => observers dictionary
         @notifications[name] ||= [] # list of observers
       end
-
     end
-
   end
-
 end

--- a/lib/nanoc/base/plugin_registry.rb
+++ b/lib/nanoc/base/plugin_registry.rb
@@ -1,19 +1,16 @@
 # encoding: utf-8
 
 module Nanoc
-
   # The class responsible for keeping track of all loaded plugins, such as
   # filters ({Nanoc::Filter}), data sources ({Nanoc::DataSource}) and VCSes
   # ({Nanoc::Extra::VCS}).
   class PluginRegistry
-
     extend Nanoc::Memoization
 
     # A module that contains class methods for plugins. It provides functions
     # for setting identifiers, registering plugins and finding plugins. Plugin
     # classes should extend this module.
     module PluginMethods
-
       # @overload identifiers(*identifiers)
       #
       #   Sets the identifiers for this plugin.
@@ -86,7 +83,6 @@ module Nanoc
       def named(name)
         Nanoc::Plugin.find(self, name)
       end
-
     end
 
     # Returns the shared {PluginRegistry} instance, creating it if none exists
@@ -218,10 +214,8 @@ module Nanoc
     def name_for_class(klass)
       klass.to_s.sub(/^(::)?/, '::')
     end
-
   end
 
   # @deprecated Use {Nanoc::PluginRegistry.instance} instead
   Plugin = PluginRegistry.instance
-
 end

--- a/lib/nanoc/base/result_data/item_rep.rb
+++ b/lib/nanoc/base/result_data/item_rep.rb
@@ -1,16 +1,13 @@
 # encoding: utf-8
 
 module Nanoc
-
   # A single representation (rep) of an item ({Nanoc::Item}). An item can
   # have multiple representations. A representation has its own output file.
   # A single item can therefore have multiple output files, each run through
   # a different set of filters with a different layout.
   class ItemRep
-
     # Contains all deprecated methods. Mixed into {Nanoc::ItemRep}.
     module Deprecated
-
       # @deprecated Modify the {#raw_paths} attribute instead
       def raw_path=(raw_path)
         raw_paths[:last] = raw_path
@@ -55,12 +52,10 @@ module Nanoc
       def written?
         raise NotImplementedError, 'Nanoc::ItemRep#written? is no longer implemented'
       end
-
     end
 
     # Contains all private methods. Mixed into {Nanoc::ItemRep}.
     module Private
-
       # @return [Hash] A hash containing the assigns that will be used in the
       #   next filter or layout operation. The keys (symbols) will be made
       #   available during the next operation.
@@ -175,7 +170,6 @@ module Nanoc
       def type
         :item_rep
       end
-
     end
 
     include Deprecated
@@ -482,7 +476,5 @@ module Nanoc
     def filter_named(name)
       Nanoc::Filter.named(name)
     end
-
   end
-
 end

--- a/lib/nanoc/base/source_data/code_snippet.rb
+++ b/lib/nanoc/base/source_data/code_snippet.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Nanoc::CodeSnippet represent a piece of custom code of a nanoc site.
   class CodeSnippet
-
     # A string containing the actual code in this code snippet.
     #
     # @return [String]
@@ -52,7 +50,5 @@ module Nanoc
     def checksum
       Nanoc::Checksummer.calc(self)
     end
-
   end
-
 end

--- a/lib/nanoc/base/source_data/configuration.rb
+++ b/lib/nanoc/base/source_data/configuration.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Represents the site configuration.
   class Configuration < ::Hash
-
     # Creates a new configuration with the given hash.
     #
     # @param [Hash] hash The actual configuration hash
@@ -18,7 +16,5 @@ module Nanoc
     def reference
       :config
     end
-
   end
-
 end

--- a/lib/nanoc/base/source_data/data_source.rb
+++ b/lib/nanoc/base/source_data/data_source.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Responsible for loading site data. It is the (abstract) superclass for all
   # data sources. Subclasses must at least implement the data reading methods
   # ({#items} and {#layouts}); all other methods involving data manipulation
@@ -26,7 +25,6 @@ module Nanoc
   #   {#create_item} and {#create_layout} methods should be implemented as
   #   well.
   class DataSource
-
     # @return [String] The root path where items returned by this data source
     #   should be mounted.
     attr_reader :items_root
@@ -241,6 +239,5 @@ module Nanoc
         "#{self.class} does not implement ##{name}"
       )
     end
-
   end
 end

--- a/lib/nanoc/base/source_data/item.rb
+++ b/lib/nanoc/base/source_data/item.rb
@@ -1,12 +1,10 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Represents a compileable item in a site. It has content and attributes, as
   # well as an identifier (which starts and ends with a slash). It can also
   # store the modification time to speed up compilation.
   class Item
-
     extend Nanoc::Memoization
 
     # @return [Hash] This item's attributes
@@ -172,7 +170,7 @@ module Nanoc
       Nanoc::NotificationCenter.post(:visit_ended,   self)
 
       # Get captured content (hax)
-      # TODO [in nanoc 4.0] remove me
+      # TODO: [in nanoc 4.0] remove me
       if key.to_s =~ /^content_for_(.*)$/
         @@_content_for_warning_issued ||= false
         @@_capturing_helper_included ||= false
@@ -295,7 +293,5 @@ module Nanoc
     def mtime
       self[:mtime]
     end
-
   end
-
 end

--- a/lib/nanoc/base/source_data/item_array.rb
+++ b/lib/nanoc/base/source_data/item_array.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Acts as an array, but allows fetching items using identifiers, e.g. `@items['/blah/']`.
   class ItemArray
-
     include Enumerable
 
     extend Forwardable
@@ -65,7 +63,5 @@ module Nanoc
       end
       @mapping.freeze
     end
-
   end
-
 end

--- a/lib/nanoc/base/source_data/layout.rb
+++ b/lib/nanoc/base/source_data/layout.rb
@@ -1,11 +1,9 @@
 # encoding: utf-8
 
 module Nanoc
-
   # Represents a layout in a nanoc site. It has content, attributes, an
   # identifier and a modification time (to speed up compilation).
   class Layout
-
     extend Nanoc::Memoization
 
     # @return [String] The raw content of this layout
@@ -122,7 +120,5 @@ module Nanoc
     def mtime
       self[:mtime]
     end
-
   end
-
 end

--- a/lib/nanoc/base/source_data/site.rb
+++ b/lib/nanoc/base/source_data/site.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc
-
   # The in-memory representation of a nanoc site. It holds references to the
   # following site data:
   #
@@ -17,7 +16,6 @@ module Nanoc
   # that contains a configuration file, site data, a rakefile, a rules file,
   # etc. The way site data is stored depends on the data source.
   class Site
-
     # The default configuration for a data source. A data source's
     # configuration overrides these options.
     DEFAULT_DATA_SOURCE_CONFIG = {
@@ -85,7 +83,7 @@ module Nanoc
           raise Nanoc::Errors::UnknownDataSource.new(data_source_hash[:type]) if data_source_class.nil?
 
           # Warn about deprecated data sources
-          # TODO [in nanoc 4.0] remove me
+          # TODO: [in nanoc 4.0] remove me
           case data_source_hash[:type]
           when 'filesystem'
             warn "Warning: the 'filesystem' data source has been renamed to 'filesystem_verbose'. Using 'filesystem' will work in nanoc 3.1.x, but it will likely not work anymore in a future release of nanoc. Please update your data source configuration and replace 'filesystem' with 'filesystem_verbose'."
@@ -251,7 +249,7 @@ module Nanoc
       ensure_identifier_uniqueness(@layouts, 'layout')
 
       # Load compiler too
-      # FIXME this should not be necessary
+      # FIXME: this should not be necessary
       compiler.load
 
       @loaded = true
@@ -301,7 +299,7 @@ module Nanoc
 
     # Executes the given block, making sure that the datasources are
     # available for the duration of the block
-    def with_datasources(&block)
+    def with_datasources(&_block)
       data_sources.each { |ds| ds.use }
       yield
     ensure
@@ -431,5 +429,4 @@ module Nanoc
       @config = Nanoc::Configuration.new(@config)
     end
   end
-
 end

--- a/lib/nanoc/base/store.rb
+++ b/lib/nanoc/base/store.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc
-
   # An abstract superclass for classes that need to store data to the
   # filesystem, such as checksums, cached compiled content and dependency
   # graphs.
@@ -15,7 +14,6 @@ module Nanoc
   #
   # @api private
   class Store
-
     # @return [String] The name of the file where data will be loaded from and
     #   stored to.
     attr_reader :filename
@@ -134,7 +132,5 @@ module Nanoc
     def pstore
       @pstore ||= PStore.new(filename)
     end
-
   end
-
 end

--- a/lib/nanoc/base/temp_filename_factory.rb
+++ b/lib/nanoc/base/temp_filename_factory.rb
@@ -3,9 +3,7 @@
 require 'tmpdir'
 
 module Nanoc
-
   class TempFilenameFactory
-
     # @return [String] The root directory for all temporary filenames
     attr_reader :root_dir
 
@@ -51,7 +49,5 @@ module Nanoc
         FileUtils.rm_rf(@root_dir)
       end
     end
-
   end
-
 end

--- a/lib/nanoc/cli.rb
+++ b/lib/nanoc/cli.rb
@@ -16,7 +16,6 @@ if Nanoc.on_windows?
 end
 
 module Nanoc::CLI
-
   module Commands
   end
 
@@ -28,7 +27,7 @@ module Nanoc::CLI
   autoload 'ErrorHandler',        'nanoc/cli/error_handler'
 
   # Deprecated; use CommandRunner instead
-  # TODO [in nanoc 4.0] remove me
+  # TODO: [in nanoc 4.0] remove me
   autoload 'Command',             'nanoc/cli/command_runner'
 
   # @return [Boolean] true if debug output is enabled, false if not
@@ -78,7 +77,7 @@ module Nanoc::CLI
   #
   # @return [void]
   def self.after_setup(&block)
-    # TODO decide what should happen if the CLI is already set up
+    # TODO: decide what should happen if the CLI is already set up
     add_after_setup_proc(block)
   end
 
@@ -224,5 +223,4 @@ module Nanoc::CLI
     @after_setup_procs ||= []
     @after_setup_procs << proc
   end
-
 end

--- a/lib/nanoc/cli/ansi_string_colorizer.rb
+++ b/lib/nanoc/cli/ansi_string_colorizer.rb
@@ -1,12 +1,10 @@
 # encoding: utf-8
 
 module Nanoc::CLI
-
   # A simple ANSI colorizer for strings. When given a string and a list of
   # attributes, it returns a colorized string.
   module ANSIStringColorizer
-
-    # TODO complete mapping
+    # TODO: complete mapping
     MAPPING = {
       :bold   => "\e[1m",
       :red    => "\e[31m",
@@ -24,7 +22,5 @@ module Nanoc::CLI
     def self.c(s, *as)
       as.map { |a| MAPPING[a] }.join('') + s + "\e[0m"
     end
-
   end
-
 end

--- a/lib/nanoc/cli/cleaning_stream.rb
+++ b/lib/nanoc/cli/cleaning_stream.rb
@@ -1,11 +1,9 @@
 # encoding: utf-8
 
 module Nanoc::CLI
-
   # An output stream that passes output through stream cleaners. This can be
   # used to strip ANSI color sequences, for instance.
   class CleaningStream
-
     # @param [IO, StringIO] stream The stream to wrap
     def initialize(stream)
       @stream = stream
@@ -122,14 +120,12 @@ module Nanoc::CLI
     protected
 
     def _nanoc_clean(s)
-      @stream_cleaners.reduce(s) { |m, c| c.clean(m) }
+      @stream_cleaners.reduce(s) { |a, e| e.clean(a) }
     end
 
     def _nanoc_swallow_broken_pipe_errors_while
       yield
     rescue Errno::EPIPE
     end
-
   end
-
 end

--- a/lib/nanoc/cli/command_runner.rb
+++ b/lib/nanoc/cli/command_runner.rb
@@ -1,11 +1,9 @@
 # encoding: utf-8
 
 module Nanoc::CLI
-
   # A command runner subclass for nanoc commands that adds nanoc-specific
   # convenience methods and error handling.
   class CommandRunner < ::Cri::CommandRunner
-
     # @see http://rubydoc.info/gems/cri/Cri/CommandRunner#call-instance_method
     #
     # @return [void]
@@ -104,10 +102,8 @@ module Nanoc::CLI
     def stack
       (site && site.compiler.stack) || []
     end
-
   end
 
   # @deprecated Use {Nanoc::CLI::CommandRunner} instead
   Command = CommandRunner
-
 end

--- a/lib/nanoc/cli/commands/autocompile.rb
+++ b/lib/nanoc/cli/commands/autocompile.rb
@@ -24,9 +24,7 @@ required :o, :host,    'specify the host to listen on (default: 0.0.0.0)'
 required :p, :port,    'specify the port to listen on (default: 3000)'
 
 module Nanoc::CLI::Commands
-
   class AutoCompile < ::Nanoc::CLI::CommandRunner
-
     def run
       warn 'WARNING: The `autocompile` command is deprecated. Please consider using `guard-nanoc` instead (see https://github.com/nanoc/guard-nanoc).'
 
@@ -65,9 +63,7 @@ module Nanoc::CLI::Commands
       puts "Running on http://#{options_for_rack[:Host]}:#{options_for_rack[:Port]}/"
       handler.run(app, options_for_rack)
     end
-
   end
-
 end
 
 runner Nanoc::CLI::Commands::AutoCompile

--- a/lib/nanoc/cli/commands/check.rb
+++ b/lib/nanoc/cli/commands/check.rb
@@ -11,9 +11,7 @@ flag :L, :list,   'list all checks'
 flag :d, :deploy, 'run checks for deployment'
 
 module Nanoc::CLI::Commands
-
   class Check < ::Nanoc::CLI::CommandRunner
-
     def run
       validate_options_and_arguments
       require_site
@@ -47,9 +45,7 @@ module Nanoc::CLI::Commands
           'nothing to do (pass either --all, --deploy or --list or a list of checks)'
       end
     end
-
   end
-
 end
 
 runner Nanoc::CLI::Commands::Check

--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -21,9 +21,7 @@ option :a, :all,   '(ignored)'
 option :f, :force, '(ignored)'
 
 module Nanoc::CLI::Commands
-
   class Compile < ::Nanoc::CLI::CommandRunner
-
     extend Nanoc::Memoization
 
     # Listens to compilation events and reacts to them. This abstract class
@@ -32,7 +30,6 @@ module Nanoc::CLI::Commands
     #
     # @abstract Subclasses must override {#start} and may override {#stop}.
     class Listener
-
       def initialize(_params = {})
       end
 
@@ -59,12 +56,10 @@ module Nanoc::CLI::Commands
       # @return [void]
       def stop
       end
-
     end
 
     # Generates diffs for every output file written
     class DiffGenerator < Listener
-
       # @see Listener#enable_for?
       def self.enable_for?(command_runner)
         command_runner.site.config[:enable_output_diff]
@@ -149,12 +144,10 @@ module Nanoc::CLI::Commands
              'content will be available.'
         nil
       end
-
     end
 
     # Records the time spent per filter and per item representation
     class TimingRecorder < Listener
-
       # @see Listener#enable_for?
       def self.enable_for?(command_runner)
         command_runner.options.fetch(:verbose, false)
@@ -215,7 +208,7 @@ module Nanoc::CLI::Commands
         # Calculate stats
         count = samples.size
         min   = samples.min
-        tot   = samples.reduce(0) { |memo, i| memo + i }
+        tot   = samples.reduce(0) { |a, e| a + e }
         avg   = tot / count
         max   = samples.max
 
@@ -253,12 +246,10 @@ module Nanoc::CLI::Commands
         end
         result
       end
-
     end
 
     # Controls garbage collection so that it only occurs once every 20 items
     class GCController < Listener
-
       # @see Listener#enable_for?
       def self.enable_for?(_command_runner)
         !ENV.key?('TRAVIS')
@@ -285,12 +276,10 @@ module Nanoc::CLI::Commands
         super
         GC.enable
       end
-
     end
 
     # Prints debug information (compilation started/ended, filtering started/ended, …)
     class DebugPrinter < Listener
-
       # @see Listener#enable_for?
       def self.enable_for?(command_runner)
         command_runner.debug?
@@ -327,12 +316,10 @@ module Nanoc::CLI::Commands
           puts "*** Dependency created from #{src.inspect} onto #{dst.inspect}"
         end
       end
-
     end
 
     # Prints file actions (created, updated, deleted, identical, skipped)
     class FileActionPrinter < Listener
-
       # @option params [Array<Nanoc::ItemRep>] :reps The list of item representations in the site
       def initialize(params = {})
         @start_times = {}
@@ -378,7 +365,6 @@ module Nanoc::CLI::Commands
       def log(level, action, path, duration)
         Nanoc::CLI::Logger.instance.file(level, action, path, duration)
       end
-
     end
 
     def initialize(options, arguments, command, params = {})
@@ -422,7 +408,8 @@ module Nanoc::CLI::Commands
     end
 
     def setup_listeners
-      @listeners = @listener_classes
+      @listeners =
+        @listener_classes
         .select { |klass| klass.enable_for?(self) }
         .map    { |klass| klass.new(:reps => reps) }
 
@@ -470,9 +457,7 @@ module Nanoc::CLI::Commands
     def prune_config_exclude
       prune_config[:exclude] || {}
     end
-
   end
-
 end
 
 runner Nanoc::CLI::Commands::Compile

--- a/lib/nanoc/cli/commands/create-item.rb
+++ b/lib/nanoc/cli/commands/create-item.rb
@@ -11,9 +11,7 @@ EOS
 required :c, :vcs, 'specify the VCS to use'
 
 module Nanoc::CLI::Commands
-
   class CreateItem < ::Nanoc::CLI::CommandRunner
-
     def run
       # Check arguments
       if arguments.length != 1
@@ -51,9 +49,7 @@ module Nanoc::CLI::Commands
 
       puts "An item has been created at #{identifier}."
     end
-
   end
-
 end
 
 runner Nanoc::CLI::Commands::CreateItem

--- a/lib/nanoc/cli/commands/create-layout.rb
+++ b/lib/nanoc/cli/commands/create-layout.rb
@@ -9,9 +9,7 @@ configuration will be used.
 EOS
 
 module Nanoc::CLI::Commands
-
   class CreateLayout < ::Nanoc::CLI::CommandRunner
-
     def run
       # Check arguments
       if arguments.length != 1
@@ -64,9 +62,7 @@ module Nanoc::CLI::Commands
 
       puts "A layout has been created at #{identifier}."
     end
-
   end
-
 end
 
 runner Nanoc::CLI::Commands::CreateLayout

--- a/lib/nanoc/cli/commands/create-site.rb
+++ b/lib/nanoc/cli/commands/create-site.rb
@@ -10,18 +10,14 @@ Create a new site at the given path. The site will use the `filesystem_unified` 
 required :d, :datasource, 'specify the data source for the new site'
 
 module Nanoc::CLI::Commands
-
   class CreateSite < ::Nanoc::CLI::CommandRunner
-
     class << self
-
       protected
 
       # Converts the given array to YAML format
       def array_to_yaml(array)
         '[ ' + array.map { |s| "'" + s + "'" }.join(', ') + ' ]'
       end
-
     end
 
     DEFAULT_CONFIG = <<EOS unless defined? DEFAULT_CONFIG
@@ -396,9 +392,7 @@ EOS
         io.write "\# before nanoc starts compiling.\n"
       end
     end
-
   end
-
 end
 
 runner Nanoc::CLI::Commands::CreateSite

--- a/lib/nanoc/cli/commands/deploy.rb
+++ b/lib/nanoc/cli/commands/deploy.rb
@@ -13,9 +13,7 @@ flag :D, :'list-deployers', 'list available deployers'
 option :n, :'dry-run',        'show what would be deployed'
 
 module Nanoc::CLI::Commands
-
   class Deploy < ::Nanoc::CLI::CommandRunner
-
     def run
       load_site
 
@@ -88,9 +86,7 @@ module Nanoc::CLI::Commands
         :dry_run => options[:'dry-run'])
       deployer.run
     end
-
   end
-
 end
 
 runner Nanoc::CLI::Commands::Deploy

--- a/lib/nanoc/cli/commands/prune.rb
+++ b/lib/nanoc/cli/commands/prune.rb
@@ -15,9 +15,7 @@ flag :y, :yes,       'confirm deletion'
 flag :n, :'dry-run', 'print files to be deleted instead of actually deleting them'
 
 module Nanoc::CLI::Commands
-
   class Prune < ::Nanoc::CLI::CommandRunner
-
     def run
       load_site
 
@@ -42,9 +40,7 @@ module Nanoc::CLI::Commands
     def prune_config_exclude
       prune_config[:exclude] || {}
     end
-
   end
-
 end
 
 runner Nanoc::CLI::Commands::Prune

--- a/lib/nanoc/cli/commands/shell.rb
+++ b/lib/nanoc/cli/commands/shell.rb
@@ -8,9 +8,7 @@ Open an IRB shell on a context that contains @items, @layouts, @config and @site
 "
 
 module Nanoc::CLI::Commands
-
   class Shell < ::Nanoc::CLI::CommandRunner
-
     def run
       require 'pry'
 
@@ -29,9 +27,7 @@ module Nanoc::CLI::Commands
         :config  => site.config
       }
     end
-
   end
-
 end
 
 runner Nanoc::CLI::Commands::Shell

--- a/lib/nanoc/cli/commands/show-data.rb
+++ b/lib/nanoc/cli/commands/show-data.rb
@@ -9,9 +9,7 @@ current site, along with dependency information.
 EOS
 
 module Nanoc::CLI::Commands
-
   class ShowData < ::Nanoc::CLI::CommandRunner
-
     def run
       load_site
 
@@ -89,7 +87,7 @@ module Nanoc::CLI::Commands
         end
         length = rep.raw_paths.keys.map { |s| s.to_s.length }.max
         rep.raw_paths.each do |snapshot_name, raw_path|
-          puts "  [ %-#{length}s ] %s" % [snapshot_name, raw_path]
+          puts format("  [ %-#{length}s ] %s", snapshot_name, raw_path)
         end
       end
     end
@@ -124,9 +122,7 @@ module Nanoc::CLI::Commands
         puts
       end
     end
-
   end
-
 end
 
 runner Nanoc::CLI::Commands::ShowData

--- a/lib/nanoc/cli/commands/show-plugins.rb
+++ b/lib/nanoc/cli/commands/show-plugins.rb
@@ -9,9 +9,7 @@ If the current directory contains a nanoc web site, the plugins defined in this 
 EOS
 
 module Nanoc::CLI::Commands
-
   class ShowPlugins < ::Nanoc::CLI::CommandRunner
-
     def run
       # Check arguments
       if arguments.size != 0
@@ -59,7 +57,7 @@ module Nanoc::CLI::Commands
           # Print plugins
           relevant_plugins.sort_by { |k| k[:identifiers].join(', ') }.each do |plugin|
             # Display
-            puts sprintf(
+            puts format(
               "    %-#{max_identifiers_length}s (%s)",
               plugin[:identifiers].join(', '),
               plugin[:class].to_s.sub(/^::/, '')
@@ -90,9 +88,7 @@ module Nanoc::CLI::Commands
     def name_for_plugin_class(klass)
       PLUGIN_CLASSES[klass]
     end
-
   end
-
 end
 
 runner Nanoc::CLI::Commands::ShowPlugins

--- a/lib/nanoc/cli/commands/show-rules.rb
+++ b/lib/nanoc/cli/commands/show-rules.rb
@@ -8,18 +8,16 @@ Prints the rules used for all items and layouts in the current site.
 "
 
 module Nanoc::CLI::Commands
-
   class ShowRules < ::Nanoc::CLI::CommandRunner
-
     def run
       require_site
 
       @c    = Nanoc::CLI::ANSIStringColorizer
       @calc = site.compiler.rule_memory_calculator
 
-      # TODO explain /foo/
-      # TODO explain content/foo.html
-      # TODO explain output/foo/index.html
+      # TODO: explain /foo/
+      # TODO: explain content/foo.html
+      # TODO: explain output/foo/index.html
 
       site.items.each   { |i| explain_item(i)   }
       site.layouts.each { |l| explain_layout(l) }
@@ -36,16 +34,16 @@ module Nanoc::CLI::Commands
           puts '    (nothing)'
         else
           @calc[rep].each do |mem|
-            puts '    %s %s' % [
+            puts format('    %s %s',
               @c.c(format('%-10s', mem[0].to_s), :blue),
               mem[1..-1].map { |m| m.inspect }.join(', ')
-            ]
+            )
           end
           if rep.raw_path
-            puts '    %s %s' % [
+            puts format('    %s %s',
               @c.c(format('%-10s', 'write to'), :blue),
               rep.raw_path
-            ]
+            )
           end
         end
       end
@@ -55,15 +53,13 @@ module Nanoc::CLI::Commands
     def explain_layout(layout)
       puts "#{@c.c('Layout ' + layout.identifier, :bold, :yellow)}:"
       puts "  (from #{layout[:filename]})" if layout[:filename]
-      puts '  %s %s' % [
+      puts format('  %s %s',
         @c.c(format('%-10s', 'filter'), :blue),
         @calc[layout].map { |m| m.inspect }.join(', ')
-      ]
+      )
       puts
     end
-
   end
-
 end
 
 runner Nanoc::CLI::Commands::ShowRules

--- a/lib/nanoc/cli/commands/sync.rb
+++ b/lib/nanoc/cli/commands/sync.rb
@@ -8,9 +8,7 @@ for data sources which rely on slow external APIs.
 EOS
 
 module Nanoc::CLI::Commands
-
   class Sync < ::Nanoc::CLI::CommandRunner
-
     def run
       # Check arguments
       if arguments.size != 0
@@ -28,9 +26,7 @@ module Nanoc::CLI::Commands
         end
       end
     end
-
   end
-
 end
 
 runner Nanoc::CLI::Commands::Sync

--- a/lib/nanoc/cli/commands/update.rb
+++ b/lib/nanoc/cli/commands/update.rb
@@ -16,9 +16,7 @@ required :c, :vcs, 'select the VCS to use'
 flag :y, :yes, 'update the data without warning'
 
 module Nanoc::CLI::Commands
-
   class Update < ::Nanoc::CLI::CommandRunner
-
     def run
       # Check arguments
       if arguments.size != 0
@@ -61,9 +59,7 @@ module Nanoc::CLI::Commands
         data_source.update
       end
     end
-
   end
-
 end
 
 runner Nanoc::CLI::Commands::Update

--- a/lib/nanoc/cli/commands/validate-css.rb
+++ b/lib/nanoc/cli/commands/validate-css.rb
@@ -9,16 +9,12 @@ Validates the site’s CSS files.
 "
 
 module Nanoc::CLI::Commands
-
   class ValidateCSS < ::Nanoc::CLI::CommandRunner
-
     def run
       warn 'The `validate-css` command is deprecated. Please use the new `check` command instead.'
       Nanoc::CLI.run %w( check css )
     end
-
   end
-
 end
 
 runner Nanoc::CLI::Commands::ValidateCSS

--- a/lib/nanoc/cli/commands/validate-html.rb
+++ b/lib/nanoc/cli/commands/validate-html.rb
@@ -9,16 +9,12 @@ Validates the site’s HTML files.
 "
 
 module Nanoc::CLI::Commands
-
   class ValidateHTML < ::Nanoc::CLI::CommandRunner
-
     def run
       warn 'The `validate-html` command is deprecated. Please use the new `check` command instead.'
       Nanoc::CLI.run %w( check html )
     end
-
   end
-
 end
 
 runner Nanoc::CLI::Commands::ValidateHTML

--- a/lib/nanoc/cli/commands/validate-links.rb
+++ b/lib/nanoc/cli/commands/validate-links.rb
@@ -12,9 +12,7 @@ flag :i, :internal, 'validate internal links only'
 flag :e, :external, 'validate external links only'
 
 module Nanoc::CLI::Commands
-
   class ValidateLinks < ::Nanoc::CLI::CommandRunner
-
     def run
       warn 'The `validate-links` command is deprecated. Please use the new `check` command instead.'
 
@@ -23,9 +21,7 @@ module Nanoc::CLI::Commands
       checks << 'elinks' if options[:external]
       Nanoc::CLI.run ['check', checks].flatten
     end
-
   end
-
 end
 
 runner Nanoc::CLI::Commands::ValidateLinks

--- a/lib/nanoc/cli/commands/view.rb
+++ b/lib/nanoc/cli/commands/view.rb
@@ -13,9 +13,7 @@ required :o, :host,    'specify the host to listen on (default: 0.0.0.0)'
 required :p, :port,    'specify the port to listen on (default: 3000)'
 
 module Nanoc::CLI::Commands
-
   class View < ::Nanoc::CLI::CommandRunner
-
     DEFAULT_HANDLER_NAME = :thin
 
     def run
@@ -80,9 +78,7 @@ module Nanoc::CLI::Commands
       # Done
       exit 1
     end
-
   end
-
 end
 
 runner Nanoc::CLI::Commands::View

--- a/lib/nanoc/cli/commands/watch.rb
+++ b/lib/nanoc/cli/commands/watch.rb
@@ -8,9 +8,7 @@ Start the watcher. When a change is detected, the site will be recompiled.
 EOS
 
 module Nanoc::CLI::Commands
-
   class Watch < ::Nanoc::CLI::CommandRunner
-
     def run
       warn 'WARNING: The `watch` command is deprecated. Please consider using `guard-nanoc` instead (see https://github.com/nanoc/guard-nanoc).'
 
@@ -44,7 +42,7 @@ module Nanoc::CLI::Commands
         begin
           site.compile
 
-          # TODO include icon (--image misc/success-icon.png)
+          # TODO: include icon (--image misc/success-icon.png)
           notify_on_compilation_success = watcher_config.fetch(:notify_on_compilation_success) { true }
           if notify_on_compilation_success
             @notifier.notify('Compilation complete')
@@ -53,7 +51,7 @@ module Nanoc::CLI::Commands
           time_spent = ((Time.now - start) * 1000.0).round
           puts "done in #{format '%is %ims', *(time_spent.divmod(1000))}"
         rescue Exception => e
-          # TODO include icon (--image misc/error-icon.png)
+          # TODO: include icon (--image misc/error-icon.png)
           notify_on_compilation_failure = watcher_config.fetch(:notify_on_compilation_failure) { true }
           if notify_on_compilation_failure
             @notifier.notify('Compilation failed')
@@ -97,7 +95,6 @@ module Nanoc::CLI::Commands
 
     # Allows sending user notifications in a cross-platform way.
     class Notifier
-
       # A list of commandline tool names that can be used to send notifications
       TOOLS = %w( growlnotify notify-send ) unless defined? TOOLS
 
@@ -172,11 +169,8 @@ module Nanoc::CLI::Commands
       def on_windows?
         Nanoc.on_windows?
       end
-
     end
-
   end
-
 end
 
 runner Nanoc::CLI::Commands::Watch

--- a/lib/nanoc/cli/error_handler.rb
+++ b/lib/nanoc/cli/error_handler.rb
@@ -1,12 +1,10 @@
 # encoding: utf-8
 
 module Nanoc::CLI
-
   # Catches errors and prints nice diagnostic messages, then exits.
   #
   # @api private
   class ErrorHandler
-
     # @option params [Nanoc::CLI::Command, nil] command The command that is
     #   currently being executed, or nil if there is none
     def initialize(params = {})
@@ -356,7 +354,5 @@ module Nanoc::CLI
         stream.puts "  #{index}. #{i}"
       end
     end
-
   end
-
 end

--- a/lib/nanoc/cli/logger.rb
+++ b/lib/nanoc/cli/logger.rb
@@ -3,11 +3,9 @@
 require 'singleton'
 
 module Nanoc::CLI
-
   # Nanoc::CLI::Logger is a singleton class responsible for generating
   # feedback in the terminal.
   class Logger
-
     # Maps actions (`:create`, `:update`, `:identical`, `:skip` and `:delete`)
     # onto their ANSI color codes.
     ACTION_COLORS = {
@@ -43,13 +41,13 @@ module Nanoc::CLI
     def file(level, action, name, duration = nil)
       log(
         level,
-        '%s%12s%s  %s%s' % [
+        format('%s%12s%s  %s%s',
           ACTION_COLORS[action.to_sym],
           action,
           "\e[0m",
-          duration.nil? ? '' : '[%2.2fs]  ' % [duration],
+          duration.nil? ? '' : format('[%2.2fs]  ', duration),
           name
-        ]
+        )
       )
     end
 
@@ -69,7 +67,5 @@ module Nanoc::CLI
       # Log when level permits it
       io.puts(message) if @level == :low || @level == level
     end
-
   end
-
 end

--- a/lib/nanoc/cli/stream_cleaners.rb
+++ b/lib/nanoc/cli/stream_cleaners.rb
@@ -1,13 +1,9 @@
 # encoding: utf-8
 
 module Nanoc::CLI
-
   module StreamCleaners
-
     autoload 'Abstract',   'nanoc/cli/stream_cleaners/abstract'
     autoload 'ANSIColors', 'nanoc/cli/stream_cleaners/ansi_colors'
     autoload 'UTF8',       'nanoc/cli/stream_cleaners/utf8'
-
   end
-
 end

--- a/lib/nanoc/cli/stream_cleaners/abstract.rb
+++ b/lib/nanoc/cli/stream_cleaners/abstract.rb
@@ -1,14 +1,12 @@
 # encoding: utf-8
 
 module Nanoc::CLI::StreamCleaners
-
   # Superclass for all stream cleaners. Stream cleaners have a single method,
   # {#clean}, that takes a string and returns a cleaned string. Stream cleaners
   # can have state, so they can act as a FSM.
   #
   # @abstract Subclasses must implement {#clean}
   class Abstract
-
     # Returns a cleaned version of the given string.
     #
     # @param [String] s The string to clean
@@ -17,7 +15,5 @@ module Nanoc::CLI::StreamCleaners
     def clean(_s)
       raise NotImplementedError, 'Subclasses of Nanoc::CLI::StreamCleaners::Abstract must implement #clean'
     end
-
   end
-
 end

--- a/lib/nanoc/cli/stream_cleaners/ansi_colors.rb
+++ b/lib/nanoc/cli/stream_cleaners/ansi_colors.rb
@@ -1,15 +1,11 @@
 # encoding: utf-8
 
 module Nanoc::CLI::StreamCleaners
-
   # Removes ANSI color escape sequences.
   class ANSIColors < Abstract
-
     # @see Nanoc::CLI::StreamCleaners::Abstract#clean
     def clean(s)
       s.gsub(/\e\[.+?m/, '')
     end
-
   end
-
 end

--- a/lib/nanoc/cli/stream_cleaners/utf8.rb
+++ b/lib/nanoc/cli/stream_cleaners/utf8.rb
@@ -1,16 +1,12 @@
 # encoding: utf-8
 
 module Nanoc::CLI::StreamCleaners
-
   # Simplifies output by replacing UTF-8 characters with their ASCII decompositions.
   class UTF8 < Abstract
-
     # @see Nanoc::CLI::StreamCleaners::Abstract#clean
     def clean(s)
-      # FIXME this decomposition is not generally usable
+      # FIXME: this decomposition is not generally usable
       s.gsub(/“|”/, '"').gsub(/‘|’/, '\'').gsub('…', '...').gsub('©', '(c)')
     end
-
   end
-
 end

--- a/lib/nanoc/data_sources.rb
+++ b/lib/nanoc/data_sources.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc::DataSources
-
   autoload 'Filesystem',         'nanoc/data_sources/filesystem'
   autoload 'FilesystemUnified',  'nanoc/data_sources/filesystem_unified'
   autoload 'FilesystemVerbose',  'nanoc/data_sources/filesystem_verbose'
@@ -12,7 +11,7 @@ module Nanoc::DataSources
   Nanoc::DataSource.register '::Nanoc::DataSources::Static',             :static
 
   # Deprecated; fetch data from online data sources manually instead
-  # TODO [in nanoc 4.0] remove me
+  # TODO: [in nanoc 4.0] remove me
   autoload 'Delicious', 'nanoc/data_sources/deprecated/delicious'
   autoload 'LastFM',    'nanoc/data_sources/deprecated/last_fm'
   autoload 'Twitter',   'nanoc/data_sources/deprecated/twitter'
@@ -21,11 +20,10 @@ module Nanoc::DataSources
   Nanoc::DataSource.register '::Nanoc::DataSources::Twitter',            :twitter
 
   # Deprecated; use `filesystem_verbose` or `filesystem_unified` instead
-  # TODO [in nanoc 4.0] remove me
+  # TODO: [in nanoc 4.0] remove me
   Nanoc::DataSource.register '::Nanoc::DataSources::FilesystemVerbose',  :filesystem
   Nanoc::DataSource.register '::Nanoc::DataSources::FilesystemUnified',  :filesystem_combined
   Nanoc::DataSource.register '::Nanoc::DataSources::FilesystemUnified',  :filesystem_compact
   FilesystemCombined = FilesystemUnified
   FilesystemCompact  = FilesystemUnified
-
 end

--- a/lib/nanoc/data_sources/deprecated/delicious.rb
+++ b/lib/nanoc/data_sources/deprecated/delicious.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::DataSources
-
   # @deprecated Fetch data from online data sources manually instead
   class Delicious < Nanoc::DataSource
-
     def items
       @items ||= begin
         require 'json'
@@ -36,7 +34,5 @@ module Nanoc::DataSources
         end
       end
     end
-
   end
-
 end

--- a/lib/nanoc/data_sources/deprecated/last_fm.rb
+++ b/lib/nanoc/data_sources/deprecated/last_fm.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::DataSources
-
   # @deprecated Fetch data from online data sources manually instead
   class LastFM < Nanoc::DataSource
-
     def items
       @items ||= begin
         require 'json'
@@ -83,7 +81,5 @@ module Nanoc::DataSources
         end
       end
     end
-
   end
-
 end

--- a/lib/nanoc/data_sources/deprecated/twitter.rb
+++ b/lib/nanoc/data_sources/deprecated/twitter.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::DataSources
-
   # @deprecated Fetch data from online data sources manually instead
   class Twitter < Nanoc::DataSource
-
     def items
       @item ||= begin
         require 'json'
@@ -32,7 +30,5 @@ module Nanoc::DataSources
         end
       end
     end
-
   end
-
 end

--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::DataSources
-
   # Provides functionality common across all filesystem data sources.
   module Filesystem
-
     # The VCS that will be called when adding, deleting and moving files. If
     # no VCS has been set, or if the VCS has been set to `nil`, a dummy VCS
     # will be returned.
@@ -107,7 +105,7 @@ module Nanoc::DataSources
           :extension        => content_filename ? ext_of(content_filename)[1..-1] : nil,
           # WARNING :file is deprecated; please create a File object manually
           # using the :content_filename or :meta_filename attributes.
-          # TODO [in nanoc 4.0] remove me
+          # TODO: [in nanoc 4.0] remove me
           :file             => content_filename ? Nanoc::Extra::FileProxy.new(content_filename) : nil
         }.merge(meta)
 
@@ -153,7 +151,8 @@ module Nanoc::DataSources
     #     'content/qux' => [ nil,    'html' ]
     #   }
     def all_split_files_in(dir_name)
-      grouped_filenames = all_files_in(dir_name)
+      grouped_filenames =
+        all_files_in(dir_name)
         .reject   { |fn| fn =~ /(~|\.orig|\.rej|\.bak)$/ }
         .group_by { |fn| basename_of(fn) }
 
@@ -318,7 +317,5 @@ module Nanoc::DataSources
     def raise_encoding_error(filename, encoding)
       raise RuntimeError.new("Could not read #{filename} because the file is not valid #{encoding}.")
     end
-
   end
-
 end

--- a/lib/nanoc/data_sources/filesystem_unified.rb
+++ b/lib/nanoc/data_sources/filesystem_unified.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc::DataSources
-
   # The filesystem_unified data source stores its items and layouts in nested
   # directories. Items and layouts are represented by one or two files; if it
   # is represented using one file, the metadata can be contained in this file.
@@ -68,7 +67,6 @@ module Nanoc::DataSources
   # understood by Ruby’s `Encoding`. If no encoding is set in the configuration,
   # one will be inferred from the environment.
   class FilesystemUnified < Nanoc::DataSource
-
     include Nanoc::DataSources::Filesystem
 
     private
@@ -121,7 +119,5 @@ module Nanoc::DataSources
       end
       filename.sub(regex, '').cleaned_identifier
     end
-
   end
-
 end

--- a/lib/nanoc/data_sources/filesystem_verbose.rb
+++ b/lib/nanoc/data_sources/filesystem_verbose.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc::DataSources
-
   # The filesystem_verbose data source is the old data source for a new nanoc
   # site. It stores all data as files on the hard disk.
   #
@@ -40,7 +39,6 @@ module Nanoc::DataSources
   # understood by Ruby’s `Encoding`. If no encoding is set in the configuration,
   # one will be inferred from the environment.
   class FilesystemVerbose < Nanoc::DataSource
-
     include Nanoc::DataSources::Filesystem
 
     private
@@ -84,7 +82,5 @@ module Nanoc::DataSources
     def identifier_for_filename(filename)
       filename.sub(/[^\/]+\.yaml$/, '')
     end
-
   end
-
 end

--- a/lib/nanoc/data_sources/static.rb
+++ b/lib/nanoc/data_sources/static.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc::DataSources
-
   # The static data source provides items from a single directory. Unlike the
   # filesystem data sources, static provides no additional item metadata. In
   # addition, all items are treated as 'binary', regardless of their extension
@@ -26,7 +25,6 @@ module Nanoc::DataSources
   # exclude them from the Blogging helper's atom feed generator, among other
   # things.
   class Static < Nanoc::DataSource
-
     identifier :static
 
     def items
@@ -58,7 +56,5 @@ module Nanoc::DataSources
     def all_files_in(dir_name)
       Nanoc::Extra::FilesystemTools.all_files_in(dir_name)
     end
-
   end
-
 end

--- a/lib/nanoc/extra.rb
+++ b/lib/nanoc/extra.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc::Extra
-
   autoload 'AutoCompiler',        'nanoc/extra/auto_compiler'
   autoload 'Checking',            'nanoc/extra/checking'
   autoload 'CHiCk',               'nanoc/extra/chick'
@@ -13,13 +12,12 @@ module Nanoc::Extra
   autoload 'JRubyNokogiriWarner', 'nanoc/extra/jruby_nokogiri_warner'
 
   # Deprecated; use {Nanoc::Context} instead
-  # TODO [in nanoc 4.0] remove me
+  # TODO: [in nanoc 4.0] remove me
   Context = ::Nanoc::Context
 
   # Deprecated
-  # TODO [in nanoc 4.0] remove me
+  # TODO: [in nanoc 4.0] remove me
   autoload 'FileProxy',         'nanoc/extra/file_proxy'
-
 end
 
 require 'nanoc/extra/core_ext'

--- a/lib/nanoc/extra/auto_compiler.rb
+++ b/lib/nanoc/extra/auto_compiler.rb
@@ -1,11 +1,9 @@
 # encoding: utf-8
 
 module Nanoc::Extra
-
   # A web server that will automatically compile items as they are requested.
   # It also serves static files such as stylesheets and images.
   class AutoCompiler
-
     # @return [Nanoc::Site] The site this autocompiler belongs to
     attr_reader :site
 
@@ -41,7 +39,7 @@ module Nanoc::Extra
         reps = site.items.map { |i| i.reps }.flatten
         rep = reps.find do |r|
           r.path == path ||
-            r.raw_path == site.config[:output_dir] + path
+          r.raw_path == site.config[:output_dir] + path
         end
 
         # Recompile
@@ -97,7 +95,5 @@ module Nanoc::Extra
     def stack
       site.compiler.stack
     end
-
   end
-
 end

--- a/lib/nanoc/extra/checking.rb
+++ b/lib/nanoc/extra/checking.rb
@@ -1,16 +1,12 @@
 # encoding: utf-8
 
 module Nanoc::Extra
-
   module Checking
-
     autoload 'Check',  'nanoc/extra/checking/check'
     autoload 'DSL',    'nanoc/extra/checking/dsl'
     autoload 'Runner', 'nanoc/extra/checking/runner.rb'
     autoload 'Issue',  'nanoc/extra/checking/issue'
-
   end
-
 end
 
 require 'nanoc/extra/checking/checks'

--- a/lib/nanoc/extra/checking/check.rb
+++ b/lib/nanoc/extra/checking/check.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc::Extra::Checking
-
   class OutputDirNotFoundError < Nanoc::Errors::Generic
     def initialize(directory_path)
       super("Unable to run check against output directory at “#{directory_path}”: directory does not exist.")
@@ -9,7 +8,6 @@ module Nanoc::Extra::Checking
   end
 
   class Check
-
     extend Nanoc::PluginRegistry::PluginMethods
 
     attr_reader :site
@@ -37,7 +35,5 @@ module Nanoc::Extra::Checking
       end
       Dir[output_dir + '/**/*'].select { |f| File.file?(f) }
     end
-
   end
-
 end

--- a/lib/nanoc/extra/checking/checks.rb
+++ b/lib/nanoc/extra/checking/checks.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc::Extra::Checking::Checks
-
   autoload 'CSS',           'nanoc/extra/checking/checks/css'
   autoload 'ExternalLinks', 'nanoc/extra/checking/checks/external_links'
   autoload 'HTML',          'nanoc/extra/checking/checks/html'
@@ -15,5 +14,4 @@ module Nanoc::Extra::Checking::Checks
   Nanoc::Extra::Checking::Check.register '::Nanoc::Extra::Checking::Checks::InternalLinks', :internal_links
   Nanoc::Extra::Checking::Check.register '::Nanoc::Extra::Checking::Checks::InternalLinks', :ilinks
   Nanoc::Extra::Checking::Check.register '::Nanoc::Extra::Checking::Checks::Stale',         :stale
-
 end

--- a/lib/nanoc/extra/checking/checks/css.rb
+++ b/lib/nanoc/extra/checking/checks/css.rb
@@ -1,9 +1,7 @@
 # encoding: utf-8
 
 module ::Nanoc::Extra::Checking::Checks
-
   class CSS < ::Nanoc::Extra::Checking::Check
-
     identifier :css
 
     def run
@@ -17,7 +15,5 @@ module ::Nanoc::Extra::Checking::Checks
         end
       end
     end
-
   end
-
 end

--- a/lib/nanoc/extra/checking/checks/external_links.rb
+++ b/lib/nanoc/extra/checking/checks/external_links.rb
@@ -7,15 +7,13 @@ require 'timeout'
 require 'uri'
 
 module ::Nanoc::Extra::Checking::Checks
-
   # A validator that verifies that all external links point to a location that exists.
   class ExternalLinks < ::Nanoc::Extra::Checking::Check
-
     identifiers :external_links, :elinks
 
     def run
       # Find all broken external hrefs
-      # TODO de-duplicate this (duplicated in internal links check)
+      # TODO: de-duplicate this (duplicated in internal links check)
       filenames = output_filenames.select { |f| File.extname(f) == '.html' }
       hrefs_with_filenames = ::Nanoc::Extra::LinkCollector.new(filenames, :external).filenames_per_href
       results = select_invalid(hrefs_with_filenames.keys)
@@ -32,7 +30,6 @@ module ::Nanoc::Extra::Checking::Checks
     end
 
     class Result
-
       attr_reader :href
       attr_reader :explanation
 
@@ -40,11 +37,9 @@ module ::Nanoc::Extra::Checking::Checks
         @href        = href
         @explanation = explanation
       end
-
     end
 
     class ArrayEnumerator
-
       def initialize(array)
         @array = array
         @index = 0
@@ -57,7 +52,6 @@ module ::Nanoc::Extra::Checking::Checks
           return @array[@index - 1]
         end
       end
-
     end
 
     def select_invalid(hrefs)
@@ -167,7 +161,5 @@ module ::Nanoc::Extra::Checking::Checks
       end
       http.request(req)
     end
-
   end
-
 end

--- a/lib/nanoc/extra/checking/checks/html.rb
+++ b/lib/nanoc/extra/checking/checks/html.rb
@@ -1,9 +1,7 @@
 # encoding: utf-8
 
 module ::Nanoc::Extra::Checking::Checks
-
   class HTML < ::Nanoc::Extra::Checking::Check
-
     identifier :html
 
     def run
@@ -17,7 +15,5 @@ module ::Nanoc::Extra::Checking::Checks
         end
       end
     end
-
   end
-
 end

--- a/lib/nanoc/extra/checking/checks/internal_links.rb
+++ b/lib/nanoc/extra/checking/checks/internal_links.rb
@@ -3,10 +3,8 @@
 require 'uri'
 
 module Nanoc::Extra::Checking::Checks
-
   # A check that verifies that all internal links point to a location that exists.
   class InternalLinks < ::Nanoc::Extra::Checking::Check
-
     # Starts the validator. The results will be printed to stdout.
     #
     # Internal links that match a regexp pattern in `@config[:checks][:internal_links][:exclude]` will
@@ -14,7 +12,7 @@ module Nanoc::Extra::Checking::Checks
     #
     # @return [void]
     def run
-      # TODO de-duplicate this (duplicated in external links check)
+      # TODO: de-duplicate this (duplicated in external links check)
       filenames = output_filenames.select { |f| File.extname(f) == '.html' }
       hrefs_with_filenames = ::Nanoc::Extra::LinkCollector.new(filenames, :internal).filenames_per_href
       hrefs_with_filenames.each_pair do |href, fns|
@@ -32,7 +30,7 @@ module Nanoc::Extra::Checking::Checks
 
     def valid?(href, origin)
       # Skip hrefs that point to self
-      # FIXME this is ugly and won’t always be correct
+      # FIXME: this is ugly and won’t always be correct
       return true if href == '.'
 
       # Skip hrefs that are specified in the exclude configuration
@@ -70,7 +68,5 @@ module Nanoc::Extra::Checking::Checks
       excludes =  @site.config.fetch(:checks, {}).fetch(:internal_links, {}).fetch(:exclude, [])
       excludes.any? { |pattern| Regexp.new(pattern).match(href) }
     end
-
   end
-
 end

--- a/lib/nanoc/extra/checking/checks/stale.rb
+++ b/lib/nanoc/extra/checking/checks/stale.rb
@@ -1,9 +1,7 @@
 # encoding: utf-8
 
 module Nanoc::Extra::Checking::Checks
-
   class Stale < ::Nanoc::Extra::Checking::Check
-
     def run
       require 'set'
 
@@ -25,7 +23,5 @@ module Nanoc::Extra::Checking::Checks
       exclude_config = @site.config.fetch(:prune, {}).fetch(:exclude, [])
       @pruner ||= Nanoc::Extra::Pruner.new(@site, :exclude => exclude_config)
     end
-
   end
-
 end

--- a/lib/nanoc/extra/checking/dsl.rb
+++ b/lib/nanoc/extra/checking/dsl.rb
@@ -1,9 +1,7 @@
 # encoding: utf-8
 
 module Nanoc::Extra::Checking
-
   class DSL
-
     attr_reader :deploy_checks
 
     def self.from_file(filename)
@@ -25,7 +23,5 @@ module Nanoc::Extra::Checking
     def deploy_check(*identifiers)
       identifiers.each { |i| @deploy_checks << i }
     end
-
   end
-
 end

--- a/lib/nanoc/extra/checking/issue.rb
+++ b/lib/nanoc/extra/checking/issue.rb
@@ -1,9 +1,7 @@
 # encoding: utf-8
 
 module Nanoc::Extra::Checking
-
   class Issue
-
     attr_reader :description
     attr_reader :subject
     attr_reader :check_class
@@ -13,7 +11,5 @@ module Nanoc::Extra::Checking
       @subject       = subject
       @check_class = check_class
     end
-
   end
-
 end

--- a/lib/nanoc/extra/checking/runner.rb
+++ b/lib/nanoc/extra/checking/runner.rb
@@ -1,12 +1,10 @@
 # encoding: utf-8
 
 module Nanoc::Extra::Checking
-
   # Runner is reponsible for running issue checks.
   #
   # @api private
   class Runner
-
     CHECKS_FILENAMES = ['Checks', 'Checks.rb', 'checks', 'checks.rb']
 
     # @param [Nanoc::Site] site The nanoc site this runner is for
@@ -124,7 +122,7 @@ module Nanoc::Extra::Checking
         checks << check
         issues.merge(check.issues)
 
-        # TODO report progress
+        # TODO: report progress
 
         puts check.issues.empty? ? 'ok'.green : 'error'.red
       end
@@ -148,5 +146,4 @@ module Nanoc::Extra::Checking
       end
     end
   end
-
 end

--- a/lib/nanoc/extra/chick.rb
+++ b/lib/nanoc/extra/chick.rb
@@ -5,17 +5,14 @@ require 'rack'
 require 'rack/cache'
 
 module Nanoc::Extra
-
   # @deprecated Use a HTTP library such as
   #   [Net::HTTP](http://ruby-doc.org/stdlib/libdoc/net/http/rdoc/) or
   #   [Curb](https://github.com/taf2/curb) instead.
   module CHiCk
-
     # @deprecated Use a HTTP library such as
     #   [Net::HTTP](http://ruby-doc.org/stdlib/libdoc/net/http/rdoc/) or
     #   [Curb](https://github.com/taf2/curb) instead.
     class Client
-
       DEFAULT_OPTIONS = {
         :cache => {
           :metastore   => 'file:tmp/rack/cache.meta',
@@ -57,14 +54,12 @@ module Nanoc::Extra
         # Done
         [status, headers, body]
       end
-
     end
 
     # @deprecated Use a HTTP library such as
     #   [Net::HTTP](http://ruby-doc.org/stdlib/libdoc/net/http/rdoc/) or
     #   [Curb](https://github.com/taf2/curb) instead.
     class CacheController
-
       def initialize(app, options = {})
         @app = app
         @options = options
@@ -77,14 +72,12 @@ module Nanoc::Extra
         end
         res
       end
-
     end
 
     # @deprecated Use a HTTP library such as
     #   [Net::HTTP](http://ruby-doc.org/stdlib/libdoc/net/http/rdoc/) or
     #   [Curb](https://github.com/taf2/curb) instead.
     class RackClient
-
       METHOD_TO_CLASS_MAPPING = {
         'DELETE'  => Net::HTTP::Delete,
         'GET'     => Net::HTTP::Get,
@@ -119,9 +112,6 @@ module Nanoc::Extra
           ]
         end
       end
-
     end
-
   end
-
 end

--- a/lib/nanoc/extra/core_ext/enumerable.rb
+++ b/lib/nanoc/extra/core_ext/enumerable.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Enumerable
-
   unless Enumerable.instance_methods.include?('group_by')
 
     # Returns a hash, which keys are evaluated result from the block, and
@@ -29,5 +28,4 @@ module Enumerable
     end
 
   end
-
 end

--- a/lib/nanoc/extra/core_ext/pathname.rb
+++ b/lib/nanoc/extra/core_ext/pathname.rb
@@ -1,9 +1,7 @@
 # encoding: utf-8
 
 module Nanoc::Extra
-
   module PathnameExtensions
-
     def components
       components = []
       tmp = self
@@ -19,9 +17,7 @@ module Nanoc::Extra
     def include_component?(component)
       components.include?(component)
     end
-
   end
-
 end
 
 class ::Pathname

--- a/lib/nanoc/extra/core_ext/time.rb
+++ b/lib/nanoc/extra/core_ext/time.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc::Extra::TimeExtensions
-
   # @return [String] The time in an ISO-8601 date format.
   def to_iso8601_date
     strftime('%Y-%m-%d')
@@ -11,7 +10,6 @@ module Nanoc::Extra::TimeExtensions
   def to_iso8601_time
     getutc.strftime('%Y-%m-%dT%H:%M:%SZ')
   end
-
 end
 
 class Time

--- a/lib/nanoc/extra/deployer.rb
+++ b/lib/nanoc/extra/deployer.rb
@@ -1,13 +1,11 @@
 # encoding: utf-8
 
 module Nanoc::Extra
-
   # Represents a deployer, an object that allows uploading the compiled site
   # to a specific (remote) location.
   #
   # @abstract Subclass and override {#run} to implement a custom filter.
   class Deployer
-
     extend Nanoc::PluginRegistry::PluginMethods
 
     # @return [String] The path to the directory that contains the files to
@@ -41,7 +39,5 @@ module Nanoc::Extra
     def run
       raise NotImplementedError.new('Nanoc::Extra::Deployer subclasses must implement #run')
     end
-
   end
-
 end

--- a/lib/nanoc/extra/deployers.rb
+++ b/lib/nanoc/extra/deployers.rb
@@ -1,15 +1,11 @@
 # encoding: utf-8
 
 module Nanoc::Extra
-
   module Deployers
-
     autoload 'Fog',   'nanoc/extra/deployers/fog'
     autoload 'Rsync', 'nanoc/extra/deployers/rsync'
 
     Nanoc::Extra::Deployer.register '::Nanoc::Extra::Deployers::Fog',   :fog
     Nanoc::Extra::Deployer.register '::Nanoc::Extra::Deployers::Rsync', :rsync
-
   end
-
 end

--- a/lib/nanoc/extra/deployers/fog.rb
+++ b/lib/nanoc/extra/deployers/fog.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc::Extra::Deployers
-
   # A deployer that deploys a site using [fog](https://github.com/geemus/fog).
   #
   # @example A deployment configuration with public and staging configurations
@@ -18,7 +17,6 @@ module Nanoc::Extra::Deployers
   #       local_root: ~/myCloud
   #       bucket:     nanoc-site-staging
   class Fog < ::Nanoc::Extra::Deployer
-
     # @see Nanoc::Extra::Deployer#run
     def run
       require 'fog'
@@ -95,7 +93,5 @@ module Nanoc::Extra::Deployers
     def error(msg)
       raise RuntimeError.new(msg)
     end
-
   end
-
 end

--- a/lib/nanoc/extra/deployers/rsync.rb
+++ b/lib/nanoc/extra/deployers/rsync.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc::Extra::Deployers
-
   # A deployer that deploys a site using rsync.
   #
   # The configuration has should include a `:dst` value, a string containing
@@ -20,7 +19,6 @@ module Nanoc::Extra::Deployers
   #       dst: "ectype:sites/stoneship-staging/public"
   #       options: [ "-glpPrtvz" ]
   class Rsync < ::Nanoc::Extra::Deployer
-
     # Default rsync options
     DEFAULT_OPTIONS = [
       '--group',
@@ -63,7 +61,5 @@ module Nanoc::Extra::Deployers
       piper = Nanoc::Extra::Piper.new(:stdout => $stdout, :stderr => $stderr)
       piper.run(cmd, nil)
     end
-
   end
-
 end

--- a/lib/nanoc/extra/file_proxy.rb
+++ b/lib/nanoc/extra/file_proxy.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::Extra
-
   # @deprecated Create a File instance directly and use that instead.
   class FileProxy
-
     instance_methods.each { |m| undef_method m unless m =~ /^__/ || m.to_s == 'object_id' }
 
     @@deprecation_warning_shown = false
@@ -34,7 +32,5 @@ module Nanoc::Extra
     def file_instance_methods
       @@file_instance_methods ||= Set.new(File.instance_methods.map { |m| m.to_sym })
     end
-
   end
-
 end

--- a/lib/nanoc/extra/filesystem_tools.rb
+++ b/lib/nanoc/extra/filesystem_tools.rb
@@ -1,17 +1,14 @@
 # encoding: utf-8
 
 module Nanoc::Extra
-
   # Contains useful functions for managing the filesystem.
   #
   # @api private
   module FilesystemTools
-
     # Error that is raised when too many symlink indirections are encountered.
     #
     # @api private
     class MaxSymlinkDepthExceededError < ::Nanoc::Errors::GenericTrivial
-
       # @return [String] The last filename that was attempted to be
       #   resolved before giving up
       attr_reader :filename
@@ -22,7 +19,6 @@ module Nanoc::Extra
         @filename = filename
         super("Too many indirections while resolving symlinks. I gave up after finding out #{filename} was yet another symlink. Sorry!")
       end
-
     end
 
     # Error that is raised when a file of an unknown type is encountered
@@ -30,7 +26,6 @@ module Nanoc::Extra
     #
     # @api private
     class UnsupportedFileTypeError < ::Nanoc::Errors::GenericTrivial
-
       # @return [String] The filename of the file whose type is not supported
       attr_reader :filename
 
@@ -40,7 +35,6 @@ module Nanoc::Extra
         @filename = filename
         super("The file at #{filename} is of an unsupported type (expected file, directory or link, but it is #{File.ftype(filename)}")
       end
-
     end
 
     # Returns all files in the given directory and directories below it,
@@ -118,7 +112,5 @@ module Nanoc::Extra
       end
     end
     module_function :resolve_symlink
-
   end
-
 end

--- a/lib/nanoc/extra/jruby_nokogiri_warner.rb
+++ b/lib/nanoc/extra/jruby_nokogiri_warner.rb
@@ -3,9 +3,7 @@
 require 'singleton'
 
 module Nanoc::Extra
-
   class JRubyNokogiriWarner
-
     include Singleton
 
     TEXT = <<EOS
@@ -42,7 +40,5 @@ EOS
       $stderr.puts TEXT
       @warned = true
     end
-
   end
-
 end

--- a/lib/nanoc/extra/link_collector.rb
+++ b/lib/nanoc/extra/link_collector.rb
@@ -3,9 +3,7 @@
 require 'set'
 
 module ::Nanoc::Extra
-
   class LinkCollector
-
     def initialize(filenames, mode = nil)
       Nanoc::Extra::JRubyNokogiriWarner.check_and_warn
 
@@ -54,7 +52,5 @@ module ::Nanoc::Extra
 
       hrefs_in_file.select(&@filter)
     end
-
   end
-
 end

--- a/lib/nanoc/extra/piper.rb
+++ b/lib/nanoc/extra/piper.rb
@@ -3,11 +3,8 @@
 require 'open3'
 
 module Nanoc::Extra
-
   class Piper
-
     class Error < ::Nanoc::Errors::Generic
-
       def initialize(command, exit_code)
         @command   = command
         @exit_code = exit_code
@@ -16,7 +13,6 @@ module Nanoc::Extra
       def message
         "command exited with a nonzero status code #{@exit_code} (command: #{@command.join(' ')})"
       end
-
     end
 
     # @option [IO] :stdout ($stdout)
@@ -48,7 +44,5 @@ module Nanoc::Extra
         end
       end
     end
-
   end
-
 end

--- a/lib/nanoc/extra/pruner.rb
+++ b/lib/nanoc/extra/pruner.rb
@@ -1,11 +1,9 @@
 # encoding: utf-8
 
 module Nanoc::Extra
-
   # Responsible for finding and deleting files in the site’s output directory
   # that are not managed by nanoc.
   class Pruner
-
     # @return [Nanoc::Site] The site this pruner belongs to
     attr_reader :site
 
@@ -84,7 +82,5 @@ module Nanoc::Extra
         Dir.rmdir(dir)
       end
     end
-
   end
-
 end

--- a/lib/nanoc/extra/validators.rb
+++ b/lib/nanoc/extra/validators.rb
@@ -1,12 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::Extra
-
   module Validators
-
     autoload 'W3C',   'nanoc/extra/validators/w3c'
     autoload 'Links', 'nanoc/extra/validators/links'
-
   end
-
 end

--- a/lib/nanoc/extra/validators/links.rb
+++ b/lib/nanoc/extra/validators/links.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::Extra::Validators
-
   # @deprecated Use the Checking API or the `check` command instead
   class Links
-
     def initialize(_dir, _index_filenames, params = {})
       @include_internal = params.key?(:internal) && params[:internal]
       @include_external = params.key?(:external) && params[:external]
@@ -16,7 +14,5 @@ module Nanoc::Extra::Validators
       checks << 'elinks' if options[:external]
       Nanoc::CLI.run ['check', checks].flatten
     end
-
   end
-
 end

--- a/lib/nanoc/extra/validators/w3c.rb
+++ b/lib/nanoc/extra/validators/w3c.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::Extra::Validators
-
   # @deprecated Use the Checking API or the `check` command instead
   class W3C
-
     def initialize(dir, types)
       @dir   = dir
       @types = types
@@ -21,7 +19,5 @@ module Nanoc::Extra::Validators
 
       Nanoc::CLI.run(['check', args].flatten)
     end
-
   end
-
 end

--- a/lib/nanoc/extra/vcs.rb
+++ b/lib/nanoc/extra/vcs.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc::Extra
-
   # A very simple representation of a version control system (VCS) that
   # abstracts the add, remove and move operations. It does not commit. This
   # class is primarily used by data sources that store data as flat files on
@@ -10,7 +9,6 @@ module Nanoc::Extra
   # @abstract Subclass and override {#add}, {#remove} and {#move} to implement
   #   a custom VCS.
   class VCS
-
     extend Nanoc::PluginRegistry::PluginMethods
 
     # Adds the file with the given filename to the working copy.
@@ -60,7 +58,5 @@ module Nanoc::Extra
         'this data source to be used.'
       )
     end
-
   end
-
 end

--- a/lib/nanoc/extra/vcses.rb
+++ b/lib/nanoc/extra/vcses.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc::Extra::VCSes
-
   autoload 'Bazaar',     'nanoc/extra/vcses/bazaar'
   autoload 'Dummy',      'nanoc/extra/vcses/dummy'
   autoload 'Git',        'nanoc/extra/vcses/git'
@@ -13,5 +12,4 @@ module Nanoc::Extra::VCSes
   Nanoc::Extra::VCS.register '::Nanoc::Extra::VCSes::Git',        :git
   Nanoc::Extra::VCS.register '::Nanoc::Extra::VCSes::Mercurial',  :mercurial, :hg
   Nanoc::Extra::VCS.register '::Nanoc::Extra::VCSes::Subversion', :subversion, :svn
-
 end

--- a/lib/nanoc/extra/vcses/bazaar.rb
+++ b/lib/nanoc/extra/vcses/bazaar.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::Extra::VCSes
-
   # @see Nanoc::Extra::VCS
   class Bazaar < Nanoc::Extra::VCS
-
     # @see Nanoc::Extra::VCS#add
     def add(filename)
       system('bzr', 'add', filename)
@@ -19,7 +17,5 @@ module Nanoc::Extra::VCSes
     def move(src, dst)
       system('bzr', 'mv', src, dst)
     end
-
   end
-
 end

--- a/lib/nanoc/extra/vcses/dummy.rb
+++ b/lib/nanoc/extra/vcses/dummy.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::Extra::VCSes
-
   # @see Nanoc::Extra::VCS
   class Dummy < Nanoc::Extra::VCS
-
     # @see Nanoc::Extra::VCS#add
     def add(_filename)
     end
@@ -18,7 +16,5 @@ module Nanoc::Extra::VCSes
     def move(src, dst)
       FileUtils.move(src, dst)
     end
-
   end
-
 end

--- a/lib/nanoc/extra/vcses/git.rb
+++ b/lib/nanoc/extra/vcses/git.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::Extra::VCSes
-
   # @see Nanoc::Extra::VCS
   class Git < Nanoc::Extra::VCS
-
     # @see Nanoc::Extra::VCS#add
     def add(filename)
       system('git', 'add', filename)
@@ -19,7 +17,5 @@ module Nanoc::Extra::VCSes
     def move(src, dst)
       system('git', 'mv', src, dst)
     end
-
   end
-
 end

--- a/lib/nanoc/extra/vcses/mercurial.rb
+++ b/lib/nanoc/extra/vcses/mercurial.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::Extra::VCSes
-
   # @see Nanoc::Extra::VCS
   class Mercurial < Nanoc::Extra::VCS
-
     # @see Nanoc::Extra::VCS#add
     def add(filename)
       system('hg', 'add', filename)
@@ -19,7 +17,5 @@ module Nanoc::Extra::VCSes
     def move(src, dst)
       system('hg', 'mv', src, dst)
     end
-
   end
-
 end

--- a/lib/nanoc/extra/vcses/subversion.rb
+++ b/lib/nanoc/extra/vcses/subversion.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::Extra::VCSes
-
   # @see Nanoc::Extra::VCS
   class Subversion < Nanoc::Extra::VCS
-
     # @see Nanoc::Extra::VCS#add
     def add(filename)
       system('svn', 'add', filename)
@@ -19,7 +17,5 @@ module Nanoc::Extra::VCSes
     def move(src, dst)
       system('svn', 'mv', src, dst)
     end
-
   end
-
 end

--- a/lib/nanoc/filters.rb
+++ b/lib/nanoc/filters.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc::Filters
-
   autoload 'AsciiDoc',        'nanoc/filters/asciidoc'
   autoload 'BlueCloth',       'nanoc/filters/bluecloth'
   autoload 'CodeRay',         'nanoc/filters/coderay'
@@ -59,5 +58,4 @@ module Nanoc::Filters
   Nanoc::Filter.register '::Nanoc::Filters::UglifyJS',        :uglify_js
   Nanoc::Filter.register '::Nanoc::Filters::XSL',             :xsl
   Nanoc::Filter.register '::Nanoc::Filters::YUICompressor',   :yui_compressor
-
 end

--- a/lib/nanoc/filters/asciidoc.rb
+++ b/lib/nanoc/filters/asciidoc.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::Filters
-
   # @since 3.2.0
   class AsciiDoc < Nanoc::Filter
-
     # Runs the content through [AsciiDoc](http://www.methods.co.nz/asciidoc/).
     # This method takes no options.
     #
@@ -18,7 +16,5 @@ module Nanoc::Filters
       piper.run(%w( asciidoc -o - - ), content)
       stdout.string
     end
-
   end
-
 end

--- a/lib/nanoc/filters/bluecloth.rb
+++ b/lib/nanoc/filters/bluecloth.rb
@@ -2,7 +2,6 @@
 
 module Nanoc::Filters
   class BlueCloth < Nanoc::Filter
-
     requires 'bluecloth'
 
     # Runs the content through [BlueCloth](http://deveiate.org/projects/BlueCloth).
@@ -14,6 +13,5 @@ module Nanoc::Filters
     def run(content, _params = {})
       ::BlueCloth.new(content).to_html
     end
-
   end
 end

--- a/lib/nanoc/filters/coderay.rb
+++ b/lib/nanoc/filters/coderay.rb
@@ -2,7 +2,6 @@
 
 module Nanoc::Filters
   class CodeRay < Nanoc::Filter
-
     requires 'coderay'
 
     # @deprecated Use the `:colorize_syntax` filter instead.
@@ -16,6 +15,5 @@ module Nanoc::Filters
       # Get result
       ::CodeRay.scan(content, params[:language]).html
     end
-
   end
 end

--- a/lib/nanoc/filters/coffeescript.rb
+++ b/lib/nanoc/filters/coffeescript.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::Filters
-
   # @since 3.3.0
   class CoffeeScript < Nanoc::Filter
-
     requires 'coffee-script'
 
     # Runs the content through [CoffeeScript](http://coffeescript.org/).
@@ -16,7 +14,5 @@ module Nanoc::Filters
     def run(content, _params = {})
       ::CoffeeScript.compile(content)
     end
-
   end
-
 end

--- a/lib/nanoc/filters/colorize_syntax.rb
+++ b/lib/nanoc/filters/colorize_syntax.rb
@@ -2,7 +2,6 @@
 
 module Nanoc::Filters
   class ColorizeSyntax < Nanoc::Filter
-
     requires 'nokogiri', 'stringio', 'open3'
 
     # The default colorizer to use for a language if the colorizer for that
@@ -279,7 +278,7 @@ module Nanoc::Filters
         if SIMON_HIGHLIGHT_OPT_MAP[key]
           cmd << SIMON_HIGHLIGHT_OPT_MAP[key]
         else
-          # TODO allow passing other options
+          # TODO: allow passing other options
           case key
           when :style
             cmd << '--style' << params[:style]
@@ -389,6 +388,5 @@ module Nanoc::Filters
       piper = Nanoc::Extra::Piper.new(:stdout => StringIO.new, :stderr => StringIO.new)
       piper.run(cmd, nil)
     end
-
   end
 end

--- a/lib/nanoc/filters/erb.rb
+++ b/lib/nanoc/filters/erb.rb
@@ -2,7 +2,6 @@
 
 module Nanoc::Filters
   class ERB < Nanoc::Filter
-
     requires 'erb'
 
     # Runs the content through [ERB](http://ruby-doc.org/stdlib/libdoc/erb/rdoc/classes/ERB.html).
@@ -33,6 +32,5 @@ module Nanoc::Filters
       erb.filename = filename
       erb.result(assigns_binding)
     end
-
   end
 end

--- a/lib/nanoc/filters/erubis.rb
+++ b/lib/nanoc/filters/erubis.rb
@@ -2,7 +2,6 @@
 
 module Nanoc::Filters
   class Erubis < Nanoc::Filter
-
     requires 'erubis'
 
     # The same as `::Erubis::Eruby` but adds `_erbout` as an alias for the
@@ -29,6 +28,5 @@ module Nanoc::Filters
       # Get result
       ErubisWithErbout.new(content, :filename => filename).result(assigns_binding)
     end
-
   end
 end

--- a/lib/nanoc/filters/haml.rb
+++ b/lib/nanoc/filters/haml.rb
@@ -2,7 +2,6 @@
 
 module Nanoc::Filters
   class Haml < Nanoc::Filter
-
     requires 'haml'
 
     # Runs the content through [Haml](http://haml-lang.com/).
@@ -22,6 +21,5 @@ module Nanoc::Filters
       proc = assigns[:content] ? lambda { assigns[:content] } : nil
       ::Haml::Engine.new(content, options).render(context, assigns, &proc)
     end
-
   end
 end

--- a/lib/nanoc/filters/handlebars.rb
+++ b/lib/nanoc/filters/handlebars.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::Filters
-
   # @since 3.4.0
   class Handlebars < Nanoc::Filter
-
     requires 'handlebars'
 
     # Runs the content through
@@ -28,7 +26,5 @@ module Nanoc::Filters
       template = handlebars.compile(content)
       template.call(context)
     end
-
   end
-
 end

--- a/lib/nanoc/filters/kramdown.rb
+++ b/lib/nanoc/filters/kramdown.rb
@@ -2,7 +2,6 @@
 
 module Nanoc::Filters
   class Kramdown < Nanoc::Filter
-
     requires 'kramdown'
 
     # Runs the content through [Kramdown](http://kramdown.gettalong.org/).
@@ -15,6 +14,5 @@ module Nanoc::Filters
       # Get result
       ::Kramdown::Document.new(content, params).to_html
     end
-
   end
 end

--- a/lib/nanoc/filters/less.rb
+++ b/lib/nanoc/filters/less.rb
@@ -2,7 +2,6 @@
 
 module Nanoc::Filters
   class Less < Nanoc::Filter
-
     requires 'less'
 
     # Runs the content through [LESS](http://lesscss.org/).
@@ -48,6 +47,5 @@ module Nanoc::Filters
       parser = ::Less::Parser.new(:paths => paths)
       parser.parse(content).to_css params
     end
-
   end
 end

--- a/lib/nanoc/filters/markaby.rb
+++ b/lib/nanoc/filters/markaby.rb
@@ -2,7 +2,6 @@
 
 module Nanoc::Filters
   class Markaby < Nanoc::Filter
-
     requires 'markaby'
 
     # Runs the content through [Markaby](http://markaby.github.io/).
@@ -15,6 +14,5 @@ module Nanoc::Filters
       # Get result
       ::Markaby::Builder.new(assigns).instance_eval(content).to_s
     end
-
   end
 end

--- a/lib/nanoc/filters/maruku.rb
+++ b/lib/nanoc/filters/maruku.rb
@@ -2,7 +2,6 @@
 
 module Nanoc::Filters
   class Maruku < Nanoc::Filter
-
     requires 'maruku'
 
     # Runs the content through [Maruku](https://github.com/bhollis/maruku/).
@@ -15,6 +14,5 @@ module Nanoc::Filters
       # Get result
       ::Maruku.new(content, params).to_html
     end
-
   end
 end

--- a/lib/nanoc/filters/mustache.rb
+++ b/lib/nanoc/filters/mustache.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::Filters
-
   # @since 3.2.0
   class Mustache < Nanoc::Filter
-
     requires 'mustache'
 
     # Runs the content through
@@ -18,7 +16,5 @@ module Nanoc::Filters
       context = item.attributes.merge({ :yield => assigns[:content] })
       ::Mustache.render(content, context)
     end
-
   end
-
 end

--- a/lib/nanoc/filters/pandoc.rb
+++ b/lib/nanoc/filters/pandoc.rb
@@ -2,7 +2,6 @@
 
 module Nanoc::Filters
   class Pandoc < Nanoc::Filter
-
     requires 'pandoc-ruby'
 
     # Runs the content through [Pandoc](http://johnmacfarlane.net/pandoc/)
@@ -15,6 +14,5 @@ module Nanoc::Filters
     def run(content, *params)
       PandocRuby.convert(content, *params)
     end
-
   end
 end

--- a/lib/nanoc/filters/rainpress.rb
+++ b/lib/nanoc/filters/rainpress.rb
@@ -2,7 +2,6 @@
 
 module Nanoc::Filters
   class Rainpress < Nanoc::Filter
-
     requires 'rainpress'
 
     # Runs the content through [Rainpress](http://code.google.com/p/rainpress/).
@@ -14,6 +13,5 @@ module Nanoc::Filters
     def run(content, params = {})
       ::Rainpress.compress(content, params)
     end
-
   end
 end

--- a/lib/nanoc/filters/rdiscount.rb
+++ b/lib/nanoc/filters/rdiscount.rb
@@ -2,7 +2,6 @@
 
 module Nanoc::Filters
   class RDiscount < Nanoc::Filter
-
     requires 'rdiscount'
 
     # Runs the content through [RDiscount](http://github.com/rtomayko/rdiscount).
@@ -17,6 +16,5 @@ module Nanoc::Filters
 
       ::RDiscount.new(content, *extensions).to_html
     end
-
   end
 end

--- a/lib/nanoc/filters/rdoc.rb
+++ b/lib/nanoc/filters/rdoc.rb
@@ -2,7 +2,6 @@
 
 module Nanoc::Filters
   class RDoc < Nanoc::Filter
-
     requires 'rdoc'
 
     def self.setup
@@ -21,6 +20,5 @@ module Nanoc::Filters
       to_html = ::RDoc::Markup::ToHtml.new(options)
       ::RDoc::Markup.new.convert(content, to_html)
     end
-
   end
 end

--- a/lib/nanoc/filters/redcarpet.rb
+++ b/lib/nanoc/filters/redcarpet.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::Filters
-
   # @since 3.2.0
   class Redcarpet < Nanoc::Filter
-
     requires 'redcarpet'
 
     # Runs the content through [Redcarpet](https://github.com/vmg/redcarpet).
@@ -81,7 +79,5 @@ module Nanoc::Filters
         end
       end
     end
-
   end
-
 end

--- a/lib/nanoc/filters/redcloth.rb
+++ b/lib/nanoc/filters/redcloth.rb
@@ -2,7 +2,6 @@
 
 module Nanoc::Filters
   class RedCloth < Nanoc::Filter
-
     requires 'redcloth'
 
     # Runs the content through [RedCloth](http://redcloth.org/). This method
@@ -42,6 +41,5 @@ module Nanoc::Filters
       # Get result
       r.to_html
     end
-
   end
 end

--- a/lib/nanoc/filters/relativize_paths.rb
+++ b/lib/nanoc/filters/relativize_paths.rb
@@ -2,7 +2,6 @@
 
 module Nanoc::Filters
   class RelativizePaths < Nanoc::Filter
-
     require 'nanoc/helpers/link_to'
     include Nanoc::Helpers::LinkTo
 
@@ -37,7 +36,7 @@ module Nanoc::Filters
       # Filter
       case params[:type]
       when :css
-        # FIXME parse CSS the proper way using csspool or something
+        # FIXME: parse CSS the proper way using csspool or something
         content.gsub(/url\((['"]?)(\/(?:[^\/].*?)?)\1\)/) do
           'url(' + $1 + relative_path_to($2) + $1 + ')'
         end
@@ -53,7 +52,7 @@ module Nanoc::Filters
           klass = ::Nokogiri::XML
         when :xhtml
           klass = ::Nokogiri::XML
-          # FIXME cleanup because it is ugly
+          # FIXME: cleanup because it is ugly
           # this cleans the XHTML namespace to process fragments and full
           # documents in the same way. At least, Nokogiri adds this namespace
           # if detects the `html` element.
@@ -98,6 +97,5 @@ module Nanoc::Filters
     def path_is_relativizable?(s)
       s[0, 1] == '/'
     end
-
   end
 end

--- a/lib/nanoc/filters/rubypants.rb
+++ b/lib/nanoc/filters/rubypants.rb
@@ -2,7 +2,6 @@
 
 module Nanoc::Filters
   class RubyPants < Nanoc::Filter
-
     requires 'rubypants'
 
     # Runs the content through [RubyPants](http://rubydoc.info/gems/rubypants/).
@@ -15,6 +14,5 @@ module Nanoc::Filters
       # Get result
       ::RubyPants.new(content).to_html
     end
-
   end
 end

--- a/lib/nanoc/filters/sass.rb
+++ b/lib/nanoc/filters/sass.rb
@@ -2,7 +2,6 @@
 
 module Nanoc::Filters
   class Sass < Nanoc::Filter
-
     requires 'sass', 'nanoc/filters/sass/sass_filesystem_importer'
 
     # Runs the content through [Sass](http://sass-lang.com/).
@@ -26,6 +25,5 @@ module Nanoc::Filters
           Pathname.new(i.raw_filename).realpath == Pathname.new(filename).realpath
       end
     end
-
   end
 end

--- a/lib/nanoc/filters/sass/sass_filesystem_importer.rb
+++ b/lib/nanoc/filters/sass/sass_filesystem_importer.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class ::Sass::Importers::Filesystem
-
   alias_method :_orig_find, :_find
 
   def _find(dir, name, options)
@@ -17,5 +16,4 @@ class ::Sass::Importers::Filesystem
     # Call original _find
     _orig_find(dir, name, options)
   end
-
 end

--- a/lib/nanoc/filters/slim.rb
+++ b/lib/nanoc/filters/slim.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::Filters
-
   # @since 3.2.0
   class Slim < Nanoc::Filter
-
     requires 'slim'
 
     # Runs the content through [Slim](http://slim-lang.com/).
@@ -24,7 +22,5 @@ module Nanoc::Filters
 
       ::Slim::Template.new(params) { content }.render(context) { assigns[:content] }
     end
-
   end
-
 end

--- a/lib/nanoc/filters/typogruby.rb
+++ b/lib/nanoc/filters/typogruby.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::Filters
-
   # @since 3.2.0
   class Typogruby < Nanoc::Filter
-
     requires 'typogruby'
 
     # Runs the content through [Typogruby](http://avdgaag.github.com/typogruby/).
@@ -17,7 +15,5 @@ module Nanoc::Filters
       # Get result
       ::Typogruby.improve(content)
     end
-
   end
-
 end

--- a/lib/nanoc/filters/uglify_js.rb
+++ b/lib/nanoc/filters/uglify_js.rb
@@ -2,7 +2,6 @@
 
 module Nanoc::Filters
   class UglifyJS < Nanoc::Filter
-
     requires 'uglifier'
 
     # Runs the content through [UglifyJS](https://github.com/mishoo/UglifyJS2/).
@@ -17,6 +16,5 @@ module Nanoc::Filters
       # Add filename to load path
       Uglifier.new(params).compile(content)
     end
-
   end
 end

--- a/lib/nanoc/filters/xsl.rb
+++ b/lib/nanoc/filters/xsl.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::Filters
-
   # @since 3.3.0
   class XSL < Nanoc::Filter
-
     requires 'nokogiri'
 
     # Runs the item content through an [XSLT](http://www.w3.org/TR/xslt)
@@ -45,7 +43,5 @@ module Nanoc::Filters
 
       xsl.apply_to(xml, ::Nokogiri::XSLT.quote_params(params))
     end
-
   end
-
 end

--- a/lib/nanoc/filters/yui_compressor.rb
+++ b/lib/nanoc/filters/yui_compressor.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::Filters
-
   # @since 3.3.0
   class YUICompressor < Nanoc::Filter
-
     requires 'yuicompressor'
 
     # Compress Javascript or CSS using [YUICompressor](http://rubydoc.info/gems/yuicompressor).
@@ -19,7 +17,5 @@ module Nanoc::Filters
     def run(content, params = {})
       ::YUICompressor.compress(content, params)
     end
-
   end
-
 end

--- a/lib/nanoc/helpers.rb
+++ b/lib/nanoc/helpers.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc::Helpers
-
   autoload 'Blogging',    'nanoc/helpers/blogging'
   autoload 'Breadcrumbs', 'nanoc/helpers/breadcrumbs'
   autoload 'Capturing',   'nanoc/helpers/capturing'
@@ -12,5 +11,4 @@ module Nanoc::Helpers
   autoload 'Tagging',     'nanoc/helpers/tagging'
   autoload 'Text',        'nanoc/helpers/text'
   autoload 'XMLSitemap',  'nanoc/helpers/xml_sitemap'
-
 end

--- a/lib/nanoc/helpers/blogging.rb
+++ b/lib/nanoc/helpers/blogging.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc::Helpers
-
   # Provides functionality for building blogs, such as finding articles and
   # constructing feeds.
   #
@@ -22,7 +21,6 @@ module Nanoc::Helpers
   #
   # The two main functions are {#sorted_articles} and {#atom_feed}.
   module Blogging
-
     # Returns an unsorted list of articles, i.e. items where the `kind`
     # attribute is set to `"article"`.
     #
@@ -54,7 +52,6 @@ module Nanoc::Helpers
     end
 
     class AtomFeedBuilder
-
       include Nanoc::Helpers::Blogging
 
       attr_accessor :site
@@ -190,7 +187,6 @@ module Nanoc::Helpers
           xml.summary summary, :type => 'html' unless summary.nil?
         end
       end
-
     end
 
     # Returns a string representing the atom feed containing recent articles,
@@ -386,7 +382,5 @@ module Nanoc::Helpers
       time = Time.parse(time) if time.is_a?(String)
       time
     end
-
   end
-
 end

--- a/lib/nanoc/helpers/breadcrumbs.rb
+++ b/lib/nanoc/helpers/breadcrumbs.rb
@@ -1,11 +1,9 @@
 # encoding: utf-8
 
 module Nanoc::Helpers
-
   # Provides support for breadcrumbs, which allow the user to go up in the
   # page hierarchy.
   module Breadcrumbs
-
     # Creates a breadcrumb trail leading from the current item to its parent,
     # to its parent’s parent, etc, until the root item is reached. This
     # function does not require that each intermediate item exist; for
@@ -29,7 +27,5 @@ module Nanoc::Helpers
 
       trail
     end
-
   end
-
 end

--- a/lib/nanoc/helpers/capturing.rb
+++ b/lib/nanoc/helpers/capturing.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc::Helpers
-
   # Provides functionality for “capturing” content in one place and reusing
   # this content elsewhere.
   #
@@ -35,10 +34,8 @@ module Nanoc::Helpers
   #     <%= @item[:content_for_summary] || '(no summary)' %>
   #   </div>
   module Capturing
-
     # @api private
     class CapturesStore
-
       def initialize
         @store = {}
       end
@@ -52,11 +49,9 @@ module Nanoc::Helpers
         @store[item.identifier] ||= {}
         @store[item.identifier][name]
       end
-
     end
 
     class ::Nanoc::Site
-
       # @api private
       def captures_store
         @captures_store ||= CapturesStore.new
@@ -67,7 +62,6 @@ module Nanoc::Helpers
         require 'set'
         @captures_store_compiled_items ||= Set.new
       end
-
     end
 
     # @overload content_for(name, &block)
@@ -127,7 +121,7 @@ module Nanoc::Helpers
           # This is an extremely ugly hack to get the compiler to recompile the
           # item from which we use content. For this, we need to manually edit
           # the content attribute to reset it. :(
-          # FIXME clean this up
+          # FIXME: clean this up
           unless @site.captures_store_compiled_items.include? item
             @site.captures_store_compiled_items << item
             item.forced_outdated = true
@@ -169,7 +163,5 @@ module Nanoc::Helpers
       # Done.
       erbout_addition
     end
-
   end
-
 end

--- a/lib/nanoc/helpers/filtering.rb
+++ b/lib/nanoc/helpers/filtering.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::Helpers
-
   # Provides functionality for filtering parts of an item or a layout.
   module Filtering
-
     require 'nanoc/helpers/capturing'
     include Nanoc::Helpers::Capturing
 
@@ -46,7 +44,5 @@ module Nanoc::Helpers
       buffer = eval('_erbout', block.binding)
       buffer << filtered_data
     end
-
   end
-
 end

--- a/lib/nanoc/helpers/html_escape.rb
+++ b/lib/nanoc/helpers/html_escape.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::Helpers
-
   # Contains functionality for HTML-escaping strings.
   module HTMLEscape
-
     require 'nanoc/helpers/capturing'
     include Nanoc::Helpers::Capturing
 
@@ -39,9 +37,9 @@ module Nanoc::Helpers
         buffer << escaped_data
       elsif string
         string.gsub('&', '&amp;')
-               .gsub('<', '&lt;')
-               .gsub('>', '&gt;')
-               .gsub('"', '&quot;')
+          .gsub('<', '&lt;')
+          .gsub('>', '&gt;')
+          .gsub('"', '&quot;')
       else
         raise 'The #html_escape or #h function needs either a ' \
           'string or a block to HTML-escape, but neither a string nor a block was given'
@@ -49,7 +47,5 @@ module Nanoc::Helpers
     end
 
     alias_method :h, :html_escape
-
   end
-
 end

--- a/lib/nanoc/helpers/link_to.rb
+++ b/lib/nanoc/helpers/link_to.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::Helpers
-
   # Contains functions for linking to items and item representations.
   module LinkTo
-
     require 'nanoc/helpers/html_escape'
     include Nanoc::Helpers::HTMLEscape
 
@@ -154,7 +152,5 @@ module Nanoc::Helpers
       # Done
       relative_path
     end
-
   end
-
 end

--- a/lib/nanoc/helpers/rendering.rb
+++ b/lib/nanoc/helpers/rendering.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::Helpers
-
   # Provides functionality for rendering layouts as partials.
   module Rendering
-
     include Nanoc::Helpers::Capturing
 
     # Renders the given layout. The given layout will be run through the first
@@ -134,7 +132,5 @@ module Nanoc::Helpers
         Nanoc::NotificationCenter.post(:processing_ended, layout)
       end
     end
-
   end
-
 end

--- a/lib/nanoc/helpers/tagging.rb
+++ b/lib/nanoc/helpers/tagging.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 module Nanoc::Helpers
-
   # Provides support for managing tags added to items.
   #
   # To add tags to items, set the `tags` attribute to an array of tags that
@@ -11,7 +10,6 @@ module Nanoc::Helpers
   #
   #   tags: [ 'foo', 'bar', 'baz' ]
   module Tagging
-
     require 'nanoc/helpers/html_escape'
     include Nanoc::Helpers::HTMLEscape
 
@@ -65,7 +63,5 @@ module Nanoc::Helpers
     def link_for_tag(tag, base_url)
       %(<a href="#{h base_url}#{h tag}" rel="tag">#{h tag}</a>)
     end
-
   end
-
 end

--- a/lib/nanoc/helpers/text.rb
+++ b/lib/nanoc/helpers/text.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 module Nanoc::Helpers
-
   # Contains several useful text-related helper functions.
   module Text
-
     # Returns an excerpt for the given string. HTML tags are ignored, so if
     # you don't want them to turn up, they should be stripped from the string
     # before passing it to the excerpt function.
@@ -35,10 +33,8 @@ module Nanoc::Helpers
     #
     # @return [String] The given string with all HTML stripped
     def strip_html(string)
-      # FIXME will need something more sophisticated than this, because it sucks
+      # FIXME: will need something more sophisticated than this, because it sucks
       string.gsub(/<[^>]*(>+|\s*\z)/m, '').strip
     end
-
   end
-
 end

--- a/lib/nanoc/helpers/xml_sitemap.rb
+++ b/lib/nanoc/helpers/xml_sitemap.rb
@@ -1,12 +1,10 @@
 # encoding: utf-8
 
 module Nanoc::Helpers
-
   # Contains functionality for building XML sitemaps that will be crawled by
   # search engines. See the [Sitemaps protocol site](http://www.sitemaps.org)
   # for details.
   module XMLSitemap
-
     # Builds an XML sitemap and returns it.
     #
     # The following attributes can optionally be set on items to change the
@@ -76,7 +74,5 @@ module Nanoc::Helpers
       # Return sitemap
       buffer
     end
-
   end
-
 end

--- a/lib/nanoc/tasks/clean.rb
+++ b/lib/nanoc/tasks/clean.rb
@@ -1,9 +1,7 @@
 # encoding: utf-8
 
 module Nanoc::Tasks
-
   class Clean
-
     def initialize(site)
       @site = site
     end
@@ -23,7 +21,5 @@ module Nanoc::Tasks
         end
       end.flatten
     end
-
   end
-
 end

--- a/lib/nanoc/version.rb
+++ b/lib/nanoc/version.rb
@@ -1,8 +1,6 @@
 # encoding: utf-8
 
 module Nanoc
-
   # The current nanoc version.
   VERSION = '3.7.4'
-
 end

--- a/nanoc.gemspec
+++ b/nanoc.gemspec
@@ -14,15 +14,16 @@ Gem::Specification.new do |s|
   s.email   = 'denis.defreyne@stoneship.org'
   s.license = 'MIT'
 
-  s.files              = Dir['[A-Z]*'] +
-                         Dir['doc/yardoc_{templates,handlers}/**/*'] +
-                         Dir['{bin,lib,tasks,test}/**/*'] +
-                         [ 'nanoc.gemspec' ]
-  s.executables        = [ 'nanoc' ]
-  s.require_paths      = [ 'lib' ]
+  s.files =
+    Dir['[A-Z]*'] +
+    Dir['doc/yardoc_{templates,handlers}/**/*'] +
+    Dir['{bin,lib,tasks,test}/**/*'] +
+    ['nanoc.gemspec']
+  s.executables        = ['nanoc']
+  s.require_paths      = ['lib']
 
-  s.rdoc_options     = [ '--main', 'README.md' ]
-  s.extra_rdoc_files = [ 'ChangeLog', 'LICENSE', 'README.md', 'NEWS.md' ]
+  s.rdoc_options     = ['--main', 'README.md']
+  s.extra_rdoc_files = ['ChangeLog', 'LICENSE', 'README.md', 'NEWS.md']
 
   s.add_runtime_dependency('cri', '~> 2.3')
 

--- a/tasks/rubocop.rake
+++ b/tasks/rubocop.rake
@@ -6,5 +6,5 @@ begin
     task.patterns = ['lib/**/*.rb']
   end
 rescue LoadError
-  warn "Could not load RuboCop. RuboCop rake tasks will be unavailable."
+  warn 'Could not load RuboCop. RuboCop rake tasks will be unavailable.'
 end

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -20,13 +20,13 @@ namespace :test do
   # test:all
   desc 'Run all tests'
   task :all do
-    run_tests "test/**/"
+    run_tests 'test/**/'
   end
 
   # test:...
   %w( base cli data_sources extra filters helpers tasks ).each do |dir|
     desc "Run all #{dir} tests"
-    task dir.to_sym do |task|
+    task dir.to_sym do |_task|
       run_tests "test/#{dir}/**/"
     end
   end
@@ -34,4 +34,4 @@ namespace :test do
 end
 
 desc 'Alias for test:all'
-task :test => [ :'test:all' ]
+task :test => [:'test:all']

--- a/test/base/checksummer_spec.rb
+++ b/test/base/checksummer_spec.rb
@@ -43,7 +43,7 @@ describe Nanoc::Checksummer do
     end
 
     it 'should checksum non-serializable hashes' do
-      subject.calc({ a: ->{} }).must_match(CHECKSUM_REGEX)
+      subject.calc({ a: -> {} }).must_match(CHECKSUM_REGEX)
     end
 
   end
@@ -53,8 +53,8 @@ describe Nanoc::Checksummer do
     let(:file)            { Tempfile.new('foo') }
     let(:filename)        { file.path }
     let(:pathname)        { Pathname.new(filename) }
-    let(:atime)           { 1234567890 }
-    let(:mtime)           { 1234567890 }
+    let(:atime)           { 1_234_567_890 }
+    let(:mtime)           { 1_234_567_890 }
     let(:data)            { 'stuffs' }
     let(:normal_checksum) { 'THy7Y28oroov/KvPxT6wcMnXr/s=' }
 
@@ -95,7 +95,7 @@ describe Nanoc::Checksummer do
 
     describe 'if the mtime changes' do
 
-      let(:mtime) { 1333333333 }
+      let(:mtime) { 1_333_333_333 }
 
       it 'should have a different checksum' do
         subject.calc(pathname).must_match(CHECKSUM_REGEX)

--- a/test/base/core_ext/date_spec.rb
+++ b/test/base/core_ext/date_spec.rb
@@ -12,4 +12,3 @@ describe 'Date' do
   end
 
 end
-

--- a/test/base/core_ext/pathname_spec.rb
+++ b/test/base/core_ext/pathname_spec.rb
@@ -7,7 +7,7 @@ describe 'Pathname#checksum' do
       # Create file
       FileUtils.mkdir_p('tmp')
       File.open('tmp/myfile', 'w') { |io| io.write('') }
-      timestamp = Time.at(1234569)
+      timestamp = Time.at(1_234_569)
       File.utime(timestamp, timestamp, 'tmp/myfile')
 
       # Create checksum
@@ -23,7 +23,7 @@ describe 'Pathname#checksum' do
       # Create file
       FileUtils.mkdir_p('tmp')
       File.open('tmp/myfile', 'w') { |io| io.write('abc') }
-      timestamp = Time.at(1234569)
+      timestamp = Time.at(1_234_569)
       File.utime(timestamp, timestamp, 'tmp/myfile')
 
       # Create checksum

--- a/test/base/test_checksum_store.rb
+++ b/test/base/test_checksum_store.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::ChecksumStoreTest < Nanoc::TestCase
-
   def test_get_with_existing_object
     require 'pstore'
 
@@ -28,5 +27,4 @@ class Nanoc::ChecksumStoreTest < Nanoc::TestCase
     obj = Nanoc::Item.new('Moo?', {}, '/animals/cow/')
     assert_equal nil, store[obj]
   end
-
 end

--- a/test/base/test_code_snippet.rb
+++ b/test/base/test_code_snippet.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::CodeSnippetTest < Nanoc::TestCase
-
   def test_load
     # Initialize
     $complete_insane_parrot = 'meow'
@@ -25,5 +24,4 @@ class Nanoc::CodeSnippetTest < Nanoc::TestCase
     # Ensure binding is correct
     assert_equal('meow', @foo)
   end
-
 end

--- a/test/base/test_compiler.rb
+++ b/test/base/test_compiler.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::CompilerTest < Nanoc::TestCase
-
   def test_compilation_rule_for
     # Mock rules
     rules = [mock, mock, mock]
@@ -589,5 +588,4 @@ class Nanoc::CompilerTest < Nanoc::TestCase
       assert_empty stack
     end
   end
-
 end

--- a/test/base/test_compiler_dsl.rb
+++ b/test/base/test_compiler_dsl.rb
@@ -1,17 +1,16 @@
 # encoding: utf-8
 
 class Nanoc::CompilerDSLTest < Nanoc::TestCase
-
   def test_compile
-    # TODO implement
+    # TODO: implement
   end
 
   def test_route
-    # TODO implement
+    # TODO: implement
   end
 
   def test_layout
-    # TODO implement
+    # TODO: implement
   end
 
   def test_preprocess_twice
@@ -381,5 +380,4 @@ EOS
     compiler_dsl.instance_eval { $venetian = @config[:venetian] }
     assert_equal 'snares', $venetian
   end
-
 end

--- a/test/base/test_context.rb
+++ b/test/base/test_context.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::ContextTest < Nanoc::TestCase
-
   def test_context_with_instance_variable
     # Create context
     context = Nanoc::Context.new({ :foo => 'bar', :baz => 'quux' })
@@ -25,5 +24,4 @@ class Nanoc::ContextTest < Nanoc::TestCase
     # Run
     assert_examples_correct 'Nanoc::Context#initialize'
   end
-
 end

--- a/test/base/test_data_source.rb
+++ b/test/base/test_data_source.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::DataSourceTest < Nanoc::TestCase
-
   def test_loading
     # Create data source
     data_source = Nanoc::DataSource.new(nil, nil, nil, nil)
@@ -40,5 +39,4 @@ class Nanoc::DataSourceTest < Nanoc::TestCase
     assert_raises(NotImplementedError) { data_source.create_item(nil, nil, nil) }
     assert_raises(NotImplementedError) { data_source.create_layout(nil, nil, nil) }
   end
-
 end

--- a/test/base/test_dependency_tracker.rb
+++ b/test/base/test_dependency_tracker.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::DependencyTrackerTest < Nanoc::TestCase
-
   def test_initialize
     # Mock items
     items = [mock, mock]
@@ -256,5 +255,4 @@ class Nanoc::DependencyTrackerTest < Nanoc::TestCase
     tracker.forget_dependencies_for(items[0])
     assert_empty tracker.objects_causing_outdatedness_of(items[0])
   end
-
 end

--- a/test/base/test_directed_graph.rb
+++ b/test/base/test_directed_graph.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::DirectedGraphTest < Nanoc::TestCase
-
   def test_direct_predecessors
     graph = Nanoc::DirectedGraph.new([1, 2, 3])
     graph.add_edge(1, 2)
@@ -63,7 +62,7 @@ class Nanoc::DirectedGraphTest < Nanoc::TestCase
 
   def test_add_edge
     graph = Nanoc::DirectedGraph.new([1, 2, 3])
-    
+
     assert_equal [], graph.successors_of(1)
     assert_equal [], graph.predecessors_of(2)
 
@@ -84,7 +83,7 @@ class Nanoc::DirectedGraphTest < Nanoc::TestCase
 
   def test_delete_edge
     graph = Nanoc::DirectedGraph.new([1, 2, 3])
-    graph.add_edge(1,2)
+    graph.add_edge(1, 2)
 
     assert_equal [2], graph.successors_of(1)
     assert_equal [1], graph.predecessors_of(2)
@@ -285,5 +284,4 @@ class Nanoc::DirectedGraphTest < Nanoc::TestCase
     YARD.parse(LIB_DIR + '/nanoc/base/directed_graph.rb')
     assert_examples_correct 'Nanoc::DirectedGraph'
   end
-
 end

--- a/test/base/test_filter.rb
+++ b/test/base/test_filter.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::FilterTest < Nanoc::TestCase
-
   def test_initialize
     # Create filter
     filter = Nanoc::Filter.new
@@ -77,5 +76,4 @@ class Nanoc::FilterTest < Nanoc::TestCase
     # Check filename
     assert_equal('?', filter.filename)
   end
-
 end

--- a/test/base/test_item.rb
+++ b/test/base/test_item.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::ItemTest < Nanoc::TestCase
-
   def test_initialize_with_attributes_with_string_keys
     item = Nanoc::Item.new('foo', { 'abc' => 'xyz' }, '/foo/')
 
@@ -49,7 +48,9 @@ class Nanoc::ItemTest < Nanoc::TestCase
   def test_compiled_content_with_default_rep_and_default_snapshot
     # Mock rep
     rep = Object.new
-    def rep.name; :default; end
+    def rep.name
+      :default
+    end
     def rep.compiled_content(params)
       "content at #{params[:snapshot].inspect}"
     end
@@ -65,7 +66,9 @@ class Nanoc::ItemTest < Nanoc::TestCase
   def test_compiled_content_with_custom_rep_and_default_snapshot
     # Mock reps
     rep = Object.new
-    def rep.name; :foo; end
+    def rep.name
+      :foo
+    end
     def rep.compiled_content(params)
       "content at #{params[:snapshot].inspect}"
     end
@@ -81,7 +84,9 @@ class Nanoc::ItemTest < Nanoc::TestCase
   def test_compiled_content_with_default_rep_and_custom_snapshot
     # Mock reps
     rep = Object.new
-    def rep.name; :default; end
+    def rep.name
+      :default
+    end
     def rep.compiled_content(params)
       "content at #{params[:snapshot].inspect}"
     end
@@ -134,7 +139,7 @@ class Nanoc::ItemTest < Nanoc::TestCase
   end
 
   def test_freeze_should_disallow_changes
-    item = Nanoc::Item.new('foo', { :a => { :b => 123 }}, '/foo/')
+    item = Nanoc::Item.new('foo', { :a => { :b => 123 } }, '/foo/')
     item.freeze
 
     assert_raises_frozen_error do
@@ -149,14 +154,13 @@ class Nanoc::ItemTest < Nanoc::TestCase
   def test_dump_and_load
     item = Nanoc::Item.new(
       'foobar',
-      { :a => { :b => 123 }},
+      { :a => { :b => 123 } },
       '/foo/')
 
     item = Marshal.load(Marshal.dump(item))
 
     assert_equal '/foo/', item.identifier
     assert_equal 'foobar', item.raw_content
-    assert_equal({ :a => { :b => 123 }}, item.attributes)
+    assert_equal({ :a => { :b => 123 } }, item.attributes)
   end
-
 end

--- a/test/base/test_item_array.rb
+++ b/test/base/test_item_array.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::ItemArrayTest < Nanoc::TestCase
-
   def setup
     super
 
@@ -229,7 +228,7 @@ class Nanoc::ItemArrayTest < Nanoc::TestCase
     assert_equal 'Item 1', @items['/new/1/'].raw_content
   end
 
-  if Array.new.respond_to?(:keep_if)
+  if [].respond_to?(:keep_if)
     def test_keep_if
       assert_equal @two, @items[1]
       assert_equal @two, @items['/two/']
@@ -289,7 +288,7 @@ class Nanoc::ItemArrayTest < Nanoc::TestCase
     assert_equal mona, @items['/mona/']
   end
 
-  if Array.new.respond_to?(:select!)
+  if [].respond_to?(:select!)
     def test_select_bang
       assert_equal @two, @items[1]
       assert_equal @two, @items['/two/']
@@ -330,5 +329,4 @@ class Nanoc::ItemArrayTest < Nanoc::TestCase
     assert_equal @two, @items[2]
     assert_equal @two, @items['/two/']
   end
-
 end

--- a/test/base/test_item_rep.rb
+++ b/test/base/test_item_rep.rb
@@ -1,16 +1,15 @@
 # encoding: utf-8
 
 class Nanoc::ItemRepTest < Nanoc::TestCase
-
   def test_created_modified_compiled
-    # TODO implement
+    # TODO: implement
   end
 
   def test_compiled_content_with_only_last_available
     # Create rep
     item = Nanoc::Item.new(
       'blah blah blah', {}, '/',
-      :binary => false, :mtime => Time.now-500
+      :binary => false, :mtime => Time.now - 500
     )
     rep = Nanoc::ItemRep.new(item, nil)
     rep.instance_eval { @content = { :last => 'last content' } }
@@ -24,7 +23,7 @@ class Nanoc::ItemRepTest < Nanoc::TestCase
     # Create rep
     item = Nanoc::Item.new(
       'blah blah blah', {}, '/',
-      :binary => false, :mtime => Time.now-500
+      :binary => false, :mtime => Time.now - 500
     )
     rep = Nanoc::ItemRep.new(item, nil)
     rep.instance_eval { @content = { :pre => 'pre content', :last => 'last content' } }
@@ -38,7 +37,7 @@ class Nanoc::ItemRepTest < Nanoc::TestCase
     # Create rep
     item = Nanoc::Item.new(
       'blah blah blah', {}, '/',
-      :binary => false, :mtime => Time.now-500
+      :binary => false, :mtime => Time.now - 500
     )
     rep = Nanoc::ItemRep.new(item, nil)
     rep.instance_eval { @content = { :pre => 'pre content', :last => 'last content' } }
@@ -52,7 +51,7 @@ class Nanoc::ItemRepTest < Nanoc::TestCase
     # Create rep
     item = Nanoc::Item.new(
       'blah blah blah', {}, '/',
-      :binary => false, :mtime => Time.now-500
+      :binary => false, :mtime => Time.now - 500
     )
     rep = Nanoc::ItemRep.new(item, nil)
     rep.instance_eval { @content = { :pre => 'pre content', :last => 'last content' } }
@@ -210,7 +209,7 @@ class Nanoc::ItemRepTest < Nanoc::TestCase
 
     # Write once
     item_rep.write
-    a_long_time_ago = Time.now-1_000_000
+    a_long_time_ago = Time.now - 1_000_000
     File.utime(a_long_time_ago, a_long_time_ago, item_rep.raw_path)
 
     # Write again
@@ -248,13 +247,15 @@ class Nanoc::ItemRepTest < Nanoc::TestCase
 
     # Create rep
     rep = Nanoc::ItemRep.new(item, :foo)
-    def rep.assigns; {}; end
+    def rep.assigns
+      {}
+    end
 
     # Create fake filter
-    def rep.filter_named(name)
+    def rep.filter_named(_name)
       @filter ||= Class.new(::Nanoc::Filter) do
         type :text => :binary
-        def run(content, params = {})
+        def run(content, _params = {})
           File.open(output_filename, 'w') { |io| io.write(content) }
         end
       end
@@ -276,13 +277,15 @@ class Nanoc::ItemRepTest < Nanoc::TestCase
 
     # Create rep
     rep = Nanoc::ItemRep.new(item, :foo)
-    def rep.assigns; {}; end
+    def rep.assigns
+      {}
+    end
 
     # Create fake filter
-    def rep.filter_named(name)
+    def rep.filter_named(_name)
       @filter ||= Class.new(::Nanoc::Filter) do
         type :binary
-        def run(content, params = {})
+        def run(content, _params = {})
           File.open(output_filename, 'w') { |io| io.write(content) }
         end
       end
@@ -340,7 +343,7 @@ class Nanoc::ItemRepTest < Nanoc::TestCase
     Class.new(::Nanoc::Filter) do
       type :binary => :text
       identifier :binary_to_text
-      def run(content, params = {})
+      def run(content, _params = {})
         content + ' textified'
       end
     end
@@ -364,10 +367,10 @@ class Nanoc::ItemRepTest < Nanoc::TestCase
 
     assert rep.binary?
 
-    def rep.filter_named(name)
+    def rep.filter_named(_name)
       Class.new(::Nanoc::Filter) do
         type :binary => :text
-        def run(content, params = {})
+        def run(_content, _params = {})
           'Some textual content'
         end
       end
@@ -375,10 +378,10 @@ class Nanoc::ItemRepTest < Nanoc::TestCase
     rep.filter(:binary_to_text)
     assert !rep.binary?
 
-    def rep.filter_named(name)
+    def rep.filter_named(_name)
       Class.new(::Nanoc::Filter) do
         type :text
-        def run(content, params = {})
+        def run(_content, _params = {})
           'Some textual content'
         end
       end
@@ -400,10 +403,10 @@ class Nanoc::ItemRepTest < Nanoc::TestCase
     create_binary_filter
 
     assert rep.binary?
-    def rep.filter_named(name)
+    def rep.filter_named(_name)
       @filter ||= Class.new(::Nanoc::Filter) do
         type :binary => :text
-        def run(content, params = {})
+        def run(_content, _params = {})
           'Some textual content'
         end
       end
@@ -415,7 +418,7 @@ class Nanoc::ItemRepTest < Nanoc::TestCase
 
   def test_new_content_should_be_frozen
     filter_class = Class.new(::Nanoc::Filter) do
-      def run(content, params = {})
+      def run(content, _params = {})
         content.gsub!('foo', 'moo')
         content
       end
@@ -424,7 +427,9 @@ class Nanoc::ItemRepTest < Nanoc::TestCase
     item = Nanoc::Item.new('foo bar', {}, '/foo/')
     rep = Nanoc::ItemRep.new(item, :default)
     rep.instance_eval { @filter_class = filter_class }
-    def rep.filter_named(name); @filter_class; end
+    def rep.filter_named(_name)
+      @filter_class
+    end
 
     assert_raises_frozen_error do
       rep.filter(:whatever)
@@ -433,7 +438,7 @@ class Nanoc::ItemRepTest < Nanoc::TestCase
 
   def test_filter_should_freeze_content
     filter_class = Class.new(::Nanoc::Filter) do
-      def run(content, params = {})
+      def run(content, _params = {})
         content.gsub!('foo', 'moo')
         content
       end
@@ -442,7 +447,9 @@ class Nanoc::ItemRepTest < Nanoc::TestCase
     item = Nanoc::Item.new('foo bar', {}, '/foo/')
     rep = Nanoc::ItemRep.new(item, :default)
     rep.instance_eval { @filter_class = filter_class }
-    def rep.filter_named(name); @filter_class; end
+    def rep.filter_named(_name)
+      @filter_class
+    end
 
     assert_raises_frozen_error do
       rep.filter(:erb)
@@ -516,7 +523,7 @@ class Nanoc::ItemRepTest < Nanoc::TestCase
 
     # Write
     notified = false
-    Nanoc::NotificationCenter.on(:rep_written, self) do |rep, raw_path, is_created, is_modified|
+    Nanoc::NotificationCenter.on(:rep_written, self) do |_rep, _raw_path, is_created, is_modified|
       notified = true
       assert is_created
       assert is_modified
@@ -546,7 +553,7 @@ class Nanoc::ItemRepTest < Nanoc::TestCase
 
     # Write
     notified = false
-    Nanoc::NotificationCenter.on(:rep_written, self) do |rep, raw_path, is_created, is_modified|
+    Nanoc::NotificationCenter.on(:rep_written, self) do |_rep, _raw_path, is_created, is_modified|
       notified = true
       refute is_created
       assert is_modified
@@ -568,7 +575,7 @@ class Nanoc::ItemRepTest < Nanoc::TestCase
   def mock_and_stub(params)
     m = mock
     params.each do |method, return_value|
-      m.stubs(method.to_sym).returns( return_value )
+      m.stubs(method.to_sym).returns(return_value)
     end
     m
   end
@@ -580,7 +587,7 @@ class Nanoc::ItemRepTest < Nanoc::TestCase
   def create_textual_filter
     f = create_filter(:text)
     f.class_eval do
-      def run(content, params = {})
+      def run(_content, _params = {})
         ''
       end
     end
@@ -590,7 +597,7 @@ class Nanoc::ItemRepTest < Nanoc::TestCase
   def create_binary_filter
     f = create_filter(:binary)
     f.class_eval do
-      def run(content, params = {})
+      def run(content, _params = {})
         File.open(output_filename, 'w') { |io| io.write(content) }
       end
     end
@@ -603,5 +610,4 @@ class Nanoc::ItemRepTest < Nanoc::TestCase
     Nanoc::Filter.register filter_klass, "#{type}_filter".to_sym
     filter_klass
   end
-
 end

--- a/test/base/test_layout.rb
+++ b/test/base/test_layout.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::LayoutTest < Nanoc::TestCase
-
   def test_initialize
     # Make sure attributes are cleaned
     layout = Nanoc::Layout.new('content', { 'foo' => 'bar' }, '/foo/')
@@ -39,14 +38,13 @@ class Nanoc::LayoutTest < Nanoc::TestCase
   def test_dump_and_load
     layout = Nanoc::Layout.new(
       'foobar',
-      { :a => { :b => 123 }},
+      { :a => { :b => 123 } },
       '/foo/')
 
     layout = Marshal.load(Marshal.dump(layout))
 
     assert_equal '/foo/', layout.identifier
     assert_equal 'foobar', layout.raw_content
-    assert_equal({ :a => { :b => 123 }}, layout.attributes)
+    assert_equal({ :a => { :b => 123 } }, layout.attributes)
   end
-
 end

--- a/test/base/test_memoization.rb
+++ b/test/base/test_memoization.rb
@@ -1,9 +1,7 @@
 # encoding: utf-8
 
 class Nanoc::MemoizationTest < Nanoc::TestCase
-
   class Sample1
-
     extend Nanoc::Memoization
 
     def initialize(value)
@@ -11,14 +9,12 @@ class Nanoc::MemoizationTest < Nanoc::TestCase
     end
 
     def run(n)
-      @value*10 + n
+      @value * 10 + n
     end
     memoize :run
-
   end
 
   class Sample2
-
     extend Nanoc::Memoization
 
     def initialize(value)
@@ -26,14 +22,12 @@ class Nanoc::MemoizationTest < Nanoc::TestCase
     end
 
     def run(n)
-      @value*100 + n
+      @value * 100 + n
     end
     memoize :run
-
   end
 
   class EqualSample
-
     extend Nanoc::Memoization
 
     def initialize(value)
@@ -44,19 +38,18 @@ class Nanoc::MemoizationTest < Nanoc::TestCase
       4
     end
 
-    def eql?(other)
+    def eql?(_other)
       true
     end
 
-    def ==(other)
+    def ==(_other)
       true
     end
 
     def run(n)
-      @value*10 + n
+      @value * 10 + n
     end
     memoize :run
-
   end
 
   def test
@@ -66,10 +59,10 @@ class Nanoc::MemoizationTest < Nanoc::TestCase
     sample2b = Sample2.new(25)
 
     3.times do
-      assert_equal 10*10+5,  sample1a.run(5)
-      assert_equal 10*15+7,  sample1b.run(7)
-      assert_equal 100*20+5, sample2a.run(5)
-      assert_equal 100*25+7, sample2b.run(7)
+      assert_equal 10 * 10 + 5,  sample1a.run(5)
+      assert_equal 10 * 15 + 7,  sample1b.run(7)
+      assert_equal 100 * 20 + 5, sample2a.run(5)
+      assert_equal 100 * 25 + 7, sample2b.run(7)
     end
   end
 
@@ -78,11 +71,10 @@ class Nanoc::MemoizationTest < Nanoc::TestCase
     sample2 = EqualSample.new(3)
 
     3.times do
-      assert_equal 2*10+5, sample1.run(5)
-      assert_equal 2*10+3, sample1.run(3)
-      assert_equal 3*10+5, sample2.run(5)
-      assert_equal 3*10+3, sample2.run(3)
+      assert_equal 2 * 10 + 5, sample1.run(5)
+      assert_equal 2 * 10 + 3, sample1.run(3)
+      assert_equal 3 * 10 + 5, sample2.run(5)
+      assert_equal 3 * 10 + 3, sample2.run(3)
     end
   end
-
 end

--- a/test/base/test_notification_center.rb
+++ b/test/base/test_notification_center.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::NotificationCenterTest < Nanoc::TestCase
-
   def test_post
     # Set up notification
     Nanoc::NotificationCenter.on :ping_received, :test do
@@ -28,5 +27,4 @@ class Nanoc::NotificationCenterTest < Nanoc::TestCase
     Nanoc::NotificationCenter.post :ping_received
     assert(!@ping_received)
   end
-
 end

--- a/test/base/test_outdatedness_checker.rb
+++ b/test/base/test_outdatedness_checker.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::OutdatednessCheckerTest < Nanoc::TestCase
-
   def test_not_outdated
     # Compile once
     with_site(:name => 'foo') do |site|
@@ -29,7 +28,7 @@ class Nanoc::OutdatednessCheckerTest < Nanoc::TestCase
     end
 
     # Delete checksums
-    with_site(:name => 'foo') do |site|
+    with_site(:name => 'foo') do |_site|
       FileUtils.rm('tmp/checksums')
     end
 
@@ -105,7 +104,7 @@ class Nanoc::OutdatednessCheckerTest < Nanoc::TestCase
 
     # Check
     with_site(:name => 'foo') do |site|
-      # FIXME ugly fugly hack
+      # FIXME: ugly fugly hack
       site.compiler.load
 
       outdatedness_checker = site.compiler.send :outdatedness_checker
@@ -137,7 +136,7 @@ class Nanoc::OutdatednessCheckerTest < Nanoc::TestCase
 
     # Check
     with_site(:name => 'foo') do |site|
-      # FIXME ugly fugly hack
+      # FIXME: ugly fugly hack
       site.compiler.load
 
       outdatedness_checker = site.compiler.send :outdatedness_checker
@@ -172,7 +171,7 @@ class Nanoc::OutdatednessCheckerTest < Nanoc::TestCase
 
     # Check
     with_site(:name => 'foo') do |site|
-      # FIXME ugly fugly hack
+      # FIXME: ugly fugly hack
       site.compiler.load
 
       outdatedness_checker = site.compiler.send :outdatedness_checker
@@ -204,7 +203,7 @@ class Nanoc::OutdatednessCheckerTest < Nanoc::TestCase
 
     # Check
     with_site(:name => 'foo') do |site|
-      # FIXME ugly fugly hack
+      # FIXME: ugly fugly hack
       site.compiler.load
 
       outdatedness_checker = site.compiler.send :outdatedness_checker
@@ -238,7 +237,7 @@ class Nanoc::OutdatednessCheckerTest < Nanoc::TestCase
 
     # Check
     with_site(:name => 'foo') do |site|
-      # FIXME ugly fugly hack
+      # FIXME: ugly fugly hack
       site.compiler.load
 
       outdatedness_checker = site.compiler.send :outdatedness_checker
@@ -248,7 +247,7 @@ class Nanoc::OutdatednessCheckerTest < Nanoc::TestCase
     end
   end
 
-  # TODO make sure outdatedness of non-outdated items is correct
+  # TODO: make sure outdatedness of non-outdated items is correct
 
   def test_outdated_if_code_snippets_outdated
     # Compile once
@@ -317,7 +316,7 @@ class Nanoc::OutdatednessCheckerTest < Nanoc::TestCase
 
   def test_outdated_if_relevant_rule_modified
     # Create site
-    with_site(:name => 'foo') do |site|
+    with_site(:name => 'foo') do |_site|
       File.open('content/index.html', 'w') { |io| io.write('o hello') }
       File.open('Rules', 'w') do |io|
         io.write("compile '/' do\n")
@@ -360,7 +359,7 @@ class Nanoc::OutdatednessCheckerTest < Nanoc::TestCase
 
   def test_items_in_rules_should_not_cause_outdatedness
     # Create site
-    with_site(:name => 'foo') do |site|
+    with_site(:name => 'foo') do |_site|
       File.open('content/index.html', 'w') { |io| io.write('o hello') }
       File.open('Rules', 'w') do |io|
         io.write("compile '/' do\n")
@@ -391,7 +390,7 @@ class Nanoc::OutdatednessCheckerTest < Nanoc::TestCase
 
   def test_non_serializable_parameters_in_rules_should_be_allowed
     # Create site
-    with_site(:name => 'foo') do |site|
+    with_site(:name => 'foo') do |_site|
       File.open('content/index.html', 'w') { |io| io.write('o hello') }
       File.open('Rules', 'w') do |io|
         io.write("compile '/' do\n")
@@ -421,5 +420,4 @@ class Nanoc::OutdatednessCheckerTest < Nanoc::TestCase
       end
     end
   end
-
 end

--- a/test/base/test_plugin.rb
+++ b/test/base/test_plugin.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::PluginTest < Nanoc::TestCase
-
   class SampleFilter < Nanoc::Filter
     identifier :_plugin_test_sample_filter
   end
@@ -24,5 +23,4 @@ class Nanoc::PluginTest < Nanoc::TestCase
 
     refute_nil filter
   end
-
 end

--- a/test/base/test_rule.rb
+++ b/test/base/test_rule.rb
@@ -1,17 +1,15 @@
 # encoding: utf-8
 
 class Nanoc::RuleTest < Nanoc::TestCase
-
   def test_initialize
-    # TODO implement
+    # TODO: implement
   end
 
   def test_applicable_to
-    # TODO implement
+    # TODO: implement
   end
 
   def test_apply_to
-    # TODO implement
+    # TODO: implement
   end
-
 end

--- a/test/base/test_rule_context.rb
+++ b/test/base/test_rule_context.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::RuleContextTest < Nanoc::TestCase
-
   def test_objects
     # Mock everything
     config = mock
@@ -59,5 +58,4 @@ class Nanoc::RuleContextTest < Nanoc::TestCase
     rep.layout 'foo'
     rep.snapshot 'awesome'
   end
-
 end

--- a/test/base/test_site.rb
+++ b/test/base/test_site.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::SiteTest < Nanoc::TestCase
-
   def test_initialize_with_dir_without_config_yaml
     assert_raises(Nanoc::Errors::GenericTrivial) do
       Nanoc::Site.new('.')
@@ -74,7 +73,7 @@ EOF
     end
 
     error = assert_raises(Nanoc::Errors::GenericTrivial) do
-      site = Nanoc::Site.new('.')
+      Nanoc::Site.new('.')
     end
     assert_equal(
       "Could not find parent configuration file 'foo/foo.yaml'",
@@ -98,7 +97,7 @@ EOF
     end
 
     error = assert_raises(Nanoc::Errors::GenericTrivial) do
-      site = Nanoc::Site.new('.')
+      Nanoc::Site.new('.')
     end
     assert_equal(
       "Cycle detected. Could not use parent configuration file '../nanoc.yaml'",
@@ -213,7 +212,6 @@ EOF
       end
     end
   end
-
 end
 
 describe 'Nanoc::Site#initialize' do

--- a/test/base/test_store.rb
+++ b/test/base/test_store.rb
@@ -1,9 +1,7 @@
 # encoding: utf-8
 
 class Nanoc::StoreTest < Nanoc::TestCase
-
   class TestStore < Nanoc::Store
-
     def data
       @data
     end
@@ -11,7 +9,6 @@ class Nanoc::StoreTest < Nanoc::TestCase
     def data=(new_data)
       @data = new_data
     end
-
   end
 
   def test_delete_and_reload_on_error
@@ -37,5 +34,4 @@ class Nanoc::StoreTest < Nanoc::TestCase
     store.load
     assert_equal(nil, store.data)
   end
-
 end

--- a/test/cli/commands/test_check.rb
+++ b/test/cli/commands/test_check.rb
@@ -1,9 +1,8 @@
 # encoding: utf-8
 
 class Nanoc::CLI::Commands::CheckTest < Nanoc::TestCase
-
   def test_check_stale
-    with_site do |site|
+    with_site do |_site|
       FileUtils.mkdir_p('output')
 
       # Should not raise now
@@ -16,5 +15,4 @@ class Nanoc::CLI::Commands::CheckTest < Nanoc::TestCase
       end
     end
   end
-
 end

--- a/test/cli/commands/test_compile.rb
+++ b/test/cli/commands/test_compile.rb
@@ -1,9 +1,8 @@
 # encoding: utf-8
 
 class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
-
   def test_profiling_information
-    with_site do |site|
+    with_site do |_site|
       Nanoc::CLI.run %w( create_item foo )
       Nanoc::CLI.run %w( create_item bar )
       Nanoc::CLI.run %w( create_item baz )
@@ -29,7 +28,7 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
   end
 
   def test_auto_prune
-    with_site do |site|
+    with_site do |_site|
       Nanoc::CLI.run %w( create_item foo )
       Nanoc::CLI.run %w( create_item bar )
       Nanoc::CLI.run %w( create_item baz )
@@ -70,7 +69,7 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
   end
 
   def test_auto_prune_with_exclude
-    with_site do |site|
+    with_site do |_site|
       Nanoc::CLI.run %w( create_item foo )
       Nanoc::CLI.run %w( create_item bar )
       Nanoc::CLI.run %w( create_item baz )
@@ -118,10 +117,21 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
   def test_setup_and_teardown_listeners
     with_site do
       test_listener_class = Class.new(::Nanoc::CLI::Commands::Compile::Listener) do
-        def start; @started = true; end
-        def stop; @stopped = true; end
-        def started?; @started; end
-        def stopped?; @stopped; end
+        def start
+          @started = true
+        end
+
+        def stop
+          @stopped = true
+        end
+
+        def started?
+          @started
+        end
+
+        def stopped?
+          @stopped
+        end
       end
 
       options = {}
@@ -201,5 +211,4 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
 
     listener
   end
-
 end

--- a/test/cli/commands/test_create_item.rb
+++ b/test/cli/commands/test_create_item.rb
@@ -1,12 +1,10 @@
 # encoding: utf-8
 
 class Nanoc::CLI::Commands::CreateItemTest < Nanoc::TestCase
-
   def test_run
-    with_site do |site|
+    with_site do |_site|
       Nanoc::CLI.run %w( create_item /blah/ )
       assert File.file?('content/blah.html')
     end
   end
-
 end

--- a/test/cli/commands/test_create_layout.rb
+++ b/test/cli/commands/test_create_layout.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::CLI::Commands::CreateLayoutTest < Nanoc::TestCase
-
   def test_can_compile_new_layout
     require 'nanoc/cli'
 
@@ -22,5 +21,4 @@ class Nanoc::CLI::Commands::CreateLayoutTest < Nanoc::TestCase
       site.compile
     end
   end
-
 end

--- a/test/cli/commands/test_create_site.rb
+++ b/test/cli/commands/test_create_site.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::CLI::Commands::CreateSiteTest < Nanoc::TestCase
-
   def test_create_site_with_existing_name
     Nanoc::CLI.run %w( create_site foo )
     assert_raises(::Nanoc::Errors::GenericTrivial) do
@@ -59,5 +58,4 @@ class Nanoc::CLI::Commands::CreateSiteTest < Nanoc::TestCase
       assert_match(/\/stylesheet.css/, File.read('output/index.html'))
     end
   end
-
 end

--- a/test/cli/commands/test_deploy.rb
+++ b/test/cli/commands/test_deploy.rb
@@ -1,10 +1,9 @@
 # encoding: utf-8
 
 class Nanoc::CLI::Commands::DeployTest < Nanoc::TestCase
-
   def test_deploy
     skip_unless_have_command 'rsync'
-    with_site do |site|
+    with_site do |_site|
       File.open('nanoc.yaml', 'w') do |io|
         io.write "deploy:\n"
         io.write "  public:\n"
@@ -23,7 +22,7 @@ class Nanoc::CLI::Commands::DeployTest < Nanoc::TestCase
   end
 
   def test_deploy_with_dry_run
-    with_site do |site|
+    with_site do |_site|
       File.open('nanoc.yaml', 'w') do |io|
         io.write "deploy:\n"
         io.write "  public:\n"
@@ -42,7 +41,7 @@ class Nanoc::CLI::Commands::DeployTest < Nanoc::TestCase
   end
 
   def test_deploy_with_list_without_config
-    with_site do |site|
+    with_site do |_site|
       FileUtils.mkdir_p('output')
       File.open('output/blah.html', 'w') { |io| io.write 'moo' }
 
@@ -58,7 +57,7 @@ class Nanoc::CLI::Commands::DeployTest < Nanoc::TestCase
   end
 
   def test_deploy_with_list
-    with_site do |site|
+    with_site do |_site|
       File.open('nanoc.yaml', 'w') do |io|
         io.write "deploy:\n"
         io.write "  public:\n"
@@ -81,7 +80,7 @@ class Nanoc::CLI::Commands::DeployTest < Nanoc::TestCase
   end
 
   def test_deploy_with_list_deployers
-    with_site do |site|
+    with_site do |_site|
       File.open('nanoc.yaml', 'w') do |io|
         io.write "deploy:\n"
         io.write "  public:\n"
@@ -105,7 +104,7 @@ class Nanoc::CLI::Commands::DeployTest < Nanoc::TestCase
 
   def test_deploy_without_kind
     skip_unless_have_command 'rsync'
-    with_site do |site|
+    with_site do |_site|
       File.open('nanoc.yaml', 'w') do |io|
         io.write "deploy:\n"
         io.write "  public:\n"
@@ -127,7 +126,7 @@ class Nanoc::CLI::Commands::DeployTest < Nanoc::TestCase
   end
 
   def test_deploy_without_target_without_default
-    with_site do |site|
+    with_site do |_site|
       File.open('nanoc.yaml', 'w') do |io|
         io.write "deploy:\n"
         io.write "  public:\n"
@@ -137,7 +136,7 @@ class Nanoc::CLI::Commands::DeployTest < Nanoc::TestCase
       FileUtils.mkdir_p('output')
       File.open('output/blah.html', 'w') { |io| io.write 'moo' }
 
-       capturing_stdio do
+      capturing_stdio do
         err = assert_raises Nanoc::Errors::GenericTrivial do
           Nanoc::CLI.run %w( deploy )
         end
@@ -148,7 +147,7 @@ class Nanoc::CLI::Commands::DeployTest < Nanoc::TestCase
 
   def test_deploy_without_target_with_default
     skip_unless_have_command 'rsync'
-    with_site do |site|
+    with_site do |_site|
       File.open('nanoc.yaml', 'w') do |io|
         io.write "deploy:\n"
         io.write "  default:\n"
@@ -166,5 +165,4 @@ class Nanoc::CLI::Commands::DeployTest < Nanoc::TestCase
       assert File.file?('mydestination/blah.html')
     end
   end
-
 end

--- a/test/cli/commands/test_help.rb
+++ b/test/cli/commands/test_help.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
 
 class Nanoc::CLI::Commands::HelpTest < Nanoc::TestCase
-
   def test_run
     Nanoc::CLI.run %w( help )
     Nanoc::CLI.run %w( help co )
   end
-
 end

--- a/test/cli/commands/test_info.rb
+++ b/test/cli/commands/test_info.rb
@@ -1,9 +1,7 @@
 # encoding: utf-8
 
 class Nanoc::CLI::Commands::InfoTest < Nanoc::TestCase
-
   def test_run
     Nanoc::CLI.run %w( info )
   end
-
 end

--- a/test/cli/commands/test_prune.rb
+++ b/test/cli/commands/test_prune.rb
@@ -1,9 +1,8 @@
 # encoding: utf-8
 
 class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
-
   def test_run_without_yes
-    with_site do |site|
+    with_site do |_site|
       # Set output dir
       File.open('nanoc.yaml', 'w') { |io| io.write 'output_dir: output2' }
       FileUtils.mkdir_p('output2')
@@ -25,7 +24,7 @@ class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
   end
 
   def test_run_with_yes
-    with_site do |site|
+    with_site do |_site|
       # Set output dir
       File.open('nanoc.yaml', 'w') { |io| io.write 'output_dir: output2' }
       FileUtils.mkdir_p('output2')
@@ -45,7 +44,7 @@ class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
   end
 
   def test_run_with_dry_run
-    with_site do |site|
+    with_site do |_site|
       # Set output dir
       File.open('nanoc.yaml', 'w') { |io| io.write 'output_dir: output2' }
       FileUtils.mkdir_p('output2')
@@ -65,7 +64,7 @@ class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
   end
 
   def test_run_with_exclude
-     with_site do |site|
+    with_site do |_site|
       # Set output dir
       File.open('nanoc.yaml', 'w') { |io| io.write "prune:\n  exclude: [ 'good-dir', 'good-file.html' ]" }
       FileUtils.mkdir_p('output')
@@ -98,7 +97,7 @@ class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
       skip 'JRuby 1.7.11 has buggy File.find behavior (see https://github.com/jruby/jruby/issues/1647)'
     end
 
-    with_site do |site|
+    with_site do |_site|
       # Set output dir
       FileUtils.rm_rf('output')
       FileUtils.mkdir_p('output-real')
@@ -121,7 +120,7 @@ class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
   end
 
   def test_run_with_nested_empty_dirs
-    with_site do |site|
+    with_site do |_site|
       # Set output dir
       File.open('nanoc.yaml', 'w') { |io| io.write 'output_dir: output' }
       FileUtils.mkdir_p('output')
@@ -138,5 +137,4 @@ class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
       assert !File.directory?('output/a')
     end
   end
-
 end

--- a/test/cli/commands/test_sync.rb
+++ b/test/cli/commands/test_sync.rb
@@ -1,5 +1,4 @@
 class Nanoc::CLI::Commands::SyncTest < Nanoc::TestCase
-
   def test_run
     with_site do
       File.open('lib/foo_data_source.rb', 'w') do |io|
@@ -25,5 +24,4 @@ class Nanoc::CLI::Commands::SyncTest < Nanoc::TestCase
       assert_equal File.read('foo_source_data.yaml'), 'sync: true'
     end
   end
-
 end

--- a/test/cli/commands/test_update.rb
+++ b/test/cli/commands/test_update.rb
@@ -1,8 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::CLI::Commands::UpdateTest < Nanoc::TestCase
-
   def test_stub
   end
-
 end

--- a/test/cli/commands/test_watch.rb
+++ b/test/cli/commands/test_watch.rb
@@ -1,9 +1,8 @@
 # encoding: utf-8
 
 class Nanoc::CLI::Commands::WatchTest < Nanoc::TestCase
-
   def test_run
-    with_site do |s|
+    with_site do |_s|
       watch_thread = Thread.new do
         Nanoc::CLI.run %w( watch )
       end
@@ -19,7 +18,7 @@ class Nanoc::CLI::Commands::WatchTest < Nanoc::TestCase
   end
 
   def test_notify
-    with_site do |s|
+    with_site do |_s|
       watch_thread = Thread.new do
         Nanoc::CLI.run %w( watch )
       end
@@ -50,7 +49,7 @@ class Nanoc::CLI::Commands::WatchTest < Nanoc::TestCase
       sleep 0.5
     end
     unless File.file?(filename)
-      raise RuntimeError, "Expected #{filename} to appear but it didn't :("
+      raise "Expected #{filename} to appear but it didn't :("
     end
   end
 
@@ -64,7 +63,7 @@ class Nanoc::CLI::Commands::WatchTest < Nanoc::TestCase
 
     actual_content = File.read(filename)
     if actual_content != expected_content
-      raise RuntimeError, "Expected #{filename} to have " \
+      raise "Expected #{filename} to have " \
         "content #{expected_content.inspect} but it had " \
         "content #{actual_content.inspect} instead :("
     end
@@ -72,5 +71,4 @@ class Nanoc::CLI::Commands::WatchTest < Nanoc::TestCase
     # Ugly, but seems to be necessary or changes are not picked up. :(
     sleep 0.5
   end
-
 end

--- a/test/cli/test_cleaning_stream.rb
+++ b/test/cli/test_cleaning_stream.rb
@@ -1,19 +1,16 @@
 # encoding: utf-8
 
 class Nanoc::CLI::CleaningStreamTest < Nanoc::TestCase
-
   class Stream
-
     attr_accessor :called_methods
 
     def initialize
       @called_methods = Set.new
     end
 
-    def method_missing(symbol, *args)
+    def method_missing(symbol, *_args)
       @called_methods << symbol
     end
-
   end
 
   def test_forward
@@ -51,10 +48,11 @@ class Nanoc::CLI::CleaningStreamTest < Nanoc::TestCase
 
   def test_broken_pipe
     stream = StringIO.new
-    def stream.write(s); raise Errno::EPIPE.new; end
+    def stream.write(_s)
+      raise Errno::EPIPE.new
+    end
 
     cleaning_stream = Nanoc::CLI::CleaningStream.new(stream)
     cleaning_stream.write('lol')
   end
-
 end

--- a/test/cli/test_cli.rb
+++ b/test/cli/test_cli.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::CLITest < Nanoc::TestCase
-
   COMMAND_CODE = <<EOS
 # encoding: utf-8
 
@@ -119,18 +118,24 @@ EOS
     }
     with_env_vars(new_env_diff) do
       io = StringIO.new
-      def io.tty?; true; end
+      def io.tty?
+        true
+      end
       refute Nanoc::CLI.enable_utf8?(io)
 
       io = StringIO.new
-      def io.tty?; false; end
+      def io.tty?
+        false
+      end
       assert Nanoc::CLI.enable_utf8?(io)
     end
   end
 
   def test_enable_utf8
     io = StringIO.new
-    def io.tty?; true; end
+    def io.tty?
+      true
+    end
 
     new_env_diff = {
       'LC_ALL'   => 'en_US.ISO-8859-1',
@@ -153,5 +158,4 @@ EOS
       with_env_vars({ 'LANG'     => 'en_US.utf8'  }) { assert Nanoc::CLI.enable_utf8?(io) }
     end
   end
-
 end

--- a/test/cli/test_error_handler.rb
+++ b/test/cli/test_error_handler.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::CLI::ErrorHandlerTest < Nanoc::TestCase
-
   def setup
     super
     @handler = Nanoc::CLI::ErrorHandler.new
@@ -13,13 +12,17 @@ class Nanoc::CLI::ErrorHandlerTest < Nanoc::TestCase
   end
 
   def test_resolution_for_with_known_gem_without_bundler
-    def @handler.using_bundler?; false; end
+    def @handler.using_bundler?
+      false
+    end
     error = LoadError.new('no such file to load -- kramdown')
     assert_match(/^Install the 'kramdown' gem using `gem install kramdown`./, @handler.send(:resolution_for, error))
   end
 
   def test_resolution_for_with_known_gem_with_bundler
-    def @handler.using_bundler?; true; end
+    def @handler.using_bundler?
+      true
+    end
     error = LoadError.new('no such file to load -- kramdown')
     assert_match(/^Make sure the gem is added to Gemfile/, @handler.send(:resolution_for, error))
   end
@@ -60,5 +63,4 @@ class Nanoc::CLI::ErrorHandlerTest < Nanoc::TestCase
       return e
     end
   end
-
 end

--- a/test/cli/test_logger.rb
+++ b/test/cli/test_logger.rb
@@ -1,8 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::CLI::LoggerTest < Nanoc::TestCase
-
   def test_stub
   end
-
 end

--- a/test/data_sources/test_filesystem.rb
+++ b/test/data_sources/test_filesystem.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
-
   class SampleFilesystemDataSource < Nanoc::DataSource
     include Nanoc::DataSources::Filesystem
   end
@@ -86,7 +85,7 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
 
     # Get all files
     output_expected = {
-      './foo'       => ['yaml', 'html'],
+      './foo'       => %w(yaml html),
       './bar.entry' => [nil,    'html'],
       './foo/qux'   => ['yaml', nil]
     }
@@ -113,7 +112,7 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
 
     # Get all files
     output_expected = {
-      './foo'       => ['yaml', 'html'],
+      './foo'       => %w(yaml html),
       './bar'       => [nil,    'html.erb'],
       './foo/qux'   => ['yaml', nil]
     }
@@ -476,8 +475,7 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
 
     # Parse it
     result = data_source.instance_eval { parse('test.html', 'test.yaml', 'foobar') }
-    assert_equal({ 'foo' => 'bar'}, result[0])
+    assert_equal({ 'foo' => 'bar' }, result[0])
     assert_equal('blah blah',       result[1])
   end
-
 end

--- a/test/data_sources/test_filesystem_unified.rb
+++ b/test/data_sources/test_filesystem_unified.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
-
   def new_data_source(params = nil)
     # Mock site
     site = Nanoc::Site.new({})
@@ -55,6 +54,7 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
       def initialize(*stuff)
         @stuff = stuff
       end
+
       def ==(other)
         @stuff == other.stuff
       end
@@ -95,12 +95,12 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
     actual_out = data_source.send(:load_objects, 'foo', 'The Foo', klass).sort_by { |i| i.stuff[0] }
 
     # Check
-    (0..expected_out.size-1).each do |i|
+    (0..expected_out.size - 1).each do |i|
       assert_equal expected_out[i].stuff[0], actual_out[i].stuff[0], 'content must match'
       assert_equal expected_out[i].stuff[2], actual_out[i].stuff[2], 'identifier must match'
       assert_equal expected_out[i].stuff[3][:mtime], actual_out[i].stuff[3][:mtime], 'mtime must match'
       assert_equal expected_out[i].stuff[1][:file].path, actual_out[i].stuff[1][:file].path, 'file paths must match'
-      expected_out[i].stuff[1][:file].close;
+      expected_out[i].stuff[1][:file].close
       actual_out[i].stuff[1][:file].close
       ['num', :filename, :extension].each do |key|
         assert_equal expected_out[i].stuff[1][key], actual_out[i].stuff[1][key], "attribute key #{key} must match"
@@ -286,6 +286,7 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
       def initialize(*stuff)
         @stuff = stuff
       end
+
       def ==(other)
         @stuff == other.stuff
       end
@@ -347,7 +348,7 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
     actual_out = data_source.send(:load_objects, 'foo', 'The Foo', klass).sort_by { |i| i.stuff[2] }
 
     # Check
-    (0..expected_out.size-1).each do |i|
+    (0..expected_out.size - 1).each do |i|
       assert_equal expected_out[i].stuff[0], actual_out[i].stuff[0], 'content must match'
       assert_equal expected_out[i].stuff[2], actual_out[i].stuff[2], 'identifier must match'
       assert_equal expected_out[i].stuff[3][:mtime], actual_out[i].stuff[3][:mtime], 'mtime must match'
@@ -374,6 +375,7 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
       def initialize(*stuff)
         @stuff = stuff
       end
+
       def ==(other)
         @stuff == other.stuff
       end
@@ -435,7 +437,7 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
     actual_out = data_source.send(:load_objects, 'foo', 'The Foo', klass).sort_by { |i| i.stuff[2] }
 
     # Check
-    (0..expected_out.size-1).each do |i|
+    (0..expected_out.size - 1).each do |i|
       assert_equal expected_out[i].stuff[0], actual_out[i].stuff[0], 'content must match'
       assert_equal expected_out[i].stuff[2], actual_out[i].stuff[2], 'identifier must match'
       assert_equal expected_out[i].stuff[3][:mtime], actual_out[i].stuff[3][:mtime], 'mtime must match'
@@ -568,5 +570,4 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
     assert_equal 1, items.size
     assert_equal Encoding.find('UTF-8'), items[0].raw_content.encoding
   end
-
 end

--- a/test/data_sources/test_filesystem_verbose.rb
+++ b/test/data_sources/test_filesystem_verbose.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::DataSources::FilesystemVerboseTest < Nanoc::TestCase
-
   def new_data_source(params = nil)
     # Mock site
     site = Nanoc::Site.new({})
@@ -42,18 +41,18 @@ class Nanoc::DataSources::FilesystemVerboseTest < Nanoc::TestCase
 
     # Check items
     assert_equal(2, items.size)
-    assert(items.any? { |a|
+    assert(items.any? do |a|
       a[:title]            == 'Foo' &&
       a[:extension]        == 'html' &&
       a[:content_filename] == 'content/foo/foo.html' &&
       a[:meta_filename]    == 'content/foo/foo.yaml'
-    })
-    assert(items.any? { |a|
+    end)
+    assert(items.any? do |a|
       a[:title]            == 'Bar' &&
       a[:extension]        == 'xml' &&
       a[:content_filename] == 'content/bar/bar.xml' &&
       a[:meta_filename]    == 'content/bar/bar.yaml'
-    })
+    end)
   end
 
   def test_items_with_period_in_name
@@ -67,7 +66,7 @@ class Nanoc::DataSources::FilesystemVerboseTest < Nanoc::TestCase
     File.open('content/foo/foo.css', 'w') do |io|
       io.write('body.foo {}')
     end
-    
+
     # Create foo.bar.css
     FileUtils.mkdir_p('content/foo.bar')
     File.open('content/foo.bar/foo.bar.yaml', 'w') do |io|
@@ -76,10 +75,10 @@ class Nanoc::DataSources::FilesystemVerboseTest < Nanoc::TestCase
     File.open('content/foo.bar/foo.bar.css', 'w') do |io|
       io.write('body.foobar {}')
     end
-    
+
     # Load
     items = data_source.items.sort_by { |i| i[:title] }
-    
+
     # Check
     assert_equal 2, items.size
     assert_equal '/foo/',                        items[0].identifier
@@ -114,18 +113,18 @@ class Nanoc::DataSources::FilesystemVerboseTest < Nanoc::TestCase
 
     # Check items
     assert_equal(2, items.size)
-    assert(items.any? { |a|
-      a[:title]            == nil &&
-      a[:extension]        == 'html' &&
+    assert(items.any? do |a|
+      a[:title].nil? &&
+      a[:extension] == 'html' &&
       a[:content_filename] == 'content/foo/foo.html' &&
-      a[:meta_filename]    == nil
-    })
-    assert(items.any? { |a|
-      a[:title]            == 'Bar' &&
-      a[:extension]        == nil &&
-      a[:content_filename] == nil &&
-      a[:meta_filename]    == 'content/bar/bar.yaml'
-    })
+      a[:meta_filename].nil?
+    end)
+    assert(items.any? do |a|
+      a[:title] == 'Bar' &&
+      a[:extension].nil? &&
+      a[:content_filename].nil? &&
+      a[:meta_filename] == 'content/bar/bar.yaml'
+    end)
   end
 
   def test_layouts
@@ -164,7 +163,7 @@ class Nanoc::DataSources::FilesystemVerboseTest < Nanoc::TestCase
     File.open('layouts/foo/foo.html', 'w') do |io|
       io.write('body.foo {}')
     end
-    
+
     # Create bar.html.erb
     FileUtils.mkdir_p('layouts/bar')
     File.open('layouts/bar/bar.yaml', 'w') do |io|
@@ -173,10 +172,10 @@ class Nanoc::DataSources::FilesystemVerboseTest < Nanoc::TestCase
     File.open('layouts/bar/bar.html.erb', 'w') do |io|
       io.write('body.foobar {}')
     end
-    
+
     # Load
     layouts = data_source.layouts.sort_by { |i| i.identifier }
-    
+
     # Check
     assert_equal 2, layouts.size
     assert_equal '/bar/', layouts[0].identifier
@@ -196,7 +195,7 @@ class Nanoc::DataSources::FilesystemVerboseTest < Nanoc::TestCase
     File.open('layouts/foo/foo.html', 'w') do |io|
       io.write('body.foo {}')
     end
-    
+
     # Create bar.html.erb
     FileUtils.mkdir_p('layouts/bar.xyz')
     File.open('layouts/bar.xyz/bar.xyz.yaml', 'w') do |io|
@@ -205,10 +204,10 @@ class Nanoc::DataSources::FilesystemVerboseTest < Nanoc::TestCase
     File.open('layouts/bar.xyz/bar.xyz.html', 'w') do |io|
       io.write('body.foobar {}')
     end
-    
+
     # Load
     layouts = data_source.layouts.sort_by { |i| i.identifier }
-    
+
     # Check
     assert_equal 2, layouts.size
     assert_equal '/bar.xyz/', layouts[0].identifier
@@ -351,5 +350,4 @@ class Nanoc::DataSources::FilesystemVerboseTest < Nanoc::TestCase
       data_source.items
     end
   end
-
 end

--- a/test/data_sources/test_static.rb
+++ b/test/data_sources/test_static.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::DataSources::StaticTest < Nanoc::TestCase
-
   def new_data_source(params = nil)
     # Mock site
     site = Nanoc::Site.new({})
@@ -84,7 +83,7 @@ class Nanoc::DataSources::StaticTest < Nanoc::TestCase
 
     actual_out = data_source.send(:items).sort_by { |i| i.identifier }
 
-    (0..expected_out.size-1).each do |i|
+    (0..expected_out.size - 1).each do |i|
       assert_equal expected_out[i].raw_content, actual_out[i].raw_content, 'content must match'
       assert_equal expected_out[i].identifier, actual_out[i].identifier, 'identifier must match'
       assert_equal expected_out[i].mtime, actual_out[i].mtime, 'mtime must match'

--- a/test/extra/checking/checks/test_css.rb
+++ b/test/extra/checking/checks/test_css.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Extra::Checking::Checks::CSSTest < Nanoc::TestCase
-
   def test_run_ok
     VCR.use_cassette('css_run_ok') do
       with_site do |site|
@@ -37,6 +36,4 @@ class Nanoc::Extra::Checking::Checks::CSSTest < Nanoc::TestCase
       end
     end
   end
-
 end
-

--- a/test/extra/checking/checks/test_external_links.rb
+++ b/test/extra/checking/checks/test_external_links.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Extra::Checking::Checks::ExternalLinksTest < Nanoc::TestCase
-
   def test_run
     with_site do |site|
       # Create files
@@ -52,13 +51,13 @@ class Nanoc::Extra::Checking::Checks::ExternalLinksTest < Nanoc::TestCase
 
   def test_fallback_to_get_when_head_is_not_allowed
     with_site do |site|
-      #Create check
+      # Create check
       check = Nanoc::Extra::Checking::Checks::ExternalLinks.new(site)
       def check.request_url_once(url, req_method = Net::HTTP::Head)
         Net::HTTPResponse.new('1.1', (req_method == Net::HTTP::Head || url.path == '/405') ? '405' : '200', 'okay')
       end
 
-      #Test
+      # Test
       assert_nil check.validate('http://127.0.0.1:9204')
       refute_nil check.validate('http://127.0.0.1:9204/405')
     end
@@ -75,5 +74,4 @@ class Nanoc::Extra::Checking::Checks::ExternalLinksTest < Nanoc::TestCase
       assert_equal '/meow?foo=bar', check.send(:path_for_url, URI.parse('http://example.com/meow?foo=bar'))
     end
   end
-
 end

--- a/test/extra/checking/checks/test_html.rb
+++ b/test/extra/checking/checks/test_html.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Extra::Checking::Checks::HTMLTest < Nanoc::TestCase
-
   def test_run_ok
     VCR.use_cassette('html_run_ok') do
       with_site do |site|
@@ -37,6 +36,4 @@ class Nanoc::Extra::Checking::Checks::HTMLTest < Nanoc::TestCase
       end
     end
   end
-
 end
-

--- a/test/extra/checking/checks/test_internal_links.rb
+++ b/test/extra/checking/checks/test_internal_links.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Extra::Checking::Checks::InternalLinksTest < Nanoc::TestCase
-
   def test_run
     with_site do |site|
       # Create files
@@ -77,5 +76,4 @@ class Nanoc::Extra::Checking::Checks::InternalLinksTest < Nanoc::TestCase
       refute check.send(:valid?, 'stuff/wrong%20foo', 'output/origin')
     end
   end
-
 end

--- a/test/extra/checking/checks/test_stale.rb
+++ b/test/extra/checking/checks/test_stale.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Extra::Checking::Checks::StaleTest < Nanoc::TestCase
-
   def check_class
     Nanoc::Extra::Checking::Checks::Stale
   end
@@ -14,7 +13,7 @@ class Nanoc::Extra::Checking::Checks::StaleTest < Nanoc::TestCase
   end
 
   def test_run_ok
-    with_site do |site|
+    with_site do |_site|
       assert Dir['content/*'].empty?
       assert Dir['output/*'].empty?
 
@@ -30,7 +29,7 @@ class Nanoc::Extra::Checking::Checks::StaleTest < Nanoc::TestCase
   end
 
   def test_run_error
-    with_site do |site|
+    with_site do |_site|
       assert Dir['content/*'].empty?
       assert Dir['output/*'].empty?
 
@@ -44,7 +43,7 @@ class Nanoc::Extra::Checking::Checks::StaleTest < Nanoc::TestCase
   end
 
   def test_run_excluded
-    with_site do |site|
+    with_site do |_site|
       assert Dir['content/*'].empty?
       assert Dir['output/*'].empty?
 
@@ -56,7 +55,7 @@ class Nanoc::Extra::Checking::Checks::StaleTest < Nanoc::TestCase
   end
 
   def test_run_excluded_with_broken_config
-    with_site do |site|
+    with_site do |_site|
       assert Dir['content/*'].empty?
       assert Dir['output/*'].empty?
 
@@ -66,5 +65,4 @@ class Nanoc::Extra::Checking::Checks::StaleTest < Nanoc::TestCase
       refute calc_issues.empty?
     end
   end
-
 end

--- a/test/extra/checking/test_check.rb
+++ b/test/extra/checking/test_check.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Extra::Checking::CheckTest < Nanoc::TestCase
-
   def test_output_filenames
     with_site do |site|
       check = Nanoc::Extra::Checking::Check.new(site)
@@ -20,5 +19,4 @@ class Nanoc::Extra::Checking::CheckTest < Nanoc::TestCase
       end
     end
   end
-
 end

--- a/test/extra/checking/test_dsl.rb
+++ b/test/extra/checking/test_dsl.rb
@@ -1,9 +1,8 @@
 # encoding: utf-8
 
 class Nanoc::Extra::Checking::DSLTest < Nanoc::TestCase
-
   def test_from_file
-    with_site do |site|
+    with_site do |_site|
       File.open('Checks', 'w') { |io| io.write("check :foo do\n\nend\ndeploy_check :bar\n") }
       dsl = Nanoc::Extra::Checking::DSL.from_file('Checks')
 
@@ -14,5 +13,4 @@ class Nanoc::Extra::Checking::DSLTest < Nanoc::TestCase
       assert_equal [:bar], dsl.deploy_checks
     end
   end
-
 end

--- a/test/extra/checking/test_runner.rb
+++ b/test/extra/checking/test_runner.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Extra::Checking::RunnerTest < Nanoc::TestCase
-
   def test_run_specific
     with_site do |site|
       File.open('output/blah', 'w') { |io| io.write('I am stale! Haha!') }
@@ -41,5 +40,4 @@ class Nanoc::Extra::Checking::RunnerTest < Nanoc::TestCase
       assert ios[:stderr].empty?
     end
   end
-
 end

--- a/test/extra/core_ext/test_enumerable.rb
+++ b/test/extra/core_ext/test_enumerable.rb
@@ -1,9 +1,7 @@
 # encoding: utf-8
 
 class Nanoc::ExtraCoreExtEnumerableTest < Nanoc::TestCase
-
   class MyCollection
-
     include Enumerable
 
     def initialize(array)
@@ -13,16 +11,14 @@ class Nanoc::ExtraCoreExtEnumerableTest < Nanoc::TestCase
     def each(&block)
       @array.each { |i| block.call(i) }
     end
-
   end
 
   def test_group_by
-    input = MyCollection.new(['foo', 'bar', 'baz'])
+    input = MyCollection.new(%w(foo bar baz))
 
-    output_expected = { ?f => ['foo'], ?b => ['bar', 'baz'] }
+    output_expected = { 'f' => ['foo'], 'b' => %w(bar baz) }
     output_actual   = input.group_by { |i| i[0] }
 
     assert_equal output_expected, output_actual
   end
-
 end

--- a/test/extra/core_ext/test_pathname.rb
+++ b/test/extra/core_ext/test_pathname.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Extra::CoreExtPathnameTest < Nanoc::TestCase
-
   def test_components
     assert_equal %w( / a bb ccc dd e ), Pathname.new('/a/bb/ccc/dd/e').components
   end
@@ -10,6 +9,4 @@ class Nanoc::Extra::CoreExtPathnameTest < Nanoc::TestCase
     assert Pathname.new('/home/ddfreyne/').include_component?('ddfreyne')
     refute Pathname.new('/home/ddfreyne/').include_component?('acid')
   end
-
 end
-

--- a/test/extra/core_ext/test_time.rb
+++ b/test/extra/core_ext/test_time.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::ExtraCoreExtTimeTest < Nanoc::TestCase
-
   def test_to_iso8601_date
     assert_equal('2008-05-19', Time.utc(2008, 5, 19, 14, 20, 0, 0).to_iso8601_date)
   end
@@ -9,5 +8,4 @@ class Nanoc::ExtraCoreExtTimeTest < Nanoc::TestCase
   def test_to_iso8601_time
     assert_equal('2008-05-19T14:20:00Z', Time.utc(2008, 5, 19, 14, 20, 0, 0).to_iso8601_time)
   end
-
 end

--- a/test/extra/deployers/test_fog.rb
+++ b/test/extra/deployers/test_fog.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Extra::Deployers::FogTest < Nanoc::TestCase
-
   def test_run
     if_have 'fog' do
       # Create deployer
@@ -10,7 +9,7 @@ class Nanoc::Extra::Deployers::FogTest < Nanoc::TestCase
         {
           :bucket     => 'mybucket',
           :provider   => 'local',
-          :local_root => 'mylocalcloud'})
+          :local_root => 'mylocalcloud' })
 
       # Create site
       FileUtils.mkdir_p('output')
@@ -39,10 +38,10 @@ class Nanoc::Extra::Deployers::FogTest < Nanoc::TestCase
           'output/',
           {
             :provider              => 'aws',
-            # FIXME bucket is necessary for deployer but fog doesn't like it
+            # FIXME: bucket is necessary for deployer but fog doesn't like it
             :bucket_name           => 'doesntmatter',
             :aws_access_key_id     => 'meh',
-            :aws_secret_access_key => 'dontcare'},
+            :aws_secret_access_key => 'dontcare' },
           :dry_run => true)
 
         # Create site
@@ -56,7 +55,7 @@ class Nanoc::Extra::Deployers::FogTest < Nanoc::TestCase
         # Run
         fog.run
       ensure
-        # Hack :(
+        # FIXME: ugly hack
         ::Fog.instance_eval { @mocking = false }
       end
     end
@@ -70,7 +69,7 @@ class Nanoc::Extra::Deployers::FogTest < Nanoc::TestCase
         {
           :bucket     => 'mybucket',
           :provider   => 'local',
-          :local_root => 'mylocalcloud'})
+          :local_root => 'mylocalcloud' })
 
       # Setup fake local cloud
       FileUtils.mkdir_p('mylocalcloud/mybucket')
@@ -97,5 +96,4 @@ class Nanoc::Extra::Deployers::FogTest < Nanoc::TestCase
       assert_equal 'I am a dog!', File.read('mylocalcloud/mybucket/bark')
     end
   end
-
 end

--- a/test/extra/deployers/test_rsync.rb
+++ b/test/extra/deployers/test_rsync.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Extra::Deployers::RsyncTest < Nanoc::TestCase
-
   def test_run_without_dst
     # Create deployer
     rsync = Nanoc::Extra::Deployers::Rsync.new(
@@ -86,5 +85,4 @@ class Nanoc::Extra::Deployers::RsyncTest < Nanoc::TestCase
       rsync.instance_eval { @shell_cms_args }
     )
   end
-
 end

--- a/test/extra/test_auto_compiler.rb
+++ b/test/extra/test_auto_compiler.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Extra::AutoCompilerTest < Nanoc::TestCase
-
   def test_handle_request_with_item_rep_with_index_filename
     if_have 'mime/types', 'rack' do
       # Create site
@@ -77,8 +76,12 @@ class Nanoc::Extra::AutoCompilerTest < Nanoc::TestCase
         @expected_path_info = 'somefile.txt'
         @actual_path_info   = env['PATH_INFO']
       end
-      def file_server.expected_path_info; @expected_path_info; end
-      def file_server.actual_path_info; @actual_path_info; end
+      def file_server.expected_path_info
+        @expected_path_info
+      end
+      def file_server.actual_path_info
+        @actual_path_info
+      end
 
       # Create site
       site = mock
@@ -111,8 +114,12 @@ class Nanoc::Extra::AutoCompilerTest < Nanoc::TestCase
         @expected_path_info = '/foo/bar/index.html'
         @actual_path_info   = env['PATH_INFO']
       end
-      def file_server.expected_path_info; @expected_path_info; end
-      def file_server.actual_path_info; @actual_path_info; end
+      def file_server.expected_path_info
+        @expected_path_info
+      end
+      def file_server.actual_path_info
+        @actual_path_info
+      end
 
       # Create site
       site = mock
@@ -145,8 +152,12 @@ class Nanoc::Extra::AutoCompilerTest < Nanoc::TestCase
         @expected_path_info = 'foo/bar/'
         @actual_path_info   = env['PATH_INFO']
       end
-      def file_server.expected_path_info; @expected_path_info; end
-      def file_server.actual_path_info; @actual_path_info; end
+      def file_server.expected_path_info
+        @expected_path_info
+      end
+      def file_server.actual_path_info
+        @actual_path_info
+      end
 
       # Create site
       site = mock
@@ -179,8 +190,12 @@ class Nanoc::Extra::AutoCompilerTest < Nanoc::TestCase
         @expected_path_info = 'foo/bar'
         @actual_path_info   = env['PATH_INFO']
       end
-      def file_server.expected_path_info; @expected_path_info; end
-      def file_server.actual_path_info; @actual_path_info; end
+      def file_server.expected_path_info
+        @expected_path_info
+      end
+      def file_server.actual_path_info
+        @actual_path_info
+      end
 
       # Create site
       site = mock
@@ -213,8 +228,12 @@ class Nanoc::Extra::AutoCompilerTest < Nanoc::TestCase
         @expected_path_info = 'foo/bar'
         @actual_path_info   = env['PATH_INFO']
       end
-      def file_server.expected_path_info; @expected_path_info; end
-      def file_server.actual_path_info; @actual_path_info; end
+      def file_server.expected_path_info
+        @expected_path_info
+      end
+      def file_server.actual_path_info
+        @actual_path_info
+      end
 
       # Create site
       site = mock
@@ -243,8 +262,12 @@ class Nanoc::Extra::AutoCompilerTest < Nanoc::TestCase
         @expected_path_info = 'four-oh-four.txt'
         @actual_path_info   = env['PATH_INFO']
       end
-      def file_server.expected_path_info; @expected_path_info; end
-      def file_server.actual_path_info; @actual_path_info; end
+      def file_server.expected_path_info
+        @expected_path_info
+      end
+      def file_server.actual_path_info
+        @actual_path_info
+      end
 
       # Create site
       site = mock
@@ -370,10 +393,10 @@ class Nanoc::Extra::AutoCompilerTest < Nanoc::TestCase
         File.open('nanoc.yaml', 'w') do |io|
           io.write 'value: Foo'
         end
-        File.utime(Time.now+5, Time.now+5, 'nanoc.yaml')
+        File.utime(Time.now + 5, Time.now + 5, 'nanoc.yaml')
 
         # Check
-        status, headers, body = autocompiler.call('REQUEST_METHOD' => 'GET', 'PATH_INFO' => '/')
+        _status, _headers, body = autocompiler.call('REQUEST_METHOD' => 'GET', 'PATH_INFO' => '/')
         body.each do |b|
           assert_match(/The Grand Value of Configuration is Foo!/, b)
         end
@@ -382,10 +405,10 @@ class Nanoc::Extra::AutoCompilerTest < Nanoc::TestCase
         File.open('nanoc.yaml', 'w') do |io|
           io.write 'value: Bar'
         end
-        File.utime(Time.now+5, Time.now+5, 'nanoc.yaml')
+        File.utime(Time.now + 5, Time.now + 5, 'nanoc.yaml')
 
         # Check
-        status, headers, body = autocompiler.call('REQUEST_METHOD' => 'GET', 'PATH_INFO' => '/')
+        _status, _headers, body = autocompiler.call('REQUEST_METHOD' => 'GET', 'PATH_INFO' => '/')
         body.each do |b|
           assert_match(/The Grand Value of Configuration is Bar!/, b)
         end
@@ -411,5 +434,4 @@ class Nanoc::Extra::AutoCompilerTest < Nanoc::TestCase
       assert_match("File not found: /software\n", result[2][0])
     end
   end
-
 end

--- a/test/extra/test_file_proxy.rb
+++ b/test/extra/test_file_proxy.rb
@@ -1,11 +1,10 @@
 # encoding: utf-8
 
 class Nanoc::Extra::FileProxyTest < Nanoc::TestCase
-
   def test_create_many
     if_implemented do
       # Create test file
-      File.open('test.txt', 'w') { |io| }
+      File.open('test.txt', 'w') { |_io| }
 
       # Create lots of file proxies
       count = Process.getrlimit(Process::RLIMIT_NOFILE)[0] + 5
@@ -13,5 +12,4 @@ class Nanoc::Extra::FileProxyTest < Nanoc::TestCase
       count.times { file_proxies << Nanoc::Extra::FileProxy.new('test.txt') }
     end
   end
-
 end

--- a/test/extra/test_filesystem_tools.rb
+++ b/test/extra/test_filesystem_tools.rb
@@ -13,7 +13,7 @@ class Nanoc::Extra::FilesystemToolsTest < Nanoc::TestCase
       File.open("dir#{i}/foo.md", 'w') { |io| io.write('o hai') }
     end
     (1..10).each do |i|
-      File.symlink("../dir#{i}", "dir#{i-1}/sub")
+      File.symlink("../dir#{i}", "dir#{i - 1}/sub")
     end
 
     # Check
@@ -43,7 +43,7 @@ class Nanoc::Extra::FilesystemToolsTest < Nanoc::TestCase
       File.open("dir#{i}/foo.md", 'w') { |io| io.write('o hai') }
     end
     (1..15).each do |i|
-      File.symlink("../dir#{i}", "dir#{i-1}/sub")
+      File.symlink("../dir#{i}", "dir#{i - 1}/sub")
     end
 
     assert_raises Nanoc::Extra::FilesystemTools::MaxSymlinkDepthExceededError do
@@ -93,12 +93,11 @@ class Nanoc::Extra::FilesystemToolsTest < Nanoc::TestCase
     File.open('foo', 'w') { |io| io.write('o hai') }
     File.symlink('foo', 'symlin-0')
     (1..7).each do |i|
-      File.symlink("symlink-#{i-1}", "symlink-#{i}")
+      File.symlink("symlink-#{i - 1}", "symlink-#{i}")
     end
 
     assert_raises Nanoc::Extra::FilesystemTools::MaxSymlinkDepthExceededError do
       Nanoc::Extra::FilesystemTools.resolve_symlink('symlink-7')
     end
   end
-
 end

--- a/test/extra/test_link_collector.rb
+++ b/test/extra/test_link_collector.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Extra::LinkCollectorTest < Nanoc::TestCase
-
   def test_all
     # Create dummy data
     File.open('file-a.html', 'w') do |io|
@@ -106,5 +105,4 @@ class Nanoc::Extra::LinkCollectorTest < Nanoc::TestCase
     assert_includes hrefs, '../stuff'
     assert_includes hrefs, '/stuff'
   end
-
 end

--- a/test/extra/test_piper.rb
+++ b/test/extra/test_piper.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Extra::PiperTest < Nanoc::TestCase
-
   def test_basic
     stdout = StringIO.new
     stderr = StringIO.new
@@ -44,5 +43,4 @@ class Nanoc::Extra::PiperTest < Nanoc::TestCase
       piper.run(cmd, nil)
     end
   end
-
 end

--- a/test/extra/test_vcs.rb
+++ b/test/extra/test_vcs.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Extra::VCSTest < Nanoc::TestCase
-
   def test_named
     assert_nil(Nanoc::Extra::VCS.named(:lkasjdlkfjlkasdfkj))
 
@@ -16,5 +15,4 @@ class Nanoc::Extra::VCSTest < Nanoc::TestCase
     assert_raises(NotImplementedError) { vcs.remove('x')    }
     assert_raises(NotImplementedError) { vcs.move('x', 'y') }
   end
-
 end

--- a/test/extra/validators/test_links.rb
+++ b/test/extra/validators/test_links.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
 
 class Nanoc::Extra::Validators::LinksTest < Nanoc::TestCase
-
 end

--- a/test/extra/validators/test_w3c.rb
+++ b/test/extra/validators/test_w3c.rb
@@ -1,10 +1,9 @@
 # encoding: utf-8
 
 class Nanoc::Extra::Validators::W3CTest < Nanoc::TestCase
-
   def test_simple
     if_have 'w3c_validators' do
-      with_site do |site|
+      with_site do |_site|
         # Create some sample files
         %w(foo bar baz).each do |filename|
           %w(xxx yyy).each do |extension|
@@ -23,7 +22,7 @@ class Nanoc::Extra::Validators::W3CTest < Nanoc::TestCase
 
   def test_with_unknown_types
     if_have 'w3c_validators' do
-      with_site do |site|
+      with_site do |_site|
         # Create validator
         w3c = Nanoc::Extra::Validators::W3C.new('.', [:foo])
 
@@ -35,5 +34,4 @@ class Nanoc::Extra::Validators::W3CTest < Nanoc::TestCase
       end
     end
   end
-
 end

--- a/test/filters/test_asciidoc.rb
+++ b/test/filters/test_asciidoc.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::AsciiDocTest < Nanoc::TestCase
-
   def test_filter
     skip_unless_have_command 'asciidoc'
 
@@ -12,5 +11,4 @@ class Nanoc::Filters::AsciiDocTest < Nanoc::TestCase
     result = filter.setup_and_run('== Blah blah')
     assert_match %r{<h2 id="_blah_blah">Blah blah</h2>}, result
   end
-
 end

--- a/test/filters/test_bluecloth.rb
+++ b/test/filters/test_bluecloth.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::BlueClothTest < Nanoc::TestCase
-
   def test_filter
     if_have 'bluecloth' do
       # Create filter
@@ -12,5 +11,4 @@ class Nanoc::Filters::BlueClothTest < Nanoc::TestCase
       assert_match %r{<blockquote>\s*<p>Quote</p>\s*</blockquote>}, result
     end
   end
-
 end

--- a/test/filters/test_coderay.rb
+++ b/test/filters/test_coderay.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::CodeRayTest < Nanoc::TestCase
-
   def test_filter_without_language
     if_have 'coderay' do
       # Get filter
@@ -38,5 +37,4 @@ class Nanoc::Filters::CodeRayTest < Nanoc::TestCase
       assert_equal code, result
     end
   end
-
 end

--- a/test/filters/test_coffeescript.rb
+++ b/test/filters/test_coffeescript.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::CoffeeScriptTest < Nanoc::TestCase
-
   def test_filter
     if_have 'coffee-script' do
       # Create filter
@@ -12,5 +11,4 @@ class Nanoc::Filters::CoffeeScriptTest < Nanoc::TestCase
       assert_equal('(function() { alert(42); }).call(this); ', result.gsub(/\s+/, ' '))
     end
   end
-
 end

--- a/test/filters/test_colorize_syntax.rb
+++ b/test/filters/test_colorize_syntax.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::ColorizeSyntaxTest < Nanoc::TestCase
-
   CODERAY_PRE  = '<div class="CodeRay"><div class="code">'
   CODERAY_POST = '</div></div>'
 
@@ -176,7 +175,7 @@ EOS
       filter = ::Nanoc::Filters::ColorizeSyntax.new
 
       # Get input and expected output
-      input = %Q(<pre title="moo"><code class="language-ruby">
+      input = %(<pre title="moo"><code class="language-ruby">
 # comment
 </code></pre>)
       expected_output = '<pre title="moo"><code class="language-ruby"><span class="hl slc"># comment</span></code></pre>'
@@ -445,5 +444,4 @@ EOS
       assert_equal(expected_output, actual_output)
     end
   end
-
 end

--- a/test/filters/test_erb.rb
+++ b/test/filters/test_erb.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::ERBTest < Nanoc::TestCase
-
   def test_filter_with_instance_variable
     # Create filter
     filter = ::Nanoc::Filters::ERB.new({ :location => 'a cheap motel' })
@@ -103,5 +102,4 @@ class Nanoc::Filters::ERBTest < Nanoc::TestCase
     result = filter.setup_and_run('<%= @local %>', :locals => { :local => 123 })
     assert_equal '123', result
   end
-
 end

--- a/test/filters/test_erubis.rb
+++ b/test/filters/test_erubis.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::ErubisTest < Nanoc::TestCase
-
   def test_filter_with_instance_variable
     if_have 'erubis' do
       # Create filter
@@ -72,5 +71,4 @@ class Nanoc::Filters::ErubisTest < Nanoc::TestCase
       assert_equal 'stuffstuff', result
     end
   end
-
 end

--- a/test/filters/test_haml.rb
+++ b/test/filters/test_haml.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::HamlTest < Nanoc::TestCase
-
   def test_filter
     if_have 'haml' do
       # Create filter
@@ -90,5 +89,4 @@ class Nanoc::Filters::HamlTest < Nanoc::TestCase
       assert_match(/Max Payne&#x000A;Mona Sax/, result)
     end
   end
-
 end

--- a/test/filters/test_handlebars.rb
+++ b/test/filters/test_handlebars.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::HandlebarsTest < Nanoc::TestCase
-
   def test_filter
     if_have 'handlebars' do
       # Create data
@@ -54,5 +53,4 @@ class Nanoc::Filters::HandlebarsTest < Nanoc::TestCase
       assert_equal('Max Payne says: No Payne No Gayne.', result)
     end
   end
-
 end

--- a/test/filters/test_kramdown.rb
+++ b/test/filters/test_kramdown.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::KramdownTest < Nanoc::TestCase
-
   def test_filter
     if_have 'kramdown' do
       # Create filter
@@ -12,5 +11,4 @@ class Nanoc::Filters::KramdownTest < Nanoc::TestCase
       assert_equal("<p>This is <em>so</em> <strong>cool</strong>!</p>\n", result)
     end
   end
-
 end

--- a/test/filters/test_less.rb
+++ b/test/filters/test_less.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::LessTest < Nanoc::TestCase
-
   def test_filter
     if_have 'less' do
       # Create item
@@ -121,5 +120,4 @@ class Nanoc::Filters::LessTest < Nanoc::TestCase
       assert_match(/^\.foo\{bar:a\}\n?\.bar\{foo:b\}/, result)
     end
   end
-
 end

--- a/test/filters/test_markaby.rb
+++ b/test/filters/test_markaby.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::MarkabyTest < Nanoc::TestCase
-
   def test_filter
     # Don’t run this test on 1.9.x, because it breaks and it annoys me
     if RUBY_VERSION >= '1.9'
@@ -18,5 +17,4 @@ class Nanoc::Filters::MarkabyTest < Nanoc::TestCase
       assert_equal('<html></html>', result)
     end
   end
-
 end

--- a/test/filters/test_maruku.rb
+++ b/test/filters/test_maruku.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::MarukuTest < Nanoc::TestCase
-
   def test_filter
     if_have 'maruku' do
       # Create filter
@@ -12,5 +11,4 @@ class Nanoc::Filters::MarukuTest < Nanoc::TestCase
       assert_equal('<p>This is <em>so</em> <em>cool</em>!</p>', result.strip)
     end
   end
-
 end

--- a/test/filters/test_mustache.rb
+++ b/test/filters/test_mustache.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::MustacheTest < Nanoc::TestCase
-
   def test_filter
     if_have 'mustache' do
       # Create item
@@ -38,5 +37,4 @@ class Nanoc::Filters::MustacheTest < Nanoc::TestCase
       assert_equal('Max says: No Payne No Gayne.', result)
     end
   end
-
 end

--- a/test/filters/test_pandoc.rb
+++ b/test/filters/test_pandoc.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::PandocTest < Nanoc::TestCase
-
   def test_filter
     if_have 'pandoc-ruby' do
       skip_unless_have_command 'pandoc'
@@ -23,11 +22,10 @@ class Nanoc::Filters::PandocTest < Nanoc::TestCase
       filter = ::Nanoc::Filters::Pandoc.new
 
       # Run filter
-      opts = [:s, {:f => :markdown, :to => :html}, 'no-wrap', :toc]
+      opts = [:s, { :f => :markdown, :to => :html }, 'no-wrap', :toc]
       result = filter.setup_and_run("# Heading\n", *opts)
       assert_match '<div id="TOC">', result
       assert_match(%r{<h1 id=\"heading\">Heading</h1>\s*}, result)
     end
   end
-
 end

--- a/test/filters/test_rainpress.rb
+++ b/test/filters/test_rainpress.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::RainpressTest < Nanoc::TestCase
-
   def test_filter
     if_have 'rainpress' do
       # Create filter
@@ -23,5 +22,4 @@ class Nanoc::Filters::RainpressTest < Nanoc::TestCase
       assert_equal('body{color:#aabbcc}', result)
     end
   end
-
 end

--- a/test/filters/test_rdiscount.rb
+++ b/test/filters/test_rdiscount.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::RDiscountTest < Nanoc::TestCase
-
   def test_filter
     if_have 'rdiscount' do
       # Create filter
@@ -25,5 +24,4 @@ class Nanoc::Filters::RDiscountTest < Nanoc::TestCase
       assert_match(output_expected, output_actual)
     end
   end
-
 end

--- a/test/filters/test_rdoc.rb
+++ b/test/filters/test_rdoc.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::RDocTest < Nanoc::TestCase
-
   def test_filter
     # Get filter
     filter = ::Nanoc::Filters::RDoc.new
@@ -10,5 +9,4 @@ class Nanoc::Filters::RDocTest < Nanoc::TestCase
     result = filter.setup_and_run('= Foo')
     assert_match(%r{\A\s*<h1( id="label-Foo")?>Foo(<span>.*</span>)?</h1>\s*\Z}, result)
   end
-
 end

--- a/test/filters/test_redcarpet.rb
+++ b/test/filters/test_redcarpet.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::RedcarpetTest < Nanoc::TestCase
-
   def test_find
     if_have 'redcarpet' do
       refute Nanoc::Filter.named(:redcarpet).nil?
@@ -106,5 +105,4 @@ class Nanoc::Filters::RedcarpetTest < Nanoc::TestCase
       assert_match(output_expected, output_actual)
     end
   end
-
 end

--- a/test/filters/test_redcloth.rb
+++ b/test/filters/test_redcloth.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::RedClothTest < Nanoc::TestCase
-
   def test_filter
     if_have 'redcloth' do
       # Get filter
@@ -27,5 +26,4 @@ class Nanoc::Filters::RedClothTest < Nanoc::TestCase
       assert_equal('<p>I am a member of SPECTRE.</p>', result)
     end
   end
-
 end

--- a/test/filters/test_relativize_paths.rb
+++ b/test/filters/test_relativize_paths.rb
@@ -1,8 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::RelativizePathsTest < Nanoc::TestCase
-
-
   def test_filter_html_with_double_quotes
     # Create filter with mock item
     filter = Nanoc::Filters::RelativizePaths.new
@@ -325,7 +323,6 @@ EOS
     assert_match(/<param (name="movie" )?content="..\/..\/example"/, actual_content)
   end
 
-
   def test_filter_implicit
     # Create filter with mock item
     filter = Nanoc::Filters::RelativizePaths.new
@@ -569,7 +566,7 @@ XML
 
       actual_content = filter.setup_and_run(raw_content, {
         :type => :xml,
-        :namespaces => {:ex => 'http://example.org'},
+        :namespaces => { :ex => 'http://example.org' },
         :select => ['ex:a/@href']
       })
 
@@ -683,7 +680,6 @@ XML
     end
   end
 
-
   def test_filter_fragment_html_with_comments
     if_have 'nokogiri' do
       # Create filter with mock item
@@ -737,5 +733,4 @@ XML
     actual_content = filter.setup_and_run(raw_content, :type => :html)
     assert_equal(expected_content, actual_content)
   end
-
 end

--- a/test/filters/test_rubypants.rb
+++ b/test/filters/test_rubypants.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::RubyPantsTest < Nanoc::TestCase
-
   def test_filter
     if_have 'rubypants' do
       # Get filter
@@ -12,5 +11,4 @@ class Nanoc::Filters::RubyPantsTest < Nanoc::TestCase
       assert_equal('Wait&#8212;what?', result)
     end
   end
-
 end

--- a/test/filters/test_sass.rb
+++ b/test/filters/test_sass.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::SassTest < Nanoc::TestCase
-
   def test_filter
     if_have 'sass' do
       # Get filter
@@ -64,7 +63,7 @@ class Nanoc::Filters::SassTest < Nanoc::TestCase
       filter = create_filter
 
       # Create sample file
-      File.open('moo.sass', 'w') { |io| io.write %Q(@import subdir/relative) }
+      File.open('moo.sass', 'w') { |io| io.write %(@import subdir/relative) }
       FileUtils.mkdir_p('subdir')
       File.open('subdir/relative.sass', 'w') { |io| io.write "body\n  color: red" }
 
@@ -275,7 +274,7 @@ class Nanoc::Filters::SassTest < Nanoc::TestCase
 
   def create_filter(params = {})
     FileUtils.mkdir_p('content')
-    File.open('content/xyzzy.sass', 'w') { |io| io.write('p\n  color: green')}
+    File.open('content/xyzzy.sass', 'w') { |io| io.write('p\n  color: green') }
 
     items = [Nanoc::Item.new(
       'blah',
@@ -284,5 +283,4 @@ class Nanoc::Filters::SassTest < Nanoc::TestCase
     params = { :item => items[0], :items => items }.merge(params)
     ::Nanoc::Filters::Sass.new(params)
   end
-
 end

--- a/test/filters/test_slim.rb
+++ b/test/filters/test_slim.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::SlimTest < Nanoc::TestCase
-
   def test_filter
     if_have 'slim' do
       # Create filter
@@ -29,5 +28,4 @@ class Nanoc::Filters::SlimTest < Nanoc::TestCase
       assert_equal('<p>The rabbit is on the branch.</p>', result)
     end
   end
-
 end

--- a/test/filters/test_typogruby.rb
+++ b/test/filters/test_typogruby.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::TypogrubyTest < Nanoc::TestCase
-
   def test_filter
     if_have 'typogruby' do
       # Get filter
@@ -14,6 +13,4 @@ class Nanoc::Filters::TypogrubyTest < Nanoc::TestCase
       assert_equal(b, result)
     end
   end
-
 end
-

--- a/test/filters/test_uglify_js.rb
+++ b/test/filters/test_uglify_js.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::UglifyJSTest < Nanoc::TestCase
-
   def test_filter
     if_have 'uglifier' do
       # Create filter
@@ -26,5 +25,4 @@ class Nanoc::Filters::UglifyJSTest < Nanoc::TestCase
       assert_equal 'donkey && alert("It is a donkey!");', result
     end
   end
-
 end

--- a/test/filters/test_xsl.rb
+++ b/test/filters/test_xsl.rb
@@ -3,7 +3,6 @@
 require 'tempfile'
 
 class Nanoc::Filters::XSLTest < Nanoc::TestCase
-
   SAMPLE_XSL = <<-EOS
 <?xml version="1.0" encoding="utf-8"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
@@ -88,10 +87,10 @@ EOS
     if_have 'nokogiri' do
       # Create our data objects
       item = Nanoc::Item.new(SAMPLE_XML_IN,
-                             { },
+                             {},
                              '/content/')
       layout = Nanoc::Layout.new(SAMPLE_XSL,
-                                 { },
+                                 {},
                                  '/layout/')
 
       # Create an instance of the filter
@@ -112,10 +111,10 @@ EOS
     if_have 'nokogiri' do
       # Create our data objects
       item = Nanoc::Item.new(SAMPLE_XML_IN_WITH_PARAMS,
-                             { },
+                             {},
                              '/content/')
       layout = Nanoc::Layout.new(SAMPLE_XSL_WITH_PARAMS,
-                                 { },
+                                 {},
                                  '/layout/')
 
       # Create an instance of the filter
@@ -137,10 +136,10 @@ EOS
     if_have 'nokogiri' do
       # Create our data objects
       item = Nanoc::Item.new(SAMPLE_XML_IN_WITH_OMIT_XML_DECL,
-                             { },
+                             {},
                              '/content/')
       layout = Nanoc::Layout.new(SAMPLE_XSL_WITH_OMIT_XML_DECL,
-                                 { },
+                                 {},
                                  '/layout/')
 
       # Create an instance of the filter
@@ -156,5 +155,4 @@ EOS
       assert_match SAMPLE_XML_OUT_WITH_OMIT_XML_DECL, result
     end
   end
-
 end

--- a/test/filters/test_yui_compressor.rb
+++ b/test/filters/test_yui_compressor.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Filters::YUICompressorTest < Nanoc::TestCase
-
   def test_filter_javascript
     if_have 'yuicompressor' do
       filter = ::Nanoc::Filters::YUICompressor.new
@@ -38,5 +37,4 @@ class Nanoc::Filters::YUICompressorTest < Nanoc::TestCase
       assert_match '*{margin:0}', result
     end
   end
-
 end

--- a/test/gem_loader.rb
+++ b/test/gem_loader.rb
@@ -7,5 +7,5 @@ begin
   Gem::Specification.load(gemspec).dependencies.each do |dep|
     gem dep.name, *dep.requirement.as_list
   end
-rescue LoadError => e
+rescue LoadError
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -30,7 +30,6 @@ VCR.configure do |c|
 end
 
 module Nanoc::TestHelpers
-
   LIB_DIR = File.expand_path(File.dirname(__FILE__) + '/../lib')
 
   def disable_nokogiri?
@@ -58,7 +57,7 @@ module Nanoc::TestHelpers
   def if_implemented
     yield
   rescue NotImplementedError, NameError
-    skip $!
+    skip $ERROR_INFO
     return
   end
 
@@ -159,7 +158,7 @@ EOS
     end
   end
 
-  def capturing_stdio(&block)
+  def capturing_stdio(&_block)
     # Store
     orig_stdout = $stdout
     orig_stderr = $stderr
@@ -208,14 +207,14 @@ EOS
 
   def assert_contains_exactly(expected, actual)
     assert_equal expected.size, actual.size,
-      'Expected %s to be of same size as %s' % [actual.inspect, expected.inspect]
+      format('Expected %s to be of same size as %s', actual.inspect, expected.inspect)
     remaining = actual.dup.to_a
     expected.each do |e|
       index = remaining.index(e)
       remaining.delete_at(index) if index
     end
     assert remaining.empty?,
-      'Expected %s to contain all the elements of %s' % [actual.inspect, expected.inspect]
+      format('Expected %s to contain all the elements of %s',actual.inspect, expected.inspect)
   end
 
   def assert_raises_frozen_error
@@ -223,12 +222,12 @@ EOS
     assert_match(/(^can't modify frozen |^unable to modify frozen object$)/, error.message)
   end
 
-  def with_env_vars(hash, &block)
+  def with_env_vars(hash, &_block)
     orig_env_hash = ENV.to_hash
-    hash.each_pair { |k,v| ENV[k] = v }
+    hash.each_pair { |k, v| ENV[k] = v }
     yield
   ensure
-    orig_env_hash.each_pair { |k,v| ENV[k] = v }
+    orig_env_hash.each_pair { |k, v| ENV[k] = v }
   end
 
   def on_windows?
@@ -236,7 +235,7 @@ EOS
   end
 
   def command?(cmd)
-    which, null = on_windows? ? ['where', 'NUL'] : ['which', '/dev/null']
+    which, null = on_windows? ? %w(where NUL) : ['which', '/dev/null']
     system("#{which} #{cmd} > #{null} 2>&1")
   end
 
@@ -255,13 +254,10 @@ EOS
   def skip_unless_symlinks_supported
     skip 'Symlinks are not supported by Ruby on Windows' unless symlinks_supported?
   end
-
 end
 
 class Nanoc::TestCase < MiniTest::Unit::TestCase
-
   include Nanoc::TestHelpers
-
 end
 
 # Unexpected system exit is unexpected
@@ -271,6 +267,6 @@ end
 #
 class Time
   def inspect
-    strftime("%a %b %d %H:%M:%S.#{'%06d' % usec} %Z %Y")
+    strftime("%a %b %d %H:%M:%S.#{format('%06d', usec)} %Z %Y")
   end
 end

--- a/test/helpers/test_blogging.rb
+++ b/test/helpers/test_blogging.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
-
   include Nanoc::Helpers::Blogging
   include Nanoc::Helpers::Text
 
@@ -66,7 +65,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       ),
       Nanoc::Item.new(
         'blah',
-        { :kind => 'article', :created_at => (Date.today - 1).to_s }, 
+        { :kind => 'article', :created_at => (Date.today - 1).to_s },
         '/1/'
       ),
       Nanoc::Item.new(
@@ -189,7 +188,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
 
       # Mock site
       @site = mock
-      @site.stubs(:config).returns({:base_url => nil})
+      @site.stubs(:config).returns({ :base_url => nil })
 
       # Create feed item
       @item = mock
@@ -521,7 +520,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @item.stubs(:[]).with(:feed_url).returns('http://example.com/feed')
 
       # Check
-      result = atom_feed :content_proc => lambda { |a| 'foobar!' }
+      result = atom_feed :content_proc => lambda { |_a| 'foobar!' }
       assert_match 'foobar!</content>', result
     end
   end
@@ -543,7 +542,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @item.stubs(:[]).with(:[]).with(:feed_url).returns('http://example.com/feed')
 
       # Check
-      result = atom_feed :excerpt_proc => lambda { |a| 'foobar!' }
+      result = atom_feed :excerpt_proc => lambda { |_a| 'foobar!' }
       assert_match 'foobar!</summary>', result
     end
   end
@@ -792,5 +791,4 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     # Check
     assert_equal('tag:example.com,2008-05-19:/foo/bar/', atom_tag_for(item))
   end
-
 end

--- a/test/helpers/test_breadcrumbs.rb
+++ b/test/helpers/test_breadcrumbs.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Helpers::BreadcrumbsTest < Nanoc::TestCase
-
   include Nanoc::Helpers::Breadcrumbs
 
   def test_breadcrumbs_trail_at_root
@@ -39,5 +38,4 @@ class Nanoc::Helpers::BreadcrumbsTest < Nanoc::TestCase
 
     assert_equal [@items[0], nil, @items[1]], breadcrumbs_trail
   end
-
 end

--- a/test/helpers/test_capturing.rb
+++ b/test/helpers/test_capturing.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Helpers::CapturingTest < Nanoc::TestCase
-
   include Nanoc::Helpers::Capturing
 
   def test_content_for
@@ -105,7 +104,7 @@ EOS
   end
 
   def test_dependencies
-    with_site do |site|
+    with_site do |_site|
       # Prepare
       File.open('lib/helpers.rb', 'w') do |io|
         io.write 'include Nanoc::Helpers::Capturing'
@@ -135,7 +134,7 @@ EOS
   end
 
   def test_dependency_without_item_variable
-    with_site do |site|
+    with_site do |_site|
       # Prepare
       File.open('lib/helpers.rb', 'w') do |io|
         io.write "include Nanoc::Helpers::Capturing\n"
@@ -170,7 +169,7 @@ EOS
   end
 
   def test_self
-    with_site do |site|
+    with_site do |_site|
       File.open('lib/helpers.rb', 'w') do |io|
         io.write 'include Nanoc::Helpers::Capturing'
       end
@@ -191,7 +190,7 @@ EOS
   end
 
   def test_recompile_dependency
-    with_site do |site|
+    with_site do |_site|
       # Prepare
       File.open('lib/helpers.rb', 'w') do |io|
         io.write 'include Nanoc::Helpers::Capturing'
@@ -221,5 +220,4 @@ EOS
       assert_equal 'New-Content', File.read('output/includer/index.html')
     end
   end
-
 end

--- a/test/helpers/test_filtering.rb
+++ b/test/helpers/test_filtering.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Helpers::FilteringTest < Nanoc::TestCase
-
   include Nanoc::Helpers::Filtering
 
   def test_filter_simple
@@ -120,5 +119,4 @@ class Nanoc::Helpers::FilteringTest < Nanoc::TestCase
     assert notifications.include?(:filtering_started)
     assert notifications.include?(:filtering_ended)
   end
-
 end

--- a/test/helpers/test_html_escape.rb
+++ b/test/helpers/test_html_escape.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Helpers::HTMLEscapeTest < Nanoc::TestCase
-
   include Nanoc::Helpers::HTMLEscape
 
   def test_html_escape_with_string
@@ -26,5 +25,4 @@ class Nanoc::Helpers::HTMLEscapeTest < Nanoc::TestCase
       h
     end
   end
-
 end

--- a/test/helpers/test_link_to.rb
+++ b/test/helpers/test_link_to.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Helpers::LinkToTest < Nanoc::TestCase
-
   include Nanoc::Helpers::LinkTo
 
   def test_link_to_with_path
@@ -54,7 +53,9 @@ class Nanoc::Helpers::LinkToTest < Nanoc::TestCase
 
   def test_link_to_to_nil_item_or_item_rep
     obj = Object.new
-    def obj.path; nil; end
+    def obj.path
+      nil
+    end
 
     assert_raises RuntimeError do
       link_to('Some Text', obj)
@@ -150,7 +151,6 @@ class Nanoc::Helpers::LinkToTest < Nanoc::TestCase
       relative_path_to(other_item_rep)
     )
   end
-
 
   def test_relative_path_to_item
     # Mock self
@@ -250,5 +250,4 @@ class Nanoc::Helpers::LinkToTest < Nanoc::TestCase
     # Run
     assert_examples_correct 'Nanoc::Helpers::LinkTo#relative_path_to'
   end
-
 end

--- a/test/helpers/test_rendering.rb
+++ b/test/helpers/test_rendering.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
-
   include Nanoc::Helpers::Rendering
 
   def test_render
@@ -38,7 +37,7 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
         io.write("layout '/foo/', nil\n")
       end
 
-      File.open('layouts/foo.erb', 'w').close()
+      File.open('layouts/foo.erb', 'w').close
 
       assert_raises(Nanoc::Errors::CannotDetermineFilter) do
         render '/foo/'
@@ -54,7 +53,7 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
         io.write("layout '/foo/', :asdf\n")
       end
 
-      File.open('layouts/foo.erb', 'w').close()
+      File.open('layouts/foo.erb', 'w').close
 
       assert_raises(Nanoc::Errors::UnknownFilter) do
         render '/foo/'
@@ -83,5 +82,4 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
       assert_equal '', result
     end
   end
-
 end

--- a/test/helpers/test_tagging.rb
+++ b/test/helpers/test_tagging.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
-
   include Nanoc::Helpers::Tagging
 
   def test_tags_for_without_tags
@@ -17,7 +16,7 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
 
   def test_tags_for_with_custom_base_url
     # Create item
-    item = Nanoc::Item.new('content', { :tags => ['foo', 'bar']}, '/path/')
+    item = Nanoc::Item.new('content', { :tags => %w(foo bar) }, '/path/')
 
     # Check
     assert_equal(
@@ -29,7 +28,7 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
 
   def test_tags_for_with_custom_none_text
     # Create item
-    item = Nanoc::Item.new('content', { :tags => []}, '/path/')
+    item = Nanoc::Item.new('content', { :tags => [] }, '/path/')
 
     # Check
     assert_equal(
@@ -40,7 +39,7 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
 
   def test_tags_for_with_custom_separator
     # Create item
-    item = Nanoc::Item.new('content', { :tags => ['foo', 'bar']}, '/path/')
+    item = Nanoc::Item.new('content', { :tags => %w(foo bar) }, '/path/')
 
     # Check
     assert_equal(
@@ -81,5 +80,4 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
       link_for_tag('foo&bar', 'http://stoneship.org/tags&stuff/')
     )
   end
-
 end

--- a/test/helpers/test_text.rb
+++ b/test/helpers/test_text.rb
@@ -1,14 +1,13 @@
 # encoding: utf-8
 
 class Nanoc::Helpers::TextTest < Nanoc::TestCase
-
   include Nanoc::Helpers::Text
 
   def test_excerpt_length
     assert_equal('...',                         excerptize('Foo bar baz quux meow woof', :length => 3))
     assert_equal('Foo ...',                     excerptize('Foo bar baz quux meow woof', :length => 7))
     assert_equal('Foo bar baz quux meow woof',  excerptize('Foo bar baz quux meow woof', :length => 26))
-    assert_equal('Foo bar baz quux meow woof',  excerptize('Foo bar baz quux meow woof', :length => 8623785))
+    assert_equal('Foo bar baz quux meow woof',  excerptize('Foo bar baz quux meow woof', :length => 8_623_785))
   end
 
   def test_excerpt_omission
@@ -16,7 +15,6 @@ class Nanoc::Helpers::TextTest < Nanoc::TestCase
   end
 
   def test_strip_html
-    # TODO implement
+    # TODO: implement
   end
-
 end

--- a/test/helpers/test_xml_sitemap.rb
+++ b/test/helpers/test_xml_sitemap.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
-
   include Nanoc::Helpers::XMLSitemap
 
   def teardown
@@ -119,7 +118,7 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
       @site = Nanoc::Site.new({ :base_url => 'http://example.com' })
 
       # Build sitemap
-      res = xml_sitemap(:rep_select => lambda { |rep| rep.name == :one_a } )
+      res = xml_sitemap(:rep_select => lambda { |rep| rep.name == :one_a })
 
       # Check
       doc = Nokogiri::XML(res)
@@ -181,5 +180,4 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
     item.reps << rep
     rep
   end
-
 end

--- a/test/tasks/test_clean.rb
+++ b/test/tasks/test_clean.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::Tasks::CleanTest < Nanoc::TestCase
-
   def test_simple
     if_have 'w3c_validators' do
       # Stub items
@@ -61,5 +60,4 @@ class Nanoc::Tasks::CleanTest < Nanoc::TestCase
       clean.run
     end
   end
-
 end

--- a/test/test_gem.rb
+++ b/test/test_gem.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Nanoc::GemTest < Nanoc::TestCase
-
   def setup
     super
     FileUtils.cd(@orig_wd)
@@ -30,5 +29,4 @@ class Nanoc::GemTest < Nanoc::TestCase
   ensure
     Dir['nanoc-*.gem'].each { |f| FileUtils.rm(f) }
   end
-
 end


### PR DESCRIPTION
This is the second part of my crusade against non-standard code style; the first part being #476.

There are two reasons why these changes were not in #476:
1. Rubocop got updated with a lot of new checks, and this PR ensures we adhere to the guidelines set forth in that new Rubocop.
2. I got over the attachment to my personal preferences (such as TODO’s not being postfixed by a colon).

I will probably squash this PR into a single commit, since it gets quite noisy otherwise.
