### PR TITLE
Rename internal monkey-patched methods

### DIFF
--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -165,7 +165,7 @@ module Nanoc::Int
 
       # Calculate checksums
       objects.each do |obj|
-        checksum_store[obj] = obj.checksum
+        checksum_store[obj] = obj.__nanoc_checksum
       end
 
       # Store

--- a/lib/nanoc/base/compilation/item_rep_proxy.rb
+++ b/lib/nanoc/base/compilation/item_rep_proxy.rb
@@ -92,7 +92,7 @@ module Nanoc::Int
     end
 
     def layout_with_identifier(layout_identifier)
-      layout ||= layouts.find { |l| l.identifier == layout_identifier.cleaned_identifier }
+      layout ||= layouts.find { |l| l.identifier == layout_identifier.__nanoc_cleaned_identifier }
       raise Nanoc::Int::Errors::UnknownLayout.new(layout_identifier) if layout.nil?
       layout
     end

--- a/lib/nanoc/base/compilation/outdatedness_checker.rb
+++ b/lib/nanoc/base/compilation/outdatedness_checker.rb
@@ -177,7 +177,7 @@ module Nanoc::Int
     # @return [Boolean] false if either the new or the old checksum for the
     #   given object is not available, true if both checksums are available
     def checksums_available?(obj)
-      checksum_store[obj] && obj.checksum
+      checksum_store[obj] && obj.__nanoc_checksum
     end
     memoize :checksums_available?
 
@@ -186,7 +186,7 @@ module Nanoc::Int
     # @return [Boolean] false if the old and new checksums for the given
     #   object differ, true if they are identical
     def checksums_identical?(obj)
-      checksum_store[obj] == obj.checksum
+      checksum_store[obj] == obj.__nanoc_checksum
     end
     memoize :checksums_identical?
 

--- a/lib/nanoc/base/compilation/rules_collection.rb
+++ b/lib/nanoc/base/compilation/rules_collection.rb
@@ -174,7 +174,7 @@ module Nanoc::Int
 
     # @return [String] The checksum for this object. If its contents change,
     #   the checksum will change as well.
-    def checksum
+    def __nanoc_checksum
       Nanoc::Int::Checksummer.calc(self)
     end
 

--- a/lib/nanoc/base/core_ext/array.rb
+++ b/lib/nanoc/base/core_ext/array.rb
@@ -3,44 +3,44 @@
 # @api private
 module Nanoc::ArrayExtensions
   # Returns a new array where all items' keys are recursively converted to
-  # symbols by calling {Nanoc::ArrayExtensions#symbolize_keys_recursively} or
-  # {Nanoc::HashExtensions#symbolize_keys_recursively}.
+  # symbols by calling {Nanoc::ArrayExtensions#__nanoc_symbolize_keys_recursively} or
+  # {Nanoc::HashExtensions#__nanoc_symbolize_keys_recursively}.
   #
   # @return [Array] The converted array
-  def symbolize_keys_recursively
+  def __nanoc_symbolize_keys_recursively
     array = []
     each do |element|
-      array << (element.respond_to?(:symbolize_keys_recursively) ? element.symbolize_keys_recursively : element)
+      array << (element.respond_to?(:__nanoc_symbolize_keys_recursively) ? element.__nanoc_symbolize_keys_recursively : element)
     end
     array
   end
 
   # Returns a new array where all items' keys are recursively converted to
-  # strings by calling {Nanoc::ArrayExtensions#stringify_keys_recursively} or
-  # {Nanoc::HashExtensions#stringify_keys_recursively}.
+  # strings by calling {Nanoc::ArrayExtensions#__nanoc_stringify_keys_recursively} or
+  # {Nanoc::HashExtensions#__nanoc_stringify_keys_recursively}.
   #
   # @return [Array] The converted array
-  def stringify_keys_recursively
+  def __nanoc_stringify_keys_recursively
     reduce([]) do |array, element|
-      array + [element.respond_to?(:stringify_keys_recursively) ? element.stringify_keys_recursively : element]
+      array + [element.respond_to?(:__nanoc_stringify_keys_recursively) ? element.__nanoc_stringify_keys_recursively : element]
     end
   end
 
   # Freezes the contents of the array, as well as all array elements. The
-  # array elements will be frozen using {#freeze_recursively} if they respond
+  # array elements will be frozen using {#__nanoc_freeze_recursively} if they respond
   # to that message, or #freeze if they do not.
   #
-  # @see Hash#freeze_recursively
+  # @see Hash#__nanoc_freeze_recursively
   #
   # @return [void]
   #
   # @since 3.2.0
-  def freeze_recursively
+  def __nanoc_freeze_recursively
     return if self.frozen?
     freeze
     each do |value|
-      if value.respond_to?(:freeze_recursively)
-        value.freeze_recursively
+      if value.respond_to?(:__nanoc_freeze_recursively)
+        value.__nanoc_freeze_recursively
       else
         value.freeze
       end
@@ -53,7 +53,7 @@ module Nanoc::ArrayExtensions
   # @return [String] The checksum for this array
   #
   # @api private
-  def checksum
+  def __nanoc_checksum
     Nanoc::Int::Checksummer.calc(self)
   end
 end

--- a/lib/nanoc/base/core_ext/hash.rb
+++ b/lib/nanoc/base/core_ext/hash.rb
@@ -3,46 +3,46 @@
 # @api private
 module Nanoc::HashExtensions
   # Returns a new hash where all keys are recursively converted to symbols by
-  # calling {Nanoc::ArrayExtensions#symbolize_keys_recursively} or
-  # {Nanoc::HashExtensions#symbolize_keys_recursively}.
+  # calling {Nanoc::ArrayExtensions#__nanoc_symbolize_keys_recursively} or
+  # {Nanoc::HashExtensions#__nanoc_symbolize_keys_recursively}.
   #
   # @return [Hash] The converted hash
-  def symbolize_keys_recursively
+  def __nanoc_symbolize_keys_recursively
     hash = {}
     each_pair do |key, value|
       new_key   = key.respond_to?(:to_sym) ? key.to_sym : key
-      new_value = value.respond_to?(:symbolize_keys_recursively) ? value.symbolize_keys_recursively : value
+      new_value = value.respond_to?(:__nanoc_symbolize_keys_recursively) ? value.__nanoc_symbolize_keys_recursively : value
       hash[new_key] = new_value
     end
     hash
   end
 
   # Returns a new hash where all keys are recursively converted to strings by
-  # calling {Nanoc::ArrayExtensions#stringify_keys_recursively} or
-  # {Nanoc::HashExtensions#stringify_keys_recursively}.
+  # calling {Nanoc::ArrayExtensions#__nanoc_stringify_keys_recursively} or
+  # {Nanoc::HashExtensions#__nanoc_stringify_keys_recursively}.
   #
   # @return [Hash] The converted hash
-  def stringify_keys_recursively
+  def __nanoc_stringify_keys_recursively
     reduce({}) do |hash, (key, value)|
-      hash.merge(key.to_s => value.respond_to?(:stringify_keys_recursively) ? value.stringify_keys_recursively : value)
+      hash.merge(key.to_s => value.respond_to?(:__nanoc_stringify_keys_recursively) ? value.__nanoc_stringify_keys_recursively : value)
     end
   end
 
   # Freezes the contents of the hash, as well as all hash values. The hash
-  # values will be frozen using {#freeze_recursively} if they respond to
+  # values will be frozen using {#__nanoc_freeze_recursively} if they respond to
   # that message, or #freeze if they do not.
   #
-  # @see Array#freeze_recursively
+  # @see Array#__nanoc_freeze_recursively
   #
   # @return [void]
   #
   # @since 3.2.0
-  def freeze_recursively
+  def __nanoc_freeze_recursively
     return if self.frozen?
     freeze
     each_pair do |_key, value|
-      if value.respond_to?(:freeze_recursively)
-        value.freeze_recursively
+      if value.respond_to?(:__nanoc_freeze_recursively)
+        value.__nanoc_freeze_recursively
       else
         value.freeze
       end
@@ -55,7 +55,7 @@ module Nanoc::HashExtensions
   # @return [String] The checksum for this hash
   #
   # @api private
-  def checksum
+  def __nanoc_checksum
     Nanoc::Int::Checksummer.calc(self)
   end
 end

--- a/lib/nanoc/base/core_ext/pathname.rb
+++ b/lib/nanoc/base/core_ext/pathname.rb
@@ -8,7 +8,7 @@ module Nanoc::PathnameExtensions
   # @return [String] The checksum for this file
   #
   # @api private
-  def checksum
+  def __nanoc_checksum
     Nanoc::Int::Checksummer.calc(self)
   end
 end

--- a/lib/nanoc/base/core_ext/string.rb
+++ b/lib/nanoc/base/core_ext/string.rb
@@ -5,7 +5,7 @@ module Nanoc::StringExtensions
   # Transforms string into an actual identifier
   #
   # @return [String] The identifier generated from the receiver
-  def cleaned_identifier
+  def __nanoc_cleaned_identifier
     "/#{self}/".gsub(/^\/+|\/+$/, '/')
   end
 
@@ -15,7 +15,7 @@ module Nanoc::StringExtensions
   # @return [String] The checksum for this string
   #
   # @api private
-  def checksum
+  def __nanoc_checksum
     Nanoc::Int::Checksummer.calc(self)
   end
 end

--- a/lib/nanoc/base/source_data/code_snippet.rb
+++ b/lib/nanoc/base/source_data/code_snippet.rb
@@ -49,7 +49,7 @@ module Nanoc::Int
 
     # @return [String] The checksum for this object. If its contents change,
     #   the checksum will change as well.
-    def checksum
+    def __nanoc_checksum
       Nanoc::Int::Checksummer.calc(self)
     end
   end

--- a/lib/nanoc/base/source_data/item.rb
+++ b/lib/nanoc/base/source_data/item.rb
@@ -69,7 +69,7 @@ module Nanoc::Int
       end
 
       # Get rest of params
-      @attributes   = attributes.symbolize_keys_recursively
+      @attributes   = attributes.__nanoc_symbolize_keys_recursively
       @identifier   = Nanoc::Identifier.new(identifier)
 
       # Set mtime
@@ -193,7 +193,7 @@ module Nanoc::Int
     #
     # @return [void]
     def freeze
-      attributes.freeze_recursively
+      attributes.__nanoc_freeze_recursively
       children.freeze
       identifier.freeze
       raw_filename.freeze if raw_filename
@@ -206,10 +206,10 @@ module Nanoc::Int
 
     # @return [String] The checksum for this object. If its contents change,
     #   the checksum will change as well.
-    def checksum
+    def __nanoc_checksum
       Nanoc::Int::Checksummer.calc(self)
     end
-    memoize :checksum
+    memoize :__nanoc_checksum
 
     def hash
       self.class.hash ^ identifier.hash

--- a/lib/nanoc/base/source_data/layout.rb
+++ b/lib/nanoc/base/source_data/layout.rb
@@ -28,7 +28,7 @@ module Nanoc::Int
     # @param [Hash] params Extra parameters. Unused.
     def initialize(raw_content, attributes, identifier, params = {})
       @raw_content  = raw_content
-      @attributes   = attributes.symbolize_keys_recursively
+      @attributes   = attributes.__nanoc_symbolize_keys_recursively
       @identifier   = Nanoc::Identifier.new(identifier)
     end
 
@@ -55,7 +55,7 @@ module Nanoc::Int
     #
     # @return [void]
     def freeze
-      attributes.freeze_recursively
+      attributes.__nanoc_freeze_recursively
       identifier.freeze
       raw_content.freeze
     end
@@ -75,10 +75,10 @@ module Nanoc::Int
 
     # @return [String] The checksum for this object. If its contents change,
     #   the checksum will change as well.
-    def checksum
+    def __nanoc_checksum
       Nanoc::Int::Checksummer.calc(self)
     end
-    memoize :checksum
+    memoize :__nanoc_checksum
 
     def hash
       self.class.hash ^ identifier.hash

--- a/lib/nanoc/base/source_data/site.rb
+++ b/lib/nanoc/base/source_data/site.rb
@@ -208,7 +208,7 @@ module Nanoc::Int
     #
     # @return [void]
     def freeze
-      config.freeze_recursively
+      config.__nanoc_freeze_recursively
       items.each(&:freeze)
       layouts.each(&:freeze)
       code_snippets.each(&:freeze)
@@ -352,7 +352,7 @@ module Nanoc::Int
 
     # Loads a configuration file.
     def load_config(config_path)
-      YAML.load_file(config_path).symbolize_keys_recursively
+      YAML.load_file(config_path).__nanoc_symbolize_keys_recursively
     end
 
     def apply_parent_config(config, config_paths = [])
@@ -404,7 +404,7 @@ module Nanoc::Int
         @config = apply_parent_config(load_config(config_path), [config_path])
       else
         # Use passed config hash
-        @config = apply_parent_config(dir_or_config_hash.symbolize_keys_recursively)
+        @config = apply_parent_config(dir_or_config_hash.__nanoc_symbolize_keys_recursively)
       end
 
       # Merge config with default config

--- a/lib/nanoc/base/views/item.rb
+++ b/lib/nanoc/base/views/item.rb
@@ -57,8 +57,8 @@ module Nanoc
     end
 
     # @api private
-    def checksum
-      @item.checksum
+    def __nanoc_checksum
+      @item.__nanoc_checksum
     end
   end
 end

--- a/lib/nanoc/data_sources/filesystem_unified.rb
+++ b/lib/nanoc/data_sources/filesystem_unified.rb
@@ -91,7 +91,7 @@ module Nanoc::DataSources
       # Write item
       FileUtils.mkdir_p(parent_path)
       File.open(path, 'w') do |io|
-        meta = attributes.stringify_keys_recursively
+        meta = attributes.__nanoc_stringify_keys_recursively
         unless meta == {}
           io.write(YAML.dump(meta).strip + "\n")
           io.write("---\n")
@@ -119,7 +119,7 @@ module Nanoc::DataSources
       else
         regex = @config && @config[:allow_periods_in_identifiers] ? /\.[^\/\.]+$/ : /\.[^\/]+$/
       end
-      filename.sub(regex, '').cleaned_identifier
+      filename.sub(regex, '').__nanoc_cleaned_identifier
     end
   end
 end

--- a/lib/nanoc/data_sources/filesystem_verbose.rb
+++ b/lib/nanoc/data_sources/filesystem_verbose.rb
@@ -62,7 +62,7 @@ module Nanoc::DataSources
 
       # Create files
       FileUtils.mkdir_p(dir_path)
-      File.open(meta_filename,    'w') { |io| io.write(YAML.dump(attributes.stringify_keys_recursively)) }
+      File.open(meta_filename,    'w') { |io| io.write(YAML.dump(attributes.__nanoc_stringify_keys_recursively)) }
       File.open(content_filename, 'w') { |io| io.write(content) }
     end
 

--- a/lib/nanoc/data_sources/static.rb
+++ b/lib/nanoc/data_sources/static.rb
@@ -42,7 +42,7 @@ module Nanoc::DataSources
         attributes[:is_hidden] = true unless config[:hide_items] == false
         identifier = filename[(prefix.length + 1)..-1] + '/'
         mtime      = File.mtime(filename)
-        checksum   = Pathname.new(filename).checksum
+        checksum   = Pathname.new(filename).__nanoc_checksum
 
         Nanoc::Int::Item.new(
           filename,

--- a/lib/nanoc/helpers/rendering.rb
+++ b/lib/nanoc/helpers/rendering.rb
@@ -77,8 +77,8 @@ module Nanoc::Helpers
     #   invoked with a block
     def render(identifier, other_assigns = {}, &block)
       # Find layout
-      layout = @site.layouts.find { |l| l.identifier == identifier.cleaned_identifier }
-      raise Nanoc::Int::Errors::UnknownLayout.new(identifier.cleaned_identifier) if layout.nil?
+      layout = @site.layouts.find { |l| l.identifier == identifier.__nanoc_cleaned_identifier }
+      raise Nanoc::Int::Errors::UnknownLayout.new(identifier.__nanoc_cleaned_identifier) if layout.nil?
 
       # Visit
       Nanoc::Int::NotificationCenter.post(:visit_started, layout)

--- a/test/base/core_ext/array_spec.rb
+++ b/test/base/core_ext/array_spec.rb
@@ -1,27 +1,27 @@
 # encoding: utf-8
 
-describe 'Array#symbolize_keys_recursively' do
+describe 'Array#__nanoc_symbolize_keys_recursively' do
   it 'should convert keys to symbols' do
     array_old = [:abc, 'xyz', { 'foo' => 'bar', :baz => :qux }]
     array_new = [:abc, 'xyz', { foo: 'bar', baz: :qux }]
-    array_old.symbolize_keys_recursively.must_equal array_new
+    array_old.__nanoc_symbolize_keys_recursively.must_equal array_new
   end
 end
 
-describe 'Array#stringify_keys_recursively' do
+describe 'Array#__nanoc_stringify_keys_recursively' do
   it 'should convert keys to strings' do
     array_old = [:abc, 'xyz', { :foo  => 'bar', 'baz' => :qux }]
     array_new = [:abc, 'xyz', { 'foo' => 'bar', 'baz' => :qux }]
-    array_old.stringify_keys_recursively.must_equal array_new
+    array_old.__nanoc_stringify_keys_recursively.must_equal array_new
   end
 end
 
-describe 'Array#freeze_recursively' do
+describe 'Array#__nanoc_freeze_recursively' do
   include Nanoc::TestHelpers
 
   it 'should prevent first-level elements from being modified' do
     array = [:a, [:b, :c], :d]
-    array.freeze_recursively
+    array.__nanoc_freeze_recursively
 
     assert_raises_frozen_error do
       array[0] = 123
@@ -30,7 +30,7 @@ describe 'Array#freeze_recursively' do
 
   it 'should prevent second-level elements from being modified' do
     array = [:a, [:b, :c], :d]
-    array.freeze_recursively
+    array.__nanoc_freeze_recursively
 
     assert_raises_frozen_error do
       array[1][0] = 123
@@ -41,7 +41,7 @@ describe 'Array#freeze_recursively' do
     a = []
     a << a
 
-    a.freeze_recursively
+    a.__nanoc_freeze_recursively
 
     assert a.frozen?
     assert a[0].frozen?
@@ -49,9 +49,9 @@ describe 'Array#freeze_recursively' do
   end
 end
 
-describe 'Array#checksum' do
+describe 'Array#__nanoc_checksum' do
   it 'should work' do
     expectation = 'CEUlNvu/3DUmlbtpFRiLHU8oHA0='
-    [[:foo, 123]].checksum.must_equal expectation
+    [[:foo, 123]].__nanoc_checksum.must_equal expectation
   end
 end

--- a/test/base/core_ext/hash_spec.rb
+++ b/test/base/core_ext/hash_spec.rb
@@ -1,51 +1,51 @@
 # encoding: utf-8
 
-describe 'Hash#symbolize_keys_recursively' do
+describe 'Hash#__nanoc_symbolize_keys_recursively' do
   it 'should convert keys to symbols' do
     hash_old = { 'foo' => 'bar' }
     hash_new = { foo: 'bar' }
-    hash_old.symbolize_keys_recursively.must_equal hash_new
+    hash_old.__nanoc_symbolize_keys_recursively.must_equal hash_new
   end
 
   it 'should not require string keys' do
     hash_old = { Time.now => 'abc' }
     hash_new = hash_old
-    hash_old.symbolize_keys_recursively.must_equal hash_new
+    hash_old.__nanoc_symbolize_keys_recursively.must_equal hash_new
   end
 end
 
-describe 'Hash#stringify_keys_recursively' do
+describe 'Hash#__nanoc_stringify_keys_recursively' do
   it 'should leave strings as strings' do
     hash_old = { 'foo' => 'bar' }
     hash_new = { 'foo' => 'bar' }
-    hash_old.stringify_keys_recursively.must_equal hash_new
+    hash_old.__nanoc_stringify_keys_recursively.must_equal hash_new
   end
 
   it 'should convert symbols to strings' do
     hash_old = { foo: 'bar' }
     hash_new = { 'foo' => 'bar' }
-    hash_old.stringify_keys_recursively.must_equal hash_new
+    hash_old.__nanoc_stringify_keys_recursively.must_equal hash_new
   end
 
   it 'should convert integers to strings' do
     hash_old = { 123   => 'bar' }
     hash_new = { '123' => 'bar' }
-    hash_old.stringify_keys_recursively.must_equal hash_new
+    hash_old.__nanoc_stringify_keys_recursively.must_equal hash_new
   end
 
   it 'should convert nil to an empty string' do
     hash_old = { nil => 'bar' }
     hash_new = { ''  => 'bar' }
-    hash_old.stringify_keys_recursively.must_equal hash_new
+    hash_old.__nanoc_stringify_keys_recursively.must_equal hash_new
   end
 end
 
-describe 'Hash#freeze_recursively' do
+describe 'Hash#__nanoc_freeze_recursively' do
   include Nanoc::TestHelpers
 
   it 'should prevent first-level elements from being modified' do
     hash = { a: { b: :c } }
-    hash.freeze_recursively
+    hash.__nanoc_freeze_recursively
 
     assert_raises_frozen_error do
       hash[:a] = 123
@@ -54,7 +54,7 @@ describe 'Hash#freeze_recursively' do
 
   it 'should prevent second-level elements from being modified' do
     hash = { a: { b: :c } }
-    hash.freeze_recursively
+    hash.__nanoc_freeze_recursively
 
     assert_raises_frozen_error do
       hash[:a][:b] = 123
@@ -65,7 +65,7 @@ describe 'Hash#freeze_recursively' do
     a = {}
     a[:x] = a
 
-    a.freeze_recursively
+    a.__nanoc_freeze_recursively
 
     assert a.frozen?
     assert a[:x].frozen?
@@ -73,15 +73,15 @@ describe 'Hash#freeze_recursively' do
   end
 end
 
-describe 'Hash#checksum' do
+describe 'Hash#__nanoc_checksum' do
   it 'should work' do
     expectation = 'wy7gHokc700tqJ/BmJ+EK6/F0bc='
-    { foo: 123 }.checksum.must_equal expectation
+    { foo: 123 }.__nanoc_checksum.must_equal expectation
   end
 
   it 'should not sort keys' do
-    a = { a: 1, c: 2, b: 3 }.checksum
-    b = { a: 1, b: 3, c: 2 }.checksum
+    a = { a: 1, c: 2, b: 3 }.__nanoc_checksum
+    b = { a: 1, b: 3, c: 2 }.__nanoc_checksum
     a.wont_equal b
   end
 end

--- a/test/base/core_ext/pathname_spec.rb
+++ b/test/base/core_ext/pathname_spec.rb
@@ -11,7 +11,7 @@ describe 'Pathname#checksum' do
 
       # Create checksum
       pathname = Pathname.new('tmp/myfile')
-      pathname.checksum.must_equal 'oU+0fYgGm4EDTl+uErBv8rB9YhU='
+      pathname.__nanoc_checksum.must_equal 'oU+0fYgGm4EDTl+uErBv8rB9YhU='
     ensure
       FileUtils.rm_rf('tmp')
     end
@@ -27,7 +27,7 @@ describe 'Pathname#checksum' do
 
       # Create checksum
       pathname = Pathname.new('tmp/myfile')
-      pathname.checksum.must_equal 'IAoqYXvcDheQjaYmZ8waPtEO8zU='
+      pathname.__nanoc_checksum.must_equal 'IAoqYXvcDheQjaYmZ8waPtEO8zU='
     ensure
       FileUtils.rm_rf('tmp')
     end

--- a/test/base/core_ext/string_spec.rb
+++ b/test/base/core_ext/string_spec.rb
@@ -1,33 +1,33 @@
 # encoding: utf-8
 
-describe 'String#cleaned_identifier' do
+describe 'String#__nanoc_cleaned_identifier' do
   it 'should not convert already clean paths' do
-    '/foo/bar/'.cleaned_identifier.must_equal '/foo/bar/'
+    '/foo/bar/'.__nanoc_cleaned_identifier.must_equal '/foo/bar/'
   end
 
   it 'should prepend slash if necessary' do
-    'foo/bar/'.cleaned_identifier.must_equal '/foo/bar/'
+    'foo/bar/'.__nanoc_cleaned_identifier.must_equal '/foo/bar/'
   end
 
   it 'should append slash if necessary' do
-    '/foo/bar'.cleaned_identifier.must_equal '/foo/bar/'
+    '/foo/bar'.__nanoc_cleaned_identifier.must_equal '/foo/bar/'
   end
 
   it 'should remove double slashes at start' do
-    '//foo/bar/'.cleaned_identifier.must_equal '/foo/bar/'
+    '//foo/bar/'.__nanoc_cleaned_identifier.must_equal '/foo/bar/'
   end
 
   it 'should remove double slashes at end' do
-    '/foo/bar//'.cleaned_identifier.must_equal '/foo/bar/'
+    '/foo/bar//'.__nanoc_cleaned_identifier.must_equal '/foo/bar/'
   end
 end
 
-describe 'String#checksum' do
+describe 'String#__nanoc_checksum' do
   it 'should work on empty strings' do
-    ''.checksum.must_equal 'PfY7essFItpoXa1f6EuB/deyUmQ='
+    ''.__nanoc_checksum.must_equal 'PfY7essFItpoXa1f6EuB/deyUmQ='
   end
 
   it 'should work on all strings' do
-    'abc'.checksum.must_equal 'NkkYRO+25f6psNSeCYykXKCg3C0='
+    'abc'.__nanoc_checksum.must_equal 'NkkYRO+25f6psNSeCYykXKCg3C0='
   end
 end

--- a/test/data_sources/test_static.rb
+++ b/test/data_sources/test_static.rb
@@ -61,7 +61,7 @@ class Nanoc::DataSources::StaticTest < Nanoc::TestCase
         '/bar.png/',
         binary: true,
         mtime: File.mtime('foo/bar.png'),
-        checksum: Pathname.new('foo/bar.png').checksum
+        checksum: Pathname.new('foo/bar.png').__nanoc_checksum
       ),
       Nanoc::Int::Item.new(
         'foo/b.c.css',
@@ -69,7 +69,7 @@ class Nanoc::DataSources::StaticTest < Nanoc::TestCase
         '/b.c.css/',
         binary: true,
         mtime: File.mtime('foo/b.c.css'),
-        checksum: Pathname.new('foo/b.c.css').checksum
+        checksum: Pathname.new('foo/b.c.css').__nanoc_checksum
       ),
       Nanoc::Int::Item.new(
         'foo/a/b/c.gif',
@@ -77,7 +77,7 @@ class Nanoc::DataSources::StaticTest < Nanoc::TestCase
         '/a/b/c.gif/',
         binary: true,
         mtime: File.mtime('foo/a/b/c.gif'),
-        checksum: Pathname.new('foo/a/b/c.gif').checksum
+        checksum: Pathname.new('foo/a/b/c.gif').__nanoc_checksum
       )
     ].sort_by(&:identifier)
 


### PR DESCRIPTION
This will allow us to get rid of the monkeypatched methods, and explicitly break when the old names are used.