### PR TITLE
Item rep writer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'compass'
 gem 'coffee-script'
 gem 'coveralls', require: false
 gem 'erubis'
+gem 'fakefs'
 gem 'fog'
 gem 'haml'
 gem 'handlebars', platforms: :ruby

--- a/lib/nanoc/base.rb
+++ b/lib/nanoc/base.rb
@@ -28,6 +28,7 @@ end
 
 # @api private
 module Nanoc::Int
+  require_relative 'base/item_rep_writer'
   require_relative 'base/pattern'
 
   # Load helper classes

--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -91,7 +91,7 @@ module Nanoc::Int
       Nanoc::Int::TempFilenameFactory.instance.cleanup(
         Nanoc::Filter::TMP_BINARY_ITEMS_DIR)
       Nanoc::Int::TempFilenameFactory.instance.cleanup(
-        Nanoc::Int::ItemRep::TMP_TEXT_ITEMS_DIR)
+        Nanoc::Int::ItemRepWriter::TMP_TEXT_ITEMS_DIR)
     end
 
     # @group Private instance methods

--- a/lib/nanoc/base/item_rep_writer.rb
+++ b/lib/nanoc/base/item_rep_writer.rb
@@ -1,0 +1,37 @@
+module Nanoc::Int
+  # @api private
+  class ItemRepWriter
+    TMP_TEXT_ITEMS_DIR = 'text_items'
+
+    def write(item_rep, raw_path)
+      # Create parent directory
+      FileUtils.mkdir_p(File.dirname(raw_path))
+
+      # Check if file will be created
+      is_created = !File.file?(raw_path)
+
+      # Notify
+      Nanoc::Int::NotificationCenter.post(:will_write_rep, item_rep, raw_path)
+
+      if item_rep.binary?
+        temp_path = item_rep.temporary_filenames[:last]
+      else
+        temp_path = temp_filename
+        File.write(temp_path, item_rep.content[:last])
+      end
+
+      # Check whether content was modified
+      is_modified = is_created || !FileUtils.identical?(raw_path, temp_path)
+
+      # Write
+      FileUtils.cp(temp_path, raw_path) if is_modified
+
+      # Notify
+      Nanoc::Int::NotificationCenter.post(:rep_written, item_rep, raw_path, is_created, is_modified)
+    end
+
+    def temp_filename
+      Nanoc::Int::TempFilenameFactory.instance.create(TMP_TEXT_ITEMS_DIR)
+    end
+  end
+end

--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -65,8 +65,7 @@ module Nanoc::CLI::Commands
         require 'tempfile'
         setup_diffs
         old_contents = {}
-        Nanoc::Int::NotificationCenter.on(:will_write_rep) do |rep, snapshot|
-          path = rep.raw_path(snapshot: snapshot)
+        Nanoc::Int::NotificationCenter.on(:will_write_rep) do |rep, path|
           old_contents[rep] = File.file?(path) ? File.read(path) : nil
         end
         Nanoc::Int::NotificationCenter.on(:rep_written) do |rep, path, _is_created, _is_modified|

--- a/spec/nanoc/base/item_rep_writer_spec.rb
+++ b/spec/nanoc/base/item_rep_writer_spec.rb
@@ -1,0 +1,128 @@
+describe Nanoc::Int::ItemRepWriter do
+  describe '#write' do
+    let(:raw_path) { 'output/blah.dat' }
+
+    let(:item) do
+      Nanoc::Int::Item.new(
+        'blah blah blah', {}, '/',
+        binary: is_binary,
+        mtime: Time.now - 500,
+      )
+    end
+
+    let(:is_binary) { false }
+
+    let(:item_rep) do
+      Nanoc::Int::ItemRep.new(item, :default).tap do |ir|
+        ir.content = content
+        ir.temporary_filenames.replace(temporary_filenames)
+      end
+    end
+
+    let(:content) do
+      { last: 'last content' }
+    end
+
+    let(:temporary_filenames) do
+      {}
+    end
+
+    subject { described_class.new.write(item_rep, raw_path) }
+
+    before do
+      expect(File.directory?('output')).to be_falsy
+    end
+
+    context 'binary item rep' do
+      let(:is_binary) { true }
+
+      let(:temporary_filenames) { { last: 'input.dat' } }
+
+      it 'copies' do
+        File.write(temporary_filenames[:last], 'binary stuff')
+
+        expect(Nanoc::Int::NotificationCenter).to receive(:post)
+          .with(:will_write_rep, item_rep, 'output/blah.dat')
+        expect(Nanoc::Int::NotificationCenter).to receive(:post)
+          .with(:rep_written, item_rep, 'output/blah.dat', true, true)
+
+        subject
+
+        expect(File.read('output/blah.dat')).to eql('binary stuff')
+      end
+
+      context 'output file already exists' do
+        let(:old_mtime) { (Time.now - 600).to_i }
+
+        before do
+          File.write(temporary_filenames[:last], 'binary stuff')
+
+          FileUtils.mkdir_p('output')
+          File.write('output/blah.dat', old_content)
+          FileUtils.touch('output/blah.dat', mtime: old_mtime)
+        end
+
+        context 'file is identical' do
+          let(:old_content) { 'binary stuff' }
+
+          it 'keeps mtime' do
+            subject
+            expect(File.mtime('output/blah.dat')).to eql(old_mtime)
+          end
+        end
+
+        context 'file is not identical' do
+          let(:old_content) { 'other binary stuff' }
+
+          it 'updates mtime' do
+            subject
+            expect(File.mtime('output/blah.dat')).to be > (Time.now - 1)
+          end
+        end
+      end
+    end
+
+    context 'textual item rep' do
+      let(:is_binary) { false }
+
+      it 'writes' do
+        expect(Nanoc::Int::NotificationCenter).to receive(:post)
+          .with(:will_write_rep, item_rep, 'output/blah.dat')
+        expect(Nanoc::Int::NotificationCenter).to receive(:post)
+          .with(:rep_written, item_rep, 'output/blah.dat', true, true)
+
+        subject
+
+        expect(File.read('output/blah.dat')).to eql('last content')
+      end
+
+      context 'output file already exists' do
+        let(:old_mtime) { (Time.now - 600).to_i }
+
+        before do
+          FileUtils.mkdir_p('output')
+          File.write('output/blah.dat', old_content)
+          FileUtils.touch('output/blah.dat', mtime: old_mtime)
+        end
+
+        context 'file is identical' do
+          let(:old_content) { 'last content' }
+
+          it 'keeps mtime' do
+            subject
+            expect(File.mtime('output/blah.dat')).to eql(old_mtime)
+          end
+        end
+
+        context 'file is not identical' do
+          let(:old_content) { 'other last content' }
+
+          it 'updates mtime' do
+            subject
+            expect(File.mtime('output/blah.dat')).to be > (Time.now - 1)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,11 @@ require 'nanoc'
 require 'nanoc/cli'
 Nanoc::CLI.setup
 
+require 'fakefs/spec_helpers'
+
 RSpec.configure do |c|
+  c.include FakeFS::SpecHelpers
+
   c.around(:each) do |example|
     Nanoc::CLI::ErrorHandler.disable
     example.run

--- a/test/base/test_item_rep.rb
+++ b/test/base/test_item_rep.rb
@@ -257,13 +257,13 @@ class Nanoc::Int::ItemRepTest < Nanoc::TestCase
     item_rep.raw_paths[:last] = 'foo/bar/baz/quux.txt'
 
     # Write once
-    item_rep.write
+    Nanoc::Int::ItemRepWriter.new.write(item_rep, item_rep.raw_paths[:last])
     a_long_time_ago = Time.now - 1_000_000
     File.utime(a_long_time_ago, a_long_time_ago, item_rep.raw_path)
 
     # Write again
     assert_equal a_long_time_ago.to_s, File.mtime(item_rep.raw_path).to_s
-    item_rep.write
+    Nanoc::Int::ItemRepWriter.new.write(item_rep, item_rep.raw_paths[:last])
     assert_equal a_long_time_ago.to_s, File.mtime(item_rep.raw_path).to_s
   end
 
@@ -280,7 +280,7 @@ class Nanoc::Int::ItemRepTest < Nanoc::TestCase
     item_rep.raw_paths[:last] = 'foo/bar/baz/quux.txt'
 
     # Write
-    item_rep.write
+    Nanoc::Int::ItemRepWriter.new.write(item_rep, item_rep.raw_paths[:last])
 
     # Check
     assert(File.file?('foo/bar/baz/quux.txt'))
@@ -372,7 +372,7 @@ class Nanoc::Int::ItemRepTest < Nanoc::TestCase
     rep.temporary_filenames[:last] = in_filename
     rep.raw_paths[:last]           = out_filename
 
-    rep.write
+    Nanoc::Int::ItemRepWriter.new.write(rep, out_filename)
 
     assert(File.exist?(out_filename))
     assert_equal(file_content, File.read(out_filename))
@@ -575,7 +575,7 @@ class Nanoc::Int::ItemRepTest < Nanoc::TestCase
       assert is_created
       assert is_modified
     end
-    item_rep.write
+    Nanoc::Int::ItemRepWriter.new.write(item_rep, item_rep.raw_paths[:last])
     assert notified
     Nanoc::Int::NotificationCenter.remove(:rep_written, self)
   end
@@ -605,7 +605,7 @@ class Nanoc::Int::ItemRepTest < Nanoc::TestCase
       refute is_created
       assert is_modified
     end
-    item_rep.write
+    Nanoc::Int::ItemRepWriter.new.write(item_rep, item_rep.raw_paths[:last])
     assert notified
     Nanoc::Int::NotificationCenter.remove(:rep_written, self)
   end


### PR DESCRIPTION
This is a refactoring that extracts item rep writing functionality into its own class. Quite WIP for the time being.

Philosophies in refactoring:

* Entities, such as item representations, should be data objects, and shouldn’t know how to interact with the outside world.
* Service classes, such as the item rep writer, can interact with the outside world (in this case, the filesystem).