### PR TITLE
Require absolute filenames

### DIFF
--- a/lib/nanoc/base/entities/content.rb
+++ b/lib/nanoc/base/entities/content.rb
@@ -15,6 +15,10 @@ module Nanoc
 
       # @param [String, nil] filename
       def initialize(filename)
+        if filename && !filename.start_with?('/')
+          raise ArgumentError, 'Content filename is not absolute'
+        end
+
         @filename = filename
       end
 

--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -96,11 +96,12 @@ module Nanoc::DataSources
           attributes[:mtime] = mtime
 
           # Create content
+          full_content_filename = content_filename && File.expand_path(content_filename)
           content =
             if is_binary
-              Nanoc::Int::BinaryContent.new(content_or_filename)
+              Nanoc::Int::BinaryContent.new(full_content_filename)
             else
-              Nanoc::Int::TextualContent.new(content_or_filename, filename: content_filename)
+              Nanoc::Int::TextualContent.new(content_or_filename, filename: full_content_filename)
             end
 
           # Create object

--- a/spec/nanoc/base/entities/content_spec.rb
+++ b/spec/nanoc/base/entities/content_spec.rb
@@ -65,12 +65,20 @@ describe Nanoc::Int::TextualContent do
       end
     end
 
-    context 'with filename' do
+    context 'with absolute filename' do
       let(:content) { described_class.new('foo', filename: '/foo.md') }
 
       it 'sets string and filename' do
         expect(content.string).to eq('foo')
         expect(content.filename).to eq('/foo.md')
+      end
+    end
+
+    context 'with relative filename' do
+      let(:content) { described_class.new('foo', filename: 'foo.md') }
+
+      it 'errors' do
+        expect { content }.to raise_error
       end
     end
   end
@@ -105,11 +113,19 @@ describe Nanoc::Int::BinaryContent do
     it 'sets filename' do
       expect(content.filename).to eql('/foo.dat')
     end
+
+    context 'with relative filename' do
+      let(:content) { described_class.new('foo.dat') }
+
+      it 'errors' do
+        expect { content }.to raise_error
+      end
+    end
   end
 
   describe '#binary?' do
     subject { content.binary? }
-    let(:content) { described_class.new('foo') }
+    let(:content) { described_class.new('/foo.dat') }
     it { is_expected.to eql(true) }
   end
 

--- a/test/base/test_item_rep.rb
+++ b/test/base/test_item_rep.rb
@@ -529,7 +529,7 @@ class Nanoc::Int::ItemRepTest < Nanoc::TestCase
   end
 
   def test_access_compiled_content_of_binary_item
-    content = Nanoc::Int::BinaryContent.new('content/somefile.dat')
+    content = Nanoc::Int::BinaryContent.new(File.expand_path('content/somefile.dat'))
     item = Nanoc::Int::Item.new(content, {}, '/somefile/')
     item_rep = Nanoc::Int::ItemRep.new(item, :foo)
     assert_raises(Nanoc::Int::Errors::CannotGetCompiledContentOfBinaryItem) do
@@ -542,7 +542,7 @@ class Nanoc::Int::ItemRepTest < Nanoc::TestCase
     FileUtils.mkdir_p('content')
     File.open('content/meow.dat', 'w') { |io| io.write('asdf') }
     item = Nanoc::Int::Item.new(
-      Nanoc::Int::BinaryContent.new('content/meow.dat'), {}, '/')
+      Nanoc::Int::BinaryContent.new(File.expand_path('content/meow.dat')), {}, '/')
 
     # Create rep
     item_rep = Nanoc::Int::ItemRep.new(item, :foo)
@@ -568,7 +568,7 @@ class Nanoc::Int::ItemRepTest < Nanoc::TestCase
     FileUtils.mkdir_p('content')
     File.open('content/meow.dat', 'w') { |io| io.write('asdf') }
     item = Nanoc::Int::Item.new(
-      Nanoc::Int::BinaryContent.new('content/meow.dat'), {}, '/')
+      Nanoc::Int::BinaryContent.new(File.expand_path('content/meow.dat')), {}, '/')
 
     # Create rep
     item_rep = Nanoc::Int::ItemRep.new(item, :foo)

--- a/test/data_sources/test_filesystem_unified.rb
+++ b/test/data_sources/test_filesystem_unified.rb
@@ -107,7 +107,7 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
     # Check
     assert_equal 1, items.size
     assert items[0].content.binary?
-    assert_equal 'foo/stuff.dat', items[0].content.filename
+    assert_equal "#{Dir.getwd}/foo/stuff.dat", items[0].content.filename
     assert_equal Nanoc::Int::BinaryContent, items[0].content.class
   end
 


### PR DESCRIPTION
This removes a dependency on the current working directory.

Documentation changes:

* Filenames used when generating items or layouts need to be absolute.