### PR TITLE
Removes specific version of cri.

### DIFF
--- a/nanoc.gemspec
+++ b/nanoc.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency('cri', '~> 2.3')
+  s.add_runtime_dependency('cri')
 
   s.add_development_dependency('bundler', '>= 1.7.10', '< 2.0')
 end


### PR DESCRIPTION
...nanoc complained about the 2.3 version of cri and bundler seemed to use 2.6 anyway. Removing the version works fine. (For me...)

UPDATE
Gets this warning:

    WARN: Unresolved specs during Gem::Specification.reset:
        cri (~> 2.3)
    WARN: Clearing out unresolved specs.
    Please report a bug if this causes problems.

Seems to me that cri is not used at this point. I don't understand why.
