### PR TITLE
Fix check variables

### DIFF
--- a/lib/nanoc/extra/checking/check.rb
+++ b/lib/nanoc/extra/checking/check.rb
@@ -14,10 +14,13 @@ module Nanoc::Extra::Checking
 
     attr_reader :site
     attr_reader :issues
+    attr_reader :output_filenames
 
     def initialize(site)
-      @site   = site
+      @site = site
+
       @issues = Set.new
+      @output_filenames = []
     end
 
     def run
@@ -30,12 +33,12 @@ module Nanoc::Extra::Checking
       @issues << Issue.new(desc, subject, self.class)
     end
 
-    def output_filenames
+    def setup
       output_dir = @site.config[:output_dir]
       unless File.exist?(output_dir)
         raise Nanoc::Extra::Checking::OutputDirNotFoundError.new(output_dir)
       end
-      Dir[output_dir + '/**/*'].select { |f| File.file?(f) }
+      @output_filenames = Dir[output_dir + '/**/*'].select { |f| File.file?(f) }
     end
   end
 end

--- a/lib/nanoc/extra/checking/check.rb
+++ b/lib/nanoc/extra/checking/check.rb
@@ -22,7 +22,10 @@ module Nanoc::Extra::Checking
       output_filenames = Dir[output_dir + '/**/*'].select { |f| File.file?(f) }
 
       context = {
-        site: site,
+        items: Nanoc::ItemCollectionView.new(site.items),
+        layouts: Nanoc::LayoutCollectionView.new(site.layouts),
+        config: Nanoc::ConfigView.new(site.config),
+        site: Nanoc::SiteView.new(site), # TODO: remove me
         output_filenames: output_filenames,
       }
 

--- a/lib/nanoc/extra/checking/checks/css.rb
+++ b/lib/nanoc/extra/checking/checks/css.rb
@@ -8,7 +8,7 @@ module ::Nanoc::Extra::Checking::Checks
     def run
       require 'w3c_validators'
 
-      Dir[site.config[:output_dir] + '/**/*.css'].each do |filename|
+      Dir[@config[:output_dir] + '/**/*.css'].each do |filename|
         results = ::W3CValidators::CSSValidator.new.validate_file(filename)
         lines = File.readlines(filename)
         results.errors.each do |e|

--- a/lib/nanoc/extra/checking/checks/html.rb
+++ b/lib/nanoc/extra/checking/checks/html.rb
@@ -8,7 +8,7 @@ module ::Nanoc::Extra::Checking::Checks
     def run
       require 'w3c_validators'
 
-      Dir[site.config[:output_dir] + '/**/*.{htm,html}'].each do |filename|
+      Dir[@config[:output_dir] + '/**/*.{htm,html}'].each do |filename|
         results = ::W3CValidators::MarkupValidator.new.validate_file(filename)
         lines = File.readlines(filename)
         results.errors.each do |e|

--- a/lib/nanoc/extra/checking/checks/internal_links.rb
+++ b/lib/nanoc/extra/checking/checks/internal_links.rb
@@ -51,7 +51,7 @@ module Nanoc::Extra::Checking::Checks
 
       # Make absolute
       if path[0, 1] == '/'
-        path = @site.config[:output_dir] + path
+        path = @config[:output_dir] + path
       else
         path = ::File.expand_path(path, ::File.dirname(origin))
       end
@@ -60,14 +60,14 @@ module Nanoc::Extra::Checking::Checks
       return true if File.file?(path)
 
       # Check whether directory with index file exists
-      return true if File.directory?(path) && @site.config[:index_filenames].any? { |fn| File.file?(File.join(path, fn)) }
+      return true if File.directory?(path) && @config[:index_filenames].any? { |fn| File.file?(File.join(path, fn)) }
 
       # Nope :(
       false
     end
 
     def excluded?(href)
-      excludes =  @site.config.fetch(:checks, {}).fetch(:internal_links, {}).fetch(:exclude, [])
+      excludes =  @config.fetch(:checks, {}).fetch(:internal_links, {}).fetch(:exclude, [])
       excludes.any? { |pattern| Regexp.new(pattern).match(href) }
     end
   end

--- a/lib/nanoc/extra/checking/checks/stale.rb
+++ b/lib/nanoc/extra/checking/checks/stale.rb
@@ -6,7 +6,7 @@ module Nanoc::Extra::Checking::Checks
     def run
       require 'set'
 
-      item_rep_paths = Set.new(@site.items.map(&:reps).flatten.map(&:raw_path))
+      item_rep_paths = Set.new(@items.map(&:reps).flatten.map(&:raw_path))
 
       output_filenames.each do |f|
         next if pruner.filename_excluded?(f)
@@ -21,7 +21,7 @@ module Nanoc::Extra::Checking::Checks
     protected
 
     def pruner
-      exclude_config = @site.config.fetch(:prune, {}).fetch(:exclude, [])
+      exclude_config = @config.fetch(:prune, {}).fetch(:exclude, [])
       @pruner ||= Nanoc::Extra::Pruner.new(@site, exclude: exclude_config)
     end
   end

--- a/lib/nanoc/extra/checking/runner.rb
+++ b/lib/nanoc/extra/checking/runner.rb
@@ -116,8 +116,7 @@ module Nanoc::Extra::Checking
       classes.each do |klass|
         print format("  %-#{length}s", "Running check #{klass.identifier}… ")
 
-        check = klass.new(@site)
-        check.setup
+        check = klass.create(@site)
         check.run
 
         checks << check

--- a/lib/nanoc/extra/checking/runner.rb
+++ b/lib/nanoc/extra/checking/runner.rb
@@ -117,6 +117,7 @@ module Nanoc::Extra::Checking
         print format("  %-#{length}s", "Running check #{klass.identifier}… ")
 
         check = klass.new(@site)
+        check.setup
         check.run
 
         checks << check

--- a/test/extra/checking/checks/test_css.rb
+++ b/test/extra/checking/checks/test_css.rb
@@ -10,8 +10,7 @@ class Nanoc::Extra::Checking::Checks::CSSTest < Nanoc::TestCase
         File.open('output/style.css', 'w') { |io| io.write('h1 { color: red; }') }
 
         # Run check
-        check = Nanoc::Extra::Checking::Checks::CSS.new(site)
-        check.setup
+        check = Nanoc::Extra::Checking::Checks::CSS.create(site)
         check.run
 
         # Check
@@ -29,8 +28,7 @@ class Nanoc::Extra::Checking::Checks::CSSTest < Nanoc::TestCase
         File.open('output/style.css', 'w') { |io| io.write('h1 { coxlor: rxed; }') }
 
         # Run check
-        check = Nanoc::Extra::Checking::Checks::CSS.new(site)
-        check.setup
+        check = Nanoc::Extra::Checking::Checks::CSS.create(site)
         check.run
 
         # Check
@@ -51,8 +49,7 @@ class Nanoc::Extra::Checking::Checks::CSSTest < Nanoc::TestCase
         File.open('output/style.css', 'w') { |io| io.write('h1 { ; {') }
 
         # Run check
-        check = Nanoc::Extra::Checking::Checks::CSS.new(site)
-        check.setup
+        check = Nanoc::Extra::Checking::Checks::CSS.create(site)
         check.run
 
         # Check

--- a/test/extra/checking/checks/test_css.rb
+++ b/test/extra/checking/checks/test_css.rb
@@ -11,6 +11,7 @@ class Nanoc::Extra::Checking::Checks::CSSTest < Nanoc::TestCase
 
         # Run check
         check = Nanoc::Extra::Checking::Checks::CSS.new(site)
+        check.setup
         check.run
 
         # Check
@@ -29,6 +30,7 @@ class Nanoc::Extra::Checking::Checks::CSSTest < Nanoc::TestCase
 
         # Run check
         check = Nanoc::Extra::Checking::Checks::CSS.new(site)
+        check.setup
         check.run
 
         # Check
@@ -50,6 +52,7 @@ class Nanoc::Extra::Checking::Checks::CSSTest < Nanoc::TestCase
 
         # Run check
         check = Nanoc::Extra::Checking::Checks::CSS.new(site)
+        check.setup
         check.run
 
         # Check

--- a/test/extra/checking/checks/test_external_links.rb
+++ b/test/extra/checking/checks/test_external_links.rb
@@ -9,7 +9,7 @@ class Nanoc::Extra::Checking::Checks::ExternalLinksTest < Nanoc::TestCase
       File.open('output/bar.html', 'w') { |io| io.write('<a href="http://example.com/">not broken</a>') }
 
       # Create check
-      check = Nanoc::Extra::Checking::Checks::ExternalLinks.new(site)
+      check = Nanoc::Extra::Checking::Checks::ExternalLinks.create(site)
       def check.request_url_once(url)
         Net::HTTPResponse.new('1.1', url.path == '/' ? '200' : '404', 'okay')
       end
@@ -23,7 +23,7 @@ class Nanoc::Extra::Checking::Checks::ExternalLinksTest < Nanoc::TestCase
   def test_valid_by_path
     with_site do |site|
       # Create check
-      check = Nanoc::Extra::Checking::Checks::ExternalLinks.new(site)
+      check = Nanoc::Extra::Checking::Checks::ExternalLinks.create(site)
       def check.request_url_once(url)
         Net::HTTPResponse.new('1.1', url.path == '/200' ? '200' : '404', 'okay')
       end
@@ -38,7 +38,7 @@ class Nanoc::Extra::Checking::Checks::ExternalLinksTest < Nanoc::TestCase
   def test_valid_by_query
     with_site do |site|
       # Create check
-      check = Nanoc::Extra::Checking::Checks::ExternalLinks.new(site)
+      check = Nanoc::Extra::Checking::Checks::ExternalLinks.create(site)
       def check.request_url_once(url)
         Net::HTTPResponse.new('1.1', url.query == 'status=200' ? '200' : '404', 'okay')
       end
@@ -52,7 +52,7 @@ class Nanoc::Extra::Checking::Checks::ExternalLinksTest < Nanoc::TestCase
   def test_fallback_to_get_when_head_is_not_allowed
     with_site do |site|
       # Create check
-      check = Nanoc::Extra::Checking::Checks::ExternalLinks.new(site)
+      check = Nanoc::Extra::Checking::Checks::ExternalLinks.create(site)
       def check.request_url_once(url, req_method = Net::HTTP::Head)
         Net::HTTPResponse.new('1.1', (req_method == Net::HTTP::Head || url.path == '/405') ? '405' : '200', 'okay')
       end
@@ -65,7 +65,7 @@ class Nanoc::Extra::Checking::Checks::ExternalLinksTest < Nanoc::TestCase
 
   def test_path_for_url
     with_site do |site|
-      check = Nanoc::Extra::Checking::Checks::ExternalLinks.new(site)
+      check = Nanoc::Extra::Checking::Checks::ExternalLinks.create(site)
 
       assert_equal '/',             check.send(:path_for_url, URI.parse('http://example.com'))
       assert_equal '/',             check.send(:path_for_url, URI.parse('http://example.com/'))

--- a/test/extra/checking/checks/test_html.rb
+++ b/test/extra/checking/checks/test_html.rb
@@ -10,7 +10,7 @@ class Nanoc::Extra::Checking::Checks::HTMLTest < Nanoc::TestCase
         File.open('output/style.css', 'w') { |io| io.write('h1 { coxlor: rxed; }') }
 
         # Run check
-        check = Nanoc::Extra::Checking::Checks::HTML.new(site)
+        check = Nanoc::Extra::Checking::Checks::HTML.create(site)
         check.run
 
         # Check
@@ -28,7 +28,7 @@ class Nanoc::Extra::Checking::Checks::HTMLTest < Nanoc::TestCase
         File.open('output/style.css', 'w') { |io| io.write('h1 { coxlor: rxed; }') }
 
         # Run check
-        check = Nanoc::Extra::Checking::Checks::HTML.new(site)
+        check = Nanoc::Extra::Checking::Checks::HTML.create(site)
         check.run
 
         # Check

--- a/test/extra/checking/checks/test_internal_links.rb
+++ b/test/extra/checking/checks/test_internal_links.rb
@@ -10,7 +10,7 @@ class Nanoc::Extra::Checking::Checks::InternalLinksTest < Nanoc::TestCase
       File.open('output/bar.html', 'w') { |io| io.write('<a href="/foo.txt">not broken</a>') }
 
       # Create check
-      check = Nanoc::Extra::Checking::Checks::InternalLinks.new(site)
+      check = Nanoc::Extra::Checking::Checks::InternalLinks.create(site)
       check.run
 
       # Test
@@ -28,7 +28,7 @@ class Nanoc::Extra::Checking::Checks::InternalLinksTest < Nanoc::TestCase
       File.open('output/stuff/blah', 'w') { |io| io.write('hi') }
 
       # Create check
-      check = Nanoc::Extra::Checking::Checks::InternalLinks.new(site)
+      check = Nanoc::Extra::Checking::Checks::InternalLinks.create(site)
 
       # Test
       assert check.send(:valid?, 'foo',         'output/origin')
@@ -45,7 +45,7 @@ class Nanoc::Extra::Checking::Checks::InternalLinksTest < Nanoc::TestCase
       FileUtils.mkdir_p('output/stuff')
       File.open('output/stuff/right', 'w') { |io| io.write('hi') }
 
-      check = Nanoc::Extra::Checking::Checks::InternalLinks.new(site)
+      check = Nanoc::Extra::Checking::Checks::InternalLinks.create(site)
 
       assert check.send(:valid?, 'stuff/right?foo=123', 'output/origin')
       refute check.send(:valid?, 'stuff/wrong?foo=123', 'output/origin')
@@ -55,7 +55,7 @@ class Nanoc::Extra::Checking::Checks::InternalLinksTest < Nanoc::TestCase
   def test_exclude
     with_site do |site|
       # Create check
-      check = Nanoc::Extra::Checking::Checks::InternalLinks.new(site)
+      check = Nanoc::Extra::Checking::Checks::InternalLinks.create(site)
       site.config.update({ checks: { internal_links: { exclude: ['^/excluded\d+'] } } })
 
       # Test
@@ -70,7 +70,7 @@ class Nanoc::Extra::Checking::Checks::InternalLinksTest < Nanoc::TestCase
       FileUtils.mkdir_p('output/stuff')
       File.open('output/stuff/right foo', 'w') { |io| io.write('hi') }
 
-      check = Nanoc::Extra::Checking::Checks::InternalLinks.new(site)
+      check = Nanoc::Extra::Checking::Checks::InternalLinks.create(site)
 
       assert check.send(:valid?, 'stuff/right%20foo', 'output/origin')
       refute check.send(:valid?, 'stuff/wrong%20foo', 'output/origin')

--- a/test/extra/checking/checks/test_mixed_content.rb
+++ b/test/extra/checking/checks/test_mixed_content.rb
@@ -25,6 +25,7 @@ class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
         '<video src="https://nanoc.ws/screen-cast.mkv"></video>'
       ])
       check = Nanoc::Extra::Checking::Checks::MixedContent.new(site)
+      check.setup
       check.run
 
       assert check.issues.empty?
@@ -43,6 +44,7 @@ class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
         '<video src="/screen-cast.mkv"></video>'
       ])
       check = Nanoc::Extra::Checking::Checks::MixedContent.new(site)
+      check.setup
       check.run
 
       assert check.issues.empty?
@@ -61,6 +63,7 @@ class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
         '<video src="//nanoc.ws/screen-cast.mkv"></video>'
       ])
       check = Nanoc::Extra::Checking::Checks::MixedContent.new(site)
+      check.setup
       check.run
 
       assert check.issues.empty?
@@ -79,6 +82,7 @@ class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
         '<video src="screen-cast.mkv"></video>'
       ])
       check = Nanoc::Extra::Checking::Checks::MixedContent.new(site)
+      check.setup
       check.run
 
       assert check.issues.empty?
@@ -97,6 +101,7 @@ class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
         '<video src="?query-string"></video>'
       ])
       check = Nanoc::Extra::Checking::Checks::MixedContent.new(site)
+      check.setup
       check.run
 
       assert check.issues.empty?
@@ -115,6 +120,7 @@ class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
         '<video src="#fragment"></video>'
       ])
       check = Nanoc::Extra::Checking::Checks::MixedContent.new(site)
+      check.setup
       check.run
 
       assert check.issues.empty?
@@ -134,6 +140,7 @@ class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
         '<video src="http://nanoc.ws/screencast.mkv"></video>'
       ])
       check = Nanoc::Extra::Checking::Checks::MixedContent.new(site)
+      check.setup
       check.run
 
       issues = check.issues.to_a
@@ -180,6 +187,7 @@ class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
         '<p>http://nanoc.ws/harmless-text</p>'
       ])
       check = Nanoc::Extra::Checking::Checks::MixedContent.new(site)
+      check.setup
       check.run
 
       assert check.issues.empty?

--- a/test/extra/checking/checks/test_mixed_content.rb
+++ b/test/extra/checking/checks/test_mixed_content.rb
@@ -24,8 +24,7 @@ class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
         '<audio src="https://nanoc.ws/theme-song.flac"></audio>',
         '<video src="https://nanoc.ws/screen-cast.mkv"></video>'
       ])
-      check = Nanoc::Extra::Checking::Checks::MixedContent.new(site)
-      check.setup
+      check = Nanoc::Extra::Checking::Checks::MixedContent.create(site)
       check.run
 
       assert check.issues.empty?
@@ -43,8 +42,7 @@ class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
         '<audio src="/theme-song.flac"></audio>',
         '<video src="/screen-cast.mkv"></video>'
       ])
-      check = Nanoc::Extra::Checking::Checks::MixedContent.new(site)
-      check.setup
+      check = Nanoc::Extra::Checking::Checks::MixedContent.create(site)
       check.run
 
       assert check.issues.empty?
@@ -62,8 +60,7 @@ class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
         '<audio src="//nanoc.ws/theme-song.flac"></audio>',
         '<video src="//nanoc.ws/screen-cast.mkv"></video>'
       ])
-      check = Nanoc::Extra::Checking::Checks::MixedContent.new(site)
-      check.setup
+      check = Nanoc::Extra::Checking::Checks::MixedContent.create(site)
       check.run
 
       assert check.issues.empty?
@@ -81,8 +78,7 @@ class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
         '<audio src="theme-song.flac"></audio>',
         '<video src="screen-cast.mkv"></video>'
       ])
-      check = Nanoc::Extra::Checking::Checks::MixedContent.new(site)
-      check.setup
+      check = Nanoc::Extra::Checking::Checks::MixedContent.create(site)
       check.run
 
       assert check.issues.empty?
@@ -100,8 +96,7 @@ class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
         '<audio src="?query-string"></audio>',
         '<video src="?query-string"></video>'
       ])
-      check = Nanoc::Extra::Checking::Checks::MixedContent.new(site)
-      check.setup
+      check = Nanoc::Extra::Checking::Checks::MixedContent.create(site)
       check.run
 
       assert check.issues.empty?
@@ -119,8 +114,7 @@ class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
         '<audio src="#fragment"></audio>',
         '<video src="#fragment"></video>'
       ])
-      check = Nanoc::Extra::Checking::Checks::MixedContent.new(site)
-      check.setup
+      check = Nanoc::Extra::Checking::Checks::MixedContent.create(site)
       check.run
 
       assert check.issues.empty?
@@ -139,8 +133,7 @@ class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
         '<audio src="http://nanoc.ws/theme-song.flac"></audio>',
         '<video src="http://nanoc.ws/screencast.mkv"></video>'
       ])
-      check = Nanoc::Extra::Checking::Checks::MixedContent.new(site)
-      check.setup
+      check = Nanoc::Extra::Checking::Checks::MixedContent.create(site)
       check.run
 
       issues = check.issues.to_a
@@ -186,8 +179,7 @@ class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
         '<video target="http://nanoc.ws/screen-cast.mkv"></video>',
         '<p>http://nanoc.ws/harmless-text</p>'
       ])
-      check = Nanoc::Extra::Checking::Checks::MixedContent.new(site)
-      check.setup
+      check = Nanoc::Extra::Checking::Checks::MixedContent.create(site)
       check.run
 
       assert check.issues.empty?

--- a/test/extra/checking/checks/test_stale.rb
+++ b/test/extra/checking/checks/test_stale.rb
@@ -7,8 +7,7 @@ class Nanoc::Extra::Checking::Checks::StaleTest < Nanoc::TestCase
 
   def calc_issues
     site = Nanoc::Int::Site.new('.')
-    check = check_class.new(site)
-    check.setup
+    check = check_class.create(site)
     check.run
     check.issues
   end

--- a/test/extra/checking/checks/test_stale.rb
+++ b/test/extra/checking/checks/test_stale.rb
@@ -8,6 +8,7 @@ class Nanoc::Extra::Checking::Checks::StaleTest < Nanoc::TestCase
   def calc_issues
     site = Nanoc::Int::Site.new('.')
     check = check_class.new(site)
+    check.setup
     check.run
     check.issues
   end

--- a/test/extra/checking/test_check.rb
+++ b/test/extra/checking/test_check.rb
@@ -3,9 +3,9 @@
 class Nanoc::Extra::Checking::CheckTest < Nanoc::TestCase
   def test_output_filenames
     with_site do |site|
-      check = Nanoc::Extra::Checking::Check.new(site)
-      assert check.output_filenames.empty?
       File.open('output/foo.html', 'w') { |io| io.write 'hello' }
+      check = Nanoc::Extra::Checking::Check.new(site)
+      check.setup
       assert_equal ['output/foo.html'], check.output_filenames
     end
   end
@@ -15,7 +15,7 @@ class Nanoc::Extra::Checking::CheckTest < Nanoc::TestCase
       site.config[:output_dir] = 'non-existent'
       check = Nanoc::Extra::Checking::Check.new(site)
       assert_raises Nanoc::Extra::Checking::OutputDirNotFoundError do
-        check.output_filenames
+        check.setup
       end
     end
   end

--- a/test/extra/checking/test_check.rb
+++ b/test/extra/checking/test_check.rb
@@ -4,8 +4,7 @@ class Nanoc::Extra::Checking::CheckTest < Nanoc::TestCase
   def test_output_filenames
     with_site do |site|
       File.open('output/foo.html', 'w') { |io| io.write 'hello' }
-      check = Nanoc::Extra::Checking::Check.new(site)
-      check.setup
+      check = Nanoc::Extra::Checking::Check.create(site)
       assert_equal ['output/foo.html'], check.output_filenames
     end
   end
@@ -13,9 +12,8 @@ class Nanoc::Extra::Checking::CheckTest < Nanoc::TestCase
   def test_no_output_dir
     with_site do |site|
       site.config[:output_dir] = 'non-existent'
-      check = Nanoc::Extra::Checking::Check.new(site)
       assert_raises Nanoc::Extra::Checking::OutputDirNotFoundError do
-        check.setup
+        Nanoc::Extra::Checking::Check.create(site)
       end
     end
   end


### PR DESCRIPTION
In checks, there should be `@items`, `@layouts` and `@config`, but no `@site`. This will make it more consistent with other places where variables are accessible.