### PR TITLE
Make globs and indentifiers with extensions the default

### DIFF
--- a/lib/nanoc/base/source_data/site.rb
+++ b/lib/nanoc/base/source_data/site.rb
@@ -24,7 +24,8 @@ module Nanoc::Int
       type: 'filesystem_unified',
       items_root: '/',
       layouts_root: '/',
-      config: {}
+      config: {},
+      identifier_style: 'full',
     }
 
     # The default configuration for a site. A site's configuration overrides

--- a/lib/nanoc/base/source_data/site.rb
+++ b/lib/nanoc/base/source_data/site.rb
@@ -39,7 +39,8 @@ module Nanoc::Int
       data_sources: [{}],
       index_filenames: ['index.html'],
       enable_output_diff: false,
-      prune: { auto_prune: false, exclude: ['.git', '.hg', '.svn', 'CVS'] }
+      prune: { auto_prune: false, exclude: ['.git', '.hg', '.svn', 'CVS'] },
+      pattern_syntax: 'glob',
     }
 
     # Creates a site object for the site specified by the given

--- a/test/base/test_compiler_dsl.rb
+++ b/test/base/test_compiler_dsl.rb
@@ -177,6 +177,7 @@ EOS
   def test_passthrough_with_full_identifiers
     with_site do
       File.open('nanoc.yaml', 'w') do |io|
+        io << 'pattern_syntax: null' << "\n"
         io << 'data_sources:' << "\n"
         io << '  -' << "\n"
         io << '    type: filesystem_unified' << "\n"

--- a/test/base/test_outdatedness_checker.rb
+++ b/test/base/test_outdatedness_checker.rb
@@ -281,7 +281,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
 
     # Change code
     FileUtils.cd('foo') do
-      File.open('nanoc.yaml', 'w') { |io| io.write('awesome: true') }
+      File.open('nanoc.yaml', 'w') { |io| io.write("awesome: true\npattern_syntax: null\n") }
     end
 
     # Check

--- a/test/base/test_outdatedness_checker.rb
+++ b/test/base/test_outdatedness_checker.rb
@@ -281,7 +281,14 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
 
     # Change code
     FileUtils.cd('foo') do
-      File.open('nanoc.yaml', 'w') { |io| io.write("awesome: true\npattern_syntax: null\n") }
+      File.open('nanoc.yaml', 'w') do |io|
+        io << 'awesome: true' << "\n"
+        io << 'pattern_syntax: null' << "\n"
+        io << 'data_sources:' << "\n"
+        io << '  -' << "\n"
+        io << '    type: filesystem_unified' << "\n"
+        io << '    identifier_style: stripped' << "\n"
+      end
     end
 
     # Check

--- a/test/cli/commands/test_compile.rb
+++ b/test/cli/commands/test_compile.rb
@@ -49,6 +49,12 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
         io.write "layout '*', :erb\n"
       end
 
+      File.open('nanoc.yaml', 'w') do |io|
+        io.write "pattern_syntax: null\n"
+        io.write "prune:\n"
+        io.write "  auto_prune: false\n"
+      end
+
       File.open('output/stray.html', 'w') do |io|
         io.write 'I am a stray file and I am about to be deleted!'
       end
@@ -58,6 +64,7 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
       assert File.file?('output/stray.html')
 
       File.open('nanoc.yaml', 'w') do |io|
+        io.write "pattern_syntax: null\n"
         io.write "prune:\n"
         io.write "  auto_prune: true\n"
       end
@@ -92,6 +99,12 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
 
       Dir.mkdir('output/excluded_dir')
 
+      File.open('nanoc.yaml', 'w') do |io|
+        io.write "pattern_syntax: null\n"
+        io.write "prune:\n"
+        io.write "  auto_prune: false\n"
+      end
+
       File.open('output/stray.html', 'w') do |io|
         io.write 'I am a stray file and I am about to be deleted!'
       end
@@ -101,6 +114,7 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
       assert File.file?('output/stray.html')
 
       File.open('nanoc.yaml', 'w') do |io|
+        io.write "pattern_syntax: null\n"
         io.write "prune:\n"
         io.write "  auto_prune: true\n"
         io.write "  exclude: [ 'excluded_dir' ]\n"

--- a/test/cli/commands/test_prune.rb
+++ b/test/cli/commands/test_prune.rb
@@ -4,7 +4,7 @@ class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
   def test_run_without_yes
     with_site do |_site|
       # Set output dir
-      File.open('nanoc.yaml', 'w') { |io| io.write 'output_dir: output2' }
+      File.open('nanoc.yaml', 'w') { |io| io.write "output_dir: output2\npattern_syntax: null\n" }
       FileUtils.mkdir_p('output2')
 
       # Create source files
@@ -26,7 +26,7 @@ class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
   def test_run_with_yes
     with_site do |_site|
       # Set output dir
-      File.open('nanoc.yaml', 'w') { |io| io.write 'output_dir: output2' }
+      File.open('nanoc.yaml', 'w') { |io| io.write "pattern_syntax: null\noutput_dir: output2" }
       FileUtils.mkdir_p('output2')
 
       # Create source files
@@ -46,7 +46,7 @@ class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
   def test_run_with_dry_run
     with_site do |_site|
       # Set output dir
-      File.open('nanoc.yaml', 'w') { |io| io.write 'output_dir: output2' }
+      File.open('nanoc.yaml', 'w') { |io| io.write "pattern_syntax: null\noutput_dir: output2" }
       FileUtils.mkdir_p('output2')
 
       # Create source files
@@ -66,7 +66,7 @@ class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
   def test_run_with_exclude
     with_site do |_site|
       # Set output dir
-      File.open('nanoc.yaml', 'w') { |io| io.write "prune:\n  exclude: [ 'good-dir', 'good-file.html' ]" }
+      File.open('nanoc.yaml', 'w') { |io| io.write "pattern_syntax: null\nprune:\n  exclude: [ 'good-dir', 'good-file.html' ]" }
       FileUtils.mkdir_p('output')
 
       # Create source files

--- a/test/cli/commands/test_prune.rb
+++ b/test/cli/commands/test_prune.rb
@@ -26,7 +26,14 @@ class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
   def test_run_with_yes
     with_site do |_site|
       # Set output dir
-      File.open('nanoc.yaml', 'w') { |io| io.write "pattern_syntax: null\noutput_dir: output2" }
+      File.open('nanoc.yaml', 'w') do |io|
+        io << 'output_dir: output2' << "\n"
+        io << 'pattern_syntax: null' << "\n"
+        io << 'data_sources:' << "\n"
+        io << '  -' << "\n"
+        io << '    type: filesystem_unified' << "\n"
+        io << '    identifier_style: stripped' << "\n"
+      end
       FileUtils.mkdir_p('output2')
 
       # Create source files
@@ -66,7 +73,15 @@ class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
   def test_run_with_exclude
     with_site do |_site|
       # Set output dir
-      File.open('nanoc.yaml', 'w') { |io| io.write "pattern_syntax: null\nprune:\n  exclude: [ 'good-dir', 'good-file.html' ]" }
+      File.open('nanoc.yaml', 'w') do |io|
+        io << 'prune:' << "\n"
+        io << '  exclude: [ "good-dir", "good-file.html" ]' << "\n"
+        io << 'pattern_syntax: null' << "\n"
+        io << 'data_sources:' << "\n"
+        io << '  -' << "\n"
+        io << '    type: filesystem_unified' << "\n"
+        io << '    identifier_style: stripped' << "\n"
+      end
       FileUtils.mkdir_p('output')
 
       # Create source files

--- a/test/extra/checking/checks/test_stale.rb
+++ b/test/extra/checking/checks/test_stale.rb
@@ -47,7 +47,7 @@ class Nanoc::Extra::Checking::Checks::StaleTest < Nanoc::TestCase
       assert Dir['content/*'].empty?
       assert Dir['output/*'].empty?
 
-      File.open('nanoc.yaml', 'w') { |io| io.write "prune:\n  exclude: [ 'excluded.html' ]" }
+      File.open('nanoc.yaml', 'w') { |io| io.write "pattern_syntax: null\nprune:\n  exclude: [ 'excluded.html' ]" }
       File.open('content/index.html', 'w') { |io| io.write('stuff') }
       File.open('output/excluded.html', 'w') { |io| io.write('stuff') }
       assert calc_issues.empty?
@@ -59,7 +59,7 @@ class Nanoc::Extra::Checking::Checks::StaleTest < Nanoc::TestCase
       assert Dir['content/*'].empty?
       assert Dir['output/*'].empty?
 
-      File.open('nanoc.yaml', 'w') { |io| io.write "prune:\n  blah: meh" }
+      File.open('nanoc.yaml', 'w') { |io| io.write "pattern_syntax: null\nprune:\n  blah: meh" }
       File.open('content/index.html', 'w') { |io| io.write('stuff') }
       File.open('output/excluded.html', 'w') { |io| io.write('stuff') }
       refute calc_issues.empty?

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -103,7 +103,7 @@ EOS
           end
         end
 
-        File.open('nanoc.yaml', 'w') { |io| io.write('stuff: 12345') }
+        File.open('nanoc.yaml', 'w') { |io| io.write('pattern_syntax: null') }
         File.open('Rules', 'w') { |io| io.write(rules_content) }
       end
     end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -103,7 +103,14 @@ EOS
           end
         end
 
-        File.open('nanoc.yaml', 'w') { |io| io.write('pattern_syntax: null') }
+        File.open('nanoc.yaml', 'w') do |io|
+          io << 'pattern_syntax: null' << "\n"
+          io << 'data_sources:' << "\n"
+          io << '  -' << "\n"
+          io << '    type: filesystem_unified' << "\n"
+          io << '    identifier_style: stripped' << "\n"
+        end
+
         File.open('Rules', 'w') { |io| io.write(rules_content) }
       end
     end


### PR DESCRIPTION
* [x] Make globs the default
* [x] Make identifiers with extensions the default

I don’t like the option names for enabling/disabling these (`pattern_syntax: glob/null` and `identifier_style: full/stripped`).