### PR TITLE
Create new temp filename factory for testing

### DIFF
--- a/test/base/temp_filename_factory_spec.rb
+++ b/test/base/temp_filename_factory_spec.rb
@@ -2,14 +2,10 @@
 
 describe Nanoc::TempFilenameFactory do
   subject do
-    Nanoc::TempFilenameFactory.instance
+    Nanoc::TempFilenameFactory.new
   end
 
   let(:prefix) { 'foo' }
-
-  before do
-    subject.cleanup(prefix)
-  end
 
   describe '#create' do
     it 'should create unique paths' do


### PR DESCRIPTION
The tests for `Nanoc::TempFilenameFactory` occasionally fail because other tests pollute the data that these tests depend on.

This PR resolves the problem by creating a new  `Nanoc::TempFilenameFactory`, rather than relying on the singleton.

This is not a bug; it’s simply tests being flaky.