### PR TITLE
Use content entity in reps

### DIFF
--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -260,9 +260,9 @@ module Nanoc::Int
     # @api private
     def assigns_for(rep)
       if rep.binary?
-        content_or_filename_assigns = { filename: rep.temporary_filenames[:last] }
+        content_or_filename_assigns = { filename: rep.content_snapshots[:last].filename }
       else
-        content_or_filename_assigns = { content: rep.content[:last] }
+        content_or_filename_assigns = { content: rep.content_snapshots[:last].string }
       end
 
       # TODO: Do not expose @site (necessary for captures store though…)
@@ -371,7 +371,7 @@ module Nanoc::Int
       if !rep.item.forced_outdated? && !outdatedness_checker.outdated?(rep) && compiled_content_cache[rep]
         # Reuse content
         Nanoc::Int::NotificationCenter.post(:cached_content_used, rep)
-        rep.content = compiled_content_cache[rep]
+        rep.content_snapshots = compiled_content_cache[rep]
       else
         # Recalculate content
         rep.snapshot(:raw)
@@ -382,7 +382,7 @@ module Nanoc::Int
       end
 
       rep.compiled = true
-      compiled_content_cache[rep] = rep.content
+      compiled_content_cache[rep] = rep.content_snapshots
 
       Nanoc::Int::NotificationCenter.post(:processing_ended,  rep)
       Nanoc::Int::NotificationCenter.post(:compilation_ended, rep)

--- a/lib/nanoc/base/item_rep_writer.rb
+++ b/lib/nanoc/base/item_rep_writer.rb
@@ -11,13 +11,15 @@ module Nanoc::Int
       is_created = !File.file?(raw_path)
 
       # Notify
-      Nanoc::Int::NotificationCenter.post(:will_write_rep, item_rep, raw_path)
+      Nanoc::Int::NotificationCenter.post(
+        :will_write_rep, item_rep, raw_path)
 
-      if item_rep.binary?
-        temp_path = item_rep.temporary_filenames[:last]
+      content = item_rep.content_snapshots[:last]
+      if content.binary?
+        temp_path = content.filename
       else
         temp_path = temp_filename
-        File.write(temp_path, item_rep.content[:last])
+        File.write(temp_path, content.string)
       end
 
       # Check whether content was modified
@@ -27,7 +29,8 @@ module Nanoc::Int
       FileUtils.cp(temp_path, raw_path) if is_modified
 
       # Notify
-      Nanoc::Int::NotificationCenter.post(:rep_written, item_rep, raw_path, is_created, is_modified)
+      Nanoc::Int::NotificationCenter.post(
+        :rep_written, item_rep, raw_path, is_created, is_modified)
     end
 
     def temp_filename

--- a/lib/nanoc/helpers/capturing.rb
+++ b/lib/nanoc/helpers/capturing.rb
@@ -113,8 +113,7 @@ module Nanoc::Helpers
             @site.unwrap.captures_store_compiled_items << item
             item.forced_outdated = true
             item.reps.each do |r|
-              raw_content = item.content.string
-              r.content = { raw: raw_content, last: raw_content }
+              r.content_snapshots = { last: item.content }
               raise Nanoc::Int::Errors::UnmetDependency.new(r)
             end
           end

--- a/spec/nanoc/base/entities/content_spec.rb
+++ b/spec/nanoc/base/entities/content_spec.rb
@@ -97,10 +97,12 @@ describe Nanoc::Int::TextualContent do
     end
 
     it 'prevents changes to string' do
+      expect(content.string).to be_frozen
       expect { content.string << 'asdf' }.to raise_frozen_error
     end
 
     it 'prevents changes to filename' do
+      expect(content.filename).to be_frozen
       expect { content.filename << 'asdf' }.to raise_frozen_error
     end
   end
@@ -137,6 +139,7 @@ describe Nanoc::Int::BinaryContent do
     end
 
     it 'prevents changes' do
+      expect(content.filename).to be_frozen
       expect { content.filename << 'asdf' }.to raise_frozen_error
     end
   end

--- a/spec/nanoc/base/item_rep_writer_spec.rb
+++ b/spec/nanoc/base/item_rep_writer_spec.rb
@@ -6,17 +6,14 @@ describe Nanoc::Int::ItemRepWriter do
 
     let(:item_rep) do
       Nanoc::Int::ItemRep.new(item, :default).tap do |ir|
-        ir.content = content
-        ir.temporary_filenames.replace(temporary_filenames)
+        ir.content_snapshots = content_snapshots
       end
     end
 
-    let(:content) do
-      { last: 'last content' }
-    end
-
-    let(:temporary_filenames) do
-      {}
+    let(:content_snapshots) do
+      {
+        last: Nanoc::Int::TextualContent.new('last content'),
+      }
     end
 
     subject { described_class.new.write(item_rep, raw_path) }
@@ -28,10 +25,14 @@ describe Nanoc::Int::ItemRepWriter do
     context 'binary item rep' do
       let(:orig_content) { Nanoc::Int::BinaryContent.new('/foo.dat') }
 
-      let(:temporary_filenames) { { last: 'input.dat' } }
+      let(:content_snapshots) do
+        {
+          last: Nanoc::Int::BinaryContent.new('/input.dat'),
+        }
+      end
 
       it 'copies' do
-        File.write(temporary_filenames[:last], 'binary stuff')
+        File.write(content_snapshots[:last].filename, 'binary stuff')
 
         expect(Nanoc::Int::NotificationCenter).to receive(:post)
           .with(:will_write_rep, item_rep, 'output/blah.dat')
@@ -47,7 +48,7 @@ describe Nanoc::Int::ItemRepWriter do
         let(:old_mtime) { (Time.now - 600).to_i }
 
         before do
-          File.write(temporary_filenames[:last], 'binary stuff')
+          File.write(content_snapshots[:last].filename, 'binary stuff')
 
           FileUtils.mkdir_p('output')
           File.write('output/blah.dat', old_content)


### PR DESCRIPTION
This lets item reps use the `Content` entity, which cleans up the code a little.