### PR TITLE
Expose views in RuleContext

### DIFF
--- a/lib/nanoc/base/compilation/rule_context.rb
+++ b/lib/nanoc/base/compilation/rule_context.rb
@@ -3,41 +3,22 @@ module Nanoc::Int
   # It provides access to the item representation that is being compiled or
   # routed.
   #
-  # The following variables will be available in this rules context:
-  #
-  # * `rep`     ({Nanoc::Int::ItemRep})         - The current item rep
-  # * `item`    ({Nanoc::Int::Item})            - The current item
-  # * `site`    ({Nanoc::Int::Site})            - The site
-  # * `config`  ({Hash})                    - The site configuration
-  # * `items`   ({Array}<{Nanoc::Int::Item}>)   - A list of all items
-  # * `layouts` ({Array}<{Nanoc::Int::Layout}>) - A list of all layouts
-  #
   # @api private
   class RuleContext < Nanoc::Int::Context
-    # @option params [Nanoc::Int::ItemRep] :rep The item representation that will
-    #   be processed in this rule context
-    #
-    # @option params [Nanoc::Int::Compiler] :compiler The compiler that is being
-    #   used to compile the site
-    #
-    # @raise [ArgumentError] if the `:rep` or the `:compiler` option is
-    #   missing
+    # @option params [Nanoc::Int::ItemRep] :rep
+    # @option params [Nanoc::Int::Compiler] :compiler
     def initialize(params = {})
-      rep = params.fetch(:rep) do
-        raise ArgumentError, 'Required :rep option is missing'
-      end
-      compiler = params.fetch(:compiler) do
-        raise ArgumentError, 'Required :compiler option is missing'
-      end
+      rep = params.fetch(:rep)
+      compiler = params.fetch(:compiler)
 
       super({
-        rep: rep,
-        item_rep: rep,
-        item: rep.item,
-        site: compiler.site,
-        config: compiler.site.config,
-        items: compiler.site.items,
-        layouts: compiler.site.layouts
+        item: Nanoc::ItemView.new(rep.item),
+        rep: Nanoc::ItemRepView.new(rep),
+        item_rep: Nanoc::ItemRepView.new(rep),
+        items: Nanoc::ItemCollectionView.new(compiler.site.items),
+        layouts: Nanoc::LayoutCollectionView.new(compiler.site.layouts),
+        config: Nanoc::ConfigView.new(compiler.site.config),
+        site: Nanoc::SiteView.new(compiler.site),
       })
     end
 
@@ -54,7 +35,7 @@ module Nanoc::Int
     #
     # @return [void]
     def filter(filter_name, filter_args = {})
-      rep.filter(filter_name, filter_args)
+      rep.unwrap.filter(filter_name, filter_args)
     end
 
     # Layouts the current representation (calls {Nanoc::Int::ItemRep#layout} with
@@ -67,7 +48,7 @@ module Nanoc::Int
     #
     # @return [void]
     def layout(layout_identifier)
-      rep.layout(layout_identifier)
+      rep.unwrap.layout(layout_identifier)
     end
 
     # Creates a snapshot of the current compiled item content. Calls
@@ -79,7 +60,7 @@ module Nanoc::Int
     #
     # @return [void]
     def snapshot(snapshot_name)
-      rep.snapshot(snapshot_name)
+      rep.unwrap.snapshot(snapshot_name)
     end
   end
 end

--- a/test/base/test_rule_context.rb
+++ b/test/base/test_rule_context.rb
@@ -15,23 +15,23 @@ class Nanoc::Int::RuleContextTest < Nanoc::TestCase
     compiler = Nanoc::Int::Compiler.new(site)
 
     # Create context
-    @rule_context = Nanoc::Int::RuleContext.new(rep: rep, compiler: compiler)
+    rule_context = Nanoc::Int::RuleContext.new(rep: rep, compiler: compiler)
 
     # Check classes
-    assert_equal Nanoc::ItemRepView,          @rule_context.rep.class
-    assert_equal Nanoc::ItemView,             @rule_context.item.class
-    assert_equal Nanoc::SiteView,             @rule_context.site.class
-    assert_equal Nanoc::ConfigView,           @rule_context.config.class
-    assert_equal Nanoc::LayoutCollectionView, @rule_context.layouts.class
-    assert_equal Nanoc::ItemCollectionView,   @rule_context.items.class
+    assert_equal Nanoc::ItemRepView,          rule_context.rep.class
+    assert_equal Nanoc::ItemView,             rule_context.item.class
+    assert_equal Nanoc::SiteView,             rule_context.site.class
+    assert_equal Nanoc::ConfigView,           rule_context.config.class
+    assert_equal Nanoc::LayoutCollectionView, rule_context.layouts.class
+    assert_equal Nanoc::ItemCollectionView,   rule_context.items.class
 
     # Check content
-    assert_equal rep,     @rule_context.rep.unwrap
-    assert_equal item,    @rule_context.item.unwrap
-    assert_equal site,    @rule_context.site.unwrap
-    assert_equal config,  @rule_context.config.unwrap
-    assert_equal layouts, @rule_context.layouts.unwrap
-    assert_equal items,   @rule_context.items.unwrap
+    assert_equal rep,     rule_context.rep.unwrap
+    assert_equal item,    rule_context.item.unwrap
+    assert_equal site,    rule_context.site.unwrap
+    assert_equal config,  rule_context.config.unwrap
+    assert_equal layouts, rule_context.layouts.unwrap
+    assert_equal items,   rule_context.items.unwrap
   end
 
   def test_actions
@@ -54,21 +54,21 @@ class Nanoc::Int::RuleContextTest < Nanoc::TestCase
     compiler = Nanoc::Int::Compiler.new(site)
 
     # Create context
-    @rule_context = Nanoc::Int::RuleContext.new(rep: rep, compiler: compiler)
+    rule_context = Nanoc::Int::RuleContext.new(rep: rep, compiler: compiler)
 
     # Check
     assert_raises(NoMethodError) do
-      @rule_context.instance_eval do
+      rule_context.instance_eval do
         item_rep.filter :foo, bar: 'baz'
       end
     end
     assert_raises(NoMethodError) do
-      @rule_context.instance_eval do
+      rule_context.instance_eval do
         item_rep.layout 'foo'
       end
     end
     assert_raises(NoMethodError) do
-      @rule_context.instance_eval do
+      rule_context.instance_eval do
         item_rep.snapshot 'awesome'
       end
     end

--- a/test/base/test_rule_context.rb
+++ b/test/base/test_rule_context.rb
@@ -49,9 +49,6 @@ class Nanoc::Int::RuleContextTest < Nanoc::TestCase
     # Mock rep
     rep = mock
     rep.stubs(:item).returns(item)
-    rep.expects(:filter).with(:foo, { bar: 'baz' })
-    rep.expects(:layout).with('foo')
-    rep.expects(:snapshot).with('awesome')
 
     # Mock compiler
     compiler = Nanoc::Int::Compiler.new(site)
@@ -60,8 +57,20 @@ class Nanoc::Int::RuleContextTest < Nanoc::TestCase
     @rule_context = Nanoc::Int::RuleContext.new(rep: rep, compiler: compiler)
 
     # Check
-    rep.filter :foo, bar: 'baz'
-    rep.layout 'foo'
-    rep.snapshot 'awesome'
+    assert_raises(NoMethodError) do
+      @rule_context.instance_eval do
+        item_rep.filter :foo, bar: 'baz'
+      end
+    end
+    assert_raises(NoMethodError) do
+      @rule_context.instance_eval do
+        item_rep.layout 'foo'
+      end
+    end
+    assert_raises(NoMethodError) do
+      @rule_context.instance_eval do
+        item_rep.snapshot 'awesome'
+      end
+    end
   end
 end

--- a/test/base/test_rule_context.rb
+++ b/test/base/test_rule_context.rb
@@ -17,13 +17,21 @@ class Nanoc::Int::RuleContextTest < Nanoc::TestCase
     # Create context
     @rule_context = Nanoc::Int::RuleContext.new(rep: rep, compiler: compiler)
 
-    # Check
-    assert_equal rep,     @rule_context.rep
-    assert_equal item,    @rule_context.item
-    assert_equal site,    @rule_context.site
-    assert_equal config,  @rule_context.config
-    assert_equal layouts, @rule_context.layouts
-    assert_equal items,   @rule_context.items
+    # Check classes
+    assert_equal Nanoc::ItemRepView,          @rule_context.rep.class
+    assert_equal Nanoc::ItemView,             @rule_context.item.class
+    assert_equal Nanoc::SiteView,             @rule_context.site.class
+    assert_equal Nanoc::ConfigView,           @rule_context.config.class
+    assert_equal Nanoc::LayoutCollectionView, @rule_context.layouts.class
+    assert_equal Nanoc::ItemCollectionView,   @rule_context.items.class
+
+    # Check content
+    assert_equal rep,     @rule_context.rep.unwrap
+    assert_equal item,    @rule_context.item.unwrap
+    assert_equal site,    @rule_context.site.unwrap
+    assert_equal config,  @rule_context.config.unwrap
+    assert_equal layouts, @rule_context.layouts.unwrap
+    assert_equal items,   @rule_context.items.unwrap
   end
 
   def test_actions


### PR DESCRIPTION
Fixes #614.

This also means that calls such as `@rep.filter …` are no longer possible within Rules (use `filter …` instead). That’s OK as long as it is documented in the migration guide.