### PR TITLE
Prevent double-wrapping layout in rendering helper

### DIFF
--- a/lib/nanoc/helpers/rendering.rb
+++ b/lib/nanoc/helpers/rendering.rb
@@ -92,7 +92,7 @@ module Nanoc::Helpers
         item: @item,
         item_rep: @item_rep,
         items: @items,
-        layout: Nanoc::LayoutView.new(layout), # FIXME: this does not need to be rewrapped
+        layout: layout,
         layouts: @layouts,
         config: @config,
         site: @site

--- a/test/helpers/test_rendering.rb
+++ b/test/helpers/test_rendering.rb
@@ -52,6 +52,23 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
     end
   end
 
+  def test_render_wrapped_class
+    with_site do |site|
+      File.open('Rules', 'w') do |io|
+        io.write("layout '/foo/', :erb\n")
+      end
+
+      File.open('layouts/foo.erb', 'w') do |io|
+        io.write 'I am the <%= @layout.unwrap.class %> class.'
+      end
+
+      @site = Nanoc::SiteView.new(site)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
+
+      assert_equal('I am the Nanoc::Int::Layout class.', render('/foo/'))
+    end
+  end
+
   def test_render_with_unknown_layout
     with_site do |site|
       @site = Nanoc::SiteView.new(site)


### PR DESCRIPTION
Potential fix for #628. @cdlm, can you verify that this indeed solves your case?

In the rendering helper, the layout (`@layout`) is wrapped twice inside a `Nanoc::LayoutView` instance. It even had a `FIXME`!