### PR TITLE
Fix rendering helper

### DIFF
--- a/lib/nanoc/base/views/layout_collection.rb
+++ b/lib/nanoc/base/views/layout_collection.rb
@@ -28,5 +28,39 @@ module Nanoc
       @layouts.each { |l| yield view_class.new(l) }
       self
     end
+
+    # @overload [](string)
+    #
+    #   Finds the item whose identifier matches the given string.
+    #
+    #   If the glob syntax is enabled, the string can be a glob, in which case
+    #   this method finds the first item that matches the given glob.
+    #
+    #   @param [String] string
+    #
+    #   @return [nil] if no item matches the string
+    #
+    #   @return [Nanoc::ItemView] if an item was found
+    #
+    # @overload [](regex)
+    #
+    #   Finds the item whose identifier matches the given regular expression.
+    #
+    #   @param [Regex] regex
+    #
+    #   @return [nil] if no item matches the regex
+    #
+    #   @return [Nanoc::ItemView] if an item was found
+    def [](arg)
+      layout = @layouts.find { |l| l.identifier == arg }
+      return view_class.new(layout) if layout
+
+      # FIXME: this should only work if globs are enabled
+      pat = Nanoc::Int::Pattern.from(arg)
+      layout = @layouts.find { |l| pat.match?(l.identifier) }
+      return view_class.new(layout) if layout
+
+      nil
+    end
   end
 end

--- a/lib/nanoc/helpers/rendering.rb
+++ b/lib/nanoc/helpers/rendering.rb
@@ -78,6 +78,7 @@ module Nanoc::Helpers
     def render(identifier, other_assigns = {}, &block)
       # Find layout
       layout = @layouts[identifier]
+      layout ||= @layouts[identifier.__nanoc_cleaned_identifier]
       raise Nanoc::Int::Errors::UnknownLayout.new(identifier) if layout.nil?
 
       # Visit

--- a/lib/nanoc/helpers/rendering.rb
+++ b/lib/nanoc/helpers/rendering.rb
@@ -77,8 +77,8 @@ module Nanoc::Helpers
     #   invoked with a block
     def render(identifier, other_assigns = {}, &block)
       # Find layout
-      layout = @site.layouts.find { |l| l.identifier == identifier.__nanoc_cleaned_identifier }
-      raise Nanoc::Int::Errors::UnknownLayout.new(identifier.__nanoc_cleaned_identifier) if layout.nil?
+      layout = @layouts[identifier]
+      raise Nanoc::Int::Errors::UnknownLayout.new(identifier) if layout.nil?
 
       # Visit
       Nanoc::Int::NotificationCenter.post(:visit_started, layout)

--- a/spec/nanoc/base/views/layout_collection_spec.rb
+++ b/spec/nanoc/base/views/layout_collection_spec.rb
@@ -22,4 +22,38 @@ describe Nanoc::LayoutCollectionView do
       expect(view.each { |l| }).to equal(view)
     end
   end
+
+  describe '#[]' do
+    let(:wrapped) do
+      [
+        Nanoc::Int::Layout.new('foo', {}, Nanoc::Identifier.new('/page.erb', style: :full)),
+        Nanoc::Int::Layout.new('bar', {}, Nanoc::Identifier.new('/home.erb', style: :full)),
+      ]
+    end
+
+    subject { view[arg] }
+
+    context 'no layouts found' do
+      let(:arg) { '/donkey.*' }
+      it { is_expected.to equal(nil) }
+    end
+
+    context 'direct identifier' do
+      let(:arg) { '/home.erb' }
+
+      it 'returns wrapped layout' do
+        expect(subject.class).to equal(Nanoc::LayoutView)
+        expect(subject.unwrap).to equal(wrapped[1])
+      end
+    end
+
+    context 'glob' do
+      let(:arg) { '/home.*' }
+
+      it 'returns wrapped layout' do
+        expect(subject.class).to equal(Nanoc::LayoutView)
+        expect(subject.unwrap).to equal(wrapped[1])
+      end
+    end
+  end
 end

--- a/spec/nanoc/base/views/mutable_layout_collection_spec.rb
+++ b/spec/nanoc/base/views/mutable_layout_collection_spec.rb
@@ -61,4 +61,40 @@ describe Nanoc::MutableLayoutCollectionView do
       expect(ret).to equal(view)
     end
   end
+
+  describe '#[]' do
+    let(:mutable_layout_collection) do
+      [
+        Nanoc::Int::Layout.new('foo', {}, Nanoc::Identifier.new('/page.erb', style: :full)),
+        Nanoc::Int::Layout.new('bar', {}, Nanoc::Identifier.new('/home.erb', style: :full)),
+      ]
+    end
+
+    let(:view) { described_class.new(mutable_layout_collection) }
+
+    subject { view[arg] }
+
+    context 'no layouts found' do
+      let(:arg) { '/donkey.*' }
+      it { is_expected.to equal(nil) }
+    end
+
+    context 'direct identifier' do
+      let(:arg) { '/home.erb' }
+
+      it 'returns wrapped layout' do
+        expect(subject.class).to equal(Nanoc::MutableLayoutView)
+        expect(subject.unwrap).to equal(mutable_layout_collection[1])
+      end
+    end
+
+    context 'glob' do
+      let(:arg) { '/home.*' }
+
+      it 'returns wrapped layout' do
+        expect(subject.class).to equal(Nanoc::MutableLayoutView)
+        expect(subject.unwrap).to equal(mutable_layout_collection[1])
+      end
+    end
+  end
 end

--- a/test/helpers/test_rendering.rb
+++ b/test/helpers/test_rendering.rb
@@ -20,6 +20,23 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
     end
   end
 
+  def test_render_with_non_cleaned_identifier
+    with_site do |site|
+      File.open('Rules', 'w') do |io|
+        io.write("layout '/foo/', :erb\n")
+      end
+
+      File.open('layouts/foo.erb', 'w') do |io|
+        io.write 'This is the <%= @layout.identifier %> layout.'
+      end
+
+      @site = site
+      @layouts = Nanoc::LayoutCollectionView.new(@site.layouts)
+
+      assert_equal('This is the /foo/ layout.', render('/foo'))
+    end
+  end
+
   def test_render_class
     with_site do |site|
       File.open('Rules', 'w') do |io|

--- a/test/helpers/test_rendering.rb
+++ b/test/helpers/test_rendering.rb
@@ -5,8 +5,6 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
 
   def test_render
     with_site do |site|
-      @site = site
-
       File.open('Rules', 'w') do |io|
         io.write("layout '/foo/', :erb\n")
       end
@@ -15,14 +13,15 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
         io.write 'This is the <%= @layout.identifier %> layout.'
       end
 
+      @site = site
+      @layouts = Nanoc::LayoutCollectionView.new(@site.layouts)
+
       assert_equal('This is the /foo/ layout.', render('/foo/'))
     end
   end
 
   def test_render_class
     with_site do |site|
-      @site = site
-
       File.open('Rules', 'w') do |io|
         io.write("layout '/foo/', :erb\n")
       end
@@ -31,6 +30,9 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
         io.write 'I am the <%= @layout.class %> class.'
       end
 
+      @site = site
+      @layouts = Nanoc::LayoutCollectionView.new(@site.layouts)
+
       assert_equal('I am the Nanoc::LayoutView class.', render('/foo/'))
     end
   end
@@ -38,6 +40,7 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
   def test_render_with_unknown_layout
     with_site do |site|
       @site = site
+      @layouts = Nanoc::LayoutCollectionView.new(@site.layouts)
 
       assert_raises(Nanoc::Int::Errors::UnknownLayout) do
         render '/dsfghjkl/'
@@ -47,13 +50,14 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
 
   def test_render_without_filter
     with_site do |site|
-      @site = site
-
       File.open('Rules', 'w') do |io|
         io.write("layout '/foo/', nil\n")
       end
 
       File.open('layouts/foo.erb', 'w').close
+
+      @site = site
+      @layouts = Nanoc::LayoutCollectionView.new(@site.layouts)
 
       assert_raises(Nanoc::Int::Errors::CannotDetermineFilter) do
         render '/foo/'
@@ -63,13 +67,14 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
 
   def test_render_with_unknown_filter
     with_site do |site|
-      @site = site
-
       File.open('Rules', 'w') do |io|
         io.write("layout '/foo/', :asdf\n")
       end
 
       File.open('layouts/foo.erb', 'w').close
+
+      @site = site
+      @layouts = Nanoc::LayoutCollectionView.new(@site.layouts)
 
       assert_raises(Nanoc::Int::Errors::UnknownFilter) do
         render '/foo/'
@@ -79,8 +84,6 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
 
   def test_render_with_block
     with_site do |site|
-      @site = site
-
       File.open('Rules', 'w') do |io|
         io.write("layout '/foo/', :erb\n")
       end
@@ -88,6 +91,9 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
       File.open('layouts/foo.erb', 'w') do |io|
         io.write '[partial-before]<%= yield %>[partial-after]'
       end
+
+      @site = site
+      @layouts = Nanoc::LayoutCollectionView.new(@site.layouts)
 
       _erbout = '[erbout-before]'
       result = render '/foo/' do


### PR DESCRIPTION
This lets `#render` take a glob as its argument, e.g. `render '/page.*'`

For this to work, there’s now `LayoutCollectionView#[]`. Unfortunately, this makes it clear that the collection views are starting to show a serious issue of code duplication.