### PR TITLE
Allow nil in layouts/content dir name

### DIFF
--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -45,6 +45,8 @@ module Nanoc::DataSources
     def load_objects(dir_name, kind, klass)
       res = []
 
+     return [] if dir_name.nil?
+
       all_split_files_in(dir_name).each do |base_filename, (meta_ext, content_exts)|
         content_exts.each do |content_ext|
           # Get filenames

--- a/test/data_sources/test_filesystem_unified.rb
+++ b/test/data_sources/test_filesystem_unified.rb
@@ -115,6 +115,21 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
     assert_nil items[0].raw_content
   end
 
+  def test_load_layouts_with_nil_dir_name
+    # Create data source
+    data_source = new_data_source(layouts_dir: nil)
+
+    # Create sample files
+    FileUtils.mkdir_p('layouts')
+    File.write('layouts/stuff.txt', 'blah blah')
+
+    # Load
+    layouts = data_source.layouts
+
+    # Check
+    assert_empty(layouts)
+  end
+
   def test_load_binary_layouts
     # Create data source
     data_source = new_data_source


### PR DESCRIPTION
This will allow usage the static data source to be replaced with the `filesystem_unified` one without awkwardly having to specify a non-existant directory, but rather having it set to nil.

Before:

```yaml
data_sources:
  -
    type: filesystem
  -
    type: filesystem
    items_root: /static
    content_dir: 'static'
    layouts_dir: 'static_layouts'
```

After:

```yaml
data_sources:
  -
    type: filesystem
  -
    type: filesystem
    items_root: /static
    content_dir: 'static'
    layouts_dir: nil
```