### PR TITLE
use older mustache for older rubies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,11 @@ gem 'maruku'
 gem 'mime-types'
 gem 'minitest', '~> 4.0'
 gem 'mocha'
-gem 'mustache'
+if RUBY_VERSION >= '2.0.0'
+  gem 'mustache', '~> 1.0'
+else
+  gem 'mustache', '~> 0.99'
+end
 gem 'nokogiri', '~> 1.6'
 gem 'pandoc-ruby'
 gem 'pry'


### PR DESCRIPTION
mustache `1.0.0` requires ruby `2.0.0+`