### PR TITLE
Use content filename when constructing identifier

### DIFF
--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -73,10 +73,10 @@ module Nanoc::DataSources
           }.merge(meta)
 
           # Get identifier
-          if meta_filename
-            identifier = identifier_for_filename(meta_filename[dir_name.length..-1])
-          elsif content_filename
+          if content_filename
             identifier = identifier_for_filename(content_filename[dir_name.length..-1])
+          elsif meta_filename
+            identifier = identifier_for_filename(meta_filename[dir_name.length..-1])
           else
             raise 'meta_filename and content_filename are both nil'
           end

--- a/test/data_sources/test_filesystem_unified.rb
+++ b/test/data_sources/test_filesystem_unified.rb
@@ -468,6 +468,18 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
     end
   end
 
+  def test_load_objects_correct_identifier_with_separate_yaml_file
+    data_source = new_data_source({ identifier_type: 'full' })
+
+    FileUtils.mkdir_p('foo')
+    File.write('foo/donkey.jpeg', 'data')
+    File.write('foo/donkey.yaml', "---\nalt: Donkey\n")
+
+    objects = data_source.send(:load_objects, 'foo', 'The Foo', Nanoc::Int::Item)
+    assert_equal 1, objects.size
+    assert_equal '/donkey.jpeg', objects.first.identifier.to_s
+  end
+
   def test_filename_for
     data_source = new_data_source
 


### PR DESCRIPTION
Given two files:

* _content/donkey.jpeg_
* _content/donkey.yaml_

The resulting identifier would be `/donkey.yaml` rather than `/donkey.jpeg`. This PR fixes that.