### PR TITLE
Upgrade Bundler before install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 1.9.3
   - 1.8.7
   - rbx-2.2.6
+before_install: gem install bundler
 matrix:
   include:
     - rvm: jruby-1.7.11


### PR DESCRIPTION
This is necessary so that Travis uses the most recent Bundler version, 1.7.10, since that is what the gemspec requires.