### PR TITLE
Rename identifier_style and pattern_syntax

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@ Changes:
 * Removed `ItemCollectionView#at`
 * Removed support for calling `ItemCollectionView#[]` with an integer
 * Renamed `identifier_style` to `identifier_type`, and made its values be `"full"` or `"legacy"`.
-* Renamed `pattern_syntax` to `pattern_type`, and made its values be `"glob"` or `"legacy"`.
+* Renamed `pattern_syntax` to `string_pattern_type`, and made its values be `"glob"` or `"legacy"`.
 
 Enhancements:
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,8 @@ Changes:
 
 * Removed `ItemCollectionView#at`
 * Removed support for calling `ItemCollectionView#[]` with an integer
-* Renamed `identifier_type` to `identifier_type`, and made its values be `"full"` or `"legacy"`.
+* Renamed `identifier_style` to `identifier_type`, and made its values be `"full"` or `"legacy"`.
+* Renamed `pattern_syntax` to `pattern_type`, and made its values be `"glob"` or `"legacy"`.
 
 Enhancements:
 
@@ -45,7 +46,7 @@ Fixes:
 Features:
 
 * Glob patterns (opt-in by setting `pattern_syntax` to `"glob"` in the site configuration)
-* Identifiers with extensions (opt-in by setting `identifier_type` to `"full"` in the data source configuration)
+* Identifiers with extensions (opt-in by setting `identifier_style` to `"full"` in the data source configuration)
 
 Enhancements:
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ Changes:
 
 * Removed `ItemCollectionView#at`
 * Removed support for calling `ItemCollectionView#[]` with an integer
+* Renamed `identifier_type` to `identifier_type`, and made its values be `"full"` or `"legacy"`.
 
 Enhancements:
 
@@ -44,7 +45,7 @@ Fixes:
 Features:
 
 * Glob patterns (opt-in by setting `pattern_syntax` to `"glob"` in the site configuration)
-* Identifiers with extensions (opt-in by setting `identifier_style` to `"full"` in the data source configuration)
+* Identifiers with extensions (opt-in by setting `identifier_type` to `"full"` in the data source configuration)
 
 Enhancements:
 

--- a/lib/nanoc/base/compilation/compiler_dsl.rb
+++ b/lib/nanoc/base/compilation/compiler_dsl.rb
@@ -260,14 +260,14 @@ module Nanoc::Int
 
     # @api private
     def create_pattern(arg)
-      case @config[:pattern_syntax]
+      case @config[:pattern_type]
       when 'glob'
         Nanoc::Int::Pattern.from(arg)
-      when nil
+      when 'legacy'
         Nanoc::Int::Pattern.from(identifier_to_regex(arg))
       else
         raise Nanoc::Int::Errors::GenericTrivial,
-          "Invalid pattern_syntax: #{@config[:pattern_syntax]}"
+          "Invalid pattern_type: #{@config[:pattern_type]}"
       end
     end
 

--- a/lib/nanoc/base/compilation/compiler_dsl.rb
+++ b/lib/nanoc/base/compilation/compiler_dsl.rb
@@ -260,14 +260,14 @@ module Nanoc::Int
 
     # @api private
     def create_pattern(arg)
-      case @config[:pattern_type]
+      case @config[:string_pattern_type]
       when 'glob'
         Nanoc::Int::Pattern.from(arg)
       when 'legacy'
         Nanoc::Int::Pattern.from(identifier_to_regex(arg))
       else
         raise Nanoc::Int::Errors::GenericTrivial,
-          "Invalid pattern_type: #{@config[:pattern_type]}"
+          "Invalid string_pattern_type: #{@config[:string_pattern_type]}"
       end
     end
 

--- a/lib/nanoc/base/compilation/item_rep_proxy.rb
+++ b/lib/nanoc/base/compilation/item_rep_proxy.rb
@@ -105,7 +105,7 @@ module Nanoc::Int
     end
 
     def use_globs?
-      @compiler.site.config[:pattern_syntax] == 'glob'
+      @compiler.site.config[:pattern_type] == 'glob'
     end
   end
 end

--- a/lib/nanoc/base/compilation/item_rep_proxy.rb
+++ b/lib/nanoc/base/compilation/item_rep_proxy.rb
@@ -105,7 +105,7 @@ module Nanoc::Int
     end
 
     def use_globs?
-      @compiler.site.config[:pattern_type] == 'glob'
+      @compiler.site.config[:string_pattern_type] == 'glob'
     end
   end
 end

--- a/lib/nanoc/base/identifiable_collection.rb
+++ b/lib/nanoc/base/identifiable_collection.rb
@@ -75,7 +75,7 @@ module Nanoc::Int
     end
 
     def use_globs?
-      @config[:pattern_type] == 'glob'
+      @config[:string_pattern_type] == 'glob'
     end
   end
 end

--- a/lib/nanoc/base/identifiable_collection.rb
+++ b/lib/nanoc/base/identifiable_collection.rb
@@ -75,7 +75,7 @@ module Nanoc::Int
     end
 
     def use_globs?
-      @config[:pattern_syntax] == 'glob'
+      @config[:pattern_type] == 'glob'
     end
   end
 end

--- a/lib/nanoc/base/source_data/identifier.rb
+++ b/lib/nanoc/base/source_data/identifier.rb
@@ -16,10 +16,10 @@ module Nanoc
     end
 
     def initialize(string, params = {})
-      @style = params.fetch(:style, :stripped)
+      @style = params.fetch(:style, :legacy)
 
       case @style
-      when :stripped
+      when :legacy
         @string = "/#{string}/".gsub(/^\/+|\/+$/, '/').freeze
       when :full
         if string !~ /\A\//
@@ -77,7 +77,7 @@ module Nanoc
 
     # @return [String]
     def with_ext(ext)
-      if @style == :stripped
+      unless full?
         raise Nanoc::Int::Errors::Generic,
           'Cannot use #with_ext on identifier that does not include the file extension'
       end

--- a/lib/nanoc/base/source_data/identifier.rb
+++ b/lib/nanoc/base/source_data/identifier.rb
@@ -16,9 +16,9 @@ module Nanoc
     end
 
     def initialize(string, params = {})
-      @style = params.fetch(:style, :legacy)
+      @type = params.fetch(:type, :legacy)
 
-      case @style
+      case @type
       when :legacy
         @string = "/#{string}/".gsub(/^\/+|\/+$/, '/').freeze
       when :full
@@ -29,7 +29,7 @@ module Nanoc
         @string = string.dup.freeze
       else
         raise Nanoc::Int::Errors::Generic,
-          "Invalid :style param for identifier: #{@style.inspect}"
+          "Invalid :type param for identifier: #{@type.inspect}"
       end
     end
 
@@ -50,10 +50,10 @@ module Nanoc
       to_s <=> other.to_s
     end
 
-    # @return [Boolean] True if this is a full-style identifier (i.e. includes
+    # @return [Boolean] True if this is a full-type identifier (i.e. includes
     #   the extension), false otherwise
     def full?
-      @style == :full
+      @type == :full
     end
 
     # @return [String]
@@ -72,7 +72,7 @@ module Nanoc
         raise Nanoc::Int::Errors::Generic,
           "Invalid prefix (does not start with a slash): #{@string.inspect}"
       end
-      Nanoc::Identifier.new(string.sub(/\/+\z/, '') + @string, style: @style)
+      Nanoc::Identifier.new(string.sub(/\/+\z/, '') + @string, type: @type)
     end
 
     # @return [String]
@@ -117,7 +117,7 @@ module Nanoc
     end
 
     def inspect
-      "<Nanoc::Identifier style=#{@style} #{to_s.inspect}>"
+      "<Nanoc::Identifier type=#{@type} #{to_s.inspect}>"
     end
   end
 end

--- a/lib/nanoc/base/source_data/site.rb
+++ b/lib/nanoc/base/source_data/site.rb
@@ -41,7 +41,7 @@ module Nanoc::Int
       index_filenames: ['index.html'],
       enable_output_diff: false,
       prune: { auto_prune: false, exclude: ['.git', '.hg', '.svn', 'CVS'] },
-      pattern_type: 'glob',
+      string_pattern_type: 'glob',
     }
 
     # Creates a site object for the site specified by the given

--- a/lib/nanoc/base/source_data/site.rb
+++ b/lib/nanoc/base/source_data/site.rb
@@ -25,7 +25,7 @@ module Nanoc::Int
       items_root: '/',
       layouts_root: '/',
       config: {},
-      identifier_style: 'full',
+      identifier_type: 'full',
     }
 
     # The default configuration for a site. A site's configuration overrides

--- a/lib/nanoc/base/source_data/site.rb
+++ b/lib/nanoc/base/source_data/site.rb
@@ -41,7 +41,7 @@ module Nanoc::Int
       index_filenames: ['index.html'],
       enable_output_diff: false,
       prune: { auto_prune: false, exclude: ['.git', '.hg', '.svn', 'CVS'] },
-      pattern_syntax: 'glob',
+      pattern_type: 'glob',
     }
 
     # Creates a site object for the site specified by the given

--- a/lib/nanoc/cli/commands/create-site.rb
+++ b/lib/nanoc/cli/commands/create-site.rb
@@ -89,7 +89,7 @@ data_sources:
     # UTF-8 (which they should be!), change this.
     encoding: utf-8
 
-    identifier_style: full
+    identifier_type: full
 
 # Configuration for the “check” command, which run unit tests on the site.
 checks:

--- a/lib/nanoc/cli/commands/create-site.rb
+++ b/lib/nanoc/cli/commands/create-site.rb
@@ -23,7 +23,7 @@ module Nanoc::CLI::Commands
 # The syntax to use for patterns in the Rules file. Can be either `"glob"`
 # (default) or `null`. The former will enable glob patterns, which behave like
 # Ruby’s File.fnmatch. The latter will enable nanoc 3.x-style patterns.
-pattern_type: glob
+string_pattern_type: glob
 
 # A list of file extensions that nanoc will consider to be textual rather than
 # binary. If an item with an extension not in this list is found,  the file

--- a/lib/nanoc/cli/commands/create-site.rb
+++ b/lib/nanoc/cli/commands/create-site.rb
@@ -23,7 +23,7 @@ module Nanoc::CLI::Commands
 # The syntax to use for patterns in the Rules file. Can be either `"glob"`
 # (default) or `null`. The former will enable glob patterns, which behave like
 # Ruby’s File.fnmatch. The latter will enable nanoc 3.x-style patterns.
-pattern_syntax: glob
+pattern_type: glob
 
 # A list of file extensions that nanoc will consider to be textual rather than
 # binary. If an item with an extension not in this list is found,  the file

--- a/lib/nanoc/cli/commands/create-site.rb
+++ b/lib/nanoc/cli/commands/create-site.rb
@@ -21,8 +21,8 @@ module Nanoc::CLI::Commands
 
     DEFAULT_CONFIG = <<EOS unless defined? DEFAULT_CONFIG
 # The syntax to use for patterns in the Rules file. Can be either `"glob"`
-# (default) or `null`. The former will enable glob patterns, which behave like
-# Ruby’s File.fnmatch. The latter will enable nanoc 3.x-style patterns.
+# (default) or `"legacy"`. The former will enable glob patterns, which behave
+# like Ruby’s File.fnmatch. The latter will enable nanoc 3.x-style patterns.
 string_pattern_type: glob
 
 # A list of file extensions that nanoc will consider to be textual rather than

--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -129,7 +129,7 @@ module Nanoc::DataSources
         unless [0, 1].include?(meta_filenames.size)
           raise "Found #{meta_filenames.size} meta files for #{basename}; expected 0 or 1"
         end
-        unless config[:identifier_style] == 'full'
+        unless config[:identifier_type] == 'full'
           unless [0, 1].include?(content_filenames.size)
             raise "Found #{content_filenames.size} content files for #{basename}; expected 0 or 1"
           end

--- a/lib/nanoc/data_sources/filesystem_unified.rb
+++ b/lib/nanoc/data_sources/filesystem_unified.rb
@@ -87,7 +87,7 @@ module Nanoc::DataSources
     # Returns the identifier derived from the given filename, first stripping
     # the given directory name off the filename.
     def identifier_for_filename(filename)
-      if config[:identifier_style] == 'full'
+      if config[:identifier_type] == 'full'
         return Nanoc::Identifier.new(filename, style: :full)
       end
 

--- a/lib/nanoc/data_sources/filesystem_unified.rb
+++ b/lib/nanoc/data_sources/filesystem_unified.rb
@@ -88,7 +88,7 @@ module Nanoc::DataSources
     # the given directory name off the filename.
     def identifier_for_filename(filename)
       if config[:identifier_type] == 'full'
-        return Nanoc::Identifier.new(filename, style: :full)
+        return Nanoc::Identifier.new(filename, type: :full)
       end
 
       if filename =~ /(^|\/)index(\.[^\/]+)?$/

--- a/lib/nanoc/data_sources/filesystem_verbose.rb
+++ b/lib/nanoc/data_sources/filesystem_verbose.rb
@@ -61,7 +61,7 @@ module Nanoc::DataSources
 
     # See {Nanoc::DataSources::Filesystem#identifier_for_filename}.
     def identifier_for_filename(filename)
-      if config[:identifier_style] == 'full'
+      if config[:identifier_type] == 'full'
         return Nanoc::Identifier.new(filename, style: :full)
       end
 

--- a/lib/nanoc/data_sources/filesystem_verbose.rb
+++ b/lib/nanoc/data_sources/filesystem_verbose.rb
@@ -62,7 +62,7 @@ module Nanoc::DataSources
     # See {Nanoc::DataSources::Filesystem#identifier_for_filename}.
     def identifier_for_filename(filename)
       if config[:identifier_type] == 'full'
-        return Nanoc::Identifier.new(filename, style: :full)
+        return Nanoc::Identifier.new(filename, type: :full)
       end
 
       filename.sub(/[^\/]+\.yaml$/, '')

--- a/spec/nanoc/base/identifier_spec.rb
+++ b/spec/nanoc/base/identifier_spec.rb
@@ -2,7 +2,7 @@
 
 describe Nanoc::Identifier do
   describe '#initialize' do
-    context 'stripped style' do
+    context 'legacy style' do
       it 'does not convert already clean paths' do
         expect(described_class.new('/foo/bar/').to_s).to eql('/foo/bar/')
       end
@@ -59,7 +59,7 @@ describe Nanoc::Identifier do
 
     subject { identifier.inspect }
 
-    it { should == '<Nanoc::Identifier style=stripped "/foo/bar/">' }
+    it { should == '<Nanoc::Identifier style=legacy "/foo/bar/">' }
   end
 
   describe '#== and #eql?' do
@@ -197,7 +197,7 @@ describe Nanoc::Identifier do
   describe '#with_ext' do
     subject { identifier.with_ext(ext) }
 
-    context 'stripped style' do
+    context 'legacy style' do
       let(:identifier) { described_class.new('/foo/') }
       let(:ext) { 'html' }
 
@@ -266,7 +266,7 @@ describe Nanoc::Identifier do
   describe '#without_ext' do
     subject { identifier.without_ext }
 
-    context 'stripped style' do
+    context 'legacy style' do
       let(:identifier) { described_class.new('/foo/') }
 
       it 'raises an error' do

--- a/spec/nanoc/base/identifier_spec.rb
+++ b/spec/nanoc/base/identifier_spec.rb
@@ -2,7 +2,7 @@
 
 describe Nanoc::Identifier do
   describe '#initialize' do
-    context 'legacy style' do
+    context 'legacy type' do
       it 'does not convert already clean paths' do
         expect(described_class.new('/foo/bar/').to_s).to eql('/foo/bar/')
       end
@@ -24,13 +24,13 @@ describe Nanoc::Identifier do
       end
     end
 
-    context 'full style' do
+    context 'full type' do
       it 'refuses string not starting with a slash' do
-        expect { described_class.new('foo', style: :full) }.to raise_error('Invalid identifier (does not start with a slash): "foo"')
+        expect { described_class.new('foo', type: :full) }.to raise_error('Invalid identifier (does not start with a slash): "foo"')
       end
 
       it 'has proper string representation' do
-        expect(described_class.new('/foo', style: :full).to_s).to eql('/foo')
+        expect(described_class.new('/foo', type: :full).to_s).to eql('/foo')
       end
     end
   end
@@ -38,7 +38,7 @@ describe Nanoc::Identifier do
   describe '#to_s' do
     it 'returns immutable string' do
       expect { described_class.new('foo/').to_s << 'lols' }.to raise_error
-      expect { described_class.new('/foo', style: :full).to_s << 'lols' }.to raise_error
+      expect { described_class.new('/foo', type: :full).to_s << 'lols' }.to raise_error
     end
   end
 
@@ -59,7 +59,7 @@ describe Nanoc::Identifier do
 
     subject { identifier.inspect }
 
-    it { should == '<Nanoc::Identifier style=legacy "/foo/bar/">' }
+    it { should == '<Nanoc::Identifier type=legacy "/foo/bar/">' }
   end
 
   describe '#== and #eql?' do
@@ -155,7 +155,7 @@ describe Nanoc::Identifier do
   end
 
   describe '#prefix' do
-    let(:identifier) { described_class.new('/foo', style: :full) }
+    let(:identifier) { described_class.new('/foo', type: :full) }
 
     subject { identifier.prefix(prefix) }
 
@@ -197,7 +197,7 @@ describe Nanoc::Identifier do
   describe '#with_ext' do
     subject { identifier.with_ext(ext) }
 
-    context 'legacy style' do
+    context 'legacy type' do
       let(:identifier) { described_class.new('/foo/') }
       let(:ext) { 'html' }
 
@@ -207,7 +207,7 @@ describe Nanoc::Identifier do
     end
 
     context 'identifier with no extension' do
-      let(:identifier) { described_class.new('/foo', style: :full) }
+      let(:identifier) { described_class.new('/foo', type: :full) }
 
       context 'extension without dot given' do
         let(:ext) { 'html' }
@@ -235,7 +235,7 @@ describe Nanoc::Identifier do
     end
 
     context 'identifier with extension' do
-      let(:identifier) { described_class.new('/foo.md', style: :full) }
+      let(:identifier) { described_class.new('/foo.md', type: :full) }
 
       context 'extension without dot given' do
         let(:ext) { 'html' }
@@ -266,7 +266,7 @@ describe Nanoc::Identifier do
   describe '#without_ext' do
     subject { identifier.without_ext }
 
-    context 'legacy style' do
+    context 'legacy type' do
       let(:identifier) { described_class.new('/foo/') }
 
       it 'raises an error' do
@@ -275,7 +275,7 @@ describe Nanoc::Identifier do
     end
 
     context 'identifier with no extension' do
-      let(:identifier) { described_class.new('/foo', style: :full) }
+      let(:identifier) { described_class.new('/foo', type: :full) }
 
       it 'does nothing' do
         expect(subject).to eql('/foo')
@@ -283,7 +283,7 @@ describe Nanoc::Identifier do
     end
 
     context 'identifier with extension' do
-      let(:identifier) { described_class.new('/foo.md', style: :full) }
+      let(:identifier) { described_class.new('/foo.md', type: :full) }
 
       it 'removes the extension' do
         expect(subject).to eql('/foo')

--- a/spec/nanoc/base/views/identifiable_collection_spec.rb
+++ b/spec/nanoc/base/views/identifiable_collection_spec.rb
@@ -5,7 +5,7 @@ shared_examples 'an identifiable collection' do
   let(:view) { described_class.new(wrapped) }
 
   let(:config) do
-    { pattern_type: 'glob' }
+    { string_pattern_type: 'glob' }
   end
 
   describe '#unwrap' do
@@ -86,7 +86,7 @@ shared_examples 'an identifiable collection' do
       let(:arg) { '/home.*' }
 
       context 'globs not enabled' do
-        let(:config) { { pattern_type: 'legacy' } }
+        let(:config) { { string_pattern_type: 'legacy' } }
 
         it 'returns nil' do
           expect(subject).to be_nil

--- a/spec/nanoc/base/views/identifiable_collection_spec.rb
+++ b/spec/nanoc/base/views/identifiable_collection_spec.rb
@@ -52,11 +52,11 @@ shared_examples 'an identifiable collection' do
 
   describe '#[]' do
     let(:page_object) do
-      double(:identifiable, identifier: Nanoc::Identifier.new('/page.erb', style: :full))
+      double(:identifiable, identifier: Nanoc::Identifier.new('/page.erb', type: :full))
     end
 
     let(:home_object) do
-      double(:identifiable, identifier: Nanoc::Identifier.new('/home.erb', style: :full))
+      double(:identifiable, identifier: Nanoc::Identifier.new('/home.erb', type: :full))
     end
 
     let(:wrapped) do
@@ -114,9 +114,9 @@ shared_examples 'an identifiable collection' do
   describe '#find_all' do
     let(:wrapped) do
       Nanoc::Int::IdentifiableCollection.new(config).tap do |arr|
-        arr << double(:identifiable, identifier: Nanoc::Identifier.new('/about.css', style: :full))
-        arr << double(:identifiable, identifier: Nanoc::Identifier.new('/about.md', style: :full))
-        arr << double(:identifiable, identifier: Nanoc::Identifier.new('/style.css', style: :full))
+        arr << double(:identifiable, identifier: Nanoc::Identifier.new('/about.css', type: :full))
+        arr << double(:identifiable, identifier: Nanoc::Identifier.new('/about.md', type: :full))
+        arr << double(:identifiable, identifier: Nanoc::Identifier.new('/style.css', type: :full))
       end
     end
 

--- a/spec/nanoc/base/views/identifiable_collection_spec.rb
+++ b/spec/nanoc/base/views/identifiable_collection_spec.rb
@@ -5,7 +5,7 @@ shared_examples 'an identifiable collection' do
   let(:view) { described_class.new(wrapped) }
 
   let(:config) do
-    { pattern_syntax: 'glob' }
+    { pattern_type: 'glob' }
   end
 
   describe '#unwrap' do
@@ -86,7 +86,7 @@ shared_examples 'an identifiable collection' do
       let(:arg) { '/home.*' }
 
       context 'globs not enabled' do
-        let(:config) { { pattern_syntax: nil } }
+        let(:config) { { pattern_type: 'legacy' } }
 
         it 'returns nil' do
           expect(subject).to be_nil

--- a/spec/nanoc/base/views/mutable_item_collection_spec.rb
+++ b/spec/nanoc/base/views/mutable_item_collection_spec.rb
@@ -6,7 +6,7 @@ describe Nanoc::MutableItemCollectionView do
   it_behaves_like 'a mutable identifiable collection'
 
   let(:config) do
-    { pattern_syntax: 'glob' }
+    { pattern_type: 'glob' }
   end
 
   describe '#create' do

--- a/spec/nanoc/base/views/mutable_item_collection_spec.rb
+++ b/spec/nanoc/base/views/mutable_item_collection_spec.rb
@@ -6,7 +6,7 @@ describe Nanoc::MutableItemCollectionView do
   it_behaves_like 'a mutable identifiable collection'
 
   let(:config) do
-    { pattern_type: 'glob' }
+    { string_pattern_type: 'glob' }
   end
 
   describe '#create' do

--- a/spec/nanoc/base/views/mutable_layout_collection_spec.rb
+++ b/spec/nanoc/base/views/mutable_layout_collection_spec.rb
@@ -6,7 +6,7 @@ describe Nanoc::MutableLayoutCollectionView do
   it_behaves_like 'a mutable identifiable collection'
 
   let(:config) do
-    { pattern_type: 'glob' }
+    { string_pattern_type: 'glob' }
   end
 
   describe '#create' do

--- a/spec/nanoc/base/views/mutable_layout_collection_spec.rb
+++ b/spec/nanoc/base/views/mutable_layout_collection_spec.rb
@@ -6,7 +6,7 @@ describe Nanoc::MutableLayoutCollectionView do
   it_behaves_like 'a mutable identifiable collection'
 
   let(:config) do
-    { pattern_syntax: 'glob' }
+    { pattern_type: 'glob' }
   end
 
   describe '#create' do

--- a/test/base/test_compiler_dsl.rb
+++ b/test/base/test_compiler_dsl.rb
@@ -177,7 +177,7 @@ EOS
   def test_passthrough_with_full_identifiers
     with_site do
       File.open('nanoc.yaml', 'w') do |io|
-        io << 'pattern_syntax: null' << "\n"
+        io << 'pattern_type: legacy' << "\n"
         io << 'data_sources:' << "\n"
         io << '  -' << "\n"
         io << '    type: filesystem_unified' << "\n"
@@ -267,15 +267,17 @@ EOS
     end
   end
 
-  def test_create_pattern_with_string
+  def test_create_pattern_with_string_with_no_config
     compiler_dsl = Nanoc::Int::CompilerDSL.new(nil, {})
 
-    pattern = compiler_dsl.create_pattern('/foo/*')
-    assert pattern.match?('/foo/a/a/a/a')
+    err = assert_raises(Nanoc::Int::Errors::GenericTrivial) do
+      compiler_dsl.create_pattern('/foo/*')
+    end
+    assert_equal 'Invalid pattern_type: ', err.message
   end
 
-  def test_create_pattern_with_string_with_glob_pattern_syntax
-    compiler_dsl = Nanoc::Int::CompilerDSL.new(nil, { pattern_syntax: 'glob' })
+  def test_create_pattern_with_string_with_glob_pattern_type
+    compiler_dsl = Nanoc::Int::CompilerDSL.new(nil, { pattern_type: 'glob' })
 
     pattern = compiler_dsl.create_pattern('/foo/*')
     assert pattern.match?('/foo/aaaa')
@@ -284,19 +286,19 @@ EOS
   end
 
   def test_create_pattern_with_regex
-    compiler_dsl = Nanoc::Int::CompilerDSL.new(nil, {})
+    compiler_dsl = Nanoc::Int::CompilerDSL.new(nil, { pattern_type: 'glob' })
 
     pattern = compiler_dsl.create_pattern(%r<\A/foo/a*/>)
     assert pattern.match?('/foo/aaaa/')
   end
 
-  def test_create_pattern_with_string_with_unknown_pattern_syntax
-    compiler_dsl = Nanoc::Int::CompilerDSL.new(nil, { pattern_syntax: 'donkey' })
+  def test_create_pattern_with_string_with_unknown_pattern_type
+    compiler_dsl = Nanoc::Int::CompilerDSL.new(nil, { pattern_type: 'donkey' })
 
     err = assert_raises(Nanoc::Int::Errors::GenericTrivial) do
       compiler_dsl.create_pattern('/foo/*')
     end
-    assert_equal 'Invalid pattern_syntax: donkey', err.message
+    assert_equal 'Invalid pattern_type: donkey', err.message
   end
 
   def test_identifier_to_regex_without_wildcards

--- a/test/base/test_compiler_dsl.rb
+++ b/test/base/test_compiler_dsl.rb
@@ -181,7 +181,7 @@ EOS
         io << 'data_sources:' << "\n"
         io << '  -' << "\n"
         io << '    type: filesystem_unified' << "\n"
-        io << '    identifier_style: full' << "\n"
+        io << '    identifier_type: full' << "\n"
       end
 
       # Create rules

--- a/test/base/test_compiler_dsl.rb
+++ b/test/base/test_compiler_dsl.rb
@@ -177,7 +177,7 @@ EOS
   def test_passthrough_with_full_identifiers
     with_site do
       File.open('nanoc.yaml', 'w') do |io|
-        io << 'pattern_type: legacy' << "\n"
+        io << 'string_pattern_type: legacy' << "\n"
         io << 'data_sources:' << "\n"
         io << '  -' << "\n"
         io << '    type: filesystem_unified' << "\n"
@@ -273,11 +273,11 @@ EOS
     err = assert_raises(Nanoc::Int::Errors::GenericTrivial) do
       compiler_dsl.create_pattern('/foo/*')
     end
-    assert_equal 'Invalid pattern_type: ', err.message
+    assert_equal 'Invalid string_pattern_type: ', err.message
   end
 
-  def test_create_pattern_with_string_with_glob_pattern_type
-    compiler_dsl = Nanoc::Int::CompilerDSL.new(nil, { pattern_type: 'glob' })
+  def test_create_pattern_with_string_with_glob_string_pattern_type
+    compiler_dsl = Nanoc::Int::CompilerDSL.new(nil, { string_pattern_type: 'glob' })
 
     pattern = compiler_dsl.create_pattern('/foo/*')
     assert pattern.match?('/foo/aaaa')
@@ -286,19 +286,19 @@ EOS
   end
 
   def test_create_pattern_with_regex
-    compiler_dsl = Nanoc::Int::CompilerDSL.new(nil, { pattern_type: 'glob' })
+    compiler_dsl = Nanoc::Int::CompilerDSL.new(nil, { string_pattern_type: 'glob' })
 
     pattern = compiler_dsl.create_pattern(%r<\A/foo/a*/>)
     assert pattern.match?('/foo/aaaa/')
   end
 
-  def test_create_pattern_with_string_with_unknown_pattern_type
-    compiler_dsl = Nanoc::Int::CompilerDSL.new(nil, { pattern_type: 'donkey' })
+  def test_create_pattern_with_string_with_unknown_string_pattern_type
+    compiler_dsl = Nanoc::Int::CompilerDSL.new(nil, { string_pattern_type: 'donkey' })
 
     err = assert_raises(Nanoc::Int::Errors::GenericTrivial) do
       compiler_dsl.create_pattern('/foo/*')
     end
-    assert_equal 'Invalid pattern_type: donkey', err.message
+    assert_equal 'Invalid string_pattern_type: donkey', err.message
   end
 
   def test_identifier_to_regex_without_wildcards

--- a/test/base/test_item_array.rb
+++ b/test/base/test_item_array.rb
@@ -27,7 +27,7 @@ class Nanoc::Int::IdentifiableCollectionTest < Nanoc::TestCase
   end
 
   def test_brackets_with_glob
-    @items = Nanoc::Int::IdentifiableCollection.new({ pattern_type: 'glob' })
+    @items = Nanoc::Int::IdentifiableCollection.new({ string_pattern_type: 'glob' })
     @items << @one
     @items << @two
 

--- a/test/base/test_item_array.rb
+++ b/test/base/test_item_array.rb
@@ -27,7 +27,7 @@ class Nanoc::Int::IdentifiableCollectionTest < Nanoc::TestCase
   end
 
   def test_brackets_with_glob
-    @items = Nanoc::Int::IdentifiableCollection.new({ pattern_syntax: 'glob' })
+    @items = Nanoc::Int::IdentifiableCollection.new({ pattern_type: 'glob' })
     @items << @one
     @items << @two
 

--- a/test/base/test_outdatedness_checker.rb
+++ b/test/base/test_outdatedness_checker.rb
@@ -283,7 +283,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
     FileUtils.cd('foo') do
       File.open('nanoc.yaml', 'w') do |io|
         io << 'awesome: true' << "\n"
-        io << 'pattern_syntax: null' << "\n"
+        io << 'pattern_type: legacy' << "\n"
         io << 'data_sources:' << "\n"
         io << '  -' << "\n"
         io << '    type: filesystem_unified' << "\n"

--- a/test/base/test_outdatedness_checker.rb
+++ b/test/base/test_outdatedness_checker.rb
@@ -283,7 +283,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
     FileUtils.cd('foo') do
       File.open('nanoc.yaml', 'w') do |io|
         io << 'awesome: true' << "\n"
-        io << 'pattern_type: legacy' << "\n"
+        io << 'string_pattern_type: legacy' << "\n"
         io << 'data_sources:' << "\n"
         io << '  -' << "\n"
         io << '    type: filesystem_unified' << "\n"

--- a/test/base/test_outdatedness_checker.rb
+++ b/test/base/test_outdatedness_checker.rb
@@ -287,7 +287,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
         io << 'data_sources:' << "\n"
         io << '  -' << "\n"
         io << '    type: filesystem_unified' << "\n"
-        io << '    identifier_style: stripped' << "\n"
+        io << '    identifier_type: legacy' << "\n"
       end
     end
 

--- a/test/base/test_site.rb
+++ b/test/base/test_site.rb
@@ -185,7 +185,7 @@ EOF
       FileUtils.mkdir_p('content/parent')
       FileUtils.mkdir_p('content/parent/bar')
 
-      data = File.read('nanoc.yaml').sub('identifier_style: full', 'identifier_style: stripped')
+      data = File.read('nanoc.yaml').sub('identifier_type: full', 'identifier_type: legacy')
       File.open('nanoc.yaml', 'w') { |io| io << data }
 
       File.open('content/parent.md', 'w') { |io| io << 'asdf' }

--- a/test/cli/commands/test_compile.rb
+++ b/test/cli/commands/test_compile.rb
@@ -50,7 +50,7 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
       end
 
       File.open('nanoc.yaml', 'w') do |io|
-        io.write "pattern_type: legacy\n"
+        io.write "string_pattern_type: legacy\n"
         io.write "prune:\n"
         io.write "  auto_prune: false\n"
       end
@@ -64,7 +64,7 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
       assert File.file?('output/stray.html')
 
       File.open('nanoc.yaml', 'w') do |io|
-        io.write "pattern_type: legacy\n"
+        io.write "string_pattern_type: legacy\n"
         io.write "prune:\n"
         io.write "  auto_prune: true\n"
       end
@@ -100,7 +100,7 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
       Dir.mkdir('output/excluded_dir')
 
       File.open('nanoc.yaml', 'w') do |io|
-        io.write "pattern_type: legacy\n"
+        io.write "string_pattern_type: legacy\n"
         io.write "prune:\n"
         io.write "  auto_prune: false\n"
       end
@@ -114,7 +114,7 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
       assert File.file?('output/stray.html')
 
       File.open('nanoc.yaml', 'w') do |io|
-        io.write "pattern_type: legacy\n"
+        io.write "string_pattern_type: legacy\n"
         io.write "prune:\n"
         io.write "  auto_prune: true\n"
         io.write "  exclude: [ 'excluded_dir' ]\n"

--- a/test/cli/commands/test_compile.rb
+++ b/test/cli/commands/test_compile.rb
@@ -50,7 +50,7 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
       end
 
       File.open('nanoc.yaml', 'w') do |io|
-        io.write "pattern_syntax: null\n"
+        io.write "pattern_type: legacy\n"
         io.write "prune:\n"
         io.write "  auto_prune: false\n"
       end
@@ -64,7 +64,7 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
       assert File.file?('output/stray.html')
 
       File.open('nanoc.yaml', 'w') do |io|
-        io.write "pattern_syntax: null\n"
+        io.write "pattern_type: legacy\n"
         io.write "prune:\n"
         io.write "  auto_prune: true\n"
       end
@@ -100,7 +100,7 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
       Dir.mkdir('output/excluded_dir')
 
       File.open('nanoc.yaml', 'w') do |io|
-        io.write "pattern_syntax: null\n"
+        io.write "pattern_type: legacy\n"
         io.write "prune:\n"
         io.write "  auto_prune: false\n"
       end
@@ -114,7 +114,7 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
       assert File.file?('output/stray.html')
 
       File.open('nanoc.yaml', 'w') do |io|
-        io.write "pattern_syntax: null\n"
+        io.write "pattern_type: legacy\n"
         io.write "prune:\n"
         io.write "  auto_prune: true\n"
         io.write "  exclude: [ 'excluded_dir' ]\n"

--- a/test/cli/commands/test_create_site.rb
+++ b/test/cli/commands/test_create_site.rb
@@ -72,7 +72,7 @@ class Nanoc::CLI::Commands::CreateSiteTest < Nanoc::TestCase
 
       # Try with encoding = specific
       File.open('nanoc.yaml', 'w') do |io|
-        io.write("pattern_syntax: glob\n")
+        io.write("pattern_type: glob\n")
         io.write("data_sources:\n")
         io.write("  -\n")
         io.write("    type: filesystem_unified\n")

--- a/test/cli/commands/test_create_site.rb
+++ b/test/cli/commands/test_create_site.rb
@@ -76,7 +76,7 @@ class Nanoc::CLI::Commands::CreateSiteTest < Nanoc::TestCase
         io.write("data_sources:\n")
         io.write("  -\n")
         io.write("    type: filesystem_unified\n")
-        io.write("    identifier_style: full\n")
+        io.write("    identifier_type: full\n")
       end
       site = Nanoc::Int::Site.new('.')
       site.compile

--- a/test/cli/commands/test_create_site.rb
+++ b/test/cli/commands/test_create_site.rb
@@ -72,7 +72,7 @@ class Nanoc::CLI::Commands::CreateSiteTest < Nanoc::TestCase
 
       # Try with encoding = specific
       File.open('nanoc.yaml', 'w') do |io|
-        io.write("pattern_type: glob\n")
+        io.write("string_pattern_type: glob\n")
         io.write("data_sources:\n")
         io.write("  -\n")
         io.write("    type: filesystem_unified\n")

--- a/test/cli/commands/test_prune.rb
+++ b/test/cli/commands/test_prune.rb
@@ -4,7 +4,7 @@ class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
   def test_run_without_yes
     with_site do |_site|
       # Set output dir
-      File.open('nanoc.yaml', 'w') { |io| io.write "output_dir: output2\npattern_syntax: null\n" }
+      File.open('nanoc.yaml', 'w') { |io| io.write "output_dir: output2\npattern_type: legacy\n" }
       FileUtils.mkdir_p('output2')
 
       # Create source files
@@ -28,7 +28,7 @@ class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
       # Set output dir
       File.open('nanoc.yaml', 'w') do |io|
         io << 'output_dir: output2' << "\n"
-        io << 'pattern_syntax: null' << "\n"
+        io << 'pattern_type: legacy' << "\n"
         io << 'data_sources:' << "\n"
         io << '  -' << "\n"
         io << '    type: filesystem_unified' << "\n"
@@ -53,7 +53,7 @@ class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
   def test_run_with_dry_run
     with_site do |_site|
       # Set output dir
-      File.open('nanoc.yaml', 'w') { |io| io.write "pattern_syntax: null\noutput_dir: output2" }
+      File.open('nanoc.yaml', 'w') { |io| io.write "pattern_type: legacy\noutput_dir: output2" }
       FileUtils.mkdir_p('output2')
 
       # Create source files
@@ -76,7 +76,7 @@ class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
       File.open('nanoc.yaml', 'w') do |io|
         io << 'prune:' << "\n"
         io << '  exclude: [ "good-dir", "good-file.html" ]' << "\n"
-        io << 'pattern_syntax: null' << "\n"
+        io << 'pattern_type: legacy' << "\n"
         io << 'data_sources:' << "\n"
         io << '  -' << "\n"
         io << '    type: filesystem_unified' << "\n"

--- a/test/cli/commands/test_prune.rb
+++ b/test/cli/commands/test_prune.rb
@@ -4,7 +4,7 @@ class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
   def test_run_without_yes
     with_site do |_site|
       # Set output dir
-      File.open('nanoc.yaml', 'w') { |io| io.write "output_dir: output2\npattern_type: legacy\n" }
+      File.open('nanoc.yaml', 'w') { |io| io.write "output_dir: output2\nstring_pattern_type: legacy\n" }
       FileUtils.mkdir_p('output2')
 
       # Create source files
@@ -28,7 +28,7 @@ class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
       # Set output dir
       File.open('nanoc.yaml', 'w') do |io|
         io << 'output_dir: output2' << "\n"
-        io << 'pattern_type: legacy' << "\n"
+        io << 'string_pattern_type: legacy' << "\n"
         io << 'data_sources:' << "\n"
         io << '  -' << "\n"
         io << '    type: filesystem_unified' << "\n"
@@ -53,7 +53,7 @@ class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
   def test_run_with_dry_run
     with_site do |_site|
       # Set output dir
-      File.open('nanoc.yaml', 'w') { |io| io.write "pattern_type: legacy\noutput_dir: output2" }
+      File.open('nanoc.yaml', 'w') { |io| io.write "string_pattern_type: legacy\noutput_dir: output2" }
       FileUtils.mkdir_p('output2')
 
       # Create source files
@@ -76,7 +76,7 @@ class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
       File.open('nanoc.yaml', 'w') do |io|
         io << 'prune:' << "\n"
         io << '  exclude: [ "good-dir", "good-file.html" ]' << "\n"
-        io << 'pattern_type: legacy' << "\n"
+        io << 'string_pattern_type: legacy' << "\n"
         io << 'data_sources:' << "\n"
         io << '  -' << "\n"
         io << '    type: filesystem_unified' << "\n"

--- a/test/cli/commands/test_prune.rb
+++ b/test/cli/commands/test_prune.rb
@@ -32,7 +32,7 @@ class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
         io << 'data_sources:' << "\n"
         io << '  -' << "\n"
         io << '    type: filesystem_unified' << "\n"
-        io << '    identifier_style: stripped' << "\n"
+        io << '    identifier_type: legacy' << "\n"
       end
       FileUtils.mkdir_p('output2')
 
@@ -80,7 +80,7 @@ class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
         io << 'data_sources:' << "\n"
         io << '  -' << "\n"
         io << '    type: filesystem_unified' << "\n"
-        io << '    identifier_style: stripped' << "\n"
+        io << '    identifier_type: legacy' << "\n"
       end
       FileUtils.mkdir_p('output')
 

--- a/test/data_sources/test_filesystem.rb
+++ b/test/data_sources/test_filesystem.rb
@@ -98,7 +98,7 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
 
   def test_all_split_files_in_with_same_extensions
     # Create data source
-    config = { identifier_style: 'full' }
+    config = { identifier_type: 'full' }
     data_source = Nanoc::DataSources::FilesystemUnified.new(nil, nil, nil, config)
 
     # Write sample files

--- a/test/data_sources/test_filesystem_unified.rb
+++ b/test/data_sources/test_filesystem_unified.rb
@@ -75,7 +75,7 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
 
   def test_load_objects_with_same_extensions
     # Create data source
-    data_source = new_data_source({ identifier_style: 'full' })
+    data_source = new_data_source({ identifier_type: 'full' })
 
     # Create a fake class
     klass = Class.new do
@@ -133,7 +133,7 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
 
   def test_identifier_for_filename_with_full_style_identifier
     # Create data source
-    data_source = new_data_source({ identifier_style: 'full' })
+    data_source = new_data_source({ identifier_type: 'full' })
 
     # Get input and expected output
     expected = {

--- a/test/data_sources/test_filesystem_unified.rb
+++ b/test/data_sources/test_filesystem_unified.rb
@@ -137,10 +137,10 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
 
     # Get input and expected output
     expected = {
-      '/foo'            => Nanoc::Identifier.new('/foo',            style: :full),
-      '/foo.html'       => Nanoc::Identifier.new('/foo.html',       style: :full),
-      '/foo/index.html' => Nanoc::Identifier.new('/foo/index.html', style: :full),
-      '/foo.html.erb'   => Nanoc::Identifier.new('/foo.html.erb',   style: :full),
+      '/foo'            => Nanoc::Identifier.new('/foo',            type: :full),
+      '/foo.html'       => Nanoc::Identifier.new('/foo.html',       type: :full),
+      '/foo/index.html' => Nanoc::Identifier.new('/foo/index.html', type: :full),
+      '/foo.html.erb'   => Nanoc::Identifier.new('/foo.html.erb',   type: :full),
     }
 
     # Check

--- a/test/extra/checking/checks/test_stale.rb
+++ b/test/extra/checking/checks/test_stale.rb
@@ -47,7 +47,7 @@ class Nanoc::Extra::Checking::Checks::StaleTest < Nanoc::TestCase
       assert Dir['content/*'].empty?
       assert Dir['output/*'].empty?
 
-      File.open('nanoc.yaml', 'w') { |io| io.write "pattern_type: legacy\nprune:\n  exclude: [ 'excluded.html' ]" }
+      File.open('nanoc.yaml', 'w') { |io| io.write "string_pattern_type: legacy\nprune:\n  exclude: [ 'excluded.html' ]" }
       File.open('content/index.html', 'w') { |io| io.write('stuff') }
       File.open('output/excluded.html', 'w') { |io| io.write('stuff') }
       assert calc_issues.empty?
@@ -59,7 +59,7 @@ class Nanoc::Extra::Checking::Checks::StaleTest < Nanoc::TestCase
       assert Dir['content/*'].empty?
       assert Dir['output/*'].empty?
 
-      File.open('nanoc.yaml', 'w') { |io| io.write "pattern_type: legacy\nprune:\n  blah: meh" }
+      File.open('nanoc.yaml', 'w') { |io| io.write "string_pattern_type: legacy\nprune:\n  blah: meh" }
       File.open('content/index.html', 'w') { |io| io.write('stuff') }
       File.open('output/excluded.html', 'w') { |io| io.write('stuff') }
       refute calc_issues.empty?

--- a/test/extra/checking/checks/test_stale.rb
+++ b/test/extra/checking/checks/test_stale.rb
@@ -47,7 +47,7 @@ class Nanoc::Extra::Checking::Checks::StaleTest < Nanoc::TestCase
       assert Dir['content/*'].empty?
       assert Dir['output/*'].empty?
 
-      File.open('nanoc.yaml', 'w') { |io| io.write "pattern_syntax: null\nprune:\n  exclude: [ 'excluded.html' ]" }
+      File.open('nanoc.yaml', 'w') { |io| io.write "pattern_type: legacy\nprune:\n  exclude: [ 'excluded.html' ]" }
       File.open('content/index.html', 'w') { |io| io.write('stuff') }
       File.open('output/excluded.html', 'w') { |io| io.write('stuff') }
       assert calc_issues.empty?
@@ -59,7 +59,7 @@ class Nanoc::Extra::Checking::Checks::StaleTest < Nanoc::TestCase
       assert Dir['content/*'].empty?
       assert Dir['output/*'].empty?
 
-      File.open('nanoc.yaml', 'w') { |io| io.write "pattern_syntax: null\nprune:\n  blah: meh" }
+      File.open('nanoc.yaml', 'w') { |io| io.write "pattern_type: legacy\nprune:\n  blah: meh" }
       File.open('content/index.html', 'w') { |io| io.write('stuff') }
       File.open('output/excluded.html', 'w') { |io| io.write('stuff') }
       refute calc_issues.empty?

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -108,7 +108,7 @@ EOS
           io << 'data_sources:' << "\n"
           io << '  -' << "\n"
           io << '    type: filesystem_unified' << "\n"
-          io << '    identifier_style: stripped' << "\n"
+          io << '    identifier_type: legacy' << "\n"
         end
 
         File.open('Rules', 'w') { |io| io.write(rules_content) }

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -104,7 +104,7 @@ EOS
         end
 
         File.open('nanoc.yaml', 'w') do |io|
-          io << 'pattern_type: legacy' << "\n"
+          io << 'string_pattern_type: legacy' << "\n"
           io << 'data_sources:' << "\n"
           io << '  -' << "\n"
           io << '    type: filesystem_unified' << "\n"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -104,7 +104,7 @@ EOS
         end
 
         File.open('nanoc.yaml', 'w') do |io|
-          io << 'pattern_syntax: null' << "\n"
+          io << 'pattern_type: legacy' << "\n"
           io << 'data_sources:' << "\n"
           io << '  -' << "\n"
           io << '    type: filesystem_unified' << "\n"


### PR DESCRIPTION
Old:

* `identifier_style` &rarr; `"full"` / `"stripped"`
* `pattern_syntax` &rarr; `"glob"` / `nil`

New:

* `identifier_type` &rarr; `"full"` / `"legacy"`
* `string_pattern_type` &rarr; `"glob"` / `"legacy"`