### PR TITLE
Implement "Mixed Content" check

### DIFF
--- a/lib/nanoc/extra/checking/checks.rb
+++ b/lib/nanoc/extra/checking/checks.rb
@@ -6,6 +6,7 @@ module Nanoc::Extra::Checking::Checks
   autoload 'HTML',          'nanoc/extra/checking/checks/html'
   autoload 'InternalLinks', 'nanoc/extra/checking/checks/internal_links'
   autoload 'Stale',         'nanoc/extra/checking/checks/stale'
+  autoload 'MixedContent',  'nanoc/extra/checking/checks/mixed_content'
 
   Nanoc::Extra::Checking::Check.register '::Nanoc::Extra::Checking::Checks::CSS',           :css
   Nanoc::Extra::Checking::Check.register '::Nanoc::Extra::Checking::Checks::ExternalLinks', :external_links
@@ -14,4 +15,5 @@ module Nanoc::Extra::Checking::Checks
   Nanoc::Extra::Checking::Check.register '::Nanoc::Extra::Checking::Checks::InternalLinks', :internal_links
   Nanoc::Extra::Checking::Check.register '::Nanoc::Extra::Checking::Checks::InternalLinks', :ilinks
   Nanoc::Extra::Checking::Check.register '::Nanoc::Extra::Checking::Checks::Stale',         :stale
+  Nanoc::Extra::Checking::Check.register '::Nanoc::Extra::Checking::Checks::MixedContent',  :mixed_content
 end

--- a/lib/nanoc/extra/checking/checks/mixed_content.rb
+++ b/lib/nanoc/extra/checking/checks/mixed_content.rb
@@ -1,0 +1,31 @@
+# encoding: utf-8
+
+module Nanoc::Extra::Checking::Checks
+  # A check that verifies HTML files do not reference external resources with
+  # URLs that would trigger "mixed content" warnings.
+  class MixedContent < ::Nanoc::Extra::Checking::Check
+    PROTOCOL_PATTERN = /^(\w+):\/\//
+
+    def run
+      filenames = output_filenames.select { |f| File.extname(f) == '.html' }
+      resource_uris_with_filenames = ::Nanoc::Extra::LinkCollector.new(filenames).filenames_per_resource_uri
+
+      resource_uris_with_filenames.each_pair do |uri, fns|
+        next unless guaranteed_insecure?(uri)
+        fns.each do |filename|
+          add_issue(
+            "mixed content include: #{uri}",
+            subject: filename)
+        end
+      end
+    end
+
+    private
+
+    def guaranteed_insecure?(href)
+      protocol = PROTOCOL_PATTERN.match(href)
+
+      protocol && protocol[1].downcase == 'http'
+    end
+  end
+end

--- a/test/extra/checking/checks/test_mixed_content.rb
+++ b/test/extra/checking/checks/test_mixed_content.rb
@@ -1,0 +1,188 @@
+# encoding: utf-8
+
+class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
+  def create_output_file(name, lines)
+    FileUtils.mkdir_p('output')
+    File.open('output/' + name, 'w') { |io|
+      io.write(lines.join('\n'))
+    }
+  end
+
+  def assert_include(haystack, needle)
+    assert haystack.include?(needle), "Expected to find '#{needle}' in #{haystack}"
+  end
+
+  def test_https_content
+    with_site do |site|
+      create_output_file('foo.html', [
+        '<img src="https://nanoc.ws/logo.png" />',
+        '<img src="HTTPS://nanoc.ws/logo.png" />',
+        '<link href="https://nanoc.ws/style.css" />',
+        '<script src="https://nanoc.ws/app.js"></script>',
+        '<form action="https://nanoc.ws/process.cgi"></form>',
+        '<iframe src="https://nanoc.ws/preview.html"></iframe>',
+        '<audio src="https://nanoc.ws/theme-song.flac"></audio>',
+        '<video src="https://nanoc.ws/screen-cast.mkv"></video>'
+      ])
+      check = Nanoc::Extra::Checking::Checks::MixedContent.new(site)
+      check.run
+
+      assert check.issues.empty?
+    end
+  end
+
+  def test_root_relative_content
+    with_site do |site|
+      create_output_file('foo.html', [
+        '<img src="/logo.png" />',
+        '<link href="/style.css" />',
+        '<script src="/app.js"></script>',
+        '<form action="/process.cgi"></form>',
+        '<iframe src="/preview.html"></iframe>',
+        '<audio src="/theme-song.flac"></audio>',
+        '<video src="/screen-cast.mkv"></video>'
+      ])
+      check = Nanoc::Extra::Checking::Checks::MixedContent.new(site)
+      check.run
+
+      assert check.issues.empty?
+    end
+  end
+
+  def test_protocol_relative_content
+    with_site do |site|
+      create_output_file('foo.html', [
+        '<img src="//nanoc.ws/logo.png" />',
+        '<link href="//nanoc.ws/style.css" />',
+        '<script src="//nanoc.ws/app.js"></script>',
+        '<form action="//nanoc.ws/process.cgi"></form>',
+        '<iframe src="//nanoc.ws/preview.html"></iframe>',
+        '<audio src="//nanoc.ws/theme-song.flac"></audio>',
+        '<video src="//nanoc.ws/screen-cast.mkv"></video>'
+      ])
+      check = Nanoc::Extra::Checking::Checks::MixedContent.new(site)
+      check.run
+
+      assert check.issues.empty?
+    end
+  end
+
+  def test_document_relative_content
+    with_site do |site|
+      create_output_file('foo.html', [
+        '<img src="logo.png" />',
+        '<link href="style.css" />',
+        '<script src="app.js"></script>',
+        '<form action="process.cgi"></form>',
+        '<iframe src="preview.html"></iframe>',
+        '<audio src="theme-song.flac"></audio>',
+        '<video src="screen-cast.mkv"></video>'
+      ])
+      check = Nanoc::Extra::Checking::Checks::MixedContent.new(site)
+      check.run
+
+      assert check.issues.empty?
+    end
+  end
+
+  def test_query_relative_content
+    with_site do |site|
+      create_output_file('foo.html', [
+        '<img src="?query-string" />',
+        '<link href="?query-string" />',
+        '<script src="?query-string"></script>',
+        '<form action="?query-string"></form>',
+        '<iframe src="?query-string"></iframe>',
+        '<audio src="?query-string"></audio>',
+        '<video src="?query-string"></video>'
+      ])
+      check = Nanoc::Extra::Checking::Checks::MixedContent.new(site)
+      check.run
+
+      assert check.issues.empty?
+    end
+  end
+
+  def test_fragment_relative_content
+    with_site do |site|
+      create_output_file('foo.html', [
+        '<img src="#fragment" />',
+        '<link href="#fragment" />',
+        '<script src="#fragment"></script>',
+        '<form action="#fragment"></form>',
+        '<iframe src="#fragment"></iframe>',
+        '<audio src="#fragment"></audio>',
+        '<video src="#fragment"></video>'
+      ])
+      check = Nanoc::Extra::Checking::Checks::MixedContent.new(site)
+      check.run
+
+      assert check.issues.empty?
+    end
+  end
+
+  def test_http_content
+    with_site do |site|
+      create_output_file('foo.html', [
+        '<img src="http://nanoc.ws/logo.png" />',
+        '<img src="HTTP://nanoc.ws/logo.png" />',
+        '<link href="http://nanoc.ws/style.css" />',
+        '<script src="http://nanoc.ws/app.js"></script>',
+        '<form action="http://nanoc.ws/process.cgi"></form>',
+        '<iframe src="http://nanoc.ws/preview.html"></iframe>',
+        '<audio src="http://nanoc.ws/theme-song.flac"></audio>',
+        '<video src="http://nanoc.ws/screencast.mkv"></video>'
+      ])
+      check = Nanoc::Extra::Checking::Checks::MixedContent.new(site)
+      check.run
+
+      issues = check.issues.to_a
+      assert_equal 8, issues.count
+
+      descriptions = issues.map { |issue| issue.description }
+      issues.each do |issue|
+        assert_equal 'output/foo.html', issue.subject
+      end
+
+      # The order of the reported issues is not important, so use this class's
+      # `assert_include` helper to avoid asserting those details
+      assert_include descriptions, 'mixed content include: http://nanoc.ws/logo.png'
+
+      assert_include descriptions, 'mixed content include: HTTP://nanoc.ws/logo.png'
+
+      assert_include descriptions, 'mixed content include: http://nanoc.ws/style.css'
+
+      assert_include descriptions, 'mixed content include: http://nanoc.ws/app.js'
+
+      assert_include descriptions, 'mixed content include: http://nanoc.ws/process.cgi'
+
+      assert_include descriptions, 'mixed content include: http://nanoc.ws/preview.html'
+
+      assert_include descriptions, 'mixed content include: http://nanoc.ws/theme-song.flac'
+
+      assert_include descriptions, 'mixed content include: http://nanoc.ws/screencast.mkv'
+    end
+  end
+
+  def test_inert_content
+    with_site do |site|
+      create_output_file('foo.html', [
+        '<a href="http://nanoc.ws">The homepage</a>',
+        '<a name="Not a link">Content</a>',
+        '<script>// inline JavaScript</script>',
+        '<img href="http://nanoc.ws/logo.png" />',
+        '<link src="http://nanoc.ws/style.css" />',
+        '<script href="http://nanoc.ws/app.js"></script>',
+        '<form src="http://nanoc.ws/process.cgi"></form>',
+        '<iframe href="http://nanoc.ws/preview.html"></iframe>',
+        '<audio href="http://nanoc.ws/theme-song.flac"></audio>',
+        '<video target="http://nanoc.ws/screen-cast.mkv"></video>',
+        '<p>http://nanoc.ws/harmless-text</p>'
+      ])
+      check = Nanoc::Extra::Checking::Checks::MixedContent.new(site)
+      check.run
+
+      assert check.issues.empty?
+    end
+  end
+end


### PR DESCRIPTION
Commit message:

> This check ensures that resources embedded within HTML documents are not
> requested using a protocol that degrades the security of the original
> connection. This avoids "mixed content" warnings in browsers that
> enforce consistent protocols, and it precludes the leaking of private
> information in browsers that do not.

Resolves gh-542