### PR TITLE
simplified piper

### DIFF
--- a/lib/nanoc/extra/deployers/rsync.rb
+++ b/lib/nanoc/extra/deployers/rsync.rb
@@ -58,7 +58,7 @@ module Nanoc::Extra::Deployers
     private
 
     def run_shell_cmd(cmd)
-      piper = Nanoc::Extra::Piper.new(:stdout => $stdout, :stderr => $stderr)
+      piper = Nanoc::Extra::Piper.new(:stdout => $stdout)
       piper.run(cmd, nil)
     end
   end

--- a/lib/nanoc/filters/asciidoc.rb
+++ b/lib/nanoc/filters/asciidoc.rb
@@ -11,8 +11,7 @@ module Nanoc::Filters
     # @return [String] The filtered content
     def run(content, _params = {})
       stdout = StringIO.new
-      stderr = $stderr
-      piper = Nanoc::Extra::Piper.new(:stdout => stdout, :stderr => stderr)
+      piper = Nanoc::Extra::Piper.new(:stdout => stdout)
       piper.run(%w( asciidoc -o - - ), content)
       stdout.string
     end

--- a/lib/nanoc/filters/colorize_syntax.rb
+++ b/lib/nanoc/filters/colorize_syntax.rb
@@ -222,8 +222,7 @@ module Nanoc::Filters
       cmd << '-O' << params.map { |k, v| "#{k}=#{v}" }.join(',') unless params.empty?
 
       stdout = StringIO.new
-      stderr = $stderr
-      piper = Nanoc::Extra::Piper.new(:stdout => stdout, :stderr => stderr)
+      piper = Nanoc::Extra::Piper.new(:stdout => stdout)
       piper.run(cmd, code)
 
       stdout.string
@@ -287,8 +286,7 @@ module Nanoc::Filters
       end
 
       stdout = StringIO.new
-      stderr = $stderr
-      piper = Nanoc::Extra::Piper.new(:stdout => stdout, :stderr => stderr)
+      piper = Nanoc::Extra::Piper.new(:stdout => stdout)
       piper.run(cmd, code)
 
       stdout.string
@@ -389,7 +387,7 @@ module Nanoc::Filters
     end
 
     def check_availability(*cmd)
-      piper = Nanoc::Extra::Piper.new(:stdout => StringIO.new, :stderr => StringIO.new)
+      piper = Nanoc::Extra::Piper.new(:stdout => StringIO.new)
       piper.run(cmd, nil)
     end
   end

--- a/test/extra/test_piper.rb
+++ b/test/extra/test_piper.rb
@@ -28,7 +28,7 @@ class Nanoc::Extra::PiperTest < Nanoc::TestCase
     piper = Nanoc::Extra::Piper.new(:stdout => stdout, :stderr => stderr)
     piper.run(cmd, input)
 
-    assert_equal(input, stdout.string)
+    assert_equal(input, stdout.string.strip)
     assert_equal('', stderr.string)
   end
 


### PR DESCRIPTION
this is what would be needed to continue with ruby-1.8.7 compatibility in #510 

problems:
1. stderr is printed in tests - would be nice to suppress it
2. there are 3 offenses, I think all 3 should be ignored ( `while =` - proper, no `$CHILD_STATUS` in 1.8.7)
3. if we would like to read `stderr` it requires tempfile like it's done in tests - we do not require `stderr` in `lib/`
