### PR TITLE
Add Ruby 2.2 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ gemspec
 
 # FIXME: we may be missing some mswin dependencies here
 all_rubies = Bundler::Dependency::PLATFORM_MAP.keys
-ruby_19_plus               = [:ruby_19, :ruby_20, :ruby_21, :jruby] & all_rubies
-ruby_19_plus_without_jruby = [:ruby_19, :ruby_20, :ruby_21]         & all_rubies
+ruby_19_plus               = [:ruby_19, :ruby_20, :ruby_21, :ruby_22, :jruby] & all_rubies
+ruby_19_plus_without_jruby = [:ruby_19, :ruby_20, :ruby_21, :ruby_22]         & all_rubies
 
 gem 'adsf'
 gem 'bluecloth', :platforms => :ruby

--- a/nanoc.gemspec
+++ b/nanoc.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('cri', '~> 2.3')
 
-  s.add_development_dependency('bundler', '~> 1.5')
+  s.add_development_dependency('bundler', '>= 1.7.10', '< 2.0')
 end


### PR DESCRIPTION
The code itself does not require any changes for Ruby 2.2, but our Gemfile wasn’t ready to handle Ruby 2.2.

**Blocked on new Bundler version.** Bundler 1.7.9 doesn’t support Ruby 2.2 yet.