### PR TITLE
Remove allow_periods_in_identifiers from default site

### DIFF
--- a/lib/nanoc/cli/commands/create-site.rb
+++ b/lib/nanoc/cli/commands/create-site.rb
@@ -74,14 +74,6 @@ data_sources:
     # same as the items root, but applies to layouts rather than items.
     layouts_root: #{Nanoc::Int::Site::DEFAULT_DATA_SOURCE_CONFIG[:layouts_root]}
 
-    # Whether to allow periods in identifiers. When turned off, everything
-    # past the first period is considered to be the extension, and when
-    # turned on, only the characters past the last period are considered to
-    # be the extension. For example,  a file named “content/about.html.erb”
-    # will have the identifier “/about/” when turned off, but when turned on
-    # it will become “/about.html/” instead.
-    allow_periods_in_identifiers: false
-
     # The encoding to use for input files. If your input files are not in
     # UTF-8 (which they should be!), change this.
     encoding: utf-8


### PR DESCRIPTION
For full identifiers, which is the default, this does not make sense.