### PR TITLE
Create mutable document view

### DIFF
--- a/lib/nanoc/base/views.rb
+++ b/lib/nanoc/base/views.rb
@@ -1,5 +1,7 @@
+require_relative 'views/mixins/document'
+require_relative 'views/mixins/mutable_document'
+
 require_relative 'views/config'
-require_relative 'views/document'
 require_relative 'views/identifiable_collection'
 require_relative 'views/item'
 require_relative 'views/item_collection'

--- a/lib/nanoc/base/views/item.rb
+++ b/lib/nanoc/base/views/item.rb
@@ -1,5 +1,7 @@
 module Nanoc
-  class ItemView < ::Nanoc::DocumentView
+  class ItemView
+    include Nanoc::DocumentViewMixin
+
     # Returns the compiled content.
     #
     # @option params [String] :rep (:default) The name of the representation

--- a/lib/nanoc/base/views/layout.rb
+++ b/lib/nanoc/base/views/layout.rb
@@ -1,4 +1,5 @@
 module Nanoc
-  class LayoutView < ::Nanoc::DocumentView
+  class LayoutView
+    include Nanoc::DocumentViewMixin
   end
 end

--- a/lib/nanoc/base/views/mixins/document.rb
+++ b/lib/nanoc/base/views/mixins/document.rb
@@ -1,5 +1,5 @@
 module Nanoc
-  class DocumentView
+  module DocumentViewMixin
     # @api private
     NONE = Object.new
 

--- a/lib/nanoc/base/views/mixins/mutable_document.rb
+++ b/lib/nanoc/base/views/mixins/mutable_document.rb
@@ -1,0 +1,22 @@
+module Nanoc
+  module MutableDocumentViewMixin
+    # Sets the value for the given attribute.
+    #
+    # @param [Symbol] key
+    #
+    # @see Hash#[]=
+    def []=(key, value)
+      unwrap.attributes[key] = value
+    end
+
+    # Updates the attributes based on the given hash.
+    #
+    # @param [Hash] hash
+    #
+    # @return [self]
+    def update_attributes(hash)
+      hash.each { |k, v| unwrap.attributes[k] = v }
+      self
+    end
+  end
+end

--- a/lib/nanoc/base/views/mutable_item.rb
+++ b/lib/nanoc/base/views/mutable_item.rb
@@ -1,22 +1,5 @@
 module Nanoc
   class MutableItemView < Nanoc::ItemView
-    # Sets the value for the given attribute.
-    #
-    # @param [Symbol] key
-    #
-    # @see Hash#[]=
-    def []=(key, value)
-      unwrap.attributes[key] = value
-    end
-
-    # Updates the attributes based on the given hash.
-    #
-    # @param [Hash] hash
-    #
-    # @return [self]
-    def update_attributes(hash)
-      hash.each { |k, v| unwrap.attributes[k] = v }
-      self
-    end
+    include Nanoc::MutableDocumentViewMixin
   end
 end

--- a/lib/nanoc/base/views/mutable_layout.rb
+++ b/lib/nanoc/base/views/mutable_layout.rb
@@ -1,12 +1,5 @@
 module Nanoc
   class MutableLayoutView < Nanoc::LayoutView
-    # Sets the value for the given attribute.
-    #
-    # @param [Symbol] key
-    #
-    # @see Hash#[]=
-    def []=(key, value)
-      unwrap.attributes[key] = value
-    end
+    include Nanoc::MutableDocumentViewMixin
   end
 end

--- a/spec/nanoc/base/views/mutable_document_view_spec.rb
+++ b/spec/nanoc/base/views/mutable_document_view_spec.rb
@@ -1,0 +1,28 @@
+shared_examples 'a mutable document view' do
+  describe '#[]=' do
+    let(:item) { entity_class.new('content', {}, '/asdf/') }
+    let(:view) { described_class.new(item) }
+
+    it 'sets attributes' do
+      view[:title] = 'Donkey'
+      expect(view[:title]).to eq('Donkey')
+    end
+  end
+
+  describe '#update_attributes' do
+    let(:item) { entity_class.new('content', {}, '/asdf/') }
+    let(:view) { described_class.new(item) }
+
+    let(:update) { { friend: 'Giraffe' } }
+
+    subject { view.update_attributes(update) }
+
+    it 'sets attributes' do
+      expect { subject }.to change { view[:friend] }.from(nil).to('Giraffe')
+    end
+
+    it 'returns self' do
+      expect(subject).to equal(view)
+    end
+  end
+end

--- a/spec/nanoc/base/views/mutable_item_spec.rb
+++ b/spec/nanoc/base/views/mutable_item_spec.rb
@@ -1,28 +1,4 @@
 describe Nanoc::MutableItemView do
-  describe '#[]=' do
-    let(:item) { Nanoc::Int::Item.new('content', {}, '/asdf/') }
-    let(:view) { described_class.new(item) }
-
-    it 'sets attributes' do
-      view[:title] = 'Donkey'
-      expect(view[:title]).to eq('Donkey')
-    end
-  end
-
-  describe '#update_attributes' do
-    let(:item) { Nanoc::Int::Item.new('content', {}, '/asdf/') }
-    let(:view) { described_class.new(item) }
-
-    let(:update) { { friend: 'Giraffe' } }
-
-    subject { view.update_attributes(update) }
-
-    it 'sets attributes' do
-      expect { subject }.to change { view[:friend] }.from(nil).to('Giraffe')
-    end
-
-    it 'returns self' do
-      expect(subject).to equal(view)
-    end
-  end
+  let(:entity_class) { Nanoc::Int::Item }
+  it_behaves_like 'a mutable document view'
 end

--- a/spec/nanoc/base/views/mutable_layout_spec.rb
+++ b/spec/nanoc/base/views/mutable_layout_spec.rb
@@ -1,11 +1,4 @@
 describe Nanoc::MutableLayoutView do
-  describe '#[]=' do
-    let(:layout) { Nanoc::Int::Layout.new('content', {}, '/asdf/') }
-    let(:view) { described_class.new(layout) }
-
-    it 'sets attributes' do
-      view[:title] = 'Donkey'
-      expect(view[:title]).to eq('Donkey')
-    end
-  end
+  let(:entity_class) { Nanoc::Int::Layout }
+  it_behaves_like 'a mutable document view'
 end


### PR DESCRIPTION
This DRYs up some view code.

It also makes `#update_attributes` available for layout views.

I’m not super happy with the use of mixins here, but it does the job and makes the code cleaner. I’ll probably revisit this at some point.