### PR TITLE
Remove private methods in views

### DIFF
--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -336,9 +336,10 @@ module Nanoc::Int
           compile_rep(rep)
           content_dependency_graph.delete_vertex(rep)
         rescue Nanoc::Int::Errors::UnmetDependency => e
-          content_dependency_graph.add_edge(e.rep, rep)
-          unless content_dependency_graph.vertices.include?(e.rep)
-            content_dependency_graph.add_vertex(e.rep)
+          other_rep = e.rep.unwrap rescue e.rep
+          content_dependency_graph.add_edge(other_rep, rep)
+          unless content_dependency_graph.vertices.include?(other_rep)
+            content_dependency_graph.add_vertex(other_rep)
           end
         end
       end

--- a/lib/nanoc/base/compilation/filter.rb
+++ b/lib/nanoc/base/compilation/filter.rb
@@ -185,6 +185,8 @@ module Nanoc
     #
     # @return [void]
     def depend_on(items)
+      items = items.map { |i| i.unwrap rescue i }
+
       # Notify
       items.each do |item|
         Nanoc::Int::NotificationCenter.post(:visit_started, item)

--- a/lib/nanoc/base/views/item.rb
+++ b/lib/nanoc/base/views/item.rb
@@ -126,11 +126,6 @@ module Nanoc
     end
 
     # @api private
-    def reference
-      @item.reference
-    end
-
-    # @api private
     def reps
       @item.reps.map { |r| Nanoc::ItemRepView.new(r) }
     end
@@ -138,16 +133,6 @@ module Nanoc
     # @api private
     def raw_filename
       @item.raw_filename
-    end
-
-    # @api private
-    def forced_outdated?
-      @item.forced_outdated?
-    end
-
-    # @api private
-    def __nanoc_checksum
-      @item.__nanoc_checksum
     end
   end
 end

--- a/lib/nanoc/base/views/item_rep.rb
+++ b/lib/nanoc/base/views/item_rep.rb
@@ -61,88 +61,13 @@ module Nanoc
     end
 
     # @api private
-    def to_recording_proxy
-      @item_rep.to_recording_proxy
-    end
-
-    # @api private
     def raw_path(params = {})
       @item_rep.raw_path(params)
     end
 
     # @api private
-    def compiled?
-      @item_rep.compiled?
-    end
-
-    # @api private
-    def compiled=(new_compiled)
-      @item_rep.compiled = new_compiled
-    end
-
-    # @api private
-    def forget_progress
-      @item_rep.forget_progress
-    end
-
-    # @api private
-    def assigns
-      @item_rep.assigns
-    end
-
-    # @api private
-    def assigns=(new_assigns)
-      @item_rep.assigns = new_assigns
-    end
-
-    # @api private
-    def type
-      @item_rep.type
-    end
-
-    # @api private
-    def reference
-      @item_rep.reference
-    end
-
-    # @api private
-    def snapshot(snapshot_name, params = {})
-      @item_rep.snapshot(snapshot_name, params)
-    end
-
-    # @api private
-    def filter(filter_name, filter_args = {})
-      @item_rep.filter(filter_name, filter_args)
-    end
-
-    # @api private
-    def layout(layout, filter_name, filter_args)
-      @item_rep.layout(layout, filter_name, filter_args)
-    end
-
-    # @api private
-    def proxy?
-      @item_rep.proxy?
-    end
-
-    # @api private
     def binary?
       @item_rep.binary?
-    end
-
-    # @api private
-    def has_snapshot?(snapshot_name)
-      @item_rep.has_snapshot?(snapshot_name)
-    end
-
-    # @api private
-    def content
-      @item_rep.content
-    end
-
-    # @api private
-    def temporary_filenames
-      @item_rep.temporary_filenames
     end
   end
 end

--- a/lib/nanoc/base/views/site.rb
+++ b/lib/nanoc/base/views/site.rb
@@ -11,25 +11,5 @@ module Nanoc
     def unwrap
       @site
     end
-
-    # @api private
-    def layouts
-      @site.layouts.map { |l| Nanoc::LayoutView.new(l) }
-    end
-
-    # @api private
-    def captures_store
-      @site.captures_store
-    end
-
-    # @api private
-    def captures_store_compiled_items
-      @site.captures_store_compiled_items
-    end
-
-    # @api private
-    def compiler
-      @site.compiler
-    end
   end
 end

--- a/lib/nanoc/helpers/capturing.rb
+++ b/lib/nanoc/helpers/capturing.rb
@@ -90,7 +90,7 @@ module Nanoc::Helpers
 
         # Capture and store
         content = capture(&block)
-        @site.captures_store[@item, name.to_sym] = content
+        @site.unwrap.captures_store[@item, name.to_sym] = content
       else # Get content
         # Get args
         if args.size != 2
@@ -102,7 +102,7 @@ module Nanoc::Helpers
         name = args[1]
 
         # Create dependency
-        current_item = @site.compiler.dependency_tracker.top
+        current_item = @site.unwrap.compiler.dependency_tracker.top
         if item != current_item
           Nanoc::Int::NotificationCenter.post(:visit_started, item)
           Nanoc::Int::NotificationCenter.post(:visit_ended,   item)
@@ -111,8 +111,8 @@ module Nanoc::Helpers
           # item from which we use content. For this, we need to manually edit
           # the content attribute to reset it. :(
           # FIXME: clean this up
-          unless @site.captures_store_compiled_items.include? item
-            @site.captures_store_compiled_items << item
+          unless @site.unwrap.captures_store_compiled_items.include? item
+            @site.unwrap.captures_store_compiled_items << item
             item.forced_outdated = true
             item.reps.each do |r|
               raw_content = item.raw_content
@@ -123,7 +123,7 @@ module Nanoc::Helpers
         end
 
         # Get content
-        @site.captures_store[item, name.to_sym]
+        @site.unwrap.captures_store[item, name.to_sym]
       end
     end
 

--- a/lib/nanoc/helpers/rendering.rb
+++ b/lib/nanoc/helpers/rendering.rb
@@ -101,7 +101,7 @@ module Nanoc::Helpers
       }.merge(other_assigns)
 
       # Get filter name
-      filter_name, filter_args = @site.compiler.rules_collection.filter_for_layout(layout)
+      filter_name, filter_args = @site.unwrap.compiler.rules_collection.filter_for_layout(layout)
       raise Nanoc::Int::Errors::CannotDetermineFilter.new(layout.identifier) if filter_name.nil?
 
       # Get filter class

--- a/test/helpers/test_capturing.rb
+++ b/test/helpers/test_capturing.rb
@@ -17,9 +17,11 @@ class Nanoc::Helpers::CapturingTest < Nanoc::TestCase
               '<% end %> foot'
 
     # Build site
-    @site = Nanoc::Int::Site.new({})
-    @item = Nanoc::Int::Item.new('moo', {}, '/blah/')
-    @item.site = @site
+    site = Nanoc::Int::Site.new({})
+    item = Nanoc::Int::Item.new('moo', {}, '/blah/')
+    item.site = site
+    @site = Nanoc::SiteView.new(Nanoc::Int::Site.new({}))
+    @item = Nanoc::ItemView.new(item)
 
     # Evaluate content
     result = ::ERB.new(content).result(binding)
@@ -33,8 +35,8 @@ class Nanoc::Helpers::CapturingTest < Nanoc::TestCase
     require 'erb'
 
     # Build site
-    @site = Nanoc::Int::Site.new({})
-    @item = Nanoc::Int::Item.new('moo', {}, '/blah/')
+    @site = Nanoc::SiteView.new(Nanoc::Int::Site.new({}))
+    @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('moo', {}, '/blah/'))
 
     # Capture
     _erbout = 'foo'
@@ -67,8 +69,8 @@ head
 foot
 EOS
 
-    @site = Nanoc::Int::Site.new({})
-    @item = Nanoc::Int::Item.new('content', {}, '/')
+    @site = Nanoc::SiteView.new(Nanoc::Int::Site.new({}))
+    @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', {}, '/'))
 
     result = ::ERB.new(content).result(binding)
 
@@ -85,16 +87,16 @@ EOS
       io.write "route '*' do ; item.identifier + 'index.html' ; end\n"
     end
 
-    @site = Nanoc::Int::Site.new({})
-    @item = Nanoc::Int::Item.new('content', {}, '/')
+    @site = Nanoc::SiteView.new(Nanoc::Int::Site.new({}))
+    @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', {}, '/'))
     content = '<% content_for :a do %>Content One<% end %>'
     ::ERB.new(content).result(binding)
 
     assert_equal 'Content One', content_for(@item, :a)
     assert_equal nil,           content_for(@item, :b)
 
-    @site = Nanoc::Int::Site.new({})
-    @item = Nanoc::Int::Item.new('content', {}, '/')
+    @site = Nanoc::SiteView.new(Nanoc::Int::Site.new({}))
+    @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', {}, '/'))
     content = '<% content_for :b do %>Content Two<% end %>'
     ::ERB.new(content).result(binding)
 

--- a/test/helpers/test_rendering.rb
+++ b/test/helpers/test_rendering.rb
@@ -13,8 +13,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
         io.write 'This is the <%= @layout.identifier %> layout.'
       end
 
-      @site = site
-      @layouts = Nanoc::LayoutCollectionView.new(@site.layouts)
+      @site = Nanoc::SiteView.new(site)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
 
       assert_equal('This is the /foo/ layout.', render('/foo/'))
     end
@@ -30,8 +30,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
         io.write 'This is the <%= @layout.identifier %> layout.'
       end
 
-      @site = site
-      @layouts = Nanoc::LayoutCollectionView.new(@site.layouts)
+      @site = Nanoc::SiteView.new(site)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
 
       assert_equal('This is the /foo/ layout.', render('/foo'))
     end
@@ -47,8 +47,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
         io.write 'I am the <%= @layout.class %> class.'
       end
 
-      @site = site
-      @layouts = Nanoc::LayoutCollectionView.new(@site.layouts)
+      @site = Nanoc::SiteView.new(site)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
 
       assert_equal('I am the Nanoc::LayoutView class.', render('/foo/'))
     end
@@ -56,8 +56,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
 
   def test_render_with_unknown_layout
     with_site do |site|
-      @site = site
-      @layouts = Nanoc::LayoutCollectionView.new(@site.layouts)
+      @site = Nanoc::SiteView.new(site)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
 
       assert_raises(Nanoc::Int::Errors::UnknownLayout) do
         render '/dsfghjkl/'
@@ -73,8 +73,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
 
       File.open('layouts/foo.erb', 'w').close
 
-      @site = site
-      @layouts = Nanoc::LayoutCollectionView.new(@site.layouts)
+      @site = Nanoc::SiteView.new(site)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
 
       assert_raises(Nanoc::Int::Errors::CannotDetermineFilter) do
         render '/foo/'
@@ -90,8 +90,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
 
       File.open('layouts/foo.erb', 'w').close
 
-      @site = site
-      @layouts = Nanoc::LayoutCollectionView.new(@site.layouts)
+      @site = Nanoc::SiteView.new(site)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
 
       assert_raises(Nanoc::Int::Errors::UnknownFilter) do
         render '/foo/'
@@ -109,8 +109,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
         io.write '[partial-before]<%= yield %>[partial-after]'
       end
 
-      @site = site
-      @layouts = Nanoc::LayoutCollectionView.new(@site.layouts)
+      @site = Nanoc::SiteView.new(site)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
 
       _erbout = '[erbout-before]'
       result = render '/foo/' do


### PR DESCRIPTION
These private methods were intended for compatibility with existing code, but do not belong there any longer. This PR also fixed some issues uncovered while removing these private methods.

Two methods that haven’t been removed and will likely become part of the public API at some point:

* `ItemRep#binary?`
* `ItemRep#raw_path`