### PR TITLE
Remove Item/Layout attribute shorthands

### DIFF
--- a/lib/nanoc/base/source_data/item.rb
+++ b/lib/nanoc/base/source_data/item.rb
@@ -140,27 +140,6 @@ module Nanoc::Int
       rep.path
     end
 
-    # Requests the attribute with the given key.
-    #
-    # @param [Symbol] key The name of the attribute to fetch
-    #
-    # @return [Object] The value of the requested attribute
-    def [](key)
-      Nanoc::Int::NotificationCenter.post(:visit_started, self)
-      Nanoc::Int::NotificationCenter.post(:visit_ended,   self)
-
-      @attributes[key]
-    end
-
-    # Sets the attribute with the given key to the given value.
-    #
-    # @param [Symbol] key The name of the attribute to set
-    #
-    # @param [Object] value The value of the attribute to set
-    def []=(key, value)
-      @attributes[key] = value
-    end
-
     # @return [Boolean] True if the item is binary; false if it is not
     def binary?
       @is_binary

--- a/lib/nanoc/base/source_data/layout.rb
+++ b/lib/nanoc/base/source_data/layout.rb
@@ -28,19 +28,6 @@ module Nanoc::Int
       @identifier   = Nanoc::Identifier.from(identifier)
     end
 
-    # Requests the attribute with the given key.
-    #
-    # @param [Symbol] key The name of the attribute to fetch.
-    #
-    # @return [Object] The value of the requested attribute.
-    def [](key)
-      @attributes[key]
-    end
-
-    def []=(key, value)
-      @attributes[key] = value
-    end
-
     # Returns the type of this object. Will always return `:layout`, because
     # this is a layout. For items, this method returns `:item`.
     #

--- a/lib/nanoc/base/views/item.rb
+++ b/lib/nanoc/base/views/item.rb
@@ -31,10 +31,11 @@ module Nanoc
 
     # @see Hash#fetch
     def fetch(key, fallback = NONE, &_block)
-      res = @item[key] # necessary for dependency tracking
+      Nanoc::Int::NotificationCenter.post(:visit_started, @item)
+      Nanoc::Int::NotificationCenter.post(:visit_ended,   @item)
 
       if @item.attributes.key?(key)
-        res
+        @item.attributes[key]
       else
         if !fallback.equal?(NONE)
           fallback
@@ -48,13 +49,18 @@ module Nanoc
 
     # @see Hash#key?
     def key?(key)
-      _res = @item[key] # necessary for dependency tracking
+      Nanoc::Int::NotificationCenter.post(:visit_started, @item)
+      Nanoc::Int::NotificationCenter.post(:visit_ended,   @item)
+
       @item.attributes.key?(key)
     end
 
     # @see Hash#[]
     def [](key)
-      @item[key]
+      Nanoc::Int::NotificationCenter.post(:visit_started, @item)
+      Nanoc::Int::NotificationCenter.post(:visit_ended,   @item)
+
+      @item.attributes[key]
     end
 
     # Returns the compiled content.

--- a/lib/nanoc/base/views/layout.rb
+++ b/lib/nanoc/base/views/layout.rb
@@ -28,8 +28,14 @@ module Nanoc
 
     # @see Hash#[]
     def [](key)
-      @layout[key]
+      Nanoc::Int::NotificationCenter.post(:visit_started, @layout)
+      Nanoc::Int::NotificationCenter.post(:visit_ended,   @layout)
+
+      @layout.attributes[key]
     end
+
+    # TODO: Add #fetch
+    # TODO: Add #key?
 
     # @api private
     def reference

--- a/lib/nanoc/base/views/mutable_item.rb
+++ b/lib/nanoc/base/views/mutable_item.rb
@@ -6,7 +6,7 @@ module Nanoc
     #
     # @see Hash#[]=
     def []=(key, value)
-      unwrap[key] = value
+      unwrap.attributes[key] = value
     end
 
     # Updates the attributes based on the given hash.
@@ -15,7 +15,7 @@ module Nanoc
     #
     # @return [self]
     def update_attributes(hash)
-      hash.each { |k, v| unwrap[k] = v }
+      hash.each { |k, v| unwrap.attributes[k] = v }
       self
     end
   end

--- a/lib/nanoc/base/views/mutable_layout.rb
+++ b/lib/nanoc/base/views/mutable_layout.rb
@@ -6,7 +6,7 @@ module Nanoc
     #
     # @see Hash#[]=
     def []=(key, value)
-      unwrap[key] = value
+      unwrap.attributes[key] = value
     end
   end
 end

--- a/spec/nanoc/base/views/item_spec.rb
+++ b/spec/nanoc/base/views/item_spec.rb
@@ -95,6 +95,11 @@ describe Nanoc::ItemView do
 
     subject { view[key] }
 
+    before do
+      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:visit_started, item).ordered
+      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:visit_ended, item).ordered
+    end
+
     context 'with existant key' do
       let(:key) { :animal }
       it { should eql?('donkey') }
@@ -111,7 +116,8 @@ describe Nanoc::ItemView do
     let(:view) { described_class.new(item) }
 
     before do
-      expect(Nanoc::Int::NotificationCenter).to receive(:post).twice
+      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:visit_started, item).ordered
+      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:visit_ended, item).ordered
     end
 
     context 'with existant key' do
@@ -150,7 +156,8 @@ describe Nanoc::ItemView do
     let(:view) { described_class.new(item) }
 
     before do
-      expect(Nanoc::Int::NotificationCenter).to receive(:post).twice
+      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:visit_started, item).ordered
+      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:visit_ended, item).ordered
     end
 
     subject { view.key?(key) }

--- a/spec/nanoc/base/views/layout_spec.rb
+++ b/spec/nanoc/base/views/layout_spec.rb
@@ -40,6 +40,28 @@ describe Nanoc::LayoutView do
     end
   end
 
+  describe '#[]' do
+    let(:layout) { Nanoc::Int::Layout.new('stuff', { animal: 'donkey' }, '/foo/') }
+    let(:view) { described_class.new(layout) }
+
+    subject { view[key] }
+
+    before do
+      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:visit_started, layout).ordered
+      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:visit_ended, layout).ordered
+    end
+
+    context 'with existant key' do
+      let(:key) { :animal }
+      it { is_expected.to eql('donkey') }
+    end
+
+    context 'with non-existant key' do
+      let(:key) { :weapon }
+      it { is_expected.to eql(nil) }
+    end
+  end
+
   describe '#hash' do
     let(:layout) { double(:layout, identifier: '/foo/') }
     let(:view) { described_class.new(layout) }

--- a/test/base/test_compiler_dsl.rb
+++ b/test/base/test_compiler_dsl.rb
@@ -60,7 +60,7 @@ class Nanoc::Int::CompilerDSLTest < Nanoc::TestCase
 
       # Apply preprocess blocks
       site.compiler.preprocess
-      assert item[:preprocessed]
+      assert item.attributes[:preprocessed]
     end
   end
 

--- a/test/base/test_item.rb
+++ b/test/base/test_item.rb
@@ -16,27 +16,9 @@ class Nanoc::Int::ItemTest < Nanoc::TestCase
     assert_equal([:item, '/path/'], item.reference)
   end
 
-  def test_lookup
-    # Create item
-    item = Nanoc::Int::Item.new(
-      'content',
-      { one: 'one in item' },
-      '/path/'
-    )
-
-    # Test finding one
-    assert_equal('one in item', item[:one])
-
-    # Test finding two
-    assert_equal(nil, item[:two])
-  end
-
-  def test_set_attribute
-    item = Nanoc::Int::Item.new('foo', {}, '/foo')
-    assert_equal nil, item[:motto]
-
-    item[:motto] = 'More human than human'
-    assert_equal 'More human than human', item[:motto]
+  def test_attributes
+    item = Nanoc::Int::Item.new('content', { 'one' => 'one in item' }, '/path/')
+    assert_equal({ one: 'one in item' }, item.attributes)
   end
 
   def test_compiled_content_with_default_rep_and_default_snapshot
@@ -137,11 +119,11 @@ class Nanoc::Int::ItemTest < Nanoc::TestCase
     item.freeze
 
     assert_raises_frozen_error do
-      item[:abc] = '123'
+      item.attributes[:abc] = '123'
     end
 
     assert_raises_frozen_error do
-      item[:a][:b] = '456'
+      item.attributes[:a][:b] = '456'
     end
   end
 

--- a/test/base/test_layout.rb
+++ b/test/base/test_layout.rb
@@ -5,20 +5,9 @@ class Nanoc::Int::LayoutTest < Nanoc::TestCase
     assert_equal({ foo: 'bar' }, layout.attributes)
   end
 
-  def test_lookup_with_known_attribute
-    # Create layout
+  def test_attributes
     layout = Nanoc::Int::Layout.new('content', { 'foo' => 'bar' }, '/foo/')
-
-    # Check attributes
-    assert_equal('bar', layout[:foo])
-  end
-
-  def test_lookup_with_unknown_attribute
-    # Create layout
-    layout = Nanoc::Int::Layout.new('content', { 'foo' => 'bar' }, '/foo/')
-
-    # Check attributes
-    assert_equal(nil, layout[:filter])
+    assert_equal({ foo: 'bar' }, layout.attributes)
   end
 
   def test_dump_and_load

--- a/test/filters/test_less.rb
+++ b/test/filters/test_less.rb
@@ -2,7 +2,7 @@ class Nanoc::Filters::LessTest < Nanoc::TestCase
   def test_filter
     if_have 'less' do
       # Create item
-      @item = Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/')
+      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'))
 
       # Create filter
       filter = ::Nanoc::Filters::Less.new(item: @item, items: [@item])
@@ -20,7 +20,7 @@ class Nanoc::Filters::LessTest < Nanoc::TestCase
       File.open('content/foo/bar/imported_file.less', 'w') { |io| io.write('p { color: red; }') }
 
       # Create item
-      @item = Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/')
+      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'))
 
       # Create filter
       filter = ::Nanoc::Filters::Less.new(item: @item, items: [@item])
@@ -39,7 +39,7 @@ class Nanoc::Filters::LessTest < Nanoc::TestCase
 
       # Create item
       File.open('content/foo/bar.txt', 'w') { |io| io.write('meh') }
-      @item = Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/')
+      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'))
 
       # Create filter
       filter = ::Nanoc::Filters::Less.new(item: @item, items: [@item])
@@ -108,7 +108,7 @@ class Nanoc::Filters::LessTest < Nanoc::TestCase
   def test_compression
     if_have 'less' do
       # Create item
-      @item = Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/')
+      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'))
 
       # Create filter
       filter = ::Nanoc::Filters::Less.new(item: @item, items: [@item])

--- a/test/helpers/test_filtering.rb
+++ b/test/helpers/test_filtering.rb
@@ -25,29 +25,23 @@ class Nanoc::Helpers::FilteringTest < Nanoc::TestCase
 
   def test_filter_with_assigns
     if_have 'rubypants' do
-      # Build content to be evaluated
       content = "<p>Foo...</p>\n" \
                 "<% filter :erb do %>\n" \
                 " <p><%%= @item[:title] %></p>\n" \
                 "<% end %>\n"
 
-      # Mock item and rep
-      @item = mock
-      @item.expects(:[]).with(:title).returns('Bar...')
-      @item.expects(:identifier).returns('/blah/')
-      @item = Nanoc::ItemView.new(@item)
-      @item_rep = mock
-      @item_rep.expects(:name).returns('default')
-      @item_rep.expects(:assigns).returns({
-        item: @item,
-        item_rep: @item_rep
-      })
-      @item_rep = Nanoc::ItemRepView.new(@item_rep)
+      item = Nanoc::Int::Item.new('stuff', { title: 'Bar...' }, '/foo.md')
+      item_rep = Nanoc::Int::ItemRep.new(item, :default)
+      item_rep.assigns = {
+        item: Nanoc::ItemView.new(item),
+        item_rep: Nanoc::ItemRepView.new(item_rep),
+      }
 
-      # Evaluate content
+      @item = Nanoc::ItemView.new(item)
+      @item_rep = Nanoc::ItemRepView.new(item_rep)
+
       result = ::ERB.new(content).result(binding)
 
-      # Check
       assert_match('<p>Foo...</p>', result)
       assert_match('<p>Bar...</p>', result)
     end

--- a/test/helpers/test_tagging.rb
+++ b/test/helpers/test_tagging.rb
@@ -3,7 +3,7 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
 
   def test_tags_for_without_tags
     # Create item
-    item = Nanoc::Int::Item.new('content', {}, '/path/')
+    item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', {}, '/path/'))
 
     # Check
     assert_equal(
@@ -14,7 +14,7 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
 
   def test_tags_for_with_custom_base_url
     # Create item
-    item = Nanoc::Int::Item.new('content', { tags: %w(foo bar) }, '/path/')
+    item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', { tags: %w(foo bar) }, '/path/'))
 
     # Check
     assert_equal(
@@ -26,7 +26,7 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
 
   def test_tags_for_with_custom_none_text
     # Create item
-    item = Nanoc::Int::Item.new('content', { tags: [] }, '/path/')
+    item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', { tags: [] }, '/path/'))
 
     # Check
     assert_equal(
@@ -37,7 +37,7 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
 
   def test_tags_for_with_custom_separator
     # Create item
-    item = Nanoc::Int::Item.new('content', { tags: %w(foo bar) }, '/path/')
+    item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', { tags: %w(foo bar) }, '/path/'))
 
     # Check
     assert_equal(
@@ -49,11 +49,11 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
 
   def test_items_with_tag
     # Create items
-    @items = [
+    @items = Nanoc::ItemCollectionView.new([
       Nanoc::Int::Item.new('item 1', { tags: [:foo]       }, '/item1/'),
       Nanoc::Int::Item.new('item 2', { tags: [:bar]       }, '/item2/'),
       Nanoc::Int::Item.new('item 3', { tags: [:foo, :bar] }, '/item3/')
-    ]
+    ])
 
     # Find items
     items_with_foo_tag = items_with_tag(:foo)


### PR DESCRIPTION
* `Item` and `Layout` no longer have `#[]` and `#[]=`. They do not serve a purpose anymore; the shorthand is handled by the views.

* Dependency tracking (“visit started” and “visit ended” notifications) should happen in the views. This PR makes that change.

* Strangely, no dependency tracking was done for attributes in layouts. This PR also fixes that issue.

* As expected, some helper/filter tests use the entities rather than the views, causing their tests to break after this change. The tests have been updated to use views rather than entities.

To do (in a separate PR):

* Move common `ItemView` and `LayoutView` method into module or superclass (`#[]`, `#fetch`, `#key?`). Same goes for the mutable variants (`#[]=`, `#update_attributes`).