### PR TITLE
Adds --force option to create site in non-empty directory

### DIFF
--- a/lib/nanoc/cli/commands/create-site.rb
+++ b/lib/nanoc/cli/commands/create-site.rb
@@ -282,7 +282,9 @@ EOS
 
       # Check whether site exists
       if File.exist?(path) && (!File.directory?(path) || !(Dir.entries(path) - %w{ . .. }).empty?) && !options[:force]
-        raise Nanoc::Int::Errors::GenericTrivial, "A site at '#{path}' already exists. Use --force to override this warning."
+        raise Nanoc::Int::Errors::GenericTrivial,
+          "The site was not created because '#{path}' already exists. " +
+          "Re-run the command using --force to create the site anyway."
       end
 
       # Check whether data source exists

--- a/lib/nanoc/cli/commands/create-site.rb
+++ b/lib/nanoc/cli/commands/create-site.rb
@@ -6,6 +6,7 @@ summary 'create a site'
 description "
 Create a new site at the given path. The site will use the `filesystem_unified` data source by default, but this can be changed using the `--datasource` command-line option.
 "
+flag nil, :force, "Force creation of new site. Disregards previous existence of site in destination"
 
 module Nanoc::CLI::Commands
   class CreateSite < ::Nanoc::CLI::CommandRunner
@@ -280,8 +281,8 @@ EOS
       data_source = options[:datasource] || 'filesystem_unified'
 
       # Check whether site exists
-      if File.exist?(path) && (!File.directory?(path) || !(Dir.entries(path) - %w{ . .. }).empty?)
-        raise Nanoc::Int::Errors::GenericTrivial, "A site at '#{path}' already exists."
+      if File.exist?(path) && (!File.directory?(path) || !(Dir.entries(path) - %w{ . .. }).empty?) && !options[:force]
+        raise Nanoc::Int::Errors::GenericTrivial, "A site at '#{path}' already exists. Use --force to override this warning."
       end
 
       # Check whether data source exists

--- a/test/cli/commands/test_create_site.rb
+++ b/test/cli/commands/test_create_site.rb
@@ -39,6 +39,17 @@ class Nanoc::CLI::Commands::CreateSiteTest < Nanoc::TestCase
     end
   end
 
+  def test_can_compile_site_in_nonempty_directory
+    FileUtils.mkdir('foo')
+    FileUtils.touch(File.join('foo', 'SomeFile.txt'))
+    Nanoc::CLI.run %w( create_site foo --force )
+
+    FileUtils.cd('foo') do
+      site = Nanoc::Int::Site.new('.')
+      site.compile
+    end
+  end
+
   def test_default_encoding
     unless defined?(Encoding)
       skip 'No Encoding class'


### PR DESCRIPTION
Continuation of #549. Allows --force flag to override the site-already-exists safeguard