### PR TITLE
Allow generic Pandoc options with :args

### DIFF
--- a/lib/nanoc/filters/pandoc.rb
+++ b/lib/nanoc/filters/pandoc.rb
@@ -11,8 +11,10 @@ module Nanoc::Filters
     # @param [String] content The content to filter
     #
     # @return [String] The filtered content
-    def run(content, *params)
-      PandocRuby.convert(content, *params)
+    def run(content, params = {})
+      args = params.key?(:args) ? params[:args] : params
+
+      PandocRuby.convert(content, *args)
     end
   end
 end

--- a/lib/nanoc/filters/pandoc.rb
+++ b/lib/nanoc/filters/pandoc.rb
@@ -5,8 +5,25 @@ module Nanoc::Filters
     requires 'pandoc-ruby'
 
     # Runs the content through [Pandoc](http://johnmacfarlane.net/pandoc/)
-    # using [PandocRuby](https://github.com/alphabetum/pandoc-ruby). Options
-    # are passed on to PandocRuby.
+    # using [PandocRuby](https://github.com/alphabetum/pandoc-ruby).
+    #
+    # Arguments can be passed to PandocRuby in two ways:
+    #
+    # * Use the `:args` option. This approach is more flexible, since it
+    #   allows passing an array instead of a hash.
+    #
+    # * Pass the arguments directly to the filter. With this approach, only
+    #   hashes can be passed, which is more limiting than the `:args` approach.
+    #
+    # The `:args` approach is recommended.
+    #
+    # @example Passing arguments using `:arg`
+    #
+    #     filter :pandoc, args: [:s, {:f => :markdown, :to => :html}, 'no-wrap', :toc]
+    #
+    # @example Passing arguments not using `:arg`
+    #
+    #     filter :pandoc, :f => :markdown, :to => :html
     #
     # @param [String] content The content to filter
     #

--- a/test/filters/test_pandoc.rb
+++ b/test/filters/test_pandoc.rb
@@ -14,7 +14,7 @@ class Nanoc::Filters::PandocTest < Nanoc::TestCase
     end
   end
 
-  def test_params
+  def test_params_old
     if_have 'pandoc-ruby' do
       skip_unless_have_command 'pandoc'
 
@@ -22,8 +22,22 @@ class Nanoc::Filters::PandocTest < Nanoc::TestCase
       filter = ::Nanoc::Filters::Pandoc.new
 
       # Run filter
-      opts = [:s, { f: :markdown, to: :html }, 'no-wrap', :toc]
-      result = filter.setup_and_run("# Heading\n", *opts)
+      args = { f: :markdown, to: :html }
+      result = filter.setup_and_run("# Heading\n", args)
+      assert_match(%r{<h1 id=\"heading\">Heading</h1>\s*}, result)
+    end
+  end
+
+  def test_params_new
+    if_have 'pandoc-ruby' do
+      skip_unless_have_command 'pandoc'
+
+      # Create filter
+      filter = ::Nanoc::Filters::Pandoc.new
+
+      # Run filter
+      args = [:s, { f: :markdown, to: :html }, 'no-wrap', :toc]
+      result = filter.setup_and_run("# Heading\n", args: args)
       assert_match '<div id="TOC">', result
       assert_match(%r{<h1 id=\"heading\">Heading</h1>\s*}, result)
     end


### PR DESCRIPTION
Potential fix for #526.

It is now possible to call Pandoc like this:

```ruby
filter :pandoc, args: [:s, {:f => :markdown, :to => :html}, 'no-wrap', :toc]
```

I don’t think this breaks backwards compatibility, even though the filter’s method signature has changed, because it was never possible to call the filter in a different way.

CC @ghiknt