### PR TITLE
Better default site

### DIFF
--- a/lib/nanoc/base/source_data/site.rb
+++ b/lib/nanoc/base/source_data/site.rb
@@ -33,7 +33,7 @@ module Nanoc::Int
     # that lacks some options, the default value will be taken from
     # `DEFAULT_CONFIG`.
     DEFAULT_CONFIG = {
-      text_extensions: %w( css erb haml htm html js less markdown md php rb sass scss txt xhtml xml coffee hb handlebars mustache ms slim ).sort,
+      text_extensions: %w( css erb haml htm html js less markdown md php rb sass scss txt xhtml xml coffee hb handlebars mustache ms slim rdoc ).sort,
       lib_dirs: %w( lib ),
       commands_dirs: %w( commands ),
       output_dir: 'output',

--- a/lib/nanoc/cli/commands/create-site.rb
+++ b/lib/nanoc/cli/commands/create-site.rb
@@ -107,11 +107,27 @@ EOS
 #!/usr/bin/env ruby
 
 compile '/**/*.html' do
-  filter :erb
   layout '/default.*'
 end
 
+# This is an example rule that matches Markdown (.md) files, and filters them
+# using the :kramdown filter. It is commented out by default, because kramdown
+# is not bundled with nanoc or Ruby.
+#
+#compile '/**/*.md' do
+#  filter :kramdown
+#  layout '/default.*'
+#end
+
 compile '/**/*' do
+end
+
+route '/**/*.{html,md}' do
+  if item.identifier =~ '/index.*'
+    '/index.html'
+  else
+    item.identifier.without_ext + '/index.html'
+  end
 end
 
 route '/**/*' do
@@ -122,6 +138,10 @@ layout '/**/*', :erb
 EOS
 
     DEFAULT_ITEM = <<EOS unless defined? DEFAULT_ITEM
+---
+title: Home
+---
+
 <h1>A Brand New nanoc Site</h1>
 
 <p>You’ve just created a new nanoc site. The page you are looking at right now is the home page for your site. To get started, consider replacing this default homepage with your own customized homepage. Some pointers on how to do so:</p>
@@ -305,40 +325,21 @@ EOS
         FileUtils.mkdir_p('lib')
         FileUtils.mkdir_p('output')
 
-        # Config
-        File.open('nanoc.yaml', 'w') { |io| io.write(DEFAULT_CONFIG) }
-        Nanoc::Int::NotificationCenter.post(:file_created, 'nanoc.yaml')
-
-        # Rules
-        File.open('Rules', 'w') do |io|
-          io.write DEFAULT_RULES
-        end
-        Nanoc::Int::NotificationCenter.post(:file_created, 'Rules')
-
-        # Home page
-        File.open('content/index.html', 'w') do |io|
-          io << '---' << "\n"
-          io << 'title: Home' << "\n"
-          io << '---' << "\n"
-          io << "\n"
-          io << DEFAULT_ITEM
-        end
-        Nanoc::Int::NotificationCenter.post(:file_created, 'content/index.html')
-
-        # Style sheet
-        File.open('content/stylesheet.css', 'w') do |io|
-          io << DEFAULT_STYLESHEET
-        end
-        Nanoc::Int::NotificationCenter.post(:file_created, 'content/stylesheet.css')
-
-        # Layout
-        File.open('layouts/default.html', 'w') do |io|
-          io << DEFAULT_LAYOUT
-        end
-        Nanoc::Int::NotificationCenter.post(:file_created, 'layouts/default.html')
+        write('nanoc.yaml', DEFAULT_CONFIG)
+        write('Rules', DEFAULT_RULES)
+        write('content/index.html', DEFAULT_ITEM)
+        write('content/stylesheet.css', DEFAULT_STYLESHEET)
+        write('layouts/default.html', DEFAULT_LAYOUT)
       end
 
       puts "Created a blank nanoc site at '#{path}'. Enjoy!"
+    end
+
+    private
+
+    def write(filename, content)
+      File.write(filename, content)
+      Nanoc::Int::NotificationCenter.post(:file_created, filename)
     end
   end
 end

--- a/test/base/test_site.rb
+++ b/test/base/test_site.rb
@@ -203,8 +203,8 @@ EOF
       qux    = site.items.find { |i| i.identifier == '/parent/bar/qux/' }
 
       assert_equal Set.new([parent, style]), Set.new(root.children)
-      assert_equal Set.new([foo, bar]),      Set.new(parent.children)
-      assert_equal Set.new([qux]),           Set.new(bar.children)
+      assert_equal Set.new([foo, bar]), Set.new(parent.children)
+      assert_equal Set.new([qux]), Set.new(bar.children)
 
       assert_equal nil,    root.parent
       assert_equal root,   parent.parent

--- a/test/cli/commands/test_create_site.rb
+++ b/test/cli/commands/test_create_site.rb
@@ -50,6 +50,19 @@ class Nanoc::CLI::Commands::CreateSiteTest < Nanoc::TestCase
     end
   end
 
+  def test_compiled_site_output
+    FileUtils.mkdir('foo')
+    FileUtils.touch(File.join('foo', 'SomeFile.txt'))
+    Nanoc::CLI.run %w( create_site foo --force )
+
+    FileUtils.cd('foo') do
+      site = Nanoc::Int::Site.new('.')
+      site.compile
+
+      assert File.file?('output/index.html')
+    end
+  end
+
   def test_default_encoding
     unless defined?(Encoding)
       skip 'No Encoding class'


### PR DESCRIPTION
The new default site now includes a sample compilation rule for RDoc, along with a sample RDoc file (hopefully clearly enough marked as “just for demonstration purposes”). It also comes with a commented-out compilation rule for Markdown files.

It also adds `rdoc` to the list of text extensions, because otherwise the site wouldn’t compile :)

Potential fix for #588.