### PR TITLE
Fix double snapshot creation error

### DIFF
--- a/lib/nanoc/base/compilation/item_rep_recorder_proxy.rb
+++ b/lib/nanoc/base/compilation/item_rep_recorder_proxy.rb
@@ -70,7 +70,7 @@ module Nanoc
 
       # Count
       existing = Set.new
-      names = @rule_memory.select { |r| r[0] == :snapshot }.map { |r| r[2] }
+      names = @rule_memory.select { |r| r[0] == :snapshot }.map { |r| r[1] }
       names.each do |n|
         if existing.include?(n)
           raise Nanoc::Errors::CannotCreateMultipleSnapshotsWithSameName.new(@item_rep, snapshot_name)

--- a/test/base/test_item_rep_recorder_proxy.rb
+++ b/test/base/test_item_rep_recorder_proxy.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+
+class Nanoc::ItemRepRecorderProxyTest < Nanoc::TestCase
+  def test_double_names
+    proxy = Nanoc::ItemRepRecorderProxy.new(mock)
+
+    proxy.snapshot(:foo, stuff: :giraffe)
+    assert_raises(Nanoc::Errors::CannotCreateMultipleSnapshotsWithSameName) do
+      proxy.snapshot(:foo, stuff: :donkey)
+    end
+  end
+
+  def test_double_params
+    proxy = Nanoc::ItemRepRecorderProxy.new(mock)
+
+    proxy.snapshot(:foo)
+    proxy.snapshot(:bar)
+  end
+end


### PR DESCRIPTION
The following does not raise an error, but should:

```ruby
snapshot(:foo, stuff: :giraffe)
snapshot(:foo, stuff: :donkey)
```

The following does raise an error, but should not:

```ruby
snapshot(:foo)
snapshot(:bar)
```

The reason is that uniqueness is tested on the *second* argument (params), but should be on the first (name).