### PR TITLE
Prevent items and layouts in attributes

### DIFF
--- a/lib/nanoc/base/checksummer.rb
+++ b/lib/nanoc/base/checksummer.rb
@@ -59,6 +59,9 @@ module Nanoc
           digest.update('attributes')
           attributes = obj.attributes.dup
           attributes.delete(:file)
+          if attributes.any? { |_k, v| v.is_a?(Nanoc::Item) || v.is_a?(Nanoc::Layout) }
+            raise 'cannot have items or layouts in attributes'
+          end
           update(attributes, digest)
         else
           data = begin

--- a/lib/nanoc/base/checksummer.rb
+++ b/lib/nanoc/base/checksummer.rb
@@ -60,7 +60,7 @@ module Nanoc
           attributes = obj.attributes.dup
           attributes.delete(:file)
           if attributes.any? { |_k, v| v.is_a?(Nanoc::Item) || v.is_a?(Nanoc::Layout) }
-            raise 'cannot have items or layouts in attributes'
+            raise Nanoc::Errors::ItemOrLayoutAttribute.new(obj)
           end
           update(attributes, digest)
         else

--- a/lib/nanoc/base/errors.rb
+++ b/lib/nanoc/base/errors.rb
@@ -193,5 +193,12 @@ module Nanoc
         super("There are multiple #{type}s with the #{identifier} identifier.")
       end
     end
+
+    # Error that is raised when an item or a layout is found as an attribute value.
+    class ItemOrLayoutAttribute < Generic
+      def initialize(subject)
+        super("Found an item or a layout in the attributes of #{subject.inspect}.")
+      end
+    end
   end
 end

--- a/test/base/checksummer_spec.rb
+++ b/test/base/checksummer_spec.rb
@@ -204,6 +204,22 @@ describe Nanoc::Checksummer do
       end
     end
 
+    describe 'with attributes containing items' do
+      let(:attributes) { { item: Nanoc::Item.new('asdf', {}, '/asdf/') } }
+
+      it 'should error' do
+        proc { subject.calc(item) }.must_raise(RuntimeError)
+      end
+    end
+
+    describe 'with attributes containing layouts' do
+      let(:attributes) { { layout: Nanoc::Layout.new('asdf', {}, '/asdf/') } }
+
+      it 'should error' do
+        proc { subject.calc(item) }.must_raise(RuntimeError)
+      end
+    end
+
     describe 'with changed content' do
       let(:content) { 'something drastically different' }
 

--- a/test/base/checksummer_spec.rb
+++ b/test/base/checksummer_spec.rb
@@ -3,21 +3,17 @@
 require 'tempfile'
 
 describe Nanoc::Checksummer do
-
   subject { Nanoc::Checksummer }
 
   CHECKSUM_REGEX = /\A[0-9a-zA-Z\/+]+=*\Z/
 
   describe 'for String' do
-
     it 'should checksum strings' do
       subject.calc('foo').must_equal('+5k/BWvkYc6T1qhGaSyf3861CyE=')
     end
-
   end
 
   describe 'for Array' do
-
     it 'should checksum arrays' do
       subject.calc([1, 'a', :a]).must_equal 'YtWOEFUAMQritkY38KXHFZM/n2E='
     end
@@ -29,11 +25,9 @@ describe Nanoc::Checksummer do
     it 'should checksum non-serializable arrays' do
       subject.calc([-> {}]).must_match(CHECKSUM_REGEX)
     end
-
   end
 
   describe 'for Hash' do
-
     it 'should checksum hashes' do
       subject.calc({ a: 1, b: 2 }).must_equal 'qY8fW6gWK7F1XQ9MLrx3Gru/RTY='
     end
@@ -45,11 +39,9 @@ describe Nanoc::Checksummer do
     it 'should checksum non-serializable hashes' do
       subject.calc({ a: -> {} }).must_match(CHECKSUM_REGEX)
     end
-
   end
 
   describe 'for Pathname' do
-
     let(:file)            { Tempfile.new('foo') }
     let(:filename)        { file.path }
     let(:pathname)        { Pathname.new(filename) }
@@ -69,14 +61,12 @@ describe Nanoc::Checksummer do
     end
 
     describe 'does not exist' do
-
       let(:non_existing_filename) { 'askldjfklaslasdfkjsajdf' }
       let(:pathname)              { Pathname.new(filename) }
 
       it 'should still checksum' do
         subject.calc(pathname).must_equal(normal_checksum)
       end
-
     end
 
     it 'should get the mtime right' do
@@ -94,43 +84,35 @@ describe Nanoc::Checksummer do
     end
 
     describe 'if the mtime changes' do
-
       let(:mtime) { 1_333_333_333 }
 
       it 'should have a different checksum' do
         subject.calc(pathname).must_match(CHECKSUM_REGEX)
         subject.calc(pathname).wont_equal(normal_checksum)
       end
-
     end
 
     describe 'if the content changes, but not the file size' do
-
       let(:data) { 'STUFF!' }
 
       it 'should have the same checksum' do
         subject.calc(pathname).must_equal(normal_checksum)
       end
-
     end
 
     describe 'if the file size changes' do
-
       let(:data) { 'stuff and stuff and stuff!!!' }
 
       it 'should have a different checksum' do
         subject.calc(pathname).must_match(CHECKSUM_REGEX)
         subject.calc(pathname).wont_equal(normal_checksum)
       end
-
     end
-
   end
 
   it 'should not have the same checksum for same content but different class'
 
   describe 'for Nanoc::RulesCollection' do
-
     let(:data)            { 'STUFF!' }
     let(:normal_checksum) { 'r4SwDpCp5saBPeZk2gQOJcipTZU=' }
 
@@ -145,20 +127,16 @@ describe Nanoc::Checksummer do
     end
 
     describe 'if the content changes' do
-
       let(:data) { 'Other stuff!' }
 
       it 'should have a different checksum' do
         subject.calc(rules_collection).must_match(CHECKSUM_REGEX)
         subject.calc(rules_collection).wont_equal(normal_checksum)
       end
-
     end
-
   end
 
   describe 'for Nanoc::CodeSnippet' do
-
     let(:data)            { 'asdf' }
     let(:filename)        { File.expand_path('bob.txt') }
     let(:code_snippet)    { Nanoc::CodeSnippet.new(data, filename) }
@@ -169,30 +147,24 @@ describe Nanoc::Checksummer do
     end
 
     describe 'if the filename changes' do
-
       let(:filename) { File.expand_path('george.txt') }
 
       it 'should have the same checksum' do
         subject.calc(code_snippet).must_equal(normal_checksum)
       end
-
     end
 
     describe 'if the content changes' do
-
       let(:data) { 'Other stuff!' }
 
       it 'should have a different checksum' do
         subject.calc(code_snippet).must_match(CHECKSUM_REGEX)
         subject.calc(code_snippet).wont_equal(normal_checksum)
       end
-
     end
-
   end
 
   describe 'for Nanoc::Configuration' do
-
     let(:wrapped)         { { a: 1, b: 2 } }
     let(:configuration)   { Nanoc::Configuration.new(wrapped) }
     let(:normal_checksum) { 'eYYQ74x29njbtXMtuKZX/ogD8JA=' }
@@ -202,20 +174,16 @@ describe Nanoc::Checksummer do
     end
 
     describe 'if the content changes' do
-
       let(:wrapped) { { a: 666, b: 2 } }
 
       it 'should have a different checksum' do
         subject.calc(configuration).must_match(CHECKSUM_REGEX)
         subject.calc(configuration).wont_equal(normal_checksum)
       end
-
     end
-
   end
 
   describe 'for Nanoc::Item' do
-
     let(:content)         { 'asdf' }
     let(:filename)        { File.expand_path('bob.txt') }
     let(:attributes)      { { a: 1, b: 2 } }
@@ -228,47 +196,37 @@ describe Nanoc::Checksummer do
     end
 
     describe 'with changed attributes' do
-
       let(:attributes) { { x: 4, y: 5 } }
 
       it 'should have a different checksum' do
         subject.calc(item).must_match(CHECKSUM_REGEX)
         subject.calc(item).wont_equal(normal_checksum)
       end
-
     end
 
     describe 'with changed content' do
-
       let(:content) { 'something drastically different' }
 
       it 'should have a different checksum' do
         subject.calc(item).must_match(CHECKSUM_REGEX)
         subject.calc(item).wont_equal(normal_checksum)
       end
-
     end
-
   end
 
   describe 'for other marshal-able classes' do
-
     let(:obj) { :foobar }
 
     it 'should checksum' do
       subject.calc(obj).must_match(CHECKSUM_REGEX)
     end
-
   end
 
   describe 'for other non-marshal-able classes' do
-
     let(:obj) { proc {} }
 
     it 'should checksum' do
       subject.calc(obj).must_match(CHECKSUM_REGEX)
     end
-
   end
-
 end

--- a/test/base/checksummer_spec.rb
+++ b/test/base/checksummer_spec.rb
@@ -208,7 +208,7 @@ describe Nanoc::Checksummer do
       let(:attributes) { { item: Nanoc::Item.new('asdf', {}, '/asdf/') } }
 
       it 'should error' do
-        proc { subject.calc(item) }.must_raise(RuntimeError)
+        proc { subject.calc(item) }.must_raise(Nanoc::Errors::ItemOrLayoutAttribute)
       end
     end
 
@@ -216,7 +216,7 @@ describe Nanoc::Checksummer do
       let(:attributes) { { layout: Nanoc::Layout.new('asdf', {}, '/asdf/') } }
 
       it 'should error' do
-        proc { subject.calc(item) }.must_raise(RuntimeError)
+        proc { subject.calc(item) }.must_raise(Nanoc::Errors::ItemOrLayoutAttribute)
       end
     end
 


### PR DESCRIPTION
This is a potential fix for #469.

This makes the checksummer explicitly abort when finding an item or a layout as an attribute, since this could potentially lead to an infinite loop, and is generally not well-supported.

An alternative fix could be to not allow items and layouts to end up in attributes in the first place.