### PR TITLE
Glob patterns

### DIFF
--- a/lib/nanoc/base.rb
+++ b/lib/nanoc/base.rb
@@ -27,6 +27,8 @@ end
 
 # @api private
 module Nanoc::Int
+  require_relative 'base/pattern'
+
   # Load helper classes
   autoload 'Context',              'nanoc/base/context'
   autoload 'Checksummer',          'nanoc/base/checksummer'

--- a/lib/nanoc/base/compilation/compiler_dsl.rb
+++ b/lib/nanoc/base/compilation/compiler_dsl.rb
@@ -254,11 +254,20 @@ module Nanoc::Int
       @rules_collection.parse(filename)
     end
 
-    private
-
+    # @api private
     def create_pattern(arg)
-      Nanoc::Int::Pattern.from(identifier_to_regex(arg))
+      case @config[:pattern_syntax]
+      when 'glob'
+        Nanoc::Int::Pattern.from(arg)
+      when nil
+        Nanoc::Int::Pattern.from(identifier_to_regex(arg))
+      else
+        raise Nanoc::Int::Errors::GenericTrivial,
+          "Invalid pattern_syntax: #{@config[:pattern_syntax]}"
+      end
     end
+
+    private
 
     # Converts the given identifier, which can contain the '*' or '+'
     # wildcard characters, matching zero or more resp. one or more

--- a/lib/nanoc/base/compilation/compiler_dsl.rb
+++ b/lib/nanoc/base/compilation/compiler_dsl.rb
@@ -77,7 +77,7 @@ module Nanoc::Int
       rep_name = params[:rep] || :default
 
       # Create rule
-      rule = Nanoc::Int::Rule.new(identifier_to_regex(identifier), rep_name, block)
+      rule = Nanoc::Int::Rule.new(create_pattern(identifier), rep_name, block)
       @rules_collection.add_item_compilation_rule(rule)
     end
 
@@ -122,7 +122,7 @@ module Nanoc::Int
       snapshot_name = params[:snapshot] || :last
 
       # Create rule
-      rule = Nanoc::Int::Rule.new(identifier_to_regex(identifier), rep_name, block, snapshot_name: snapshot_name)
+      rule = Nanoc::Int::Rule.new(create_pattern(identifier), rep_name, block, snapshot_name: snapshot_name)
       @rules_collection.add_item_routing_rule(rule)
     end
 
@@ -151,7 +151,8 @@ module Nanoc::Int
     #
     #     layout '/custom/',  :haml, :format => :html5
     def layout(identifier, filter_name, params = {})
-      @rules_collection.layout_filter_mapping[identifier_to_regex(identifier)] = [filter_name, params]
+      pattern = Nanoc::Int::Pattern.from(create_pattern(identifier))
+      @rules_collection.layout_filter_mapping[pattern] = [filter_name, params]
     end
 
     # Creates a pair of compilation and routing rules that indicate that the
@@ -188,7 +189,7 @@ module Nanoc::Int
 
       # Create compilation rule
       compilation_block = proc {}
-      compilation_rule = Nanoc::Int::Rule.new(identifier_to_regex(identifier), rep_name, compilation_block)
+      compilation_rule = Nanoc::Int::Rule.new(create_pattern(identifier), rep_name, compilation_block)
       @rules_collection.add_item_compilation_rule(compilation_rule)
 
       # Create routing rule
@@ -199,7 +200,7 @@ module Nanoc::Int
         # data source.
         item[:extension].nil? || (item[:content_filename].nil? && item.identifier =~ %r{#{item[:extension]}/$}) ? item.identifier.chop : item.identifier.chop + '.' + item[:extension]
       end
-      routing_rule = Nanoc::Int::Rule.new(identifier_to_regex(identifier), rep_name, routing_block, snapshot_name: :last)
+      routing_rule = Nanoc::Int::Rule.new(create_pattern(identifier), rep_name, routing_block, snapshot_name: :last)
       @rules_collection.add_item_routing_rule(routing_rule)
     end
 
@@ -227,10 +228,10 @@ module Nanoc::Int
 
       rep_name = params[:rep] || :default
 
-      compilation_rule = Nanoc::Int::Rule.new(identifier_to_regex(identifier), rep_name, proc {})
+      compilation_rule = Nanoc::Int::Rule.new(create_pattern(identifier), rep_name, proc {})
       @rules_collection.add_item_compilation_rule(compilation_rule)
 
-      routing_rule = Nanoc::Int::Rule.new(identifier_to_regex(identifier), rep_name, proc {}, snapshot_name: :last)
+      routing_rule = Nanoc::Int::Rule.new(create_pattern(identifier), rep_name, proc {}, snapshot_name: :last)
       @rules_collection.add_item_routing_rule(routing_rule)
     end
 
@@ -254,6 +255,10 @@ module Nanoc::Int
     end
 
     private
+
+    def create_pattern(arg)
+      Nanoc::Int::Pattern.from(identifier_to_regex(arg))
+    end
 
     # Converts the given identifier, which can contain the '*' or '+'
     # wildcard characters, matching zero or more resp. one or more

--- a/lib/nanoc/base/compilation/rule.rb
+++ b/lib/nanoc/base/compilation/rule.rb
@@ -5,11 +5,6 @@ module Nanoc::Int
   #
   # @api private
   class Rule
-    # @return [Regexp] The regex that determines which items this rule can be
-    #   applied to. This rule can be applied to items with a identifier
-    #   matching this regex.
-    attr_reader :identifier_regex
-
     # @return [Symbol] The name of the representation that will be compiled
     #   using this rule
     attr_reader :rep_name
@@ -24,8 +19,7 @@ module Nanoc::Int
     # compiler and block. The block will be called during compilation with the
     # item rep as its argument.
     #
-    # @param [Regexp] identifier_regex A regular expression that will be used
-    #   to determine whether this rule is applicable to certain items.
+    # @param [Nanoc::Int::Pattern] pattern
     #
     # @param [String, Symbol] rep_name The name of the item representation
     #   where this rule can be applied to
@@ -36,8 +30,13 @@ module Nanoc::Int
     # @option params [Symbol, nil] :snapshot (nil) The name of the snapshot
     #   this rule will apply to. Ignored for compilation rules, but used for
     #   routing rules.
-    def initialize(identifier_regex, rep_name, block, params = {})
-      @identifier_regex = identifier_regex
+    def initialize(pattern, rep_name, block, params = {})
+      # TODO: remove me
+      unless pattern.is_a?(Nanoc::Int::StringPattern) || pattern.is_a?(Nanoc::Int::RegexpPattern)
+        raise "Can only create rules with patterns"
+      end
+
+      @pattern          = pattern
       @rep_name         = rep_name.to_sym
       @snapshot_name    = params[:snapshot_name]
 
@@ -49,7 +48,7 @@ module Nanoc::Int
     # @return [Boolean] true if this rule can be applied to the given item
     #   rep, false otherwise
     def applicable_to?(item)
-      item.identifier =~ @identifier_regex
+      @pattern.match?(item.identifier)
     end
 
     # Applies this rule to the given item rep.
@@ -80,8 +79,7 @@ module Nanoc::Int
     #
     # @return [nil, Array] Captured groups, if any
     def matches(identifier)
-      matches = @identifier_regex.match(identifier.to_s)
-      matches && matches.captures
+      @pattern.captures(identifier)
     end
   end
 end

--- a/lib/nanoc/base/compilation/rules_collection.rb
+++ b/lib/nanoc/base/compilation/rules_collection.rb
@@ -153,8 +153,8 @@ module Nanoc::Int
     # @return [Array, nil] A tuple containing the filter name and the filter
     #   arguments for the given layout.
     def filter_for_layout(layout)
-      @layout_filter_mapping.each_pair do |layout_identifier, filter_name_and_args|
-        return filter_name_and_args if layout.identifier =~ layout_identifier
+      @layout_filter_mapping.each_pair do |pattern, filter_name_and_args|
+        return filter_name_and_args if pattern.match?(layout.identifier)
       end
       nil
     end

--- a/lib/nanoc/base/pattern.rb
+++ b/lib/nanoc/base/pattern.rb
@@ -1,0 +1,63 @@
+# encoding: utf-8
+
+module Nanoc::Int
+  # @api private
+  class Pattern
+    def self.from(obj)
+      case obj
+      when Nanoc::Int::StringPattern, Nanoc::Int::RegexpPattern
+        obj
+      when String
+        Nanoc::Int::StringPattern.new(obj)
+      when Regexp
+        Nanoc::Int::RegexpPattern.new(obj)
+      else
+        raise ArgumentError, "Do not know how to convert #{obj} into a Nanoc::Pattern"
+      end
+    end
+
+    def initialize(_obj)
+      raise NotImplementedError
+    end
+
+    def match?(_identifier)
+      raise NotImplementedError
+    end
+
+    def captures(_identifier)
+      raise NotImplementedError
+    end
+  end
+
+  # @api private
+  class StringPattern
+    def initialize(string)
+      @string = string
+    end
+
+    def match?(identifier)
+      # TODO: allow matching /foo.{md,txt} using File::FNM_EXTGLOB
+      File.fnmatch(@string, identifier.to_s, File::FNM_PATHNAME)
+    end
+
+    def captures(_identifier)
+      nil
+    end
+  end
+
+  # @api private
+  class RegexpPattern
+    def initialize(regexp)
+      @regexp = regexp
+    end
+
+    def match?(identifier)
+      (identifier.to_s =~ @regexp) != nil
+    end
+
+    def captures(identifier)
+      matches = @regexp.match(identifier.to_s)
+      matches && matches.captures
+    end
+  end
+end

--- a/lib/nanoc/base/pattern.rb
+++ b/lib/nanoc/base/pattern.rb
@@ -36,8 +36,8 @@ module Nanoc::Int
     end
 
     def match?(identifier)
-      # TODO: allow matching /foo.{md,txt} using File::FNM_EXTGLOB
-      File.fnmatch(@string, identifier.to_s, File::FNM_PATHNAME)
+      opts = File::FNM_PATHNAME | File::FNM_EXTGLOB
+      File.fnmatch(@string, identifier.to_s, opts)
     end
 
     def captures(_identifier)

--- a/nanoc.gemspec
+++ b/nanoc.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.rdoc_options     = ['--main', 'README.md']
   s.extra_rdoc_files = ['ChangeLog', 'LICENSE', 'README.md', 'NEWS.md']
 
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.0.0'
 
   s.add_runtime_dependency('cri', '~> 2.3')
 

--- a/spec/nanoc/base/pattern_spec.rb
+++ b/spec/nanoc/base/pattern_spec.rb
@@ -23,6 +23,29 @@ describe Nanoc::Int::Pattern do
   end
 end
 
+describe Nanoc::Int::RegexpPattern do
+  describe '#match?' do
+    it 'matches' do
+      pattern = described_class.new(/the answer is (\d+)/)
+
+      expect(pattern.match?('the answer is 42')).to eql(true)
+      expect(pattern.match?('the answer is donkey')).to eql(false)
+    end
+  end
+
+  describe '#captures' do
+    it 'returns nil if it does not match' do
+      pattern = described_class.new(/the answer is (\d+)/)
+      expect(pattern.captures('the answer is donkey')).to be_nil
+    end
+
+    it 'returns array if it matches' do
+      pattern = described_class.new(/the answer is (\d+)/)
+      expect(pattern.captures('the answer is 42')).to eql(['42'])
+    end
+  end
+end
+
 describe Nanoc::Int::StringPattern do
   describe '#match?' do
     it 'matches simple strings' do
@@ -46,6 +69,13 @@ describe Nanoc::Int::StringPattern do
       expect(pattern.match?('boat')).to eql(true)
       expect(pattern.match?('gloat')).to eql(true)
       expect(pattern.match?('stoat')).to eql(false)
+    end
+  end
+
+  describe '#captures' do
+    it 'returns nil' do
+      pattern = described_class.new('d*key')
+      expect(pattern.captures('donkey')).to be_nil
     end
   end
 end

--- a/spec/nanoc/base/pattern_spec.rb
+++ b/spec/nanoc/base/pattern_spec.rb
@@ -22,3 +22,30 @@ describe Nanoc::Int::Pattern do
     end
   end
 end
+
+describe Nanoc::Int::StringPattern do
+  describe '#match?' do
+    it 'matches simple strings' do
+      pattern = described_class.new('d*key')
+
+      expect(pattern.match?('donkey')).to eql(true)
+      expect(pattern.match?('giraffe')).to eql(false)
+    end
+
+    it 'matches with pathname option' do
+      pattern = described_class.new('/foo/*/bar/**/*.animal')
+
+      expect(pattern.match?('/foo/x/bar/a/b/donkey.animal')).to eql(true)
+      expect(pattern.match?('/foo/x/bar/donkey.animal')).to eql(true)
+      expect(pattern.match?('/foo/x/railroad/donkey.animal')).to eql(false)
+    end
+
+    it 'matches with extglob option' do
+      pattern = described_class.new('{b,gl}oat')
+
+      expect(pattern.match?('boat')).to eql(true)
+      expect(pattern.match?('gloat')).to eql(true)
+      expect(pattern.match?('stoat')).to eql(false)
+    end
+  end
+end

--- a/spec/nanoc/base/pattern_spec.rb
+++ b/spec/nanoc/base/pattern_spec.rb
@@ -1,0 +1,24 @@
+# encoding: utf-8
+
+describe Nanoc::Int::Pattern do
+  describe '.from' do
+    it 'converts from string' do
+      pattern = described_class.from('/foo/x[ab]z/bar.*')
+      expect(pattern.match?('/foo/xaz/bar.html')).to eql(true)
+      expect(pattern.match?('/foo/xyz/bar.html')).to eql(false)
+    end
+
+    it 'converts from regex' do
+      pattern = described_class.from(%r{\A/foo/x[ab]z/bar\..*\z})
+      expect(pattern.match?('/foo/xaz/bar.html')).to eql(true)
+      expect(pattern.match?('/foo/xyz/bar.html')).to eql(false)
+    end
+
+    it 'converts from pattern' do
+      pattern = described_class.from('/foo/x[ab]z/bar.*')
+      pattern = described_class.from(pattern)
+      expect(pattern.match?('/foo/xaz/bar.html')).to eql(true)
+      expect(pattern.match?('/foo/xyz/bar.html')).to eql(false)
+    end
+  end
+end

--- a/test/base/test_compiler.rb
+++ b/test/base/test_compiler.rb
@@ -53,7 +53,7 @@ class Nanoc::Int::CompilerTest < Nanoc::TestCase
 
     # Create compiler
     compiler = Nanoc::Int::Compiler.new(site)
-    compiler.rules_collection.layout_filter_mapping[/.*/] = [:erb, { foo: 'bar' }]
+    compiler.rules_collection.layout_filter_mapping[Nanoc::Int::Pattern.from(/.*/)] = [:erb, { foo: 'bar' }]
 
     # Mock layout
     layout = MiniTest::Mock.new
@@ -69,7 +69,7 @@ class Nanoc::Int::CompilerTest < Nanoc::TestCase
 
     # Create compiler
     compiler = Nanoc::Int::Compiler.new(site)
-    compiler.rules_collection.layout_filter_mapping[/.*/] = [:some_unknown_filter, { foo: 'bar' }]
+    compiler.rules_collection.layout_filter_mapping[Nanoc::Int::Pattern.from(/.*/)] = [:some_unknown_filter, { foo: 'bar' }]
 
     # Mock layout
     layout = MiniTest::Mock.new
@@ -85,7 +85,7 @@ class Nanoc::Int::CompilerTest < Nanoc::TestCase
 
     # Create compiler
     compiler = Nanoc::Int::Compiler.new(site)
-    compiler.rules_collection.layout_filter_mapping[%r{^/foo/$}] = [:erb, { foo: 'bar' }]
+    compiler.rules_collection.layout_filter_mapping[Nanoc::Int::Pattern.from(%r{^/foo/$})] = [:erb, { foo: 'bar' }]
 
     # Mock layout
     layout = MiniTest::Mock.new
@@ -101,10 +101,10 @@ class Nanoc::Int::CompilerTest < Nanoc::TestCase
 
     # Create compiler
     compiler = Nanoc::Int::Compiler.new(site)
-    compiler.rules_collection.layout_filter_mapping[%r{^/a/b/c/.*/$}] = [:erb, { char: 'd' }]
-    compiler.rules_collection.layout_filter_mapping[%r{^/a/.*/$}]     = [:erb, { char: 'b' }]
-    compiler.rules_collection.layout_filter_mapping[%r{^/a/b/.*/$}]   = [:erb, { char: 'c' }] # never used!
-    compiler.rules_collection.layout_filter_mapping[%r{^/.*/$}]       = [:erb, { char: 'a' }]
+    compiler.rules_collection.layout_filter_mapping[Nanoc::Int::Pattern.from(%r{^/a/b/c/.*/$})] = [:erb, { char: 'd' }]
+    compiler.rules_collection.layout_filter_mapping[Nanoc::Int::Pattern.from(%r{^/a/.*/$})]     = [:erb, { char: 'b' }]
+    compiler.rules_collection.layout_filter_mapping[Nanoc::Int::Pattern.from(%r{^/a/b/.*/$})]   = [:erb, { char: 'c' }] # never used!
+    compiler.rules_collection.layout_filter_mapping[Nanoc::Int::Pattern.from(%r{^/.*/$})]       = [:erb, { char: 'a' }]
 
     # Mock layout
     layouts = [mock, mock, mock, mock]
@@ -149,7 +149,7 @@ class Nanoc::Int::CompilerTest < Nanoc::TestCase
       layout '/blah/'
       filter :erb
     end
-    rule = Nanoc::Int::Rule.new(/blah/, :meh, rule_block)
+    rule = Nanoc::Int::Rule.new(Nanoc::Int::Pattern.from(/blah/), :meh, rule_block)
 
     # Create layout
     layout = Nanoc::Int::Layout.new('head <%= yield %> foot', {}, '/blah/')
@@ -163,7 +163,7 @@ class Nanoc::Int::CompilerTest < Nanoc::TestCase
     # Create compiler
     compiler = Nanoc::Int::Compiler.new(site)
     compiler.rules_collection.expects(:compilation_rule_for).times(2).with(rep).returns(rule)
-    compiler.rules_collection.layout_filter_mapping[%r{^/blah/$}] = [:erb, {}]
+    compiler.rules_collection.layout_filter_mapping[Nanoc::Int::Pattern.from(%r{^/blah/$})] = [:erb, {}]
     site.stubs(:compiler).returns(compiler)
 
     # Compile

--- a/test/base/test_compiler_dsl.rb
+++ b/test/base/test_compiler_dsl.rb
@@ -267,6 +267,38 @@ EOS
     end
   end
 
+  def test_create_pattern_with_string
+    compiler_dsl = Nanoc::Int::CompilerDSL.new(nil, {})
+
+    pattern = compiler_dsl.create_pattern('/foo/*')
+    assert pattern.match?('/foo/a/a/a/a')
+  end
+
+  def test_create_pattern_with_string_with_glob_pattern_syntax
+    compiler_dsl = Nanoc::Int::CompilerDSL.new(nil, { pattern_syntax: 'glob' })
+
+    pattern = compiler_dsl.create_pattern('/foo/*')
+    assert pattern.match?('/foo/aaaa')
+    refute pattern.match?('/foo/aaaa/')
+    refute pattern.match?('/foo/a/a/a/a')
+  end
+
+  def test_create_pattern_with_regex
+    compiler_dsl = Nanoc::Int::CompilerDSL.new(nil, {})
+
+    pattern = compiler_dsl.create_pattern(%r<\A/foo/a*/>)
+    assert pattern.match?('/foo/aaaa/')
+  end
+
+  def test_create_pattern_with_string_with_unknown_pattern_syntax
+    compiler_dsl = Nanoc::Int::CompilerDSL.new(nil, { pattern_syntax: 'donkey' })
+
+    err = assert_raises(Nanoc::Int::Errors::GenericTrivial) do
+      compiler_dsl.create_pattern('/foo/*')
+    end
+    assert_equal 'Invalid pattern_syntax: donkey', err.message
+  end
+
   def test_identifier_to_regex_without_wildcards
     # Create compiler DSL
     compiler_dsl = Nanoc::Int::CompilerDSL.new(nil, {})

--- a/test/base/test_rule.rb
+++ b/test/base/test_rule.rb
@@ -14,11 +14,11 @@ class Nanoc::Int::RuleTest < Nanoc::TestCase
   end
 
   def test_matches
-    regexp     = %r</(.*)/(.*)/>
+    pattern    = Nanoc::Int::Pattern.from(%r</(.*)/(.*)/>)
     identifier = '/anything/else/'
     expected   = ['anything', 'else']
 
-    rule = Nanoc::Int::Rule.new(regexp, :string, Proc.new {})
+    rule = Nanoc::Int::Rule.new(pattern, :string, Proc.new {})
 
     assert_equal expected, rule.send(:matches, identifier)
   end


### PR DESCRIPTION
This adds glob patterns to nanoc 4. They are not super useful yet, because identifiers are still old-style (without extensions), but it is a good step forward.

Also, I guess I lied about nanoc 4 not getting new features!

Note that `File::FNM_EXTGLOB` is only available in Ruby 2.0 and up. Because of this, nanoc now depends on Ruby ≥ 2.0.0. (This should be fine, since Ruby 1.9.3 reached end-of-life status last February.)

Documentation for this new feature:

## Glob patterns in Rules

nanoc 4 supports using globs. Globs are more powerful than nanoc’s original pattern syntax, and they are also more commonplace, such as in Unix shells.

To enable globs, set `pattern_syntax` to `"glob"` in the configuration. For example:

```yaml
pattern_syntax: "glob"
```

The three most useful wildcards are the following:

`*`
: Matches any file or directory name. Does not cross directory boundaries. For example, `/projects/*.md` matches `/projects/nanoc.md`, but not `/projects/cri.adoc` nor `/projects/nanoc/about.md`.

`**`
: Matches any file or directory name, and crosses directory boundaries. For example, `/projects/**/*.md` matches both `/projects/nanoc.md` and `/projects/nanoc/history.md`.

`[abc]`
: Matches any single character in the set. For example, `/people/[kt]im.md` matches only `/people/kim.md` and `/people/tim.md`.

`{foo,bar}`
: Matches either string in the comma-separated list. More than two strings are possible. For example, `/c{at,ub,ount}s.txt` matches `/cats.txt`, `/cubs.txt` and `/counts.txt`.

nanoc 4 uses Ruby’s [`File.fnmatch` method](http://ruby-doc.org/core/File.html#method-c-fnmatch) with the `File::FNM_PATHNAME` option enabled. Please consult the [`File.fnmatch`](http://ruby-doc.org/core/File.html#method-c-fnmatch) documentation for other supported patterns, and more comprehensive documentation.

Patterns based on regular expressions are still supported in nanoc 4, so you can still use e.g. `%r{\A/projects/(cri|nanoc)\.md\Z}` to match both `/projects/nanoc.md` and `/projects/cri.md`.