### PR TITLE
Print kramdown warnings

### DIFF
--- a/lib/nanoc/filters/kramdown.rb
+++ b/lib/nanoc/filters/kramdown.rb
@@ -11,8 +11,13 @@ module Nanoc::Filters
     #
     # @return [String] The filtered content
     def run(content, params = {})
-      # Get result
-      ::Kramdown::Document.new(content, params).to_html
+      document = ::Kramdown::Document.new(content, params)
+
+      document.warnings.each do |warning|
+        $stderr.puts "kramdown warning: #{warning}"
+      end
+
+      document.to_html
     end
   end
 end

--- a/test/filters/test_kramdown.rb
+++ b/test/filters/test_kramdown.rb
@@ -11,4 +11,18 @@ class Nanoc::Filters::KramdownTest < Nanoc::TestCase
       assert_equal("<p>This is <em>so</em> <strong>cool</strong>!</p>\n", result)
     end
   end
+
+  def test_warnings
+    if_have 'kramdown' do
+      # Create filter
+      filter = ::Nanoc::Filters::Kramdown.new
+
+      # Run filter
+      io = capturing_stdio do
+        filter.setup_and_run('{:foo}this is bogus')
+      end
+      assert_empty io[:stdout]
+      assert_equal "kramdown warning: Found span IAL after text - ignoring it\n", io[:stderr]
+    end
+  end
 end


### PR DESCRIPTION
Potential fix for #459.

The warnings are not particularly useful, since they do not contain line number information; that information is unfortunately not provided by kramdown yet.