### PR TITLE
Add option to preserve order in Atom feed

### DIFF
--- a/lib/nanoc/helpers/blogging.rb
+++ b/lib/nanoc/helpers/blogging.rb
@@ -273,8 +273,8 @@ module Nanoc::Helpers
     # @option params [Number] :limit (5) The maximum number of articles to
     #   show
     #
-    # @option params [Array] :articles (sorted_articles) A list of articles to
-    #   include in the feed
+    # @option params [Array] :articles (articles) A list of articles to include
+    #   in the feed
     #
     # @option params [Boolean] :preserve_order (false) Whether or not the
     #   ordering of the list of articles should be preserved. If false, the

--- a/lib/nanoc/helpers/blogging.rb
+++ b/lib/nanoc/helpers/blogging.rb
@@ -56,6 +56,7 @@ module Nanoc::Helpers
 
       attr_accessor :limit
       attr_accessor :relevant_articles
+      attr_accessor :preserve_order
       attr_accessor :content_proc
       attr_accessor :excerpt_proc
       attr_accessor :title
@@ -85,9 +86,13 @@ module Nanoc::Helpers
       protected
 
       def sorted_relevant_articles
-        relevant_articles.sort_by do |a|
-          attribute_to_time(a[:created_at])
-        end.reverse.first(limit)
+        all = relevant_articles
+
+        unless @preserve_order
+          all = all.sort_by { |a| attribute_to_time(a[:created_at]) }
+        end
+
+        all.reverse.first(limit)
       end
 
       def last_article
@@ -271,6 +276,11 @@ module Nanoc::Helpers
     # @option params [Array] :articles (sorted_articles) A list of articles to
     #   include in the feed
     #
+    # @option params [Boolean] :preserve_order (false) Whether or not the
+    #   ordering of the list of articles should be preserved. If false, the
+    #   articles will be sorted by `created_at`. If true, the list of articles
+    #   will be used as-is, and should have the most recent articles last.
+    #
     # @option params [Proc] :content_proc (->{ |article|
     #   article.compiled_content(:snapshot => :pre) }) A proc that returns the
     #   content of the given article, which is passed as a parameter. This
@@ -303,6 +313,7 @@ module Nanoc::Helpers
       # Fill builder
       builder.limit             = params[:limit] || 5
       builder.relevant_articles = params[:articles] || articles || []
+      builder.preserve_order    = params.fetch(:preserve_order, false)
       builder.content_proc      = params[:content_proc] || ->(a) { a.compiled_content(snapshot: :pre) }
       builder.excerpt_proc      = params[:excerpt_proc] || ->(a) { a[:excerpt] }
       builder.title             = params[:title] || @item[:title] || @site.config[:title]

--- a/test/helpers/test_blogging.rb
+++ b/test/helpers/test_blogging.rb
@@ -503,6 +503,36 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     end
   end
 
+  def test_atom_feed_preserve_order
+    if_have 'builder' do
+      # Mock articles
+      @items = [mock_article, mock_article]
+      @items.each_with_index do |article, i|
+        article.stubs(:[]).with(:title).returns("Article #{i}")
+      end
+      @items[0].stubs(:[]).with(:created_at).returns('01-01-2015')
+      @items[1].stubs(:[]).with(:created_at).returns('01-01-2014')
+
+      # Mock site
+      @site = mock
+      @site.stubs(:config).returns({ base_url: 'http://example.com' })
+
+      # Create feed item
+      @item = mock
+      @item.stubs(:[]).with(:title).returns('My Blog Or Something')
+      @item.stubs(:[]).with(:author_name).returns('J. Doe')
+      @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
+      @item.stubs(:[]).with(:feed_url).returns('http://example.com/feed')
+
+      # Check
+      result = atom_feed(preserve_order: true)
+      assert_match(
+        Regexp.new('Article 1.*Article 0', Regexp::MULTILINE),
+        result
+      )
+    end
+  end
+
   def test_atom_feed_with_content_proc_param
     if_have 'builder' do
       # Mock article


### PR DESCRIPTION
Potential fix for #533.

This also fixes the incorrect default for the `:articles` option.