### PR TITLE
Add Vagrant integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ doc/yardoc
 /.yardoc
 *~
 /Gemfile.lock
+/.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,18 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 1024
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo apt-get update
+    sudo apt-get install -y build-essential zlib1g-dev ruby-dev gem
+    sudo gem install bundler
+    cd /vagrant
+    bundle install
+  SHELL
+end


### PR DESCRIPTION
I don't take it for granted that the maintainers would even *want* to commit to this technology, but since I had already created this configuration for myself (in support of gh-543), I figured it couldn't hurt to share it (just in case).

Commit message:

> Vagrant [1] (together with VirtualBox [2]) provides a consistent and
> reproducable interface for creating a development environment. This
> reduces the "set up" documentation required by this project, supports
> contributors who work in a wide range of environments, and minimizes
> friction when the project's requirements change.
>
> [1] https://www.vagrantup.com/
> [2] https://www.virtualbox.org/