### PR TITLE
Disable UnusedMethodArgument for abstract methods

### DIFF
--- a/lib/nanoc/base/compilation/filter.rb
+++ b/lib/nanoc/base/compilation/filter.rb
@@ -131,7 +131,7 @@ module Nanoc
     # @return [String, void] If the filter output binary content, the return
     #   value is undefined; if the filter outputs textual content, the return
     #   value will be the filtered content.
-    def run(_content_or_filename, _params = {})
+    def run(content_or_filename, params = {}) # rubocop:disable Lint/UnusedMethodArgument
       raise NotImplementedError.new('Nanoc::Filter subclasses must implement #run')
     end
 

--- a/lib/nanoc/base/source_data/code_snippet.rb
+++ b/lib/nanoc/base/source_data/code_snippet.rb
@@ -20,7 +20,7 @@ module Nanoc
     #
     # @param [String] filename The filename corresponding to this code snippet
     #
-    # @param [Time, Hash] params Extra parameters. Ignored by nanoc; it is
+    # @param [Time, Hash] _params Extra parameters. Ignored by nanoc; it is
     #   only included for backwards compatibility.
     def initialize(data, filename, _params = nil)
       @data     = data

--- a/lib/nanoc/base/source_data/data_source.rb
+++ b/lib/nanoc/base/source_data/data_source.rb
@@ -205,7 +205,7 @@ module Nanoc
     #   files that should be generated.
     #
     # @return [void]
-    def create_item(_content, _attributes, _identifier, _params = {})
+    def create_item(content, attributes, identifier, params = {}) # rubocop:disable Lint/UnusedMethodArgument
       not_implemented('create_item')
     end
 
@@ -228,7 +228,7 @@ module Nanoc
     #   files that should be generated.
     #
     # @return [void]
-    def create_layout(_content, _attributes, _identifier, _params = {})
+    def create_layout(content, attributes, identifier, params = {}) # rubocop:disable Lint/UnusedMethodArgument
       not_implemented('create_layout')
     end
 

--- a/lib/nanoc/base/store.rb
+++ b/lib/nanoc/base/store.rb
@@ -50,7 +50,7 @@ module Nanoc
     # @abstract This method must be implemented by the subclass.
     #
     # @return [void]
-    def data=(_new_data)
+    def data=(new_data) # rubocop:disable Lint/UnusedMethodArgument
       raise NotImplementedError.new('Nanoc::Store subclasses must implement #data and #data=')
     end
 

--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -38,7 +38,7 @@ module Nanoc::CLI::Commands
       # @return [Boolean] true if this listener should be enabled for the given command runner, false otherwise
       #
       # @abstract Returns `true` by default, but subclasses may override this.
-      def self.enable_for?(_command_runner)
+      def self.enable_for?(command_runner) # rubocop:disable Lint/UnusedMethodArgument
         true
       end
 

--- a/lib/nanoc/cli/stream_cleaners/abstract.rb
+++ b/lib/nanoc/cli/stream_cleaners/abstract.rb
@@ -12,7 +12,7 @@ module Nanoc::CLI::StreamCleaners
     # @param [String] s The string to clean
     #
     # @return [String] The cleaned string
-    def clean(_s)
+    def clean(s) # rubocop:disable Lint/UnusedMethodArgument
       raise NotImplementedError, 'Subclasses of Nanoc::CLI::StreamCleaners::Abstract must implement #clean'
     end
   end

--- a/lib/nanoc/extra/checking/runner.rb
+++ b/lib/nanoc/extra/checking/runner.rb
@@ -12,7 +12,7 @@ module Nanoc::Extra::Checking
       @site = site
     end
 
-    # @param [String] The name of the Checks file
+    # @return [String] The name of the Checks file
     def checks_filename
       @_checks_filename ||= CHECKS_FILENAMES.find { |f| File.file?(f) }
     end

--- a/lib/nanoc/extra/vcs.rb
+++ b/lib/nanoc/extra/vcs.rb
@@ -18,7 +18,7 @@ module Nanoc::Extra
     # @return [void]
     #
     # @abstract
-    def add(_filename)
+    def add(filename) # rubocop:disable Lint/UnusedMethodArgument
       not_implemented('add')
     end
 
@@ -31,7 +31,7 @@ module Nanoc::Extra
     # @return [void]
     #
     # @abstract
-    def remove(_filename)
+    def remove(filename) # rubocop:disable Lint/UnusedMethodArgument
       not_implemented('remove')
     end
 
@@ -46,7 +46,7 @@ module Nanoc::Extra
     # @return [void]
     #
     # @abstract
-    def move(_src, _dst)
+    def move(src, dst) # rubocop:disable Lint/UnusedMethodArgument
       not_implemented('move')
     end
 

--- a/lib/nanoc/filters/colorize_syntax.rb
+++ b/lib/nanoc/filters/colorize_syntax.rb
@@ -196,7 +196,7 @@ module Nanoc::Filters
     #
     # @return [String] The colorized output, which is identical to the input
     #   in this case
-    def dummy(code, _language, _params = {})
+    def dummy(code, language, params = {}) # rubocop:disable Lint/UnusedMethodArgument
       code
     end
 

--- a/lib/nanoc/filters/xsl.rb
+++ b/lib/nanoc/filters/xsl.rb
@@ -23,7 +23,7 @@ module Nanoc::Filters
     #
     #     layout 'xsl-report', :xsl, :awesome => 'definitely'
     #
-    # @param [String] content Ignored. As the filter can be run only as a
+    # @param [String] _content Ignored. As the filter can be run only as a
     #   layout, the value of the `:content` parameter passed to the class at
     #   initialization is used as the content to transform.
     #


### PR DESCRIPTION
Conflict!
- [Rubocop](https://github.com/bbatsov/rubocop) tells us to prefix unused variables with an underscore. This makes sense, and recently, in PR #500, I made some style changes to the nanoc source code to please Rubocop.
- [YARD](http://yardoc.org/) uses parameter names in its `@param` annotations. When doing the rename mentioned above, these parameter names got out of sync with the actual source code. From a documentation point of view, having underscore parameter names is ugly.

The solution: tag abstract methods with `# rubocop:disable Lint/UnusedMethodArgument` to pacify Rubocop.

(I also fixed a `@param` that should have been a `@return`, so that now both Rubocop and YARD are happy.)
