### PR TITLE
Require Ruby 2.2+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
   - 2.2.2
-  - 2.0.0
 branches:
   only:
     - master

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # Set up env
 $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__) + '/lib'))
 require './test/gem_loader.rb'

--- a/bin/nanoc
+++ b/bin/nanoc
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-# encoding: utf-8
-
 require 'nanoc'
 require 'nanoc/cli'
 

--- a/lib/nanoc.rb
+++ b/lib/nanoc.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc
   # @return [String] A string containing information about this nanoc version
   #   and its environment (Ruby engine and version, Rubygems version if any).

--- a/lib/nanoc/base.rb
+++ b/lib/nanoc/base.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc
   require 'nanoc/base/core_ext'
 

--- a/lib/nanoc/base/checksummer.rb
+++ b/lib/nanoc/base/checksummer.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # Creates checksums for given objects.
   #

--- a/lib/nanoc/base/compilation/checksum_store.rb
+++ b/lib/nanoc/base/compilation/checksum_store.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # Stores checksums for objects in order to be able to detect whether a file
   # has changed since the last site compilation.

--- a/lib/nanoc/base/compilation/compiled_content_cache.rb
+++ b/lib/nanoc/base/compilation/compiled_content_cache.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # Represents a cache than can be used to store already compiled content,
   # to prevent it from being needlessly recompiled.

--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # Responsible for compiling a site’s item representations.
   #

--- a/lib/nanoc/base/compilation/compiler_dsl.rb
+++ b/lib/nanoc/base/compilation/compiler_dsl.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # Contains methods that will be executed by the site’s `Rules` file.
   class CompilerDSL

--- a/lib/nanoc/base/compilation/dependency_tracker.rb
+++ b/lib/nanoc/base/compilation/dependency_tracker.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # Responsible for remembering dependencies between items and layouts. It is
   # used to speed up compilation by only letting an item be recompiled when it

--- a/lib/nanoc/base/compilation/filter.rb
+++ b/lib/nanoc/base/compilation/filter.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc
   # Nanoc::Filter is responsible for filtering items. It is the superclass
   # for all textual filters.

--- a/lib/nanoc/base/compilation/item_rep_proxy.rb
+++ b/lib/nanoc/base/compilation/item_rep_proxy.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # Represents an item representation, but provides an interface that is
   # easier to use when writing compilation and routing rules. It is also

--- a/lib/nanoc/base/compilation/item_rep_recorder_proxy.rb
+++ b/lib/nanoc/base/compilation/item_rep_recorder_proxy.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # Represents a fake iem representation that does not actually perform any
   # actual filtering, layouting or snapshotting, but instead keeps track of

--- a/lib/nanoc/base/compilation/outdatedness_checker.rb
+++ b/lib/nanoc/base/compilation/outdatedness_checker.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # Responsible for determining whether an item or a layout is outdated.
   #

--- a/lib/nanoc/base/compilation/outdatedness_reasons.rb
+++ b/lib/nanoc/base/compilation/outdatedness_reasons.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # Module that contains all outdatedness reasons.
   #

--- a/lib/nanoc/base/compilation/rule.rb
+++ b/lib/nanoc/base/compilation/rule.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # Contains the processing information for a item.
   #

--- a/lib/nanoc/base/compilation/rule_context.rb
+++ b/lib/nanoc/base/compilation/rule_context.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # Provides a context in which compilation and routing rules can be executed.
   # It provides access to the item representation that is being compiled or

--- a/lib/nanoc/base/compilation/rule_memory_calculator.rb
+++ b/lib/nanoc/base/compilation/rule_memory_calculator.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # Calculates rule memories for objects that can be run through a rule (item
   # representations and layouts).

--- a/lib/nanoc/base/compilation/rule_memory_store.rb
+++ b/lib/nanoc/base/compilation/rule_memory_store.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # Stores rule memories for objects that can be run through a rule (item
   # representations and layouts).

--- a/lib/nanoc/base/compilation/rules_collection.rb
+++ b/lib/nanoc/base/compilation/rules_collection.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # Keeps track of the rules in a site.
   #

--- a/lib/nanoc/base/context.rb
+++ b/lib/nanoc/base/context.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # Provides a context and a binding for use in filters such as the ERB and
   # Haml ones.

--- a/lib/nanoc/base/core_ext.rb
+++ b/lib/nanoc/base/core_ext.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'nanoc/base/core_ext/array'
 require 'nanoc/base/core_ext/hash'
 require 'nanoc/base/core_ext/pathname'

--- a/lib/nanoc/base/core_ext/array.rb
+++ b/lib/nanoc/base/core_ext/array.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # @api private
 module Nanoc::ArrayExtensions
   # Returns a new array where all items' keys are recursively converted to

--- a/lib/nanoc/base/core_ext/hash.rb
+++ b/lib/nanoc/base/core_ext/hash.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # @api private
 module Nanoc::HashExtensions
   # Returns a new hash where all keys are recursively converted to symbols by

--- a/lib/nanoc/base/core_ext/pathname.rb
+++ b/lib/nanoc/base/core_ext/pathname.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # @api private
 module Nanoc::PathnameExtensions
   # Calculates the checksum for the file referenced to by this pathname. Any

--- a/lib/nanoc/base/core_ext/string.rb
+++ b/lib/nanoc/base/core_ext/string.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # @api private
 module Nanoc::StringExtensions
   # Transforms string into an actual identifier

--- a/lib/nanoc/base/directed_graph.rb
+++ b/lib/nanoc/base/directed_graph.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # Represents a directed graph. It is used by the dependency tracker for
   # storing and querying dependencies between items.

--- a/lib/nanoc/base/error.rb
+++ b/lib/nanoc/base/error.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc
   # Generic error. Superclass for all nanoc-specific errors.
   class Error < ::StandardError

--- a/lib/nanoc/base/errors.rb
+++ b/lib/nanoc/base/errors.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # Module that contains all nanoc-specific errors.
   #

--- a/lib/nanoc/base/identifiable_collection.rb
+++ b/lib/nanoc/base/identifiable_collection.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # @api private
   class IdentifiableCollection

--- a/lib/nanoc/base/memoization.rb
+++ b/lib/nanoc/base/memoization.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # Adds support for memoizing functions.
   #

--- a/lib/nanoc/base/notification_center.rb
+++ b/lib/nanoc/base/notification_center.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # Provides a way to send notifications between objects. It allows blocks
   # associated with a certain notification name to be registered; these blocks

--- a/lib/nanoc/base/pattern.rb
+++ b/lib/nanoc/base/pattern.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # @api private
   class Pattern

--- a/lib/nanoc/base/plugin_registry.rb
+++ b/lib/nanoc/base/plugin_registry.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # The class responsible for keeping track of all loaded plugins, such as
   # filters ({Nanoc::Filter}) and data sources ({Nanoc::DataSource}).

--- a/lib/nanoc/base/result_data/item_rep.rb
+++ b/lib/nanoc/base/result_data/item_rep.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # A single representation (rep) of an item ({Nanoc::Int::Item}). An item can
   # have multiple representations. A representation has its own output file.

--- a/lib/nanoc/base/source_data/code_snippet.rb
+++ b/lib/nanoc/base/source_data/code_snippet.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # Nanoc::Int::CodeSnippet represent a piece of custom code of a nanoc site.
   #

--- a/lib/nanoc/base/source_data/configuration.rb
+++ b/lib/nanoc/base/source_data/configuration.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # Represents the site configuration.
   #

--- a/lib/nanoc/base/source_data/data_source.rb
+++ b/lib/nanoc/base/source_data/data_source.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc
   # Responsible for loading site data. It is the (abstract) superclass for all
   # data sources. Subclasses must at least implement the data reading methods

--- a/lib/nanoc/base/source_data/identifier.rb
+++ b/lib/nanoc/base/source_data/identifier.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc
   class Identifier
     include Comparable

--- a/lib/nanoc/base/source_data/item.rb
+++ b/lib/nanoc/base/source_data/item.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # Represents a compileable item in a site. It has content and attributes, as
   # well as an identifier (which starts and ends with a slash). It can also

--- a/lib/nanoc/base/source_data/layout.rb
+++ b/lib/nanoc/base/source_data/layout.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # Represents a layout in a nanoc site. It has content, attributes, an
   # identifier and a modification time (to speed up compilation).

--- a/lib/nanoc/base/source_data/site.rb
+++ b/lib/nanoc/base/source_data/site.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # The in-memory representation of a nanoc site. It holds references to the
   # following site data:

--- a/lib/nanoc/base/store.rb
+++ b/lib/nanoc/base/store.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Int
   # An abstract superclass for classes that need to store data to the
   # filesystem, such as checksums, cached compiled content and dependency

--- a/lib/nanoc/base/temp_filename_factory.rb
+++ b/lib/nanoc/base/temp_filename_factory.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'tmpdir'
 
 module Nanoc::Int

--- a/lib/nanoc/base/views/config.rb
+++ b/lib/nanoc/base/views/config.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc
   class ConfigView
     # @api private

--- a/lib/nanoc/base/views/identifiable_collection.rb
+++ b/lib/nanoc/base/views/identifiable_collection.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc
   class IdentifiableCollectionView
     include Enumerable

--- a/lib/nanoc/base/views/item.rb
+++ b/lib/nanoc/base/views/item.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc
   class ItemView
     # @api private

--- a/lib/nanoc/base/views/item_collection.rb
+++ b/lib/nanoc/base/views/item_collection.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc
   class ItemCollectionView < ::Nanoc::IdentifiableCollectionView
     # @api private

--- a/lib/nanoc/base/views/item_rep.rb
+++ b/lib/nanoc/base/views/item_rep.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc
   class ItemRepView
     # @api private

--- a/lib/nanoc/base/views/layout.rb
+++ b/lib/nanoc/base/views/layout.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc
   class LayoutView
     # @api private

--- a/lib/nanoc/base/views/layout_collection.rb
+++ b/lib/nanoc/base/views/layout_collection.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc
   class LayoutCollectionView < ::Nanoc::IdentifiableCollectionView
     # @api private

--- a/lib/nanoc/base/views/mutable_config.rb
+++ b/lib/nanoc/base/views/mutable_config.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc
   class MutableConfigView < Nanoc::ConfigView
     # Sets the value for the given attribute.

--- a/lib/nanoc/base/views/mutable_identifiable_collection.rb
+++ b/lib/nanoc/base/views/mutable_identifiable_collection.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc
   class MutableIdentifiableCollectionView < Nanoc::IdentifiableCollectionView
     # Deletes every object for which the block evaluates to true.

--- a/lib/nanoc/base/views/mutable_item.rb
+++ b/lib/nanoc/base/views/mutable_item.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc
   class MutableItemView < Nanoc::ItemView
     # Sets the value for the given attribute.

--- a/lib/nanoc/base/views/mutable_item_collection.rb
+++ b/lib/nanoc/base/views/mutable_item_collection.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc
   class MutableItemCollectionView < Nanoc::MutableIdentifiableCollectionView
     # @api private

--- a/lib/nanoc/base/views/mutable_layout.rb
+++ b/lib/nanoc/base/views/mutable_layout.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc
   class MutableLayoutView < Nanoc::LayoutView
     # Sets the value for the given attribute.

--- a/lib/nanoc/base/views/mutable_layout_collection.rb
+++ b/lib/nanoc/base/views/mutable_layout_collection.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc
   class MutableLayoutCollectionView < Nanoc::MutableIdentifiableCollectionView
     # @api private

--- a/lib/nanoc/base/views/site.rb
+++ b/lib/nanoc/base/views/site.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc
   class SiteView
     # @api private

--- a/lib/nanoc/cli.rb
+++ b/lib/nanoc/cli.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 begin
   require 'cri'
 rescue LoadError => e

--- a/lib/nanoc/cli/ansi_string_colorizer.rb
+++ b/lib/nanoc/cli/ansi_string_colorizer.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::CLI
   # A simple ANSI colorizer for strings. When given a string and a list of
   # attributes, it returns a colorized string.

--- a/lib/nanoc/cli/cleaning_stream.rb
+++ b/lib/nanoc/cli/cleaning_stream.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::CLI
   # An output stream that passes output through stream cleaners. This can be
   # used to strip ANSI color sequences, for instance.

--- a/lib/nanoc/cli/command_runner.rb
+++ b/lib/nanoc/cli/command_runner.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::CLI
   # A command runner subclass for nanoc commands that adds nanoc-specific
   # convenience methods and error handling.

--- a/lib/nanoc/cli/commands/check.rb
+++ b/lib/nanoc/cli/commands/check.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 usage 'check [options] [names]'
 summary 'run issue checks'
 description "

--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 usage 'compile [options]'
 summary 'compile items of this site'
 description <<-EOS

--- a/lib/nanoc/cli/commands/create-site.rb
+++ b/lib/nanoc/cli/commands/create-site.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 usage 'create-site [options] path'
 aliases :create_site, :cs
 summary 'create a site'

--- a/lib/nanoc/cli/commands/deploy.rb
+++ b/lib/nanoc/cli/commands/deploy.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 usage 'deploy [options]'
 summary 'deploy the compiled site'
 description "

--- a/lib/nanoc/cli/commands/nanoc.rb
+++ b/lib/nanoc/cli/commands/nanoc.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 usage 'nanoc command [options] [arguments]'
 summary 'nanoc, a static site compiler written in Ruby'
 

--- a/lib/nanoc/cli/commands/prune.rb
+++ b/lib/nanoc/cli/commands/prune.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 usage 'prune'
 summary 'remove files not managed by nanoc from the output directory'
 description <<-EOS

--- a/lib/nanoc/cli/commands/shell.rb
+++ b/lib/nanoc/cli/commands/shell.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 usage 'shell'
 summary 'open a shell on the nanoc environment'
 aliases 'console'

--- a/lib/nanoc/cli/commands/show-data.rb
+++ b/lib/nanoc/cli/commands/show-data.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 usage 'show-data'
 aliases :debug
 summary 'show data in this site'

--- a/lib/nanoc/cli/commands/show-plugins.rb
+++ b/lib/nanoc/cli/commands/show-plugins.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 summary 'show all available plugins'
 aliases :info
 usage 'show-plugins [options]'

--- a/lib/nanoc/cli/commands/show-rules.rb
+++ b/lib/nanoc/cli/commands/show-rules.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 usage 'show-rules [thing]'
 aliases :explain
 summary 'describe the rules for each item'

--- a/lib/nanoc/cli/commands/view.rb
+++ b/lib/nanoc/cli/commands/view.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 usage 'view [options]'
 summary 'start the web server that serves static files'
 description <<-EOS

--- a/lib/nanoc/cli/error_handler.rb
+++ b/lib/nanoc/cli/error_handler.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::CLI
   # Catches errors and prints nice diagnostic messages, then exits.
   #

--- a/lib/nanoc/cli/logger.rb
+++ b/lib/nanoc/cli/logger.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'singleton'
 
 module Nanoc::CLI

--- a/lib/nanoc/cli/stream_cleaners.rb
+++ b/lib/nanoc/cli/stream_cleaners.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::CLI
   # @api private
   module StreamCleaners

--- a/lib/nanoc/cli/stream_cleaners/abstract.rb
+++ b/lib/nanoc/cli/stream_cleaners/abstract.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::CLI::StreamCleaners
   # Superclass for all stream cleaners. Stream cleaners have a single method,
   # {#clean}, that takes a string and returns a cleaned string. Stream cleaners

--- a/lib/nanoc/cli/stream_cleaners/ansi_colors.rb
+++ b/lib/nanoc/cli/stream_cleaners/ansi_colors.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::CLI::StreamCleaners
   # Removes ANSI color escape sequences.
   #

--- a/lib/nanoc/cli/stream_cleaners/utf8.rb
+++ b/lib/nanoc/cli/stream_cleaners/utf8.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::CLI::StreamCleaners
   # Simplifies output by replacing UTF-8 characters with their ASCII decompositions.
   #

--- a/lib/nanoc/data_sources.rb
+++ b/lib/nanoc/data_sources.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # @api private
 module Nanoc::DataSources
   autoload 'Filesystem',         'nanoc/data_sources/filesystem'

--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::DataSources
   # Provides functionality common across all filesystem data sources.
   #

--- a/lib/nanoc/data_sources/filesystem_unified.rb
+++ b/lib/nanoc/data_sources/filesystem_unified.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::DataSources
   # The filesystem_unified data source stores its items and layouts in nested
   # directories. Items and layouts are represented by one or two files; if it

--- a/lib/nanoc/extra.rb
+++ b/lib/nanoc/extra.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # @api private
 module Nanoc::Extra
   autoload 'Checking',            'nanoc/extra/checking'

--- a/lib/nanoc/extra/checking.rb
+++ b/lib/nanoc/extra/checking.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Extra
   # @api private
   module Checking

--- a/lib/nanoc/extra/checking/check.rb
+++ b/lib/nanoc/extra/checking/check.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Extra::Checking
   # @api private
   class OutputDirNotFoundError < Nanoc::Int::Errors::Generic

--- a/lib/nanoc/extra/checking/checks.rb
+++ b/lib/nanoc/extra/checking/checks.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # @api private
 module Nanoc::Extra::Checking::Checks
   autoload 'CSS',           'nanoc/extra/checking/checks/css'

--- a/lib/nanoc/extra/checking/checks/css.rb
+++ b/lib/nanoc/extra/checking/checks/css.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module ::Nanoc::Extra::Checking::Checks
   # @api private
   class CSS < ::Nanoc::Extra::Checking::Check

--- a/lib/nanoc/extra/checking/checks/external_links.rb
+++ b/lib/nanoc/extra/checking/checks/external_links.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'net/http'
 require 'net/https'
 require 'nokogiri'

--- a/lib/nanoc/extra/checking/checks/html.rb
+++ b/lib/nanoc/extra/checking/checks/html.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module ::Nanoc::Extra::Checking::Checks
   # @api private
   class HTML < ::Nanoc::Extra::Checking::Check

--- a/lib/nanoc/extra/checking/checks/internal_links.rb
+++ b/lib/nanoc/extra/checking/checks/internal_links.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'uri'
 
 module Nanoc::Extra::Checking::Checks

--- a/lib/nanoc/extra/checking/checks/mixed_content.rb
+++ b/lib/nanoc/extra/checking/checks/mixed_content.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Extra::Checking::Checks
   # A check that verifies HTML files do not reference external resources with
   # URLs that would trigger "mixed content" warnings.

--- a/lib/nanoc/extra/checking/checks/stale.rb
+++ b/lib/nanoc/extra/checking/checks/stale.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Extra::Checking::Checks
   # @api private
   class Stale < ::Nanoc::Extra::Checking::Check

--- a/lib/nanoc/extra/checking/dsl.rb
+++ b/lib/nanoc/extra/checking/dsl.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Extra::Checking
   # @api private
   class DSL

--- a/lib/nanoc/extra/checking/issue.rb
+++ b/lib/nanoc/extra/checking/issue.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Extra::Checking
   # @api private
   class Issue

--- a/lib/nanoc/extra/checking/runner.rb
+++ b/lib/nanoc/extra/checking/runner.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Extra::Checking
   # Runner is reponsible for running issue checks.
   #

--- a/lib/nanoc/extra/core_ext.rb
+++ b/lib/nanoc/extra/core_ext.rb
@@ -1,4 +1,2 @@
-# encoding: utf-8
-
 require 'nanoc/extra/core_ext/pathname'
 require 'nanoc/extra/core_ext/time'

--- a/lib/nanoc/extra/core_ext/pathname.rb
+++ b/lib/nanoc/extra/core_ext/pathname.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Extra
   # @api private
   module PathnameExtensions

--- a/lib/nanoc/extra/core_ext/time.rb
+++ b/lib/nanoc/extra/core_ext/time.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # @api private
 module Nanoc::Extra::TimeExtensions
   # @return [String] The time in an ISO-8601 date format.

--- a/lib/nanoc/extra/deployer.rb
+++ b/lib/nanoc/extra/deployer.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Extra
   # Represents a deployer, an object that allows uploading the compiled site
   # to a specific (remote) location.

--- a/lib/nanoc/extra/deployers.rb
+++ b/lib/nanoc/extra/deployers.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Extra
   # @api private
   module Deployers

--- a/lib/nanoc/extra/deployers/fog.rb
+++ b/lib/nanoc/extra/deployers/fog.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Extra::Deployers
   # A deployer that deploys a site using [fog](https://github.com/geemus/fog).
   #

--- a/lib/nanoc/extra/deployers/rsync.rb
+++ b/lib/nanoc/extra/deployers/rsync.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Extra::Deployers
   # A deployer that deploys a site using rsync.
   #

--- a/lib/nanoc/extra/filesystem_tools.rb
+++ b/lib/nanoc/extra/filesystem_tools.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Extra
   # Contains useful functions for managing the filesystem.
   #

--- a/lib/nanoc/extra/jruby_nokogiri_warner.rb
+++ b/lib/nanoc/extra/jruby_nokogiri_warner.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'singleton'
 
 module Nanoc::Extra

--- a/lib/nanoc/extra/link_collector.rb
+++ b/lib/nanoc/extra/link_collector.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'set'
 
 module ::Nanoc::Extra

--- a/lib/nanoc/extra/piper.rb
+++ b/lib/nanoc/extra/piper.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'open3'
 
 module Nanoc::Extra

--- a/lib/nanoc/extra/pruner.rb
+++ b/lib/nanoc/extra/pruner.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Extra
   # Responsible for finding and deleting files in the site’s output directory
   # that are not managed by nanoc.

--- a/lib/nanoc/filters.rb
+++ b/lib/nanoc/filters.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # @api private
 module Nanoc::Filters
   autoload 'AsciiDoc',        'nanoc/filters/asciidoc'

--- a/lib/nanoc/filters/asciidoc.rb
+++ b/lib/nanoc/filters/asciidoc.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @since 3.2.0
   #

--- a/lib/nanoc/filters/bluecloth.rb
+++ b/lib/nanoc/filters/bluecloth.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @api private
   class BlueCloth < Nanoc::Filter

--- a/lib/nanoc/filters/coffeescript.rb
+++ b/lib/nanoc/filters/coffeescript.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @since 3.3.0
   #

--- a/lib/nanoc/filters/colorize_syntax.rb
+++ b/lib/nanoc/filters/colorize_syntax.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @api private
   class ColorizeSyntax < Nanoc::Filter

--- a/lib/nanoc/filters/erb.rb
+++ b/lib/nanoc/filters/erb.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @api private
   class ERB < Nanoc::Filter

--- a/lib/nanoc/filters/erubis.rb
+++ b/lib/nanoc/filters/erubis.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @api private
   class Erubis < Nanoc::Filter

--- a/lib/nanoc/filters/haml.rb
+++ b/lib/nanoc/filters/haml.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @api private
   class Haml < Nanoc::Filter

--- a/lib/nanoc/filters/handlebars.rb
+++ b/lib/nanoc/filters/handlebars.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @since 3.4.0
   #

--- a/lib/nanoc/filters/kramdown.rb
+++ b/lib/nanoc/filters/kramdown.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @api private
   class Kramdown < Nanoc::Filter

--- a/lib/nanoc/filters/less.rb
+++ b/lib/nanoc/filters/less.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @api private
   class Less < Nanoc::Filter

--- a/lib/nanoc/filters/markaby.rb
+++ b/lib/nanoc/filters/markaby.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @api private
   class Markaby < Nanoc::Filter

--- a/lib/nanoc/filters/maruku.rb
+++ b/lib/nanoc/filters/maruku.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @api private
   class Maruku < Nanoc::Filter

--- a/lib/nanoc/filters/mustache.rb
+++ b/lib/nanoc/filters/mustache.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @since 3.2.0
   #

--- a/lib/nanoc/filters/pandoc.rb
+++ b/lib/nanoc/filters/pandoc.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @api private
   class Pandoc < Nanoc::Filter

--- a/lib/nanoc/filters/rainpress.rb
+++ b/lib/nanoc/filters/rainpress.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @api private
   class Rainpress < Nanoc::Filter

--- a/lib/nanoc/filters/rdiscount.rb
+++ b/lib/nanoc/filters/rdiscount.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @api private
   class RDiscount < Nanoc::Filter

--- a/lib/nanoc/filters/rdoc.rb
+++ b/lib/nanoc/filters/rdoc.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @api private
   class RDoc < Nanoc::Filter

--- a/lib/nanoc/filters/redcarpet.rb
+++ b/lib/nanoc/filters/redcarpet.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @since 3.2.0
   #

--- a/lib/nanoc/filters/redcloth.rb
+++ b/lib/nanoc/filters/redcloth.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @api private
   class RedCloth < Nanoc::Filter

--- a/lib/nanoc/filters/relativize_paths.rb
+++ b/lib/nanoc/filters/relativize_paths.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @api private
   class RelativizePaths < Nanoc::Filter

--- a/lib/nanoc/filters/rubypants.rb
+++ b/lib/nanoc/filters/rubypants.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @api private
   class RubyPants < Nanoc::Filter

--- a/lib/nanoc/filters/sass.rb
+++ b/lib/nanoc/filters/sass.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @api private
   class Sass < Nanoc::Filter

--- a/lib/nanoc/filters/sass/sass_filesystem_importer.rb
+++ b/lib/nanoc/filters/sass/sass_filesystem_importer.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # @api private
 class ::Sass::Importers::Filesystem
   alias_method :_orig_find, :_find

--- a/lib/nanoc/filters/slim.rb
+++ b/lib/nanoc/filters/slim.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @since 3.2.0
   #

--- a/lib/nanoc/filters/typogruby.rb
+++ b/lib/nanoc/filters/typogruby.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @since 3.2.0
   #

--- a/lib/nanoc/filters/uglify_js.rb
+++ b/lib/nanoc/filters/uglify_js.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @api private
   class UglifyJS < Nanoc::Filter

--- a/lib/nanoc/filters/xsl.rb
+++ b/lib/nanoc/filters/xsl.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @since 3.3.0
   #

--- a/lib/nanoc/filters/yui_compressor.rb
+++ b/lib/nanoc/filters/yui_compressor.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Filters
   # @since 3.3.0
   #

--- a/lib/nanoc/helpers.rb
+++ b/lib/nanoc/helpers.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Helpers
   autoload 'Blogging',    'nanoc/helpers/blogging'
   autoload 'Breadcrumbs', 'nanoc/helpers/breadcrumbs'

--- a/lib/nanoc/helpers/blogging.rb
+++ b/lib/nanoc/helpers/blogging.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Helpers
   # Provides functionality for building blogs, such as finding articles and
   # constructing feeds.

--- a/lib/nanoc/helpers/breadcrumbs.rb
+++ b/lib/nanoc/helpers/breadcrumbs.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Helpers
   # Provides support for breadcrumbs, which allow the user to go up in the
   # page hierarchy.

--- a/lib/nanoc/helpers/capturing.rb
+++ b/lib/nanoc/helpers/capturing.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Helpers
   # Provides functionality for “capturing” content in one place and reusing
   # this content elsewhere.

--- a/lib/nanoc/helpers/filtering.rb
+++ b/lib/nanoc/helpers/filtering.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Helpers
   # Provides functionality for filtering parts of an item or a layout.
   module Filtering

--- a/lib/nanoc/helpers/html_escape.rb
+++ b/lib/nanoc/helpers/html_escape.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Helpers
   # Contains functionality for HTML-escaping strings.
   module HTMLEscape

--- a/lib/nanoc/helpers/link_to.rb
+++ b/lib/nanoc/helpers/link_to.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Helpers
   # Contains functions for linking to items and item representations.
   module LinkTo

--- a/lib/nanoc/helpers/rendering.rb
+++ b/lib/nanoc/helpers/rendering.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Helpers
   # Provides functionality for rendering layouts as partials.
   module Rendering

--- a/lib/nanoc/helpers/tagging.rb
+++ b/lib/nanoc/helpers/tagging.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Helpers
   # Provides support for managing tags added to items.
   #

--- a/lib/nanoc/helpers/text.rb
+++ b/lib/nanoc/helpers/text.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Helpers
   # Contains several useful text-related helper functions.
   module Text

--- a/lib/nanoc/helpers/xml_sitemap.rb
+++ b/lib/nanoc/helpers/xml_sitemap.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc::Helpers
   # Contains functionality for building XML sitemaps that will be crawled by
   # search engines. See the [Sitemaps protocol site](http://www.sitemaps.org)

--- a/lib/nanoc/version.rb
+++ b/lib/nanoc/version.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Nanoc
   # The current nanoc version.
   VERSION = '4.0.0b2'

--- a/nanoc.gemspec
+++ b/nanoc.gemspec
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 $LOAD_PATH.unshift(File.expand_path('../lib/', __FILE__))
 require 'nanoc/version'
 

--- a/nanoc.gemspec
+++ b/nanoc.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.rdoc_options     = ['--main', 'README.md']
   s.extra_rdoc_files = ['ChangeLog', 'LICENSE', 'README.md', 'NEWS.md']
 
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.2.0'
 
   s.add_runtime_dependency('cri', '~> 2.3')
 

--- a/spec/nanoc/base/identifier_spec.rb
+++ b/spec/nanoc/base/identifier_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Nanoc::Identifier do
   describe '#initialize' do
     context 'legacy type' do

--- a/spec/nanoc/base/pattern_spec.rb
+++ b/spec/nanoc/base/pattern_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Nanoc::Int::Pattern do
   describe '.from' do
     it 'converts from string' do

--- a/spec/nanoc/base/views/config_spec.rb
+++ b/spec/nanoc/base/views/config_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Nanoc::ConfigView do
   let(:config) do
     { amount: 9000, animal: 'donkey' }

--- a/spec/nanoc/base/views/identifiable_collection_spec.rb
+++ b/spec/nanoc/base/views/identifiable_collection_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # Needs :view_class
 shared_examples 'an identifiable collection' do
   let(:view) { described_class.new(wrapped) }

--- a/spec/nanoc/base/views/item_collection_spec.rb
+++ b/spec/nanoc/base/views/item_collection_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Nanoc::ItemCollectionView do
   let(:view_class) { Nanoc::ItemView }
   it_behaves_like 'an identifiable collection'

--- a/spec/nanoc/base/views/item_rep_spec.rb
+++ b/spec/nanoc/base/views/item_rep_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Nanoc::ItemRepView do
   describe '#== and #eql?' do
     let(:item_rep) { double(:item_rep, item: item, name: :jacques) }

--- a/spec/nanoc/base/views/item_spec.rb
+++ b/spec/nanoc/base/views/item_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Nanoc::ItemView do
   describe '#== and #eql?' do
     let(:item) { Nanoc::Int::Item.new('content', {}, '/asdf/') }

--- a/spec/nanoc/base/views/layout_collection_spec.rb
+++ b/spec/nanoc/base/views/layout_collection_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Nanoc::LayoutCollectionView do
   let(:view_class) { Nanoc::LayoutView }
   it_behaves_like 'an identifiable collection'

--- a/spec/nanoc/base/views/layout_spec.rb
+++ b/spec/nanoc/base/views/layout_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Nanoc::LayoutView do
   describe '#== and #eql?' do
     let(:layout) { Nanoc::Int::Layout.new('content', {}, '/asdf/') }

--- a/spec/nanoc/base/views/mutable_config_spec.rb
+++ b/spec/nanoc/base/views/mutable_config_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Nanoc::MutableConfigView do
   describe '#[]=' do
     let(:config) { {} }

--- a/spec/nanoc/base/views/mutable_identifiable_collection_spec.rb
+++ b/spec/nanoc/base/views/mutable_identifiable_collection_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 shared_examples 'a mutable identifiable collection' do
   let(:view) { described_class.new(wrapped) }
 

--- a/spec/nanoc/base/views/mutable_item_collection_spec.rb
+++ b/spec/nanoc/base/views/mutable_item_collection_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Nanoc::MutableItemCollectionView do
   let(:view_class) { Nanoc::MutableItemView }
   it_behaves_like 'an identifiable collection'

--- a/spec/nanoc/base/views/mutable_item_spec.rb
+++ b/spec/nanoc/base/views/mutable_item_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Nanoc::MutableItemView do
   describe '#[]=' do
     let(:item) { Nanoc::Int::Item.new('content', {}, '/asdf/') }

--- a/spec/nanoc/base/views/mutable_layout_collection_spec.rb
+++ b/spec/nanoc/base/views/mutable_layout_collection_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Nanoc::MutableLayoutCollectionView do
   let(:view_class) { Nanoc::MutableLayoutView }
   it_behaves_like 'an identifiable collection'

--- a/spec/nanoc/base/views/mutable_layout_spec.rb
+++ b/spec/nanoc/base/views/mutable_layout_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Nanoc::MutableLayoutView do
   describe '#[]=' do
     let(:layout) { Nanoc::Int::Layout.new('content', {}, '/asdf/') }

--- a/spec/nanoc/cli/commands/shell_spec.rb
+++ b/spec/nanoc/cli/commands/shell_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Nanoc::CLI::Commands::Shell do
   describe '#env_for' do
     subject { described_class.env_for(site) }

--- a/spec/nanoc/helpers/blogging_spec.rb
+++ b/spec/nanoc/helpers/blogging_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Nanoc::Helpers::Blogging do
   let(:mod) do
     Class.new(Nanoc::Int::Context) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__) + '/../lib'))
 require 'nanoc'
 require 'nanoc/cli'

--- a/tasks/doc.rake
+++ b/tasks/doc.rake
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'yard'
 
 YARD::Rake::YardocTask.new(:doc) do |yard|

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'rspec/core/rake_task'
 
 def run_tests(dir_glob)

--- a/test/base/checksummer_spec.rb
+++ b/test/base/checksummer_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'tempfile'
 
 describe Nanoc::Int::Checksummer do

--- a/test/base/core_ext/array_spec.rb
+++ b/test/base/core_ext/array_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe 'Array#__nanoc_symbolize_keys_recursively' do
   it 'should convert keys to symbols' do
     array_old = [:abc, 'xyz', { 'foo' => 'bar', :baz => :qux }]

--- a/test/base/core_ext/hash_spec.rb
+++ b/test/base/core_ext/hash_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe 'Hash#__nanoc_symbolize_keys_recursively' do
   it 'should convert keys to symbols' do
     hash_old = { 'foo' => 'bar' }

--- a/test/base/core_ext/pathname_spec.rb
+++ b/test/base/core_ext/pathname_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe 'Pathname#checksum' do
   it 'should work on empty files' do
     begin

--- a/test/base/core_ext/string_spec.rb
+++ b/test/base/core_ext/string_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe 'String#__nanoc_cleaned_identifier' do
   it 'should not convert already clean paths' do
     '/foo/bar/'.__nanoc_cleaned_identifier.must_equal '/foo/bar/'

--- a/test/base/temp_filename_factory_spec.rb
+++ b/test/base/temp_filename_factory_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Nanoc::Int::TempFilenameFactory do
   subject do
     Nanoc::Int::TempFilenameFactory.new

--- a/test/base/test_checksum_store.rb
+++ b/test/base/test_checksum_store.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Int::ChecksumStoreTest < Nanoc::TestCase
   def test_get_with_existing_object
     require 'pstore'

--- a/test/base/test_code_snippet.rb
+++ b/test/base/test_code_snippet.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Int::CodeSnippetTest < Nanoc::TestCase
   def test_load
     # Initialize

--- a/test/base/test_compiler.rb
+++ b/test/base/test_compiler.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Int::CompilerTest < Nanoc::TestCase
   def test_compilation_rule_for
     # Mock rules

--- a/test/base/test_compiler_dsl.rb
+++ b/test/base/test_compiler_dsl.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Int::CompilerDSLTest < Nanoc::TestCase
   def test_compile
     # TODO: implement

--- a/test/base/test_context.rb
+++ b/test/base/test_context.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Int::ContextTest < Nanoc::TestCase
   def test_context_with_instance_variable
     # Create context

--- a/test/base/test_data_source.rb
+++ b/test/base/test_data_source.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::DataSourceTest < Nanoc::TestCase
   def test_loading
     # Create data source

--- a/test/base/test_dependency_tracker.rb
+++ b/test/base/test_dependency_tracker.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Int::DependencyTrackerTest < Nanoc::TestCase
   def test_initialize
     # Mock items

--- a/test/base/test_directed_graph.rb
+++ b/test/base/test_directed_graph.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Int::DirectedGraphTest < Nanoc::TestCase
   def test_direct_predecessors
     graph = Nanoc::Int::DirectedGraph.new([1, 2, 3])

--- a/test/base/test_filter.rb
+++ b/test/base/test_filter.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::FilterTest < Nanoc::TestCase
   def test_initialize
     # Create filter

--- a/test/base/test_item.rb
+++ b/test/base/test_item.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Int::ItemTest < Nanoc::TestCase
   def test_initialize_with_attributes_with_string_keys
     item = Nanoc::Int::Item.new('foo', { 'abc' => 'xyz' }, '/foo/')

--- a/test/base/test_item_array.rb
+++ b/test/base/test_item_array.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Int::IdentifiableCollectionTest < Nanoc::TestCase
   def setup
     super

--- a/test/base/test_item_rep.rb
+++ b/test/base/test_item_rep.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Int::ItemRepTest < Nanoc::TestCase
   def test_created_modified_compiled
     # TODO: implement

--- a/test/base/test_item_rep_recorder_proxy.rb
+++ b/test/base/test_item_rep_recorder_proxy.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Int::ItemRepRecorderProxyTest < Nanoc::TestCase
   def test_double_names
     proxy = Nanoc::Int::ItemRepRecorderProxy.new(mock)

--- a/test/base/test_layout.rb
+++ b/test/base/test_layout.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Int::LayoutTest < Nanoc::TestCase
   def test_initialize
     # Make sure attributes are cleaned

--- a/test/base/test_memoization.rb
+++ b/test/base/test_memoization.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Int::MemoizationTest < Nanoc::TestCase
   class Sample1
     extend Nanoc::Int::Memoization

--- a/test/base/test_notification_center.rb
+++ b/test/base/test_notification_center.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Int::NotificationCenterTest < Nanoc::TestCase
   def test_post
     # Set up notification

--- a/test/base/test_outdatedness_checker.rb
+++ b/test/base/test_outdatedness_checker.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
   def test_not_outdated
     # Compile once

--- a/test/base/test_plugin.rb
+++ b/test/base/test_plugin.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::PluginTest < Nanoc::TestCase
   class SampleFilter < Nanoc::Filter
     identifier :_plugin_test_sample_filter

--- a/test/base/test_rule.rb
+++ b/test/base/test_rule.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Int::RuleTest < Nanoc::TestCase
   def test_initialize
     # TODO: implement

--- a/test/base/test_rule_context.rb
+++ b/test/base/test_rule_context.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Int::RuleContextTest < Nanoc::TestCase
   def test_objects
     # Mock everything

--- a/test/base/test_site.rb
+++ b/test/base/test_site.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Int::SiteTest < Nanoc::TestCase
   def test_initialize_with_dir_without_config_yaml
     assert_raises(Nanoc::Int::Errors::GenericTrivial) do

--- a/test/base/test_store.rb
+++ b/test/base/test_store.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Int::StoreTest < Nanoc::TestCase
   class TestStore < Nanoc::Int::Store
     def data

--- a/test/cli/commands/test_check.rb
+++ b/test/cli/commands/test_check.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::CLI::Commands::CheckTest < Nanoc::TestCase
   def test_check_stale
     with_site do |_site|

--- a/test/cli/commands/test_compile.rb
+++ b/test/cli/commands/test_compile.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
   def test_profiling_information
     with_site do |_site|

--- a/test/cli/commands/test_create_site.rb
+++ b/test/cli/commands/test_create_site.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::CLI::Commands::CreateSiteTest < Nanoc::TestCase
   def test_create_site_with_existing_name
     Nanoc::CLI.run %w( create_site foo )

--- a/test/cli/commands/test_deploy.rb
+++ b/test/cli/commands/test_deploy.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::CLI::Commands::DeployTest < Nanoc::TestCase
   def test_deploy
     skip_unless_have_command 'rsync'

--- a/test/cli/commands/test_help.rb
+++ b/test/cli/commands/test_help.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::CLI::Commands::HelpTest < Nanoc::TestCase
   def test_run
     Nanoc::CLI.run %w( help )

--- a/test/cli/commands/test_info.rb
+++ b/test/cli/commands/test_info.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::CLI::Commands::InfoTest < Nanoc::TestCase
   def test_run
     Nanoc::CLI.run %w( info )

--- a/test/cli/commands/test_prune.rb
+++ b/test/cli/commands/test_prune.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
   def test_run_without_yes
     with_site do |_site|

--- a/test/cli/test_cleaning_stream.rb
+++ b/test/cli/test_cleaning_stream.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::CLI::CleaningStreamTest < Nanoc::TestCase
   class Stream
     attr_accessor :called_methods

--- a/test/cli/test_cli.rb
+++ b/test/cli/test_cli.rb
@@ -1,9 +1,5 @@
-# encoding: utf-8
-
 class Nanoc::CLITest < Nanoc::TestCase
   COMMAND_CODE = <<EOS
-# encoding: utf-8
-
 usage       '_test [options]'
 summary     'meh'
 description 'longer meh'
@@ -14,8 +10,6 @@ end
 EOS
 
   SUBCOMMAND_CODE = <<EOS
-# encoding: utf-8
-
 usage       '_sub [options]'
 summary     'meh sub'
 description 'longer meh sub'

--- a/test/cli/test_error_handler.rb
+++ b/test/cli/test_error_handler.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::CLI::ErrorHandlerTest < Nanoc::TestCase
   def setup
     super

--- a/test/cli/test_logger.rb
+++ b/test/cli/test_logger.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::CLI::LoggerTest < Nanoc::TestCase
   def test_stub
   end

--- a/test/data_sources/test_filesystem.rb
+++ b/test/data_sources/test_filesystem.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
   class SampleFilesystemDataSource < Nanoc::DataSource
     include Nanoc::DataSources::Filesystem

--- a/test/data_sources/test_filesystem_unified.rb
+++ b/test/data_sources/test_filesystem_unified.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
   def new_data_source(params = nil)
     # Mock site

--- a/test/extra/checking/checks/test_css.rb
+++ b/test/extra/checking/checks/test_css.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Extra::Checking::Checks::CSSTest < Nanoc::TestCase
   def test_run_ok
     VCR.use_cassette('css_run_ok') do

--- a/test/extra/checking/checks/test_external_links.rb
+++ b/test/extra/checking/checks/test_external_links.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Extra::Checking::Checks::ExternalLinksTest < Nanoc::TestCase
   def test_run
     with_site do |site|

--- a/test/extra/checking/checks/test_html.rb
+++ b/test/extra/checking/checks/test_html.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Extra::Checking::Checks::HTMLTest < Nanoc::TestCase
   def test_run_ok
     VCR.use_cassette('html_run_ok') do

--- a/test/extra/checking/checks/test_internal_links.rb
+++ b/test/extra/checking/checks/test_internal_links.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Extra::Checking::Checks::InternalLinksTest < Nanoc::TestCase
   def test_run
     with_site do |site|

--- a/test/extra/checking/checks/test_mixed_content.rb
+++ b/test/extra/checking/checks/test_mixed_content.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
   def create_output_file(name, lines)
     FileUtils.mkdir_p('output')

--- a/test/extra/checking/checks/test_stale.rb
+++ b/test/extra/checking/checks/test_stale.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Extra::Checking::Checks::StaleTest < Nanoc::TestCase
   def check_class
     Nanoc::Extra::Checking::Checks::Stale

--- a/test/extra/checking/test_check.rb
+++ b/test/extra/checking/test_check.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Extra::Checking::CheckTest < Nanoc::TestCase
   def test_output_filenames
     with_site do |site|

--- a/test/extra/checking/test_dsl.rb
+++ b/test/extra/checking/test_dsl.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Extra::Checking::DSLTest < Nanoc::TestCase
   def test_from_file
     with_site do |_site|

--- a/test/extra/checking/test_runner.rb
+++ b/test/extra/checking/test_runner.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Extra::Checking::RunnerTest < Nanoc::TestCase
   def test_run_specific
     with_site do |site|

--- a/test/extra/core_ext/test_pathname.rb
+++ b/test/extra/core_ext/test_pathname.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Extra::CoreExtPathnameTest < Nanoc::TestCase
   def test_components
     assert_equal %w( / a bb ccc dd e ), Pathname.new('/a/bb/ccc/dd/e').__nanoc_components

--- a/test/extra/core_ext/test_time.rb
+++ b/test/extra/core_ext/test_time.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::ExtraCoreExtTimeTest < Nanoc::TestCase
   def test___nanoc_to_iso8601_date
     assert_equal('2008-05-19', Time.utc(2008, 5, 19, 14, 20, 0, 0).__nanoc_to_iso8601_date)

--- a/test/extra/deployers/test_fog.rb
+++ b/test/extra/deployers/test_fog.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Extra::Deployers::FogTest < Nanoc::TestCase
   def test_run
     if_have 'fog' do

--- a/test/extra/deployers/test_rsync.rb
+++ b/test/extra/deployers/test_rsync.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Extra::Deployers::RsyncTest < Nanoc::TestCase
   def test_run_without_dst
     # Create deployer

--- a/test/extra/test_filesystem_tools.rb
+++ b/test/extra/test_filesystem_tools.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Extra::FilesystemToolsTest < Nanoc::TestCase
   def setup
     super

--- a/test/extra/test_link_collector.rb
+++ b/test/extra/test_link_collector.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Extra::LinkCollectorTest < Nanoc::TestCase
   def test_all
     # Create dummy data

--- a/test/extra/test_piper.rb
+++ b/test/extra/test_piper.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Extra::PiperTest < Nanoc::TestCase
   def test_basic
     stdout = StringIO.new

--- a/test/filters/test_asciidoc.rb
+++ b/test/filters/test_asciidoc.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::AsciiDocTest < Nanoc::TestCase
   def test_filter
     skip_unless_have_command 'asciidoc'

--- a/test/filters/test_bluecloth.rb
+++ b/test/filters/test_bluecloth.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::BlueClothTest < Nanoc::TestCase
   def test_filter
     if_have 'bluecloth' do

--- a/test/filters/test_coffeescript.rb
+++ b/test/filters/test_coffeescript.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::CoffeeScriptTest < Nanoc::TestCase
   def test_filter
     if_have 'coffee-script' do

--- a/test/filters/test_colorize_syntax.rb
+++ b/test/filters/test_colorize_syntax.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::ColorizeSyntaxTest < Nanoc::TestCase
   CODERAY_PRE  = '<div class="CodeRay"><div class="code">'
   CODERAY_POST = '</div></div>'

--- a/test/filters/test_erb.rb
+++ b/test/filters/test_erb.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::ERBTest < Nanoc::TestCase
   def test_filter_with_instance_variable
     # Create filter

--- a/test/filters/test_erubis.rb
+++ b/test/filters/test_erubis.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::ErubisTest < Nanoc::TestCase
   def test_filter_with_instance_variable
     if_have 'erubis' do

--- a/test/filters/test_haml.rb
+++ b/test/filters/test_haml.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::HamlTest < Nanoc::TestCase
   def test_filter
     if_have 'haml' do

--- a/test/filters/test_handlebars.rb
+++ b/test/filters/test_handlebars.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::HandlebarsTest < Nanoc::TestCase
   def test_filter
     if_have 'handlebars' do

--- a/test/filters/test_kramdown.rb
+++ b/test/filters/test_kramdown.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::KramdownTest < Nanoc::TestCase
   def test_filter
     if_have 'kramdown' do

--- a/test/filters/test_less.rb
+++ b/test/filters/test_less.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::LessTest < Nanoc::TestCase
   def test_filter
     if_have 'less' do

--- a/test/filters/test_markaby.rb
+++ b/test/filters/test_markaby.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::MarkabyTest < Nanoc::TestCase
   def test_filter
     if_have 'markaby' do

--- a/test/filters/test_maruku.rb
+++ b/test/filters/test_maruku.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::MarukuTest < Nanoc::TestCase
   def test_filter
     if_have 'maruku' do

--- a/test/filters/test_mustache.rb
+++ b/test/filters/test_mustache.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::MustacheTest < Nanoc::TestCase
   def test_filter
     if_have 'mustache' do

--- a/test/filters/test_pandoc.rb
+++ b/test/filters/test_pandoc.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::PandocTest < Nanoc::TestCase
   def test_filter
     if_have 'pandoc-ruby' do

--- a/test/filters/test_rainpress.rb
+++ b/test/filters/test_rainpress.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::RainpressTest < Nanoc::TestCase
   def test_filter
     if_have 'rainpress' do

--- a/test/filters/test_rdiscount.rb
+++ b/test/filters/test_rdiscount.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::RDiscountTest < Nanoc::TestCase
   def test_filter
     if_have 'rdiscount' do

--- a/test/filters/test_rdoc.rb
+++ b/test/filters/test_rdoc.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::RDocTest < Nanoc::TestCase
   def test_filter
     # Get filter

--- a/test/filters/test_redcarpet.rb
+++ b/test/filters/test_redcarpet.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::RedcarpetTest < Nanoc::TestCase
   def test_find
     if_have 'redcarpet' do

--- a/test/filters/test_redcloth.rb
+++ b/test/filters/test_redcloth.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::RedClothTest < Nanoc::TestCase
   def test_filter
     if_have 'redcloth' do

--- a/test/filters/test_relativize_paths.rb
+++ b/test/filters/test_relativize_paths.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::RelativizePathsTest < Nanoc::TestCase
   def test_filter_html_with_double_quotes
     # Create filter with mock item

--- a/test/filters/test_rubypants.rb
+++ b/test/filters/test_rubypants.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::RubyPantsTest < Nanoc::TestCase
   def test_filter
     if_have 'rubypants' do

--- a/test/filters/test_sass.rb
+++ b/test/filters/test_sass.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::SassTest < Nanoc::TestCase
   def test_filter
     if_have 'sass' do

--- a/test/filters/test_slim.rb
+++ b/test/filters/test_slim.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::SlimTest < Nanoc::TestCase
   def test_filter
     if_have 'slim' do

--- a/test/filters/test_typogruby.rb
+++ b/test/filters/test_typogruby.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::TypogrubyTest < Nanoc::TestCase
   def test_filter
     if_have 'typogruby' do

--- a/test/filters/test_uglify_js.rb
+++ b/test/filters/test_uglify_js.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::UglifyJSTest < Nanoc::TestCase
   def test_filter
     if_have 'uglifier' do

--- a/test/filters/test_xsl.rb
+++ b/test/filters/test_xsl.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'tempfile'
 
 class Nanoc::Filters::XSLTest < Nanoc::TestCase

--- a/test/filters/test_yui_compressor.rb
+++ b/test/filters/test_yui_compressor.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Filters::YUICompressorTest < Nanoc::TestCase
   def test_filter_javascript
     if_have 'yuicompressor' do

--- a/test/gem_loader.rb
+++ b/test/gem_loader.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 begin
   require 'rubygems'
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # Set up gem loading (necessary for cri dependency)
 require File.dirname(__FILE__) + '/gem_loader.rb'
 

--- a/test/helpers/test_blogging.rb
+++ b/test/helpers/test_blogging.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
   include Nanoc::Helpers::Blogging
   include Nanoc::Helpers::Text

--- a/test/helpers/test_breadcrumbs.rb
+++ b/test/helpers/test_breadcrumbs.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Helpers::BreadcrumbsTest < Nanoc::TestCase
   include Nanoc::Helpers::Breadcrumbs
 

--- a/test/helpers/test_capturing.rb
+++ b/test/helpers/test_capturing.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Helpers::CapturingTest < Nanoc::TestCase
   include Nanoc::Helpers::Capturing
 

--- a/test/helpers/test_filtering.rb
+++ b/test/helpers/test_filtering.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Helpers::FilteringTest < Nanoc::TestCase
   include Nanoc::Helpers::Filtering
 

--- a/test/helpers/test_html_escape.rb
+++ b/test/helpers/test_html_escape.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Helpers::HTMLEscapeTest < Nanoc::TestCase
   include Nanoc::Helpers::HTMLEscape
 

--- a/test/helpers/test_link_to.rb
+++ b/test/helpers/test_link_to.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Helpers::LinkToTest < Nanoc::TestCase
   include Nanoc::Helpers::LinkTo
 

--- a/test/helpers/test_rendering.rb
+++ b/test/helpers/test_rendering.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
   include Nanoc::Helpers::Rendering
 

--- a/test/helpers/test_tagging.rb
+++ b/test/helpers/test_tagging.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
   include Nanoc::Helpers::Tagging
 

--- a/test/helpers/test_text.rb
+++ b/test/helpers/test_text.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Helpers::TextTest < Nanoc::TestCase
   include Nanoc::Helpers::Text
 

--- a/test/helpers/test_xml_sitemap.rb
+++ b/test/helpers/test_xml_sitemap.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
   include Nanoc::Helpers::XMLSitemap
 

--- a/test/test_gem.rb
+++ b/test/test_gem.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Nanoc::GemTest < Nanoc::TestCase
   def setup
     super


### PR DESCRIPTION
This sets Ruby 2.2 as the minimum required version.

It also removes the magic encoding comments, which are no longer necessary because UTF-8 is now the default source encoding.

Fixes #597.