### PR TITLE
Improve Nanoc::Int::ItemArray

### DIFF
--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -177,7 +177,7 @@ module Nanoc::Int
     #
     # @return [Nanoc::Int::DependencyTracker] The dependency tracker for this site
     def dependency_tracker
-      dt = Nanoc::Int::DependencyTracker.new(@site.items + @site.layouts)
+      dt = Nanoc::Int::DependencyTracker.new(@site.items.to_a + @site.layouts)
       dt.compiler = self
       dt
     end
@@ -197,7 +197,7 @@ module Nanoc::Int
     #
     # @api private
     def objects
-      site.items + site.layouts + site.code_snippets +
+      site.items.to_a + site.layouts + site.code_snippets +
         [site.config, rules_collection]
     end
 

--- a/lib/nanoc/base/source_data/item_array.rb
+++ b/lib/nanoc/base/source_data/item_array.rb
@@ -9,17 +9,10 @@ module Nanoc::Int
 
     extend Forwardable
 
-    EXCLUDED_METHODS  = [
-      :[], :at, :slice, :class, :singleton_class, :clone, :dup, :initialize_dup, :initialize_clone,
-      :freeze, :methods, :singleton_methods, :protected_methods, :private_methods, :public_methods,
-      :instance_variables, :instance_variable_get, :instance_variable_set, :instance_variable_defined?,
-      :instance_of?, :kind_of?, :is_a?, :tap, :send, :public_send, :respond_to?, :respond_to_missing?,
-      :extend, :display, :method, :public_method, :define_singleton_method, :object_id, :equal?,
-      :instance_eval, :instance_exec, :__send__, :__id__
-    ]
-
-    DELEGATED_METHODS = (Array.instance_methods + Enumerable.instance_methods).map(&:to_sym) - EXCLUDED_METHODS
-    def_delegators :@items, *DELEGATED_METHODS
+    def_delegator :@items, :each
+    def_delegator :@items, :size
+    def_delegator :@items, :<<
+    def_delegator :@items, :concat
 
     def initialize(config)
       @config = config
@@ -33,23 +26,19 @@ module Nanoc::Int
       super
     end
 
-    def [](*args)
-      if 1 == args.size && args.first.is_a?(String)
-        item_with_identifier(args.first) || item_matching_glob(args.first)
-      elsif 1 == args.size && args.first.is_a?(Regexp)
-        @items.select { |i| i.identifier.to_s =~ args.first }
+    def [](arg)
+      case arg
+      when String
+        item_with_identifier(arg) || item_matching_glob(arg)
+      when Regexp
+        @items.find { |i| i.identifier.to_s =~ arg }
       else
-        @items[*args]
+        raise ArgumentError, "don’t know how to fetch items by #{arg.inspect}"
       end
     end
-    alias_method :slice, :[]
 
-    def at(arg)
-      if arg.is_a?(String)
-        item_with_identifier(arg)
-      else
-        @items[arg]
-      end
+    def to_a
+      @items
     end
 
     protected

--- a/lib/nanoc/base/views/item_collection.rb
+++ b/lib/nanoc/base/views/item_collection.rb
@@ -36,18 +36,6 @@ module Nanoc
       @items.size
     end
 
-    # Finds the item whose identifier matches the given string.
-    #
-    # @param [String] arg
-    #
-    # @return [nil] if no item matches the string
-    #
-    # @return [Nanoc::ItemView] if an item was found
-    def at(arg)
-      item = @items.at(arg)
-      item && view_class.new(item)
-    end
-
     # Finds all items whose identifier matches the given argument.
     #
     # @param [String, Regex] arg
@@ -82,12 +70,7 @@ module Nanoc
     #   @return [Nanoc::ItemView] if an item was found
     def [](arg)
       res = @items[arg]
-      case res
-      when nil
-        nil
-      else
-        view_class.new(res)
-      end
+      res && view_class.new(res)
     end
   end
 end

--- a/spec/nanoc/base/views/layout_collection_spec.rb
+++ b/spec/nanoc/base/views/layout_collection_spec.rb
@@ -55,5 +55,14 @@ describe Nanoc::LayoutCollectionView do
         expect(subject.unwrap).to equal(wrapped[1])
       end
     end
+
+    context 'regex' do
+      let(:arg) { %r{\A/home} }
+
+      it 'returns wrapped layout' do
+        expect(subject.class).to equal(Nanoc::LayoutView)
+        expect(subject.unwrap).to equal(wrapped[1])
+      end
+    end
   end
 end

--- a/test/base/test_compiler.rb
+++ b/test/base/test_compiler.rb
@@ -306,7 +306,7 @@ class Nanoc::Int::CompilerTest < Nanoc::TestCase
 
       # At this point, even the already compiled items in the previous pass
       # should have their compiled content assigned, so this should work:
-      site.items[0].reps[0].compiled_content
+      site.items['/index.*'].reps[0].compiled_content
     end
   end
 

--- a/test/base/test_item_array.rb
+++ b/test/base/test_item_array.rb
@@ -26,24 +26,6 @@ class Nanoc::Int::ItemArrayTest < Nanoc::TestCase
     assert_equal @one, @items.find { |i| i.identifier == '/one/' }
   end
 
-  def test_brackets_and_slice_and_at_with_index
-    assert_equal @one, @items[0]
-    assert_equal @one, @items.slice(0)
-    assert_equal @one, @items.at(0)
-
-    assert_equal @two, @items[1]
-    assert_equal @two, @items.slice(1)
-    assert_equal @two, @items.at(1)
-
-    assert_nil @items[2]
-    assert_nil @items.slice(2)
-    assert_nil @items.at(2)
-
-    assert_equal @two, @items[-1]
-    assert_equal @two, @items.slice(-1)
-    assert_equal @two, @items.at(-1)
-  end
-
   def test_brackets_with_glob
     @items = Nanoc::Int::ItemArray.new({ pattern_syntax: 'glob' })
     @items << @one
@@ -53,297 +35,47 @@ class Nanoc::Int::ItemArrayTest < Nanoc::TestCase
     assert_equal @two, @items['/*wo/']
   end
 
-  def test_brackets_and_slice_with_range
-    assert_equal [@one, @two], @items[0..1]
-    assert_equal [@one, @two], @items[0, 2]
-
-    assert_equal [@one, @two], @items.slice(0..1)
-    assert_equal [@one, @two], @items.slice(0, 2)
-  end
-
-  def test_brackets_and_slice_and_at_with_identifier
+  def test_brackets_with_identifier
     assert_equal @one, @items['/one/']
-    assert_equal @one, @items.slice('/one/')
-    assert_equal @one, @items.at('/one/')
-
     assert_equal @two, @items['/two/']
-    assert_equal @two, @items.slice('/two/')
-    assert_equal @two, @items.at('/two/')
-
     assert_nil @items['/max-payne/']
-    assert_nil @items.slice('/max-payne/')
-    assert_nil @items.at('/max-payne/')
   end
 
-  def test_brackets_and_slice_and_at_with_malformed_identifier
+  def test_brackets_with_malformed_identifier
     assert_nil @items['one/']
-    assert_nil @items.slice('one/')
-    assert_nil @items.at('one/')
-
     assert_nil @items['/one']
-    assert_nil @items.slice('/one')
-    assert_nil @items.at('/one')
-
     assert_nil @items['one']
-    assert_nil @items.slice('one')
-    assert_nil @items.at('one')
-
     assert_nil @items['//one/']
-    assert_nil @items.slice('//one/')
-    assert_nil @items.at('//one/')
   end
 
-  def test_brackets_and_slice_and_at_frozen
+  def test_brackets_frozen
     @items.freeze
 
     assert_equal @one, @items['/one/']
-    assert_equal @one, @items.slice('/one/')
-    assert_equal @one, @items.at('/one/')
-
     assert_nil @items['/tenthousand/']
-    assert_nil @items.slice('/tenthousand/')
-    assert_nil @items.at('/tenthousand/')
   end
 
   def test_regex
     foo = Nanoc::Int::Item.new('Item Foo', {}, '/foo/')
     @items << foo
 
-    assert_equal [@one], @items[/n/]
-    assert_equal [@two, foo], @items[%r{o/}]
+    assert_equal @one, @items[/n/]
+    assert_equal @two, @items[%r{o/}] # not foo
   end
 
   def test_less_than_less_than
-    assert_nil @items[2]
     assert_nil @items['/foo/']
 
     foo = Nanoc::Int::Item.new('Item Foo', {}, '/foo/')
     @items << foo
 
-    assert_equal foo, @items[2]
     assert_equal foo, @items['/foo/']
-  end
-
-  def test_assign
-    assert_raises(TypeError) do
-      @items['/blah/'] = Nanoc::Int::Item.new('Item blah', {}, '/blah/')
-    end
-
-    new_item =  Nanoc::Int::Item.new('New Item One', {}, '/one-new/')
-    @items[0] = new_item
-
-    assert_equal new_item, @items[0]
-    assert_equal new_item, @items['/one-new/']
-    assert_nil @items['/one/']
-  end
-
-  def test_assign_frozen
-    @items.freeze
-
-    new_item = Nanoc::Int::Item.new('New Item One', {}, '/one-new/')
-
-    assert_raises_frozen_error do
-      @items[0] = new_item
-    end
-  end
-
-  def test_clear
-    @items.clear
-
-    assert_nil @items[0]
-    assert_nil @items[1]
-    assert_nil @items[2]
-
-    assert_nil @items['/one/']
-    assert_nil @items['/two/']
-  end
-
-  def test_collect_bang
-    @items.collect! do |i|
-      Nanoc::Int::Item.new("New #{i.raw_content}", {}, "/new#{i.identifier}")
-    end
-
-    assert_nil @items['/one/']
-    assert_nil @items['/two/']
-
-    assert_equal 'New Item One', @items[0].raw_content
-    assert_equal 'New Item One', @items['/new/one/'].raw_content
-
-    assert_equal 'New Item Two', @items[1].raw_content
-    assert_equal 'New Item Two', @items['/new/two/'].raw_content
-  end
-
-  def test_collect_bang_frozen
-    @items.freeze
-
-    assert_raises_frozen_error do
-      @items.collect! do |i|
-        Nanoc::Int::Item.new("New #{i.raw_content}", {}, "/new#{i.identifier}")
-      end
-    end
   end
 
   def test_concat
     new_item = Nanoc::Int::Item.new('New item', {}, '/new/')
     @items.concat([new_item])
 
-    assert_equal new_item, @items[2]
     assert_equal new_item, @items['/new/']
-  end
-
-  def test_delete
-    assert_equal @two, @items[1]
-    assert_equal @two, @items['/two/']
-
-    @items.delete(@two)
-
-    assert_nil @items[1]
-    assert_nil @items['/two/']
-  end
-
-  def test_delete_at
-    assert_equal @two, @items[1]
-    assert_equal @two, @items['/two/']
-
-    @items.delete_at(1)
-
-    assert_nil @items[1]
-    assert_nil @items['/two/']
-  end
-
-  def test_delete_if
-    assert_equal @two, @items[1]
-    assert_equal @two, @items['/two/']
-
-    @items.delete_if { |i| i.identifier == '/two/' }
-
-    assert_nil @items[1]
-    assert_nil @items['/two/']
-  end
-
-  def test_fill_all
-    @items.fill { |i| Nanoc::Int::Item.new("Item #{i}", {}, "/new/#{i}/") }
-
-    assert_nil @items['/one/']
-    assert_nil @items['/two/']
-
-    assert_equal 'Item 0', @items[0].raw_content
-    assert_equal 'Item 0', @items['/new/0/'].raw_content
-    assert_equal 'Item 1', @items[1].raw_content
-    assert_equal 'Item 1', @items['/new/1/'].raw_content
-  end
-
-  def test_fill_range
-    @items.fill(1..-1) { |i| Nanoc::Int::Item.new("Item #{i}", {}, "/new/#{i}/") }
-
-    assert_equal @one, @items['/one/']
-    assert_nil @items['/two/']
-
-    assert_equal @one, @items[0]
-    assert_equal @one, @items['/one/']
-    assert_equal 'Item 1', @items[1].raw_content
-    assert_equal 'Item 1', @items['/new/1/'].raw_content
-  end
-
-  if [].respond_to?(:keep_if)
-    def test_keep_if
-      assert_equal @two, @items[1]
-      assert_equal @two, @items['/two/']
-
-      @items.keep_if { |i| i.identifier == '/one/' }
-
-      assert_equal @one, @items[0]
-      assert_equal @one, @items['/one/']
-      assert_nil @items[1]
-      assert_nil @items['/two/']
-    end
-  end
-
-  def test_pop
-    @items.pop
-
-    assert_equal @one, @items[0]
-    assert_equal @one, @items['/one/']
-    assert_nil @items[1]
-    assert_nil @items['/two/']
-  end
-
-  def test_push
-    pushy = Nanoc::Int::Item.new('Pushy', {}, '/pushy/')
-    @items.push(pushy)
-
-    assert_equal @one, @items[0]
-    assert_equal @one, @items['/one/']
-    assert_equal @two, @items[1]
-    assert_equal @two, @items['/two/']
-    assert_equal pushy, @items[2]
-    assert_equal pushy, @items['/pushy/']
-  end
-
-  def test_reject_bang
-    assert_equal @two, @items[1]
-    assert_equal @two, @items['/two/']
-
-    @items.reject! { |i| i.identifier == '/two/' }
-
-    assert_nil @items[1]
-    assert_nil @items['/two/']
-  end
-
-  def test_replace
-    max  = Nanoc::Int::Item.new('Max', {}, '/max/')
-    mona = Nanoc::Int::Item.new('Mona', {}, '/mona/')
-
-    @items.replace([max, mona])
-
-    assert_nil @items['/one/']
-    assert_nil @items['/two/']
-
-    assert_equal max, @items[0]
-    assert_equal max, @items['/max/']
-    assert_equal mona, @items[1]
-    assert_equal mona, @items['/mona/']
-  end
-
-  if [].respond_to?(:select!)
-    def test_select_bang
-      assert_equal @two, @items[1]
-      assert_equal @two, @items['/two/']
-
-      @items.select! { |i| i.identifier == '/two/' }
-
-      assert_nil @items[1]
-      assert_nil @items['/one/']
-    end
-  end
-
-  def test_shift
-    @items.shift
-
-    assert_equal @two, @items[0]
-    assert_equal @two, @items['/two/']
-    assert_nil @items['/one/']
-    assert_nil @items[1]
-  end
-
-  def test_slice_bang
-    @items.slice!(1)
-
-    assert_equal @one, @items[0]
-    assert_equal @one, @items['/one/']
-    assert_nil @items[1]
-    assert_nil @items['/two/']
-  end
-
-  def test_unshift
-    unshifty = Nanoc::Int::Item.new('Unshifty', {}, '/unshifty/')
-    @items.unshift(unshifty)
-
-    assert_equal unshifty, @items[0]
-    assert_equal unshifty, @items['/unshifty/']
-    assert_equal @one, @items[1]
-    assert_equal @one, @items['/one/']
-    assert_equal @two, @items[2]
-    assert_equal @two, @items['/two/']
   end
 end

--- a/test/base/test_outdatedness_checker.rb
+++ b/test/base/test_outdatedness_checker.rb
@@ -13,7 +13,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
     # Check
     with_site(name: 'foo') do |site|
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items[0].reps[0]
+      rep = site.items['/'].reps[0]
       assert_nil outdatedness_checker.outdatedness_reason_for(rep)
     end
   end

--- a/test/base/test_site.rb
+++ b/test/base/test_site.rb
@@ -153,8 +153,8 @@ EOF
       site.load
 
       # Check
-      assert_equal 1,       site.data_sources.size
-      assert_equal Nanoc::Identifier.new('/foo/'), site.items[0].identifier
+      assert_equal 1, site.data_sources.size
+      refute_nil site.items['/foo/']
     end
   end
 

--- a/test/helpers/test_breadcrumbs.rb
+++ b/test/helpers/test_breadcrumbs.rb
@@ -5,37 +5,45 @@ class Nanoc::Helpers::BreadcrumbsTest < Nanoc::TestCase
 
   def test_breadcrumbs_trail_at_root
     @items = Nanoc::Int::ItemArray.new({})
-    @items << Nanoc::Int::Item.new('root', {}, '/')
-    @item = @items.last
+    item = Nanoc::Int::Item.new('root', {}, '/')
+    @items << item
+    @item = item
 
-    assert_equal [@items[0]], breadcrumbs_trail
+    assert_equal [item], breadcrumbs_trail
   end
 
   def test_breadcrumbs_trail_with_1_parent
     @items = Nanoc::Int::ItemArray.new({})
-    @items << Nanoc::Int::Item.new('parent', {}, '/')
-    @items << Nanoc::Int::Item.new('child',  {}, '/foo/')
-    @item = @items.last
+    parent_item = Nanoc::Int::Item.new('parent', {}, '/')
+    child_item  = Nanoc::Int::Item.new('child',  {}, '/foo/')
+    @items << parent_item
+    @items << child_item
+    @item = child_item
 
-    assert_equal [@items[0], @items[1]], breadcrumbs_trail
+    assert_equal [parent_item, child_item], breadcrumbs_trail
   end
 
   def test_breadcrumbs_trail_with_many_parents
     @items = Nanoc::Int::ItemArray.new({})
-    @items << Nanoc::Int::Item.new('grandparent', {}, '/')
-    @items << Nanoc::Int::Item.new('parent',      {}, '/foo/')
-    @items << Nanoc::Int::Item.new('child',       {}, '/foo/bar/')
-    @item = @items.last
+    grandparent_item = Nanoc::Int::Item.new('grandparent', {}, '/')
+    parent_item      = Nanoc::Int::Item.new('parent',      {}, '/foo/')
+    child_item       = Nanoc::Int::Item.new('child',       {}, '/foo/bar/')
+    @items << grandparent_item
+    @items << parent_item
+    @items << child_item
+    @item = child_item
 
-    assert_equal [@items[0], @items[1], @items[2]], breadcrumbs_trail
+    assert_equal [grandparent_item, parent_item, child_item], breadcrumbs_trail
   end
 
   def test_breadcrumbs_trail_with_nils
     @items = Nanoc::Int::ItemArray.new({})
-    @items << Nanoc::Int::Item.new('grandparent', {}, '/')
-    @items << Nanoc::Int::Item.new('child',       {}, '/foo/bar/')
-    @item = @items.last
+    grandparent_item = Nanoc::Int::Item.new('grandparent', {}, '/')
+    child_item       = Nanoc::Int::Item.new('child',       {}, '/foo/bar/')
+    @items << grandparent_item
+    @items << child_item
+    @item = child_item
 
-    assert_equal [@items[0], nil, @items[1]], breadcrumbs_trail
+    assert_equal [grandparent_item, nil, child_item], breadcrumbs_trail
   end
 end

--- a/test/helpers/test_xml_sitemap.rb
+++ b/test/helpers/test_xml_sitemap.rb
@@ -14,25 +14,29 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
   def test_xml_sitemap
     if_have 'builder', 'nokogiri' do
       # Create items
-      @items = []
+      @items = Nanoc::Int::ItemArray.new({})
 
       # Create item 1
-      @items << Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'))
-      create_item_rep(@items.last.unwrap, :one_a, '/item-one/a/')
-      create_item_rep(@items.last.unwrap, :one_b, '/item-one/b/')
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'))
+      @items << item
+      create_item_rep(item.unwrap, :one_a, '/item-one/a/')
+      create_item_rep(item.unwrap, :one_b, '/item-one/b/')
 
       # Create item 2
-      @items << Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 2', { is_hidden: true }, '/item-two/'))
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 2', { is_hidden: true }, '/item-two/'))
+      @items << item
 
       # Create item 3
       attrs = { mtime: Time.parse('2004-07-12'), changefreq: 'daily', priority: 0.5 }
-      @items << Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 3', attrs, '/item-three/'))
-      create_item_rep(@items.last.unwrap, :three_a, '/item-three/a/')
-      create_item_rep(@items.last.unwrap, :three_b, '/item-three/b/')
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 3', attrs, '/item-three/'))
+      @items << item
+      create_item_rep(item.unwrap, :three_a, '/item-three/a/')
+      create_item_rep(item.unwrap, :three_b, '/item-three/b/')
 
       # Create item 4
-      @items << Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 4', {}, '/item-four/'))
-      create_item_rep(@items.last.unwrap, :four_a, nil)
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 4', {}, '/item-four/'))
+      @items << item
+      create_item_rep(item.unwrap, :four_a, nil)
 
       # Create sitemap item
       @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'))
@@ -71,11 +75,12 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
   def test_sitemap_with_items_as_param
     if_have 'builder', 'nokogiri' do
       # Create items
-      @items = []
+      @items = Nanoc::Int::ItemArray.new({})
       @items << nil
-      @items << Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'))
-      create_item_rep(@items.last.unwrap, :one_a, '/item-one/a/')
-      create_item_rep(@items.last.unwrap, :one_b, '/item-one/b/')
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'))
+      @items << item
+      create_item_rep(item.unwrap, :one_a, '/item-one/a/')
+      create_item_rep(item.unwrap, :one_b, '/item-one/b/')
       @items << nil
 
       # Create sitemap item
@@ -85,7 +90,7 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
       @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
 
       # Build sitemap
-      res = xml_sitemap(items: [@items[1]])
+      res = xml_sitemap(items: [item])
 
       # Check
       doc = Nokogiri::XML(res)
@@ -107,10 +112,11 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
   def test_filter
     if_have 'builder', 'nokogiri' do
       # Create items
-      @items = []
-      @items << Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'))
-      create_item_rep(@items.last.unwrap, :one_a, '/item-one/a/')
-      create_item_rep(@items.last.unwrap, :one_b, '/item-one/b/')
+      @items = Nanoc::Int::ItemArray.new({})
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'))
+      @items << item
+      create_item_rep(item.unwrap, :one_a, '/item-one/a/')
+      create_item_rep(item.unwrap, :one_b, '/item-one/b/')
 
       # Create sitemap item
       @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'))
@@ -137,16 +143,19 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
   def test_sorted
     if_have 'builder', 'nokogiri' do
       # Create items
-      @items = []
-      @items << Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/george/'))
-      create_item_rep(@items.last.unwrap, :a_alice,   '/george/alice/')
-      create_item_rep(@items.last.unwrap, :b_zoey,    '/george/zoey/')
-      @items << Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/walton/'))
-      create_item_rep(@items.last.unwrap, :a_eve,     '/walton/eve/')
-      create_item_rep(@items.last.unwrap, :b_bob,     '/walton/bob/')
-      @items << Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/lucas/'))
-      create_item_rep(@items.last.unwrap, :a_trudy,   '/lucas/trudy/')
-      create_item_rep(@items.last.unwrap, :b_mallory, '/lucas/mallory/')
+      @items = Nanoc::Int::ItemArray.new({})
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/george/'))
+      @items << item
+      create_item_rep(item.unwrap, :a_alice,   '/george/alice/')
+      create_item_rep(item.unwrap, :b_zoey,    '/george/zoey/')
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/walton/'))
+      @items << item
+      create_item_rep(item.unwrap, :a_eve,     '/walton/eve/')
+      create_item_rep(item.unwrap, :b_bob,     '/walton/bob/')
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/lucas/'))
+      @items << item
+      create_item_rep(item.unwrap, :a_trudy,   '/lucas/trudy/')
+      create_item_rep(item.unwrap, :b_mallory, '/lucas/mallory/')
 
       # Create sitemap item
       @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'))


### PR DESCRIPTION
`Nanoc::Int::ItemArray` is icky (too array-like, with too much magic delegation). This improves ItemArray to be more in line with the API that `ItemCollectionView` exposes.

* [x] Fix #[] with regex returning array
* [x] Remove anything non-essential
* [x] Remove #at
* [x] Remove #slice
* [x] Remove #+
* [x] Remove integer indexing
* [x] Remove #last

From the public API point of view, only the removal of `#at`, `#[]` returning an array, and integer indexing has changed.

Future work could include renaming `ItemArray` to `ItemCollection`, but for the sake of not diverging too much from 3.x, I’ll keep it this way for now.