### PR TITLE
Document + fix view API

### DIFF
--- a/lib/nanoc/base/views/item.rb
+++ b/lib/nanoc/base/views/item.rb
@@ -15,15 +15,18 @@ module Nanoc
       @item
     end
 
+    # @see Object#==
     def ==(other)
       identifier == other.identifier
     end
     alias_method :eql?, :==
 
+    # @see Object#hash
     def hash
       self.class.hash ^ identifier.hash
     end
 
+    # @return [Nanoc::Identifier]
     def identifier
       @item.identifier
     end
@@ -56,26 +59,68 @@ module Nanoc
       @item[key]
     end
 
+    # Returns the compiled content.
+    #
+    # @option params [String] :rep (:default) The name of the representation
+    #   from which the compiled content should be fetched. By default, the
+    #   compiled content will be fetched from the default representation.
+    #
+    # @option params [String] :snapshot The name of the snapshot from which to
+    #   fetch the compiled content. By default, the returned compiled content
+    #   will be the content compiled right before the first layout call (if
+    #   any).
+    #
+    # @return [String] The content of the given rep at the given snapshot.
     def compiled_content(params = {})
       @item.compiled_content(params)
     end
 
+    # Returns the item path, as used when being linked to. It starts
+    # with a slash and it is relative to the output directory. It does not
+    # include the path to the output directory. It will not include the
+    # filename if the filename is an index filename.
+    #
+    # @option params [String] :rep (:default) The name of the representation
+    #   from which the path should be fetched. By default, the path will be
+    #   fetched from the default representation.
+    #
+    # @option params [Symbol] :snapshot (:last) The snapshot for which the
+    #   path should be returned.
+    #
+    # @return [String] The item’s path.
     def path(params = {})
       @item.path(params)
     end
 
+    # Returns the children of this item. For items with identifiers that have
+    # extensions, returns an empty collection.
+    #
+    # @return [Enumerable<Nanoc::ItemView>]
     def children
       @item.children.map { |i| Nanoc::ItemView.new(i) }
     end
 
+    # Returns the parent of this item, if one exists. For items with identifiers
+    # that have extensions, returns nil.
+    #
+    # @return [Nanoc::ItemView] if the item has a parent
+    #
+    # @return [nil] if the item has no parent
     def parent
       Nanoc::ItemView.new(@item.parent)
     end
 
+    # @return [Boolean] True if the item is binary, false otherwise
     def binary?
       @item.binary?
     end
 
+    # For textual items, returns the raw (source) content of this item; for
+    # binary items, returns `nil`.
+    #
+    # @return [String] if the item is textual
+    #
+    # @return [nil] if the item is binary
     def raw_content
       @item.raw_content
     end

--- a/lib/nanoc/base/views/item_collection.rb
+++ b/lib/nanoc/base/views/item_collection.rb
@@ -19,8 +19,16 @@ module Nanoc
       Nanoc::ItemView
     end
 
+    # Calls the given block once for each item, passing that item as a parameter.
+    #
+    # @yieldparam [Nanoc::ItemView] item
+    #
+    # @yieldreturn [void]
+    #
+    # @return [self]
     def each
       @items.each { |i| yield view_class.new(i) }
+      self
     end
 
     # @return [Integer]
@@ -28,16 +36,45 @@ module Nanoc
       @items.size
     end
 
+    # @overload at(string)
+    #
+    #   Finds the item whose identifier matches the given string.
+    #
+    #   @param [String] string
+    #
+    #   @return [nil] if no item matches the string
+    #
+    #   @return [Nanoc::ItemView] if an item was found
     def at(arg)
       item = @items.at(arg)
       item && view_class.new(item)
     end
 
-    def [](*args)
-      res = @items[*args]
+    # @overload [](string)
+    #
+    #   Finds the item whose identifier matches the given string.
+    #
+    #   If the glob syntax is enabled, the string can be a glob, in which case
+    #   this method finds the first item that matches the given glob.
+    #
+    #   @param [String] string
+    #
+    #   @return [nil] if no item matches the string
+    #
+    #   @return [Nanoc::ItemView] if an item was found
+    #
+    # @overload [](regex)
+    #
+    #   Finds the item whose identifier matches the given regular expression.
+    #
+    #   @param [Regex] regex
+    #
+    #   @return [nil] if no item matches the regex
+    #
+    #   @return [Nanoc::ItemView] if an item was found
+    def [](arg)
+      res = @items[arg]
       case res
-      when Array
-        res.map { |r| view_class.new(r) }
       when nil
         nil
       else

--- a/lib/nanoc/base/views/item_rep.rb
+++ b/lib/nanoc/base/views/item_rep.rb
@@ -12,27 +12,50 @@ module Nanoc
       @item_rep
     end
 
+    # @see Object#==
     def ==(other)
       item.identifier == other.item.identifier && name == other.name
     end
     alias_method :eql?, :==
 
+    # @see Object#hash
     def hash
       self.class.hash ^ item.identifier.hash ^ name.hash
     end
 
+    # @return [Symbol]
     def name
       @item_rep.name
     end
 
+    # Returns the compiled content.
+    #
+    # @option params [String] :snapshot The name of the snapshot from which to
+    #   fetch the compiled content. By default, the returned compiled content
+    #   will be the content compiled right before the first layout call (if
+    #   any).
+    #
+    # @return [String] The content at the given snapshot.
     def compiled_content(params = {})
       @item_rep.compiled_content(params)
     end
 
+    # Returns the item rep’s path, as used when being linked to. It starts
+    # with a slash and it is relative to the output directory. It does not
+    # include the path to the output directory. It will not include the
+    # filename if the filename is an index filename.
+    #
+    # @option params [Symbol] :snapshot (:last) The snapshot for which the
+    #   path should be returned.
+    #
+    # @return [String] The item rep’s path.
     def path(params = {})
       @item_rep.path(params)
     end
 
+    # Returns the item that this item rep belongs to.
+    #
+    # @return [Nanoc::ItemView]
     def item
       Nanoc::ItemView.new(@item_rep.item)
     end

--- a/lib/nanoc/base/views/layout.rb
+++ b/lib/nanoc/base/views/layout.rb
@@ -12,19 +12,23 @@ module Nanoc
       @layout
     end
 
+    # @see Object#==
     def ==(other)
       identifier == other.identifier
     end
     alias_method :eql?, :==
 
+    # @see Object#hash
     def hash
       self.class.hash ^ identifier.hash
     end
 
+    # @return [Nanoc::Identifier]
     def identifier
       @layout.identifier
     end
 
+    # @see Hash#[]
     def [](key)
       @layout[key]
     end

--- a/lib/nanoc/base/views/layout_collection.rb
+++ b/lib/nanoc/base/views/layout_collection.rb
@@ -11,7 +11,7 @@ module Nanoc
 
     # @api private
     def unwrap
-      @item
+      @layouts
     end
 
     # @api private
@@ -19,8 +19,14 @@ module Nanoc
       Nanoc::LayoutView
     end
 
+    # Calls the given block once for each layout, passing that layout as a parameter.
+    #
+    # @yieldparam [Nanoc::LayoutView] layout
+    #
+    # @yieldreturn [void]
     def each
       @layouts.each { |l| yield view_class.new(l) }
+      self
     end
   end
 end

--- a/lib/nanoc/base/views/mutable_config.rb
+++ b/lib/nanoc/base/views/mutable_config.rb
@@ -2,6 +2,11 @@
 
 module Nanoc
   class MutableConfigView < Nanoc::ConfigView
+    # Sets the value for the given attribute.
+    #
+    # @param [Symbol] key
+    #
+    # @see Hash#[]=
     def []=(key, value)
       @config[key] = value
     end

--- a/lib/nanoc/base/views/mutable_item.rb
+++ b/lib/nanoc/base/views/mutable_item.rb
@@ -2,12 +2,23 @@
 
 module Nanoc
   class MutableItemView < Nanoc::ItemView
+    # Sets the value for the given attribute.
+    #
+    # @param [Symbol] key
+    #
+    # @see Hash#[]=
     def []=(key, value)
       unwrap[key] = value
     end
 
+    # Updates the attributes based on the given hash.
+    #
+    # @param [Hash] hash
+    #
+    # @return [self]
     def update_attributes(hash)
       hash.each { |k, v| unwrap[k] = v }
+      self
     end
   end
 end

--- a/lib/nanoc/base/views/mutable_item_collection.rb
+++ b/lib/nanoc/base/views/mutable_item_collection.rb
@@ -7,16 +7,37 @@ module Nanoc
       Nanoc::MutableItemView
     end
 
+    # Creates a new item and adds it to the site’s collection of items.
+    #
+    # @param [String] content The uncompiled item content (if it is a textual
+    #   item) or the path to the filename containing the content (if it is a
+    #   binary item).
+    #
+    # @param [Hash] attributes A hash containing this item's attributes.
+    #
+    # @param [Nanoc::Identifier, String] identifier This item's identifier.
+    #
+    # @param [Hash] params Extra parameters.
+    #
+    # @option params [Symbol, nil] :binary (true) Whether or not this item is
+    #   binary
+    #
+    # @return [self]
     def create(content, attributes, identifier, params = {})
       @items << Nanoc::Int::Item.new(content, attributes, identifier, params)
+      self
     end
 
+    # Deletes every item for which the block evaluates to true.
+    #
+    # @yieldparam [Nanoc::ItemView] item
+    #
+    # @yieldreturn [Boolean]
+    #
+    # @return [self]
     def delete_if(&block)
       @items.delete_if(&block)
-    end
-
-    def concat(other)
-      @items.concat(other)
+      self
     end
   end
 end

--- a/lib/nanoc/base/views/mutable_layout.rb
+++ b/lib/nanoc/base/views/mutable_layout.rb
@@ -2,6 +2,11 @@
 
 module Nanoc
   class MutableLayoutView < Nanoc::LayoutView
+    # Sets the value for the given attribute.
+    #
+    # @param [Symbol] key
+    #
+    # @see Hash#[]=
     def []=(key, value)
       unwrap[key] = value
     end

--- a/lib/nanoc/base/views/mutable_layout_collection.rb
+++ b/lib/nanoc/base/views/mutable_layout_collection.rb
@@ -7,12 +7,30 @@ module Nanoc
       Nanoc::MutableLayoutView
     end
 
-    def create(content, attributes, identifier, params = {})
-      @layouts << Nanoc::Int::Layout.new(content, attributes, identifier, params)
+    # Creates a new layout and adds it to the site’s collection of layouts.
+    #
+    # @param [String] content The layout content.
+    #
+    # @param [Hash] attributes A hash containing this layout's attributes.
+    #
+    # @param [Nanoc::Identifier, String] identifier This layout's identifier.
+    #
+    # @return [self]
+    def create(content, attributes, identifier)
+      @layouts << Nanoc::Int::Layout.new(content, attributes, identifier)
+      self
     end
 
+    # Deletes every layout for which the block evaluates to true.
+    #
+    # @yieldparam [Nanoc::LayoutView] layout
+    #
+    # @yieldreturn [Boolean]
+    #
+    # @return [self]
     def delete_if(&block)
       @layouts.delete_if(&block)
+      self
     end
   end
 end

--- a/spec/nanoc/base/views/item_collection_spec.rb
+++ b/spec/nanoc/base/views/item_collection_spec.rb
@@ -10,7 +10,17 @@ describe Nanoc::ItemCollectionView do
   end
 
   describe '#each' do
-    # …
+    let(:wrapped) do
+      [
+        Nanoc::Int::Item.new('foo', {}, '/foo/'),
+        Nanoc::Int::Item.new('bar', {}, '/bar/'),
+        Nanoc::Int::Item.new('baz', {}, '/baz/'),
+      ]
+    end
+
+    it 'returns self' do
+      expect(view.each { |i| }).to equal(view)
+    end
   end
 
   describe '#size' do
@@ -58,20 +68,6 @@ describe Nanoc::ItemCollectionView do
     subject { view[arg] }
 
     let(:arg) { 'some argument' }
-
-    context 'wrapped returns array' do
-      let(:item) { double(:item) }
-
-      before do
-        expect(wrapped).to receive(:[]).with(arg) { [item] }
-      end
-
-      it 'returns wrapped items' do
-        expect(subject.size).to equal(1)
-        expect(subject[0].class).to equal(Nanoc::ItemView)
-        expect(subject[0].unwrap).to equal(item)
-      end
-    end
 
     context 'wrapped returns nil' do
       before do

--- a/spec/nanoc/base/views/layout_collection_spec.rb
+++ b/spec/nanoc/base/views/layout_collection_spec.rb
@@ -1,0 +1,25 @@
+# encoding: utf-8
+
+describe Nanoc::LayoutCollectionView do
+  let(:wrapped) { double(:wrapped) }
+  let(:view) { described_class.new(wrapped) }
+
+  describe '#unwrap' do
+    subject { view.unwrap }
+    it { should equal(wrapped) }
+  end
+
+  describe '#each' do
+    let(:wrapped) do
+      [
+        Nanoc::Int::Layout.new('foo', {}, '/foo/'),
+        Nanoc::Int::Layout.new('bar', {}, '/bar/'),
+        Nanoc::Int::Layout.new('baz', {}, '/baz/'),
+      ]
+    end
+
+    it 'returns self' do
+      expect(view.each { |l| }).to equal(view)
+    end
+  end
+end

--- a/spec/nanoc/base/views/mutable_item_collection_spec.rb
+++ b/spec/nanoc/base/views/mutable_item_collection_spec.rb
@@ -12,6 +12,11 @@ describe Nanoc::MutableItemCollectionView do
       view.each { |i| i[:seen] = true }
       expect(mutable_item_collection.first[:seen]).to eql(true)
     end
+
+    it 'returns self' do
+      ret = view.each { |i| i[:seen] = true }
+      expect(ret).to equal(view)
+    end
   end
 
   describe '#create' do
@@ -26,6 +31,11 @@ describe Nanoc::MutableItemCollectionView do
 
       expect(mutable_item_collection.size).to eq(2)
       expect(mutable_item_collection.last.raw_content).to eq('new content')
+    end
+
+    it 'returns self' do
+      ret = view.create('new content', { title: 'New Page' }, '/new/')
+      expect(ret).to equal(view)
     end
   end
 
@@ -45,24 +55,10 @@ describe Nanoc::MutableItemCollectionView do
       view.delete_if { |i| i.raw_content == 'blah' }
       expect(mutable_item_collection).not_to be_empty
     end
-  end
 
-  describe '#concat' do
-    let(:mutable_item_collection) do
-      [Nanoc::Int::Item.new('content', {}, '/asdf/')]
-    end
-
-    let(:items_array_to_concat) do
-      [Nanoc::Int::Item.new('shiny', {}, '/new/')]
-    end
-
-    let(:view) { described_class.new(mutable_item_collection) }
-
-    subject { view.concat(items_array_to_concat) }
-
-    it 'concats' do
-      expect { subject }.to change { view.size }.from(1).to(2)
-      expect(view[1].unwrap).to eql(items_array_to_concat[0])
+    it 'returns self' do
+      ret = view.delete_if { |i| false }
+      expect(ret).to equal(view)
     end
   end
 end

--- a/spec/nanoc/base/views/mutable_item_spec.rb
+++ b/spec/nanoc/base/views/mutable_item_spec.rb
@@ -22,5 +22,9 @@ describe Nanoc::MutableItemView do
     it 'sets attributes' do
       expect { subject }.to change { view[:friend] }.from(nil).to('Giraffe')
     end
+
+    it 'returns self' do
+      expect(subject).to equal(view)
+    end
   end
 end

--- a/spec/nanoc/base/views/mutable_layout_collection_spec.rb
+++ b/spec/nanoc/base/views/mutable_layout_collection_spec.rb
@@ -12,6 +12,11 @@ describe Nanoc::MutableLayoutCollectionView do
       view.each { |l| l[:seen] = true }
       expect(mutable_layout_collection.first[:seen]).to eql(true)
     end
+
+    it 'returns self' do
+      ret = view.each { |l| l[:seen] = true }
+      expect(ret).to equal(view)
+    end
   end
 
   describe '#create' do
@@ -26,6 +31,11 @@ describe Nanoc::MutableLayoutCollectionView do
 
       expect(mutable_layout_collection.size).to eq(2)
       expect(mutable_layout_collection.last.raw_content).to eq('new content')
+    end
+
+    it 'returns self' do
+      ret = view.create('new content', { title: 'New Page' }, '/new/')
+      expect(ret).to equal(view)
     end
   end
 
@@ -44,6 +54,11 @@ describe Nanoc::MutableLayoutCollectionView do
     it 'deletes no non-matching' do
       view.delete_if { |l| l.raw_content == 'blah' }
       expect(mutable_layout_collection).not_to be_empty
+    end
+
+    it 'returns self' do
+      ret = view.delete_if { |l| false }
+      expect(ret).to equal(view)
     end
   end
 end


### PR DESCRIPTION
This adds documentation to the view API where it was missing or incomplete.

**Also:**

- I added specs where necessary and fixed some issues—all discovered while writing documentation.

- I removed `#concat`, because it doesn’t make sense (there is no way to get a collection of items that isn’t already in the site).