### PR TITLE
Do not upload files with identical etags

### DIFF
--- a/test/extra/deployers/test_fog.rb
+++ b/test/extra/deployers/test_fog.rb
@@ -126,4 +126,151 @@ class Nanoc::Extra::Deployers::FogTest < Nanoc::TestCase
       assert_equal 'I am a dog!', File.read('mylocalcloud/mybucket/bark')
     end
   end
+
+  def test_upload
+    if_have 'fog' do
+      fog = Nanoc::Extra::Deployers::Fog.new(
+        'output/', provider: 'aws')
+
+      key_old = '__old'
+      key_same = '__same'
+      key_new = '__new'
+
+      File.write(key_same, 'hallo')
+      File.write(key_new, 'hallo new')
+
+      etags = {
+        key_same => '598d4c200461b81522a3328565c25f7c',
+        key_new => '598d4c200461b81522a3328565c25f7c',
+      }
+
+      keys_to_destroy = [key_old, key_same, key_new]
+      keys_to_invalidate = []
+
+      s3_files = mock
+      s3_files.stubs(:create)
+      s3_directory = mock
+      s3_directory.stubs(:files).returns(s3_files)
+
+      # key_same
+      refute fog.send(:needs_upload?, key_same, key_same, etags)
+      fog.send(
+        :upload, key_same, key_same, etags, keys_to_destroy, keys_to_invalidate, s3_directory)
+
+      assert_equal([key_old, key_new], keys_to_destroy)
+      assert_equal([], keys_to_invalidate)
+
+      # key_new
+      assert fog.send(:needs_upload?, key_new, key_new, etags)
+      fog.send(
+        :upload, key_new, key_new, etags, keys_to_destroy, keys_to_invalidate, s3_directory)
+
+      assert_equal([key_old], keys_to_destroy)
+      assert_equal([key_new], keys_to_invalidate)
+    end
+  end
+
+  def test_read_etags_with_local_provider
+    if_have 'fog' do
+      fog = Nanoc::Extra::Deployers::Fog.new(
+        'output/', provider: 'local')
+
+      files = [
+        mock('file_a'),
+        mock('file_b'),
+      ]
+
+      assert_equal({}, fog.send(:read_etags, files))
+    end
+  end
+
+  def test_read_etags_with_aws_provider
+    if_have 'fog' do
+      fog = Nanoc::Extra::Deployers::Fog.new(
+        'output/', provider: 'aws')
+
+      files = [
+        mock('file_a', key: 'key_a', etag: 'etag_a'),
+        mock('file_b', key: 'key_b', etag: 'etag_b'),
+      ]
+
+      expected = {
+        'key_a' => 'etag_a',
+        'key_b' => 'etag_b',
+      }
+
+      assert_equal(expected, fog.send(:read_etags, files))
+    end
+  end
+
+  def test_calc_local_etag_with_local_provider
+    if_have 'fog' do
+      fog = Nanoc::Extra::Deployers::Fog.new(
+        'output/', provider: 'local')
+
+      file_path = 'blah.tmp'
+      File.write(file_path, 'hallo')
+
+      assert_nil fog.send(:calc_local_etag, file_path)
+    end
+  end
+
+  def test_calc_local_etag_with_aws_provider
+    if_have 'fog' do
+      fog = Nanoc::Extra::Deployers::Fog.new(
+        'output/', provider: 'aws')
+
+      file_path = 'blah.tmp'
+      File.write(file_path, 'hallo')
+
+      assert_equal(
+        '598d4c200461b81522a3328565c25f7c',
+        fog.send(:calc_local_etag, file_path))
+    end
+  end
+
+  def test_needs_upload_with_missing_remote_etag
+    if_have 'fog' do
+      fog = Nanoc::Extra::Deployers::Fog.new(
+        'output/', provider: 'aws')
+
+      file_path = 'blah.tmp'
+      File.write(file_path, 'hallo')
+
+      key = 'some_key'
+      etags = {}
+
+      assert fog.send(:needs_upload?, key, file_path, etags)
+    end
+  end
+
+  def test_needs_upload_with_different_etags
+    if_have 'fog' do
+      fog = Nanoc::Extra::Deployers::Fog.new(
+        'output/', provider: 'aws')
+
+      file_path = 'blah.tmp'
+      File.write(file_path, 'hallo')
+
+      key = 'some_key'
+      etags = { key => 'some_etag' }
+
+      assert fog.send(:needs_upload?, key, file_path, etags)
+    end
+  end
+
+  def test_needs_upload_with_identical_etags
+    if_have 'fog' do
+      fog = Nanoc::Extra::Deployers::Fog.new(
+        'output/', provider: 'aws')
+
+      file_path = 'blah.tmp'
+      File.write(file_path, 'hallo')
+
+      key = 'some_key'
+      etags = { key => '598d4c200461b81522a3328565c25f7c' }
+
+      refute fog.send(:needs_upload?, key, file_path, etags)
+    end
+  end
 end


### PR DESCRIPTION
This is continued off #480. Replaces #536 (code identical, but this time on `master` instead of `release-3.7.x`).

This PR has quite a bit of extra tests and refactorings that make these tests possible. I also tested this with an actual S3 and can confirm that it works.