### PR TITLE
View API convenience methods

### DIFF
--- a/lib/nanoc/base/views/config.rb
+++ b/lib/nanoc/base/views/config.rb
@@ -3,6 +3,9 @@
 module Nanoc
   class ConfigView
     # @api private
+    NONE = Object.new
+
+    # @api private
     def initialize(config)
       @config = config
     end
@@ -12,6 +15,25 @@ module Nanoc
       @config
     end
 
+    # @see Hash#fetch
+    def fetch(key, fallback=NONE, &block)
+      @config.fetch(key) do
+        if !fallback.equal?(NONE)
+          fallback
+        elsif block_given?
+          yield(key)
+        else
+          raise KeyError, "key not found: #{key.inspect}"
+        end
+      end
+    end
+
+    # @see Hash#key?
+    def key?(key)
+      @config.key?(key)
+    end
+
+    # @see Hash#[]
     def [](key)
       @config[key]
     end

--- a/lib/nanoc/base/views/item.rb
+++ b/lib/nanoc/base/views/item.rb
@@ -3,6 +3,9 @@
 module Nanoc
   class ItemView
     # @api private
+    NONE = Object.new
+
+    # @api private
     def initialize(item)
       @item = item
     end
@@ -25,6 +28,30 @@ module Nanoc
       @item.identifier
     end
 
+    # @see Hash#fetch
+    def fetch(key, fallback=NONE, &block)
+      res = @item[key] # necessary for dependency tracking
+
+      if @item.attributes.key?(key)
+        res
+      else
+        if !fallback.equal?(NONE)
+          fallback
+        elsif block_given?
+          yield(key)
+        else
+          raise KeyError, "key not found: #{key.inspect}"
+        end
+      end
+    end
+
+    # @see Hash#key?
+    def key?(key)
+      _res = @item[key] # necessary for dependency tracking
+      @item.attributes.key?(key)
+    end
+
+    # @see Hash#[]
     def [](key)
       @item[key]
     end
@@ -39,6 +66,10 @@ module Nanoc
 
     def children
       @item.children.map { |i| Nanoc::ItemView.new(i) }
+    end
+
+    def parent
+      Nanoc::ItemView.new(@item.parent)
     end
 
     def binary?

--- a/lib/nanoc/base/views/item_collection.rb
+++ b/lib/nanoc/base/views/item_collection.rb
@@ -23,6 +23,11 @@ module Nanoc
       @items.each { |i| yield view_class.new(i) }
     end
 
+    # @return [Integer]
+    def size
+      @items.size
+    end
+
     def at(arg)
       item = @items.at(arg)
       item && view_class.new(item)

--- a/lib/nanoc/base/views/mutable_item.rb
+++ b/lib/nanoc/base/views/mutable_item.rb
@@ -5,5 +5,9 @@ module Nanoc
     def []=(key, value)
       unwrap[key] = value
     end
+
+    def update_attributes(hash)
+      hash.each { |k, v| unwrap[k] = v }
+    end
   end
 end

--- a/lib/nanoc/base/views/mutable_item_collection.rb
+++ b/lib/nanoc/base/views/mutable_item_collection.rb
@@ -14,5 +14,9 @@ module Nanoc
     def delete_if(&block)
       @items.delete_if(&block)
     end
+
+    def concat(other)
+      @items.concat(other)
+    end
   end
 end

--- a/spec/nanoc/base/views/config_spec.rb
+++ b/spec/nanoc/base/views/config_spec.rb
@@ -1,0 +1,69 @@
+# encoding: utf-8
+
+describe Nanoc::ConfigView do
+  let(:config) do
+    { amount: 9000, animal: 'donkey' }
+  end
+
+  let(:view) { described_class.new(config) }
+
+  describe '#[]' do
+    subject { view[key] }
+
+    context 'with existant key' do
+      let(:key) { :animal }
+      it { should eql?('donkey') }
+    end
+
+    context 'with non-existant key' do
+      let(:key) { :weapon }
+      it { should eql?(nil) }
+    end
+  end
+
+  describe '#fetch' do
+    context 'with existant key' do
+      let(:key) { :animal }
+
+      subject { view.fetch(key) }
+
+      it { should eql?('donkey') }
+    end
+
+    context 'with non-existant key' do
+      let(:key) { :weapon }
+
+      context 'with fallback' do
+        subject { view.fetch(key, 'nothing sorry') }
+        it { should eql?('nothing sorry') }
+      end
+
+      context 'with block' do
+        subject { view.fetch(key) { 'nothing sorry' } }
+        it { should eql?('nothing sorry') }
+      end
+
+      context 'with no fallback and no block' do
+        subject { view.fetch(key) }
+
+        it 'raises' do
+          expect { subject }.to raise_error(KeyError)
+        end
+      end
+    end
+  end
+
+  describe '#key?' do
+    subject { view.key?(key) }
+
+    context 'with existant key' do
+      let(:key) { :animal }
+      it { should eql?(true) }
+    end
+
+    context 'with non-existant key' do
+      let(:key) { :weapon }
+      it { should eql?(false) }
+    end
+  end
+end

--- a/spec/nanoc/base/views/item_collection_spec.rb
+++ b/spec/nanoc/base/views/item_collection_spec.rb
@@ -13,6 +13,20 @@ describe Nanoc::ItemCollectionView do
     # …
   end
 
+  describe '#size' do
+    let(:wrapped) do
+      [
+        Nanoc::Int::Item.new('foo', {}, '/foo/'),
+        Nanoc::Int::Item.new('bar', {}, '/bar/'),
+        Nanoc::Int::Item.new('baz', {}, '/baz/'),
+      ]
+    end
+
+    subject { view.size }
+
+    it { should == 3 }
+  end
+
   describe '#at' do
     subject { view.at(arg) }
 

--- a/spec/nanoc/base/views/mutable_item_collection_spec.rb
+++ b/spec/nanoc/base/views/mutable_item_collection_spec.rb
@@ -46,4 +46,23 @@ describe Nanoc::MutableItemCollectionView do
       expect(mutable_item_collection).not_to be_empty
     end
   end
+
+  describe '#concat' do
+    let(:mutable_item_collection) do
+      [Nanoc::Int::Item.new('content', {}, '/asdf/')]
+    end
+
+    let(:items_array_to_concat) do
+      [Nanoc::Int::Item.new('shiny', {}, '/new/')]
+    end
+
+    let(:view) { described_class.new(mutable_item_collection) }
+
+    subject { view.concat(items_array_to_concat) }
+
+    it 'concats' do
+      expect { subject }.to change { view.size }.from(1).to(2)
+      expect(view[1].unwrap).to eql(items_array_to_concat[0])
+    end
+  end
 end

--- a/spec/nanoc/base/views/mutable_item_spec.rb
+++ b/spec/nanoc/base/views/mutable_item_spec.rb
@@ -10,4 +10,17 @@ describe Nanoc::MutableItemView do
       expect(view[:title]).to eq('Donkey')
     end
   end
+
+  describe '#update_attributes' do
+    let(:item) { Nanoc::Int::Item.new('content', {}, '/asdf/') }
+    let(:view) { described_class.new(item) }
+
+    let(:update) { { friend: 'Giraffe' } }
+
+    subject { view.update_attributes(update) }
+
+    it 'sets attributes' do
+      expect { subject }.to change { view[:friend] }.from(nil).to('Giraffe')
+    end
+  end
 end


### PR DESCRIPTION
Fixes for #570.

Two ugly things:

* The dependency tracking support. Having to evaluate `@item[key]` just so the dependency tracking doesn’t break is pretty icky.

* The amount of duplication. I couldn’t find a clean and non-intrusive way to implement this.

I’m okay with both ugly bits, because they’re abstracted away and we can refactor this later. (I’d *love* to refactor the dependency tracking out of `Nanoc::Int::Item` and into the view classes.)