### PR TITLE
Fix freezing

### DIFF
--- a/lib/nanoc/base/entities/content.rb
+++ b/lib/nanoc/base/entities/content.rb
@@ -22,6 +22,11 @@ module Nanoc
         @filename = filename
       end
 
+      def freeze
+        super
+        @filename.freeze
+      end
+
       # @param [String] content The uncompiled item content (if it is textual
       #   content) or the path to the filename containing the content (if this
       #   is binary content).
@@ -59,6 +64,11 @@ module Nanoc
       def initialize(string, params = {})
         super(params[:filename])
         @string = string
+      end
+
+      def freeze
+        super
+        @string.freeze
       end
 
       def binary?

--- a/lib/nanoc/base/source_data/item.rb
+++ b/lib/nanoc/base/source_data/item.rb
@@ -21,6 +21,11 @@ module Nanoc::Int
       @forced_outdated_status = ForcedOutdatedStatus.new
     end
 
+    def freeze
+      super
+      @children.freeze
+    end
+
     # Returns the rep with the given name.
     #
     # @param [Symbol] rep_name The name of the representation to return

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,7 @@ RSpec::Matchers.define :raise_frozen_error do |expected|
   match do |actual|
     begin
       actual.call
+      false
     rescue => e
       unless e.is_a?(RuntimeError) || e.is_a?(TypeError)
         false


### PR DESCRIPTION
The freeze tests didn’t check whether an error was raised at all; just that *if* an error is raised, it is the correct one.