### PR TITLE
Allow accessing :pre snapshot inside layout

### DIFF
--- a/lib/nanoc/base/result_data/item_rep.rb
+++ b/lib/nanoc/base/result_data/item_rep.rb
@@ -235,29 +235,29 @@ module Nanoc
       Nanoc::NotificationCenter.post(:visit_ended,   item)
 
       # Get name of last pre-layout snapshot
-      snapshot = params.fetch(:snapshot) { @content[:pre] ? :pre : :last }
-      is_moving = [:pre, :post, :last].include?(snapshot)
+      snapshot_name = params.fetch(:snapshot) { @content[:pre] ? :pre : :last }
+      is_moving = [:pre, :post, :last].include?(snapshot_name)
 
       # Check existance of snapshot
-      real_snapshot = snapshots.find { |s| s.first == snapshot }
-      if !is_moving && (real_snapshot.nil? || real_snapshot[-1] == false)
-        raise Nanoc::Errors::NoSuchSnapshot.new(self, snapshot)
+      snapshot = snapshots.find { |s| s.first == snapshot_name }
+      if !is_moving && (snapshot.nil? || snapshot[-1] == false)
+        raise Nanoc::Errors::NoSuchSnapshot.new(self, snapshot_name)
       end
 
       # Verify snapshot is usable
       is_still_moving =
-        case snapshot
+        case snapshot_name
         when :post, :last
           true
         when :pre
-          real_snapshot.nil? || !real_snapshot[-1]
+          snapshot.nil? || !snapshot[-1]
         end
-      is_usable_snapshot = @content[snapshot] && (self.compiled? || !is_still_moving)
+      is_usable_snapshot = @content[snapshot_name] && (self.compiled? || !is_still_moving)
       unless is_usable_snapshot
         raise Nanoc::Errors::UnmetDependency.new(self)
       end
 
-      @content[snapshot]
+      @content[snapshot_name]
     end
 
     # Checks whether content exists at a given snapshot.
@@ -425,11 +425,16 @@ module Nanoc
     #
     # @return [void]
     def snapshot(snapshot_name, params = {})
-      is_final = params.fetch(:final) { true }
-      @content[snapshot_name] = @content[:last] unless self.binary?
+      is_final = params.fetch(:final, true)
+
+      unless self.binary?
+        @content[snapshot_name] = @content[:last]
+      end
+
       if snapshot_name == :pre && is_final
         snapshots << [:pre, true]
       end
+
       write(snapshot_name) if is_final
     end
 

--- a/lib/nanoc/base/result_data/item_rep.rb
+++ b/lib/nanoc/base/result_data/item_rep.rb
@@ -239,7 +239,8 @@ module Nanoc
       is_moving = [:pre, :post, :last].include?(snapshot)
 
       # Check existance of snapshot
-      if !is_moving && snapshots.find { |s| s.first == snapshot && s.last == true }.nil?
+      real_snapshot = snapshots.find { |s| s.first == snapshot }
+      if !is_moving && (real_snapshot.nil? || real_snapshot[-1] == false)
         raise Nanoc::Errors::NoSuchSnapshot.new(self, snapshot)
       end
 
@@ -249,7 +250,7 @@ module Nanoc
         when :post, :last
           true
         when :pre
-          !@content.key?(:post)
+          real_snapshot.nil? || !real_snapshot[-1]
         end
       is_usable_snapshot = @content[snapshot] && (self.compiled? || !is_still_moving)
       unless is_usable_snapshot
@@ -426,6 +427,9 @@ module Nanoc
     def snapshot(snapshot_name, params = {})
       is_final = params.fetch(:final) { true }
       @content[snapshot_name] = @content[:last] unless self.binary?
+      if snapshot_name == :pre && is_final
+        snapshots << [:pre, true]
+      end
       write(snapshot_name) if is_final
     end
 

--- a/test/base/test_item_rep.rb
+++ b/test/base/test_item_rep.rb
@@ -101,10 +101,31 @@ class Nanoc::ItemRepTest < Nanoc::TestCase
     )
     rep = Nanoc::ItemRep.new(item, nil)
     rep.expects(:compiled?).returns(false)
+    rep.snapshots = [[:pre, true]]
     rep.instance_eval { @content = { pre: 'pre!', post: 'post!', last: 'last!' } }
 
     # Check
     assert_equal 'pre!', rep.compiled_content(snapshot: :pre)
+  end
+
+  def test_compiled_content_with_final_pre_snapshot_in_layout
+    # Mock layout
+    layout = Nanoc::Layout.new(
+      %(BEFORE <%= @item_rep.compiled_content(snapshot: :pre) %> AFTER),
+      {},
+      '/somelayout/')
+
+    # Create item and item rep
+    item = Nanoc::Item.new(
+      'blah blah', {}, '/',
+      binary: false
+    )
+    rep = create_rep_for(item, :foo)
+    rep.assigns = { item_rep: rep }
+
+    # Run and check
+    rep.layout(layout, :erb, {})
+    assert_equal('BEFORE blah blah AFTER', rep.instance_eval { @content[:last] })
   end
 
   def test_filter


### PR DESCRIPTION
Second part of the fix for #537.

This PR has two commits:

1. The fix itself, which consists of recording the `:pre` snapshot in the `snapshots` instance variable (which is filled in only with data from explicit snapshots), and let `#compiled_content` use the snapshots variable to determine whether the `:pre` snapshot is usable.

2. Some cleanup (e.g. renaming `snapshot` to `snapshot_name` to avoid confusion).

The code related to the fix isn’t as nice as it could be:

* Ideally, I’d redo the `snapshots` instance variable to be a hash instead of an array (not sure why it is an array in the first place) but that breaks backwards compatibility in the API. :(

* The `snapshots` instance variable is a bit weird anyway. It is used to check whether `#compiled_content` is trying to access a snapshot that exists, but I believe `@content` can be used for that purpose.

* I would also love snapshots to be a first-class concept. `Nanoc::Snapshot` would be great—instead of `snapshot[0]`, we’d have `snapshot.name`, and instead of `snapshot[1]`, we’d have `snapshot.final?`.