### PR TITLE
Improve HTML/CSS validator error messages

### DIFF
--- a/lib/nanoc/extra/checking/checks/css.rb
+++ b/lib/nanoc/extra/checking/checks/css.rb
@@ -9,8 +9,12 @@ module ::Nanoc::Extra::Checking::Checks
 
       Dir[site.config[:output_dir] + '/**/*.css'].each do |filename|
         results = ::W3CValidators::CSSValidator.new.validate_file(filename)
+        lines = File.readlines(filename)
         results.errors.each do |e|
-          desc = e.message.gsub(%r{\s+}, ' ').strip
+          line_num = e.line.to_i - 1
+          line = lines[line_num]
+          message = e.message.gsub(%r{\s+}, ' ').strip.sub(/\s+:$/, '')
+          desc = "line #{line_num + 1}: #{message}: #{line}"
           add_issue(desc, subject: filename)
         end
       end

--- a/lib/nanoc/extra/checking/checks/html.rb
+++ b/lib/nanoc/extra/checking/checks/html.rb
@@ -9,8 +9,12 @@ module ::Nanoc::Extra::Checking::Checks
 
       Dir[site.config[:output_dir] + '/**/*.{htm,html}'].each do |filename|
         results = ::W3CValidators::MarkupValidator.new.validate_file(filename)
+        lines = File.readlines(filename)
         results.errors.each do |e|
-          desc = e.message.gsub(%r{\s+}, ' ').strip
+          line_num = e.line.to_i - 1
+          line = lines[line_num]
+          message = e.message.gsub(%r{\s+}, ' ').strip.sub(/\s+:$/, '')
+          desc = "line #{line_num + 1}: #{message}: #{line}"
           add_issue(desc, subject: filename)
         end
       end

--- a/test/extra/checking/checks/test_css.rb
+++ b/test/extra/checking/checks/test_css.rb
@@ -33,6 +33,30 @@ class Nanoc::Extra::Checking::Checks::CSSTest < Nanoc::TestCase
 
         # Check
         refute check.issues.empty?
+        assert_equal 1, check.issues.size
+        assert_equal 'line 1: Property coxlor doesn\'t exist: h1 { coxlor: rxed; }',
+          check.issues.to_a[0].description
+      end
+    end
+  end
+
+  def test_run_parse_error
+    VCR.use_cassette('css_run_parse_error') do
+      with_site do |site|
+        # Create files
+        FileUtils.mkdir_p('output')
+        File.open('output/blah.html', 'w') { |io| io.write('<h1>Hi!</h1>') }
+        File.open('output/style.css', 'w') { |io| io.write('h1 { ; {') }
+
+        # Run check
+        check = Nanoc::Extra::Checking::Checks::CSS.new(site)
+        check.run
+
+        # Check
+        refute check.issues.empty?
+        assert_equal 1, check.issues.size
+        assert_equal 'line 1: Parse Error: h1 { ; {',
+          check.issues.to_a[0].description
       end
     end
   end

--- a/test/extra/checking/checks/test_html.rb
+++ b/test/extra/checking/checks/test_html.rb
@@ -33,6 +33,10 @@ class Nanoc::Extra::Checking::Checks::HTMLTest < Nanoc::TestCase
 
         # Check
         refute check.issues.empty?
+        assert_equal 2, check.issues.size
+        assert_equal 'line 1: no document type declaration; will parse without validation: <h2>Hi!</h1>', check.issues.to_a[0].description
+        assert_equal 'line 1: end tag for element "H1" which is not open: <h2>Hi!</h1>', check.issues.to_a[1].description
+          check.issues.to_a[0].description
       end
     end
   end

--- a/test/fixtures/vcr_cassettes/css_run_parse_error.yml
+++ b/test/fixtures/vcr_cassettes/css_run_parse_error.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://jigsaw.w3.org/css-validator/validator?output=soap12&profile=css3&text=h1%20%7B%20%3B%20%7B
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Date:
+      - Sat, 06 Dec 2014 11:12:00 GMT
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Language:
+      - en
+      Content-Type:
+      - application/soap+xml;charset=utf-8
+      Server:
+      - Jigsaw/2.3.0-beta2
+      Vary:
+      - Accept-Language
+      X-W3c-Validator-Errors:
+      - '1'
+      X-W3c-Validator-Status:
+      - Invalid
+    body:
+      encoding: UTF-8
+      string: "<?xml version='1.0' encoding=\"utf-8\"?>\n<env:Envelope xmlns:env=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <env:Body>\n        <m:cssvalidationresponse\n            env:encodingStyle=\"http://www.w3.org/2003/05/soap-encoding\"\n
+        \           xmlns:m=\"http://www.w3.org/2005/07/css-validator\">\n            <m:uri>file://localhost/TextArea</m:uri>\n
+        \           <m:checkedby>http://jigsaw.w3.org/css-validator/</m:checkedby>\n
+        \           <m:csslevel>css3</m:csslevel>\n            <m:date>2014-12-06T11:12:00Z</m:date>\n
+        \           <m:validity>false</m:validity>\n            <m:result>\n                <m:errors
+        xml:lang=\"en\">\n                    <m:errorcount>1</m:errorcount>\n                                                                    \n
+        \               <m:errorlist>\n                    <m:uri>file://localhost/TextArea</m:uri>\n
+        \                           \n                        <m:error>\n                            <m:line>1</m:line>\n
+        \                           <m:errortype>parse-error</m:errortype>\n                            <m:context>h1</m:context>
+        \       \n                            <m:errorsubtype>\n                                unrecognized\n
+        \                           </m:errorsubtype>\n                            <m:skippedstring>\n
+        \                               ; {\n                            </m:skippedstring>\n
+        \                           <m:type>generator.unrecognize</m:type>\n        \n
+        \                           <m:message>\n        \n                                Parse
+        Error\n                            </m:message>\n                        </m:error>\n
+        \           \n                    </m:errorlist>\n        \n                </m:errors>\n
+        \               <m:warnings xml:lang=\"en\">\n                    <m:warningcount>0</m:warningcount>\n
+        \               </m:warnings>\n            </m:result>\n        </m:cssvalidationresponse>\n
+        \   </env:Body>\n</env:Envelope>\n\n"
+    http_version: 
+  recorded_at: Sat, 06 Dec 2014 11:12:00 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
This improves the error messages generated by the HTML and CSS validators.

Potential fix for #484. CC @dgmstuart

Example for `h1 { coxlor: rxed; }`:

```
line 1: Property coxlor doesn't exist: h1 { coxlor: rxed; }
```

Contrast this with before:

```
Property coxlor doesn't exist
```

Example for `h1 { ; {`:

```
line 1: Parse Error: h1 { ; {
```

Contrast this with before:

```
Parse Error
```