### PR TITLE
Allows creation of site in current directory

### DIFF
--- a/lib/nanoc/cli/commands/create-site.rb
+++ b/lib/nanoc/cli/commands/create-site.rb
@@ -4,7 +4,7 @@ usage 'create-site [options] path'
 aliases :create_site, :cs
 summary 'create a site'
 description "
-Create a new site at the given path (defaults to current working directory). The site will use the `filesystem_unified` data source by default, but this can be changed using the `--datasource` command-line option.
+Create a new site at the given path. The site will use the `filesystem_unified` data source by default, but this can be changed using the `--datasource` command-line option.
 "
 
 module Nanoc::CLI::Commands
@@ -280,7 +280,7 @@ EOS
       data_source = options[:datasource] || 'filesystem_unified'
 
       # Check whether site exists
-      if File.exist?(File.join(path, 'nanoc.yaml'))
+      if File.exist?(path) && (!File.directory?(path) || !(Dir.entries(path) - %w{ . .. }).empty?)
         raise Nanoc::Int::Errors::GenericTrivial, "A site at '#{path}' already exists."
       end
 

--- a/lib/nanoc/cli/commands/create-site.rb
+++ b/lib/nanoc/cli/commands/create-site.rb
@@ -4,7 +4,7 @@ usage 'create-site [options] path'
 aliases :create_site, :cs
 summary 'create a site'
 description "
-Create a new site at the given path. The site will use the `filesystem_unified` data source by default, but this can be changed using the `--datasource` command-line option.
+Create a new site at the given path (defaults to current working directory). The site will use the `filesystem_unified` data source by default, but this can be changed using the `--datasource` command-line option.
 "
 
 module Nanoc::CLI::Commands
@@ -280,7 +280,7 @@ EOS
       data_source = options[:datasource] || 'filesystem_unified'
 
       # Check whether site exists
-      if File.exist?(path)
+      if File.exist?(File.join(path, 'nanoc.yaml'))
         raise Nanoc::Int::Errors::GenericTrivial, "A site at '#{path}' already exists."
       end
 

--- a/test/cli/commands/test_create_site.rb
+++ b/test/cli/commands/test_create_site.rb
@@ -21,9 +21,8 @@ class Nanoc::CLI::Commands::CreateSiteTest < Nanoc::TestCase
     FileUtils.mkdir('foo')
 
     FileUtils.cd('foo') do
-      Nanoc::CLI.run %w( create_site )
-      site = Nanoc::Site.new('.')
-      site.load_data
+      Nanoc::CLI.run %w( create_site ./ )
+      site = Nanoc::Int::Site.new('.')
       site.compile
     end
   end

--- a/test/cli/commands/test_create_site.rb
+++ b/test/cli/commands/test_create_site.rb
@@ -17,6 +17,17 @@ class Nanoc::CLI::Commands::CreateSiteTest < Nanoc::TestCase
     end
   end
 
+  def test_can_compile_new_site_in_current_directory
+    FileUtils.mkdir('foo')
+
+    FileUtils.cd('foo') do
+      Nanoc::CLI.run %w( create_site )
+      site = Nanoc::Site.new('.')
+      site.load_data
+      site.compile
+    end
+  end
+
   def test_can_compile_new_site_with_binary_items
     Nanoc::CLI.run %w( create_site foo )
 


### PR DESCRIPTION
Had issues when moving from Jekyll to nanoc with Github Pages where it didn't properly detect if there was a site that existed already.

I'm open to suggestions where detecting the presence of 'nanoc.yaml' assumes a site exists.