### PR TITLE
Allow acessing :pre snapshot in item itself

### DIFF
--- a/lib/nanoc/base/result_data/item_rep.rb
+++ b/lib/nanoc/base/result_data/item_rep.rb
@@ -243,12 +243,20 @@ module Nanoc
         raise Nanoc::Errors::NoSuchSnapshot.new(self, snapshot)
       end
 
-      # Require compilation
-      if @content[snapshot].nil? || (!self.compiled? && is_moving)
+      # Verify snapshot is usable
+      is_still_moving =
+        case snapshot
+        when :post, :last
+          true
+        when :pre
+          !@content.key?(:post)
+        end
+      is_usable_snapshot = @content[snapshot] && (self.compiled? || !is_still_moving)
+      unless is_usable_snapshot
         raise Nanoc::Errors::UnmetDependency.new(self)
-      else
-        @content[snapshot]
       end
+
+      @content[snapshot]
     end
 
     # Checks whether content exists at a given snapshot.

--- a/test/base/test_item_rep.rb
+++ b/test/base/test_item_rep.rb
@@ -77,6 +77,36 @@ class Nanoc::ItemRepTest < Nanoc::TestCase
     end
   end
 
+  def test_compiled_content_with_moving_pre_snapshot
+    # Create rep
+    item = Nanoc::Item.new(
+      'blah blah', {}, '/',
+      binary: false
+    )
+    rep = Nanoc::ItemRep.new(item, nil)
+    rep.expects(:compiled?).returns(false)
+    rep.instance_eval { @content = { pre: 'pre!', last: 'last!' } }
+
+    # Check
+    assert_raises(Nanoc::Errors::UnmetDependency) do
+      rep.compiled_content(snapshot: :pre)
+    end
+  end
+
+  def test_compiled_content_with_non_moving_pre_snapshot
+    # Create rep
+    item = Nanoc::Item.new(
+      'blah blah', {}, '/',
+      binary: false
+    )
+    rep = Nanoc::ItemRep.new(item, nil)
+    rep.expects(:compiled?).returns(false)
+    rep.instance_eval { @content = { pre: 'pre!', post: 'post!', last: 'last!' } }
+
+    # Check
+    assert_equal 'pre!', rep.compiled_content(snapshot: :pre)
+  end
+
   def test_filter
     # Mock site
     site = MiniTest::Mock.new


### PR DESCRIPTION
Fix for #537.

The `:pre` snapshot can now be accessed within the item itself, provided that the `:post` snapshot is present (because at that point, the `:pre` snapshot stops moving).

The implementation of the fix in this PR is conceptually the same as in the aforementioned bug, but refactored.

CC @nanoc/contributors @jethrogb