### PR TITLE
Add views

### DIFF
--- a/lib/nanoc/base.rb
+++ b/lib/nanoc/base.rb
@@ -23,6 +23,15 @@ module Nanoc
   autoload 'Layout',               'nanoc/base/source_data/layout'
   autoload 'Site',                 'nanoc/base/source_data/site'
 
+  # Load view classes
+  autoload 'ConfigView',           'nanoc/base/views/config'
+  autoload 'ItemView',             'nanoc/base/views/item'
+  autoload 'ItemRepView',          'nanoc/base/views/item_rep'
+  autoload 'ItemCollectionView',   'nanoc/base/views/item_collection'
+  autoload 'LayoutView',           'nanoc/base/views/layout'
+  autoload 'LayoutCollectionView', 'nanoc/base/views/layout_collection'
+  autoload 'SiteView',             'nanoc/base/views/site'
+
   # Load result data classes
   autoload 'ItemRep',              'nanoc/base/result_data/item_rep'
 

--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -268,13 +268,13 @@ module Nanoc
       end
 
       content_or_filename_assigns.merge({
-        item: rep.item,
-        rep: rep,
-        item_rep: rep,
-        items: site.items,
-        layouts: site.layouts,
-        config: site.config,
-        site: site
+        item: Nanoc::ItemView.new(rep.item),
+        rep: Nanoc::ItemRepView.new(rep),
+        item_rep: Nanoc::ItemRepView.new(rep),
+        items: Nanoc::ItemCollectionView.new(site.items),
+        layouts: Nanoc::LayoutCollectionView.new(site.layouts),
+        config: Nanoc::ConfigView.new(site.config),
+        site: Nanoc::SiteView.new(site),
       })
     end
 

--- a/lib/nanoc/base/result_data/item_rep.rb
+++ b/lib/nanoc/base/result_data/item_rep.rb
@@ -5,6 +5,8 @@ module Nanoc
   # have multiple representations. A representation has its own output file.
   # A single item can therefore have multiple output files, each run through
   # a different set of filters with a different layout.
+  #
+  # @api private
   class ItemRep
     # Contains all private methods. Mixed into {Nanoc::ItemRep}.
     #

--- a/lib/nanoc/base/source_data/configuration.rb
+++ b/lib/nanoc/base/source_data/configuration.rb
@@ -2,6 +2,8 @@
 
 module Nanoc
   # Represents the site configuration.
+  #
+  # @api private
   class Configuration < ::Hash
     # Creates a new configuration with the given hash.
     #

--- a/lib/nanoc/base/source_data/item.rb
+++ b/lib/nanoc/base/source_data/item.rb
@@ -4,6 +4,8 @@ module Nanoc
   # Represents a compileable item in a site. It has content and attributes, as
   # well as an identifier (which starts and ends with a slash). It can also
   # store the modification time to speed up compilation.
+  #
+  # @api private
   class Item
     extend Nanoc::Memoization
 

--- a/lib/nanoc/base/source_data/item_array.rb
+++ b/lib/nanoc/base/source_data/item_array.rb
@@ -2,6 +2,8 @@
 
 module Nanoc
   # Acts as an array, but allows fetching items using identifiers, e.g. `@items['/blah/']`.
+  #
+  # @api private
   class ItemArray
     include Enumerable
 

--- a/lib/nanoc/base/source_data/layout.rb
+++ b/lib/nanoc/base/source_data/layout.rb
@@ -3,6 +3,8 @@
 module Nanoc
   # Represents a layout in a nanoc site. It has content, attributes, an
   # identifier and a modification time (to speed up compilation).
+  #
+  # @api private
   class Layout
     extend Nanoc::Memoization
 

--- a/lib/nanoc/base/source_data/site.rb
+++ b/lib/nanoc/base/source_data/site.rb
@@ -15,6 +15,8 @@ module Nanoc
   # The physical representation of a {Nanoc::Site} is usually a directory
   # that contains a configuration file, site data, a rakefile, a rules file,
   # etc. The way site data is stored depends on the data source.
+  #
+  # @api private
   class Site
     # The default configuration for a data source. A data source's
     # configuration overrides these options.

--- a/lib/nanoc/base/views/config.rb
+++ b/lib/nanoc/base/views/config.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+
+module Nanoc
+  class ConfigView
+    # @api private
+    def initialize(config)
+      @config = config
+    end
+
+    # @api private
+    def unwrap
+      @config
+    end
+
+    def [](key)
+      @config[key]
+    end
+  end
+end

--- a/lib/nanoc/base/views/item.rb
+++ b/lib/nanoc/base/views/item.rb
@@ -1,0 +1,56 @@
+# encoding: utf-8
+
+module Nanoc
+  class ItemView
+    # @api private
+    def initialize(item)
+      @item = item
+    end
+
+    # @api private
+    def unwrap
+      @item
+    end
+
+    def identifier
+      @item.identifier
+    end
+
+    def [](key)
+      @item[key]
+    end
+
+    def compiled_content(params = {})
+      @item.compiled_content(params)
+    end
+
+    def path(params = {})
+      @item.path(params)
+    end
+
+    # @api private
+    def reference
+      @item.reference
+    end
+
+    # @api private
+    def reps
+      @item.reps.map { |r| Nanoc::ItemRepView.new(r) }
+    end
+
+    # @api private
+    def raw_filename
+      @item.raw_filename
+    end
+
+    # @api private
+    def forced_outdated?
+      @item.forced_outdated?
+    end
+
+    # @api private
+    def checksum
+      @item.checksum
+    end
+  end
+end

--- a/lib/nanoc/base/views/item_collection.rb
+++ b/lib/nanoc/base/views/item_collection.rb
@@ -1,0 +1,35 @@
+# encoding: utf-8
+
+module Nanoc
+  class ItemCollectionView
+    include Enumerable
+
+    # @api private
+    def initialize(items)
+      @items = items
+    end
+
+    # @api private
+    def unwrap
+      @item
+    end
+
+    def each
+      @items.each { |i| yield Nanoc::ItemView.new(i) }
+    end
+
+    def at(arg)
+      Nanoc::ItemView.new(@items.at(arg))
+    end
+
+    def [](*args)
+      res = @items[*args]
+      case res
+      when Array
+        res.map { Nanoc::ItemView.new(res) }
+      else
+        Nanoc::ItemView.new(res)
+      end
+    end
+  end
+end

--- a/lib/nanoc/base/views/item_rep.rb
+++ b/lib/nanoc/base/views/item_rep.rb
@@ -1,0 +1,116 @@
+# encoding: utf-8
+
+module Nanoc
+  class ItemRepView
+    # @api private
+    def initialize(item_rep)
+      @item_rep = item_rep
+    end
+
+    # @api private
+    def unwrap
+      @item_rep
+    end
+
+    def name
+      @item_rep.name
+    end
+
+    def compiled_content(params = {})
+      @item_rep.compiled_content(params)
+    end
+
+    def path(params = {})
+      @item_rep.path(params)
+    end
+
+    def item
+      Nanoc::ItemView.new(@item_rep.item)
+    end
+
+    # @api private
+    def to_recording_proxy
+      @item_rep.to_recording_proxy
+    end
+
+    # @api private
+    def raw_path(params = {})
+      @item_rep.raw_path(params)
+    end
+
+    # @api private
+    def compiled?
+      @item_rep.compiled?
+    end
+
+    # @api private
+    def compiled=(new_compiled)
+      @item_rep.compiled = new_compiled
+    end
+
+    # @api private
+    def forget_progress
+      @item_rep.forget_progress
+    end
+
+    # @api private
+    def assigns
+      @item_rep.assigns
+    end
+
+    # @api private
+    def assigns=(new_assigns)
+      @item_rep.assigns = new_assigns
+    end
+
+    # @api private
+    def type
+      @item_rep.type
+    end
+
+    # @api private
+    def reference
+      @item_rep.reference
+    end
+
+    # @api private
+    def snapshot(snapshot_name, params = {})
+      @item_rep.snapshot(snapshot_name, params)
+    end
+
+    # @api private
+    def filter(filter_name, filter_args = {})
+      @item_rep.filter(filter_name, filter_args)
+    end
+
+    # @api private
+    def layout(layout, filter_name, filter_args)
+      @item_rep.layout(layout, filter_name, filter_args)
+    end
+
+    # @api private
+    def proxy?
+      @item_rep.proxy?
+    end
+
+    # @api private
+    def binary?
+      @item_rep.binary?
+    end
+
+    # @api private
+    def has_snapshot?(snapshot_name)
+      @item_rep.has_snapshot?(snapshot_name)
+    end
+
+    # @api private
+    def content
+      @item_rep.content
+    end
+
+    # @api private
+    def temporary_filenames
+      @item_rep.temporary_filenames
+    end
+  end
+end

--- a/lib/nanoc/base/views/layout.rb
+++ b/lib/nanoc/base/views/layout.rb
@@ -1,0 +1,33 @@
+# encoding: utf-8
+
+module Nanoc
+  class LayoutView
+    # @api private
+    def initialize(layout)
+      @layout = layout
+    end
+
+    # @api private
+    def unwrap
+      @layout
+    end
+
+    def identifier
+      @layout.identifier
+    end
+
+    def [](key)
+      @layout[key]
+    end
+
+    # @api private
+    def reference
+      @layout.reference
+    end
+
+    # @api private
+    def raw_content
+      @layout.raw_content
+    end
+  end
+end

--- a/lib/nanoc/base/views/layout_collection.rb
+++ b/lib/nanoc/base/views/layout_collection.rb
@@ -1,0 +1,21 @@
+# encoding: utf-8
+
+module Nanoc
+  class LayoutCollectionView
+    include Enumerable
+
+    # @api private
+    def initialize(layouts)
+      @layouts = layouts
+    end
+
+    # @api private
+    def unwrap
+      @item
+    end
+
+    def each
+      @layouts.each { |l| yield Nanoc::LayoutView.new(l) }
+    end
+  end
+end

--- a/lib/nanoc/base/views/site.rb
+++ b/lib/nanoc/base/views/site.rb
@@ -1,0 +1,35 @@
+# encoding: utf-8
+
+module Nanoc
+  class SiteView
+    # @api private
+    def initialize(site)
+      @site = site
+    end
+
+    # @api private
+    def unwrap
+      @site
+    end
+
+    # @api private
+    def layouts
+      @site.layouts.map { |l| Nanoc::LayoutView.new(l) }
+    end
+
+    # @api private
+    def captures_store
+      @site.captures_store
+    end
+
+    # @api private
+    def captures_store_compiled_items
+      @site.captures_store_compiled_items
+    end
+
+    # @api private
+    def compiler
+      @site.compiler
+    end
+  end
+end

--- a/lib/nanoc/filters/sass/sass_filesystem_importer.rb
+++ b/lib/nanoc/filters/sass/sass_filesystem_importer.rb
@@ -13,6 +13,7 @@ class ::Sass::Importers::Filesystem
     filter = options[:nanoc_current_filter]
     if filter
       item = filter.imported_filename_to_item(full_filename)
+      item = item.unwrap if item.respond_to?(:unwrap)
       filter.depend_on([item]) unless item.nil?
     end
 

--- a/lib/nanoc/helpers/capturing.rb
+++ b/lib/nanoc/helpers/capturing.rb
@@ -98,6 +98,7 @@ module Nanoc::Helpers
             "and the name of the capture) but got #{args.size} instead"
         end
         item = args[0]
+        item = item.unwrap if item.respond_to?(:unwrap)
         name = args[1]
 
         # Create dependency


### PR DESCRIPTION
These “view” classes will be part of the public API, and wrap/hide the entities behind them. This will make it much easier to provide a clean, tight public API.

* Create views for all public entities
  * [x] item
  * [x] item representation
  * [x] item collection
  * [x] layout
  * [x] layout collection (new)
  * [x] site
  * [x] config
* [x] Mark entities as private

Later:

* Add tests
* Add documentation

New view instances are created quite often. A future optimisation might be to cache and reuse these.