### PR TITLE
Enforce trailing comma

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,10 @@
+# ----- CONFIGURED -----
+
+TrailingComma:
+  EnforcedStyleForMultiline: comma
+
+
+
 # ----- TO ENABLE LATER -----
 # To make merges easier, I’ve decided to enable these at a later point in time.
 
@@ -131,11 +138,6 @@ SignalException:
 # single value) should still not be considered to be accessors. This is a purely
 # semantic difference.
 TrivialAccessors:
-  Enabled: false
-
-# Trailing commas improve diffs. One could argue that diff algorithms should be
-# able to handle this, but they cannot, so this is disabled.
-TrailingComma:
   Enabled: false
 
 # This does not always semantically make sense.

--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -451,7 +451,7 @@ module Nanoc::Int
         checksum_store,
         compiled_content_cache,
         dependency_tracker,
-        rule_memory_store
+        rule_memory_store,
       ]
     end
   end

--- a/lib/nanoc/base/compilation/dependency_tracker.rb
+++ b/lib/nanoc/base/compilation/dependency_tracker.rb
@@ -159,7 +159,7 @@ module Nanoc::Int
     def data
       {
         edges: @graph.edges,
-        vertices: @graph.vertices.map { |obj| obj && obj.reference }
+        vertices: @graph.vertices.map { |obj| obj && obj.reference },
       }
     end
 

--- a/lib/nanoc/base/plugin_registry.rb
+++ b/lib/nanoc/base/plugin_registry.rb
@@ -183,7 +183,7 @@ module Nanoc::Int
             plugins << {
               class: klass,
               superclass: superclass,
-              identifiers: [identifier]
+              identifiers: [identifier],
             }
           end
         end

--- a/lib/nanoc/base/services/recording_executor.rb
+++ b/lib/nanoc/base/services/recording_executor.rb
@@ -7,11 +7,11 @@ module Nanoc
         @rule_memory = []
       end
 
-      def filter(rep, filter_name, filter_args = {})
+      def filter(_rep, filter_name, filter_args = {})
         @rule_memory << [:filter, filter_name, filter_args]
       end
 
-      def layout(rep, layout_identifier, extra_filter_args = nil)
+      def layout(_rep, layout_identifier, extra_filter_args = nil)
         if extra_filter_args
           @rule_memory << [:layout, layout_identifier, extra_filter_args]
         else
@@ -19,7 +19,7 @@ module Nanoc
         end
       end
 
-      def snapshot(rep, snapshot_name, params = {})
+      def snapshot(_rep, snapshot_name, params = {})
         @rule_memory << [:snapshot, snapshot_name, params]
 
         # Count
@@ -33,7 +33,7 @@ module Nanoc
         end
       end
 
-      def record_write(rep, path)
+      def record_write(_rep, path)
         @rule_memory << [:write, path]
       end
     end

--- a/lib/nanoc/base/source_data/site.rb
+++ b/lib/nanoc/base/source_data/site.rb
@@ -90,7 +90,7 @@ module Nanoc::Int
             self,
             data_source_hash[:items_root],
             data_source_hash[:layouts_root],
-            data_source_hash.merge(data_source_hash[:config] || {})
+            data_source_hash.merge(data_source_hash[:config] || {}),
           )
         end
       end
@@ -307,7 +307,7 @@ module Nanoc::Int
         code_snippets = Dir["#{lib}/**/*.rb"].sort.map do |filename|
           Nanoc::Int::CodeSnippet.new(
             File.read(filename),
-            filename
+            filename,
           )
         end
         @code_snippets.concat(code_snippets)

--- a/lib/nanoc/cli/ansi_string_colorizer.rb
+++ b/lib/nanoc/cli/ansi_string_colorizer.rb
@@ -10,7 +10,7 @@ module Nanoc::CLI
       red: "\e[31m",
       green: "\e[32m",
       yellow: "\e[33m",
-      blue: "\e[34m"
+      blue: "\e[34m",
     }
 
     # @param [String] s The string to colorize

--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -396,7 +396,7 @@ module Nanoc::CLI::Commands
         Nanoc::CLI::Commands::Compile::DebugPrinter,
         Nanoc::CLI::Commands::Compile::TimingRecorder,
         Nanoc::CLI::Commands::Compile::GCController,
-        Nanoc::CLI::Commands::Compile::FileActionPrinter
+        Nanoc::CLI::Commands::Compile::FileActionPrinter,
       ]
     end
 

--- a/lib/nanoc/cli/commands/show-plugins.rb
+++ b/lib/nanoc/cli/commands/show-plugins.rb
@@ -32,7 +32,7 @@ module Nanoc::CLI::Commands
       PLUGIN_CLASS_ORDER.each do |superclass|
         plugins_with_this_superclass = {
           builtin: plugins_builtin.select { |p| p[:superclass] == superclass },
-          custom: plugins_custom.select  { |p| p[:superclass] == superclass }
+          custom: plugins_custom.select  { |p| p[:superclass] == superclass },
         }
 
         # Print kind
@@ -58,7 +58,7 @@ module Nanoc::CLI::Commands
             puts format(
               "    %-#{max_identifiers_length}s (%s)",
               plugin[:identifiers].join(', '),
-              plugin[:class].to_s.sub(/^::/, '')
+              plugin[:class].to_s.sub(/^::/, ''),
             )
           end
         end
@@ -72,13 +72,13 @@ module Nanoc::CLI::Commands
     PLUGIN_CLASS_ORDER = [
       Nanoc::Filter,
       Nanoc::DataSource,
-      Nanoc::Extra::Deployer
+      Nanoc::Extra::Deployer,
     ] unless defined? PLUGIN_CLASS_ORDER
 
     PLUGIN_CLASSES = {
       Nanoc::Filter          => 'Filters',
       Nanoc::DataSource      => 'Data Sources',
-      Nanoc::Extra::Deployer => 'Deployers'
+      Nanoc::Extra::Deployer => 'Deployers',
     } unless defined? PLUGIN_CLASSES
 
     def name_for_plugin_class(klass)

--- a/lib/nanoc/cli/commands/view.rb
+++ b/lib/nanoc/cli/commands/view.rb
@@ -24,7 +24,7 @@ module Nanoc::CLI::Commands
       # Set options
       options_for_rack = {
         Port: (options[:port] || 3000).to_i,
-        Host: (options[:host] || '0.0.0.0')
+        Host: (options[:host] || '0.0.0.0'),
       }
 
       # Get handler

--- a/lib/nanoc/cli/error_handler.rb
+++ b/lib/nanoc/cli/error_handler.rb
@@ -207,7 +207,7 @@ module Nanoc::CLI
       'redcloth'       => 'RedCloth',
       'rubypants'      => 'rubypants',
       'sass'           => 'sass',
-      'w3c_validators' => 'w3c_validators'
+      'w3c_validators' => 'w3c_validators',
     }
 
     # Attempts to find a resolution for the given error, or nil if no

--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -169,7 +169,7 @@ module Nanoc::DataSources
     # basename before concatenating it with a period and the extension).
     def filename_for(_base_filename, _ext)
       raise NotImplementedError.new(
-        "#{self.class} does not implement #filename_for"
+        "#{self.class} does not implement #filename_for",
       )
     end
 
@@ -177,7 +177,7 @@ module Nanoc::DataSources
     # can be the content filename or the meta filename.
     def identifier_for_filename(_filename)
       raise NotImplementedError.new(
-        "#{self.class} does not implement #identifier_for_filename"
+        "#{self.class} does not implement #identifier_for_filename",
       )
     end
 
@@ -234,7 +234,7 @@ module Nanoc::DataSources
       pieces = data.split(/^(-{5}|-{3})[ \t]*\r?\n?/, 3)
       if pieces.size < 4
         raise RuntimeError.new(
-          "The file '#{content_filename}' appears to start with a metadata section (three or five dashes at the top) but it does not seem to be in the correct format."
+          "The file '#{content_filename}' appears to start with a metadata section (three or five dashes at the top) but it does not seem to be in the correct format.",
         )
       end
 

--- a/lib/nanoc/extra/deployers/rsync.rb
+++ b/lib/nanoc/extra/deployers/rsync.rb
@@ -32,7 +32,7 @@ module Nanoc::Extra::Deployers
       '--compress',
       '--exclude=".hg"',
       '--exclude=".svn"',
-      '--exclude=".git"'
+      '--exclude=".git"',
     ]
 
     # @see Nanoc::Extra::Deployer#run

--- a/lib/nanoc/extra/link_collector.rb
+++ b/lib/nanoc/extra/link_collector.rb
@@ -11,7 +11,7 @@ module ::Nanoc::Extra
       'img' => :src,
       'link' => :href,
       'script' => :src,
-      'video' => :src
+      'video' => :src,
     }
 
     def initialize(filenames, mode = nil)

--- a/lib/nanoc/helpers/rendering.rb
+++ b/lib/nanoc/helpers/rendering.rb
@@ -95,7 +95,7 @@ module Nanoc::Helpers
         layout: layout,
         layouts: @layouts,
         config: @config,
-        site: @site
+        site: @site,
       }.merge(other_assigns)
 
       # Get filter name

--- a/spec/nanoc/base/checksummer_spec.rb
+++ b/spec/nanoc/base/checksummer_spec.rb
@@ -123,7 +123,7 @@ describe Nanoc::Int::Checksummer do
   end
 
   context 'Time' do
-    let(:obj) { Time.at(111223) }
+    let(:obj) { Time.at(111_223) }
     it { is_expected.to eql('Time<111223>') }
   end
 

--- a/spec/nanoc/base/services/executor_spec.rb
+++ b/spec/nanoc/base/services/executor_spec.rb
@@ -90,7 +90,7 @@ describe Nanoc::Int::Executor do
         File.write('/foo.dat', 'Foo Data')
 
         filter_class = Class.new(::Nanoc::Filter) do
-          type :binary => :text
+          type binary: :text
 
           def run(filename, _params = {})
             "Compiled data for #{filename}"
@@ -117,7 +117,7 @@ describe Nanoc::Int::Executor do
           .to receive(:post).with(:filtering_ended, rep, :whatever)
 
         filter_class = Class.new(::Nanoc::Filter) do
-          type :text => :binary
+          type text: :binary
 
           def run(content, _params = {})
             File.write(output_filename, "Binary #{content}")
@@ -149,7 +149,7 @@ describe Nanoc::Int::Executor do
         filter_class = Class.new(::Nanoc::Filter) do
           type :binary
 
-          def run(content, _params = {})
+          def run(_content, _params = {})
           end
         end
 
@@ -185,7 +185,7 @@ describe Nanoc::Int::Executor do
         filter_class = Class.new(::Nanoc::Filter) do
           type :binary
 
-          def run(filename, _params = {})
+          def run(_filename, _params = {})
           end
         end
 
@@ -381,7 +381,7 @@ describe Nanoc::Int::Executor do
 
       context 'raw path' do
         before do
-          rep.raw_paths = { :something => 'output/donkey.md' }
+          rep.raw_paths = { something: 'output/donkey.md' }
         end
 
         it 'writes' do

--- a/spec/nanoc/base/views/item_rep_spec.rb
+++ b/spec/nanoc/base/views/item_rep_spec.rb
@@ -82,7 +82,7 @@ describe Nanoc::ItemRepView do
 
     let(:rep) do
       Nanoc::Int::ItemRep.new(item, :default).tap do |ir|
-        ir.compiled = true,
+        ir.compiled = true
         ir.snapshot_contents = {
           last: Nanoc::Int::TextualContent.new('Hallo'),
         }

--- a/spec/nanoc/base/views/item_spec.rb
+++ b/spec/nanoc/base/views/item_spec.rb
@@ -72,7 +72,7 @@ describe Nanoc::ItemView do
 
     let(:rep) do
       Nanoc::Int::ItemRep.new(item, :default).tap do |ir|
-        ir.compiled = true,
+        ir.compiled = true
         ir.snapshot_defs = [
           Nanoc::Int::SnapshotDef.new(:last, false),
           Nanoc::Int::SnapshotDef.new(:specific, true),

--- a/spec/nanoc/helpers/blogging_spec.rb
+++ b/spec/nanoc/helpers/blogging_spec.rb
@@ -16,7 +16,7 @@ describe Nanoc::Helpers::Blogging do
       Nanoc::Int::Item.new(
         'blah',
         { kind: 'item' },
-        '/0/'
+        '/0/',
       )
     end
 
@@ -24,7 +24,7 @@ describe Nanoc::Helpers::Blogging do
       Nanoc::Int::Item.new(
         'blah blah',
         { kind: 'article' },
-        '/1/'
+        '/1/',
       )
     end
 
@@ -32,7 +32,7 @@ describe Nanoc::Helpers::Blogging do
       Nanoc::Int::Item.new(
         'blah blah blah',
         { kind: 'article' },
-        '/2/'
+        '/2/',
       )
     end
 
@@ -60,7 +60,7 @@ describe Nanoc::Helpers::Blogging do
       Nanoc::Int::Item.new(
         'blah',
         { kind: 'item' },
-        '/0/'
+        '/0/',
       )
     end
 
@@ -68,7 +68,7 @@ describe Nanoc::Helpers::Blogging do
       Nanoc::Int::Item.new(
         'blah blah',
         { kind: 'article', created_at: (Date.today - 1).to_s },
-        '/1/'
+        '/1/',
       )
     end
 
@@ -76,7 +76,7 @@ describe Nanoc::Helpers::Blogging do
       Nanoc::Int::Item.new(
         'blah blah blah',
         { kind: 'article', created_at: (Time.now - 500).to_s },
-        '/2/'
+        '/2/',
       )
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,7 +23,7 @@ RSpec.configure do |c|
   end
 end
 
-RSpec::Matchers.define :raise_frozen_error do |expected|
+RSpec::Matchers.define :raise_frozen_error do |_expected|
   match do |actual|
     begin
       actual.call
@@ -39,11 +39,11 @@ RSpec::Matchers.define :raise_frozen_error do |expected|
 
   supports_block_expectations
 
-  failure_message do |actual|
+  failure_message do |_actual|
     'expected that proc would raise a frozen error'
   end
 
-  failure_message_when_negated do |actual|
+  failure_message_when_negated do |_actual|
     'expected that proc would not raise a frozen error'
   end
 end

--- a/tasks/doc.rake
+++ b/tasks/doc.rake
@@ -11,6 +11,6 @@ YARD::Rake::YardocTask.new(:doc) do |yard|
     '--output-dir',      'doc/yardoc',
     '--template-path',   'doc/yardoc_templates',
     '--load',            'doc/yardoc_handlers/identifier.rb',
-    '--query',           '@api.text != "private"',
+    '--query',           '@api.text != "private"'
   ]
 end

--- a/test/base/test_compiler.rb
+++ b/test/base/test_compiler.rb
@@ -116,7 +116,7 @@ class Nanoc::Int::CompilerTest < Nanoc::TestCase
       0 => 'd',
       1 => 'b', # never used! not c, because b takes priority
       2 => 'b',
-      3 => 'a'
+      3 => 'a',
     }
 
     # Check
@@ -137,7 +137,7 @@ class Nanoc::Int::CompilerTest < Nanoc::TestCase
       raw: 'raw.txt',
       pre: 'pre.txt',
       post: 'post.txt',
-      last: 'last.txt'
+      last: 'last.txt',
     }
 
     # Create rule

--- a/test/base/test_item.rb
+++ b/test/base/test_item.rb
@@ -10,7 +10,7 @@ class Nanoc::Int::ItemTest < Nanoc::TestCase
     item = Nanoc::Int::Item.new(
       'content',
       { one: 'one in item' },
-      '/path/'
+      '/path/',
     )
 
     assert_equal([:item, '/path/'], item.reference)

--- a/test/base/test_item_rep.rb
+++ b/test/base/test_item_rep.rb
@@ -2,7 +2,7 @@ class Nanoc::Int::ItemRepTest < Nanoc::TestCase
   def test_compiled_content_with_only_last_available
     # Create rep
     item = Nanoc::Int::Item.new(
-      'blah blah blah', {}, '/',
+      'blah blah blah', {}, '/'
     )
     rep = Nanoc::Int::ItemRep.new(item, nil)
     rep.snapshot_contents = {
@@ -17,7 +17,7 @@ class Nanoc::Int::ItemRepTest < Nanoc::TestCase
   def test_compiled_content_with_pre_and_last_available
     # Create rep
     item = Nanoc::Int::Item.new(
-      'blah blah blah', {}, '/',
+      'blah blah blah', {}, '/'
     )
     rep = Nanoc::Int::ItemRep.new(item, nil)
     rep.snapshot_contents = {
@@ -33,7 +33,7 @@ class Nanoc::Int::ItemRepTest < Nanoc::TestCase
   def test_compiled_content_with_custom_snapshot
     # Create rep
     item = Nanoc::Int::Item.new(
-      'blah blah blah', {}, '/',
+      'blah blah blah', {}, '/'
     )
     rep = Nanoc::Int::ItemRep.new(item, nil)
     rep.snapshot_contents = {
@@ -49,7 +49,7 @@ class Nanoc::Int::ItemRepTest < Nanoc::TestCase
   def test_compiled_content_with_invalid_snapshot
     # Create rep
     item = Nanoc::Int::Item.new(
-      'blah blah blah', {}, '/',
+      'blah blah blah', {}, '/'
     )
     rep = Nanoc::Int::ItemRep.new(item, nil)
     rep.snapshot_contents = {
@@ -66,7 +66,7 @@ class Nanoc::Int::ItemRepTest < Nanoc::TestCase
   def test_compiled_content_with_uncompiled_content
     # Create rep
     item = Nanoc::Int::Item.new(
-      'blah blah', {}, '/',
+      'blah blah', {}, '/'
     )
     rep = Nanoc::Int::ItemRep.new(item, nil)
     rep.expects(:compiled?).returns(false)
@@ -80,7 +80,7 @@ class Nanoc::Int::ItemRepTest < Nanoc::TestCase
   def test_compiled_content_with_moving_pre_snapshot
     # Create rep
     item = Nanoc::Int::Item.new(
-      'blah blah', {}, '/',
+      'blah blah', {}, '/'
     )
     rep = Nanoc::Int::ItemRep.new(item, nil)
     rep.expects(:compiled?).returns(false)
@@ -98,7 +98,7 @@ class Nanoc::Int::ItemRepTest < Nanoc::TestCase
   def test_compiled_content_with_non_moving_pre_snapshot
     # Create rep
     item = Nanoc::Int::Item.new(
-      'blah blah', {}, '/',
+      'blah blah', {}, '/'
     )
     rep = Nanoc::Int::ItemRep.new(item, nil)
     rep.expects(:compiled?).returns(false)

--- a/test/base/test_site.rb
+++ b/test/base/test_site.rb
@@ -75,7 +75,7 @@ EOF
     end
     assert_equal(
       "Could not find parent configuration file 'foo/foo.yaml'",
-      error.message
+      error.message,
     )
   end
 
@@ -99,7 +99,7 @@ EOF
     end
     assert_equal(
       "Cycle detected. Could not use parent configuration file '../nanoc.yaml'",
-      error.message
+      error.message,
     )
   end
 
@@ -313,8 +313,8 @@ describe 'Nanoc::Int::Site#data_sources' do
     proc do
       site = Nanoc::Int::Site.new(
         data_sources: [
-          { type: 'fklsdhailfdjalghlkasdflhagjskajdf' }
-        ]
+          { type: 'fklsdhailfdjalghlkasdflhagjskajdf' },
+        ],
       )
       site.data_sources
     end.must_raise Nanoc::Int::Errors::UnknownDataSource

--- a/test/cli/commands/test_compile.rb
+++ b/test/cli/commands/test_compile.rb
@@ -219,7 +219,7 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
         level: level,
         action: action,
         path: path,
-        duration: duration
+        duration: duration,
       }
     end
 

--- a/test/data_sources/test_filesystem.rb
+++ b/test/data_sources/test_filesystem.rb
@@ -40,7 +40,7 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
     output_expected = {
       './foo'       => ['yaml', ['html']],
       './bar.entry' => [nil,    ['html']],
-      './foo/qux'   => ['yaml', [nil]]
+      './foo/qux'   => ['yaml', [nil]],
     }
     output_actual = data_source.send :all_split_files_in, '.'
 
@@ -67,7 +67,7 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
     output_expected = {
       './foo'       => ['yaml', ['html']],
       './bar'       => [nil,    ['html.erb']],
-      './foo/qux'   => ['yaml', [nil]]
+      './foo/qux'   => ['yaml', [nil]],
     }
     output_actual = data_source.send :all_split_files_in, '.'
 
@@ -89,7 +89,7 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
     expected = {
       './aaa/foo' => [nil, ['html']],
       './bbb/foo' => [nil, ['html']],
-      './ccc/foo' => [nil, ['html']]
+      './ccc/foo' => [nil, ['html']],
     }
     assert_equal expected, data_source.send(:all_split_files_in, '.')
   end
@@ -146,7 +146,7 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
       '/foo/bar.xyz.html' => '/foo/bar.xyz',
       '/foo/bar/'         => '/foo/bar/',
       '/foo/bar.xyz/'     => '/foo/bar.xyz/',
-      '/foo.xyz/bar.xyz/' => '/foo.xyz/bar.xyz/'
+      '/foo.xyz/bar.xyz/' => '/foo.xyz/bar.xyz/',
     }
 
     # Check
@@ -176,7 +176,7 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
       '/foo/bar.xyz.html' => '/foo/bar',
       '/foo/bar/'         => '/foo/bar/',
       '/foo/bar.xyz/'     => '/foo/bar.xyz/',
-      '/foo.xyz/bar.xyz/' => '/foo.xyz/bar.xyz/'
+      '/foo.xyz/bar.xyz/' => '/foo.xyz/bar.xyz/',
     }
 
     # Check
@@ -206,7 +206,7 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
       '/foo/bar.xyz.html' => '.html',
       '/foo/bar/'         => '',
       '/foo/bar.xyz/'     => '',
-      '/foo.xyz/bar.xyz/' => ''
+      '/foo.xyz/bar.xyz/' => '',
     }
 
     # Check
@@ -236,7 +236,7 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
       '/foo/bar.xyz.html' => '.xyz.html',
       '/foo/bar/'         => '',
       '/foo/bar.xyz/'     => '',
-      '/foo.xyz/bar.xyz/' => ''
+      '/foo.xyz/bar.xyz/' => '',
     }
 
     # Check

--- a/test/data_sources/test_filesystem_unified.rb
+++ b/test/data_sources/test_filesystem_unified.rb
@@ -53,7 +53,7 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
         'test 3',
         { 'num' => 3, :filename => 'foo/a/b/c.html', :extension => 'html', mtime: File.mtime('foo/a/b/c.html') },
         '/a/b/c/',
-      )
+      ),
     ]
     actual_out = data_source.send(:load_objects, 'foo', 'The Foo', klass).sort_by { |i| i.stuff[0].string }
 
@@ -171,7 +171,7 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
       '/foo'            => '/foo/',
       '/foo.html'       => '/foo/',
       '/foo/index.html' => '/foo/',
-      '/foo.entry.html' => '/foo.entry/'
+      '/foo.entry.html' => '/foo.entry/',
     }
 
     # Check
@@ -193,7 +193,7 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
       '/foo'            => '/foo/',
       '/foo.html'       => '/foo/',
       '/foo/index.html' => '/foo/',
-      '/foo.html.erb'   => '/foo/'
+      '/foo.html.erb'   => '/foo/',
     }
 
     # Check
@@ -217,7 +217,7 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
       'foo/qux.bar.qux.yaml' => '/foo/qux.bar.qux/',
       'foo/index.yaml'       => '/foo/',
       'index.yaml'           => '/',
-      'foo/blah_index.yaml'  => '/foo/blah_index/'
+      'foo/blah_index.yaml'  => '/foo/blah_index/',
     }
 
     data_source = new_data_source(allow_periods_in_identifiers: true)
@@ -226,7 +226,7 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
       [meta_filename, content_filename].each do |filename|
         assert_equal(
           expected_identifier,
-          data_source.instance_eval { identifier_for_filename(filename) }
+          data_source.instance_eval { identifier_for_filename(filename) },
         )
       end
     end
@@ -243,7 +243,7 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
       'foo/qux.bar.qux.yaml' => '/foo/qux/',
       'foo/index.yaml'       => '/foo/',
       'index.yaml'           => '/',
-      'foo/blah_index.yaml'  => '/foo/blah_index/'
+      'foo/blah_index.yaml'  => '/foo/blah_index/',
     }
 
     data_source = new_data_source
@@ -252,7 +252,7 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
       [meta_filename, content_filename].each do |filename|
         assert_equal(
           expected_identifier,
-          data_source.instance_eval { identifier_for_filename(filename) }
+          data_source.instance_eval { identifier_for_filename(filename) },
         )
       end
     end
@@ -337,7 +337,7 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
           :meta_filename    => 'foo/a/b/c.yaml',
           :extension        => nil,
           :file             => nil,
-          mtime: File.mtime('foo/a/b/c.yaml')
+          mtime: File.mtime('foo/a/b/c.yaml'),
         },
         '/a/b/c/',
       ),
@@ -349,7 +349,7 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
           :meta_filename    => 'foo/b.c.yaml',
           :extension        => 'html',
           :file             => File.open('foo/b.c.html'),
-          mtime: File.mtime('foo/b.c.html') > File.mtime('foo/b.c.yaml') ? File.mtime('foo/b.c.html') : File.mtime('foo/b.c.yaml')
+          mtime: File.mtime('foo/b.c.html') > File.mtime('foo/b.c.yaml') ? File.mtime('foo/b.c.html') : File.mtime('foo/b.c.yaml'),
         },
         '/b.c/',
       ),
@@ -360,10 +360,10 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
           meta_filename: nil,
           extension: 'html',
           file: File.open('foo/car.html'),
-          mtime: File.mtime('foo/car.html')
+          mtime: File.mtime('foo/car.html'),
         },
         '/car/',
-      )
+      ),
     ]
 
     # Get actual output ordered by identifier
@@ -419,7 +419,7 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
           :meta_filename    => 'foo/a/b/c.yaml',
           :extension        => nil,
           :file             => nil,
-          mtime: File.mtime('foo/a/b/c.yaml')
+          mtime: File.mtime('foo/a/b/c.yaml'),
         },
         '/a/b/c/',
       ),
@@ -431,7 +431,7 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
           :meta_filename    => 'foo/b.yaml',
           :extension        => 'html.erb',
           :file             => File.open('foo/b.html.erb'),
-          mtime: File.mtime('foo/b.html.erb') > File.mtime('foo/b.yaml') ? File.mtime('foo/b.html.erb') : File.mtime('foo/b.yaml')
+          mtime: File.mtime('foo/b.html.erb') > File.mtime('foo/b.yaml') ? File.mtime('foo/b.html.erb') : File.mtime('foo/b.yaml'),
         },
         '/b/',
       ),
@@ -442,10 +442,10 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
           meta_filename: nil,
           extension: 'html',
           file: File.open('foo/car.html'),
-          mtime: File.mtime('foo/car.html')
+          mtime: File.mtime('foo/car.html'),
         },
         '/car/',
-      )
+      ),
     ]
 
     # Get actual output ordered by identifier

--- a/test/extra/checking/checks/test_mixed_content.rb
+++ b/test/extra/checking/checks/test_mixed_content.rb
@@ -20,7 +20,7 @@ class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
         '<form action="https://nanoc.ws/process.cgi"></form>',
         '<iframe src="https://nanoc.ws/preview.html"></iframe>',
         '<audio src="https://nanoc.ws/theme-song.flac"></audio>',
-        '<video src="https://nanoc.ws/screen-cast.mkv"></video>'
+        '<video src="https://nanoc.ws/screen-cast.mkv"></video>',
       ])
       check = Nanoc::Extra::Checking::Checks::MixedContent.create(site)
       check.run
@@ -38,7 +38,7 @@ class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
         '<form action="/process.cgi"></form>',
         '<iframe src="/preview.html"></iframe>',
         '<audio src="/theme-song.flac"></audio>',
-        '<video src="/screen-cast.mkv"></video>'
+        '<video src="/screen-cast.mkv"></video>',
       ])
       check = Nanoc::Extra::Checking::Checks::MixedContent.create(site)
       check.run
@@ -56,7 +56,7 @@ class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
         '<form action="//nanoc.ws/process.cgi"></form>',
         '<iframe src="//nanoc.ws/preview.html"></iframe>',
         '<audio src="//nanoc.ws/theme-song.flac"></audio>',
-        '<video src="//nanoc.ws/screen-cast.mkv"></video>'
+        '<video src="//nanoc.ws/screen-cast.mkv"></video>',
       ])
       check = Nanoc::Extra::Checking::Checks::MixedContent.create(site)
       check.run
@@ -74,7 +74,7 @@ class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
         '<form action="process.cgi"></form>',
         '<iframe src="preview.html"></iframe>',
         '<audio src="theme-song.flac"></audio>',
-        '<video src="screen-cast.mkv"></video>'
+        '<video src="screen-cast.mkv"></video>',
       ])
       check = Nanoc::Extra::Checking::Checks::MixedContent.create(site)
       check.run
@@ -92,7 +92,7 @@ class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
         '<form action="?query-string"></form>',
         '<iframe src="?query-string"></iframe>',
         '<audio src="?query-string"></audio>',
-        '<video src="?query-string"></video>'
+        '<video src="?query-string"></video>',
       ])
       check = Nanoc::Extra::Checking::Checks::MixedContent.create(site)
       check.run
@@ -110,7 +110,7 @@ class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
         '<form action="#fragment"></form>',
         '<iframe src="#fragment"></iframe>',
         '<audio src="#fragment"></audio>',
-        '<video src="#fragment"></video>'
+        '<video src="#fragment"></video>',
       ])
       check = Nanoc::Extra::Checking::Checks::MixedContent.create(site)
       check.run
@@ -129,7 +129,7 @@ class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
         '<form action="http://nanoc.ws/process.cgi"></form>',
         '<iframe src="http://nanoc.ws/preview.html"></iframe>',
         '<audio src="http://nanoc.ws/theme-song.flac"></audio>',
-        '<video src="http://nanoc.ws/screencast.mkv"></video>'
+        '<video src="http://nanoc.ws/screencast.mkv"></video>',
       ])
       check = Nanoc::Extra::Checking::Checks::MixedContent.create(site)
       check.run
@@ -175,7 +175,7 @@ class Nanoc::Extra::Checking::Checks::MixedContentTest < Nanoc::TestCase
         '<iframe href="http://nanoc.ws/preview.html"></iframe>',
         '<audio href="http://nanoc.ws/theme-song.flac"></audio>',
         '<video target="http://nanoc.ws/screen-cast.mkv"></video>',
-        '<p>http://nanoc.ws/harmless-text</p>'
+        '<p>http://nanoc.ws/harmless-text</p>',
       ])
       check = Nanoc::Extra::Checking::Checks::MixedContent.create(site)
       check.run

--- a/test/extra/deployers/test_fog.rb
+++ b/test/extra/deployers/test_fog.rb
@@ -85,7 +85,7 @@ class Nanoc::Extra::Deployers::FogTest < Nanoc::TestCase
         # Run
         fog.run
       ensure
-        # HACK :(
+        # HACK: (
         ::Fog.instance_eval { @mocking = false }
       end
     end

--- a/test/extra/deployers/test_rsync.rb
+++ b/test/extra/deployers/test_rsync.rb
@@ -57,7 +57,7 @@ class Nanoc::Extra::Deployers::RsyncTest < Nanoc::TestCase
     opts = Nanoc::Extra::Deployers::Rsync::DEFAULT_OPTIONS
     assert_equal(
       ['rsync', opts, 'output/', 'asdf'].flatten,
-      rsync.instance_eval { @shell_cms_args }
+      rsync.instance_eval { @shell_cms_args },
     )
   end
 
@@ -80,7 +80,7 @@ class Nanoc::Extra::Deployers::RsyncTest < Nanoc::TestCase
     opts = Nanoc::Extra::Deployers::Rsync::DEFAULT_OPTIONS
     assert_equal(
       ['echo', 'rsync', opts, 'output/', 'asdf'].flatten,
-      rsync.instance_eval { @shell_cms_args }
+      rsync.instance_eval { @shell_cms_args },
     )
   end
 end

--- a/test/extra/test_filesystem_tools.rb
+++ b/test/extra/test_filesystem_tools.rb
@@ -28,7 +28,7 @@ class Nanoc::Extra::FilesystemToolsTest < Nanoc::TestCase
       'dir0/sub/sub/sub/sub/sub/sub/sub/foo.md',
       'dir0/sub/sub/sub/sub/sub/sub/sub/sub/foo.md',
       'dir0/sub/sub/sub/sub/sub/sub/sub/sub/sub/foo.md',
-      'dir0/sub/sub/sub/sub/sub/sub/sub/sub/sub/sub/foo.md'
+      'dir0/sub/sub/sub/sub/sub/sub/sub/sub/sub/sub/foo.md',
     ]
     actual_files = Nanoc::Extra::FilesystemTools.all_files_in('dir0', nil).sort
     assert_equal expected_files, actual_files

--- a/test/filters/test_erb.rb
+++ b/test/filters/test_erb.rb
@@ -28,7 +28,7 @@ class Nanoc::Filters::ERBTest < Nanoc::TestCase
     filter = ::Nanoc::Filters::ERB.new({
       item: item,
       item_rep: item_rep,
-      location: 'a cheap motel'
+      location: 'a cheap motel',
     })
 
     # Run filter

--- a/test/filters/test_handlebars.rb
+++ b/test/filters/test_handlebars.rb
@@ -17,7 +17,7 @@ class Nanoc::Filters::HandlebarsTest < Nanoc::TestCase
         item: item,
         layout: layout,
         config: config,
-        content: 'No Payne No Gayne'
+        content: 'No Payne No Gayne',
       }
       filter = ::Nanoc::Filters::Handlebars.new(assigns)
 
@@ -42,7 +42,7 @@ class Nanoc::Filters::HandlebarsTest < Nanoc::TestCase
       # Create filter
       assigns = {
         item: item,
-        content: 'No Payne No Gayne'
+        content: 'No Payne No Gayne',
       }
       filter = ::Nanoc::Filters::Handlebars.new(assigns)
 

--- a/test/filters/test_mustache.rb
+++ b/test/filters/test_mustache.rb
@@ -5,7 +5,7 @@ class Nanoc::Filters::MustacheTest < Nanoc::TestCase
       item = Nanoc::Int::Item.new(
         'content',
         { title: 'Max Payne', protagonist: 'Max Payne' },
-        '/games/max-payne/'
+        '/games/max-payne/',
       )
 
       # Create filter
@@ -23,7 +23,7 @@ class Nanoc::Filters::MustacheTest < Nanoc::TestCase
       item = Nanoc::Int::Item.new(
         'content',
         { title: 'Max Payne', protagonist: 'Max Payne' },
-        '/games/max-payne/'
+        '/games/max-payne/',
       )
 
       # Create filter

--- a/test/filters/test_relativize_paths.rb
+++ b/test/filters/test_relativize_paths.rb
@@ -565,7 +565,7 @@ XML
       actual_content = filter.setup_and_run(raw_content, {
         type: :xml,
         namespaces: { ex: 'http://example.org' },
-        select: ['ex:a/@href']
+        select: ['ex:a/@href'],
       })
 
       assert_match(/<foo xmlns="http:\/\/example.org">/,    actual_content)

--- a/test/filters/test_xsl.rb
+++ b/test/filters/test_xsl.rb
@@ -97,7 +97,7 @@ EOS
       assigns = {
         item: item,
         layout: layout,
-        content: item.raw_content
+        content: item.raw_content,
       }
       filter = ::Nanoc::Filters::XSL.new(assigns)
 
@@ -123,7 +123,7 @@ EOS
       assigns = {
         item: item,
         layout: layout,
-        content: item.raw_content
+        content: item.raw_content,
       }
       filter = ::Nanoc::Filters::XSL.new(assigns)
 
@@ -150,7 +150,7 @@ EOS
       assigns = {
         item: item,
         layout: layout,
-        content: item.raw_content
+        content: item.raw_content,
       }
       filter = ::Nanoc::Filters::XSL.new(assigns)
 

--- a/test/helpers/test_blogging.rb
+++ b/test/helpers/test_blogging.rb
@@ -113,7 +113,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       end
       assert_equal(
         'Cannot build Atom feed: no articles',
-        error.message
+        error.message,
       )
     end
   end
@@ -138,7 +138,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       end
       assert_equal(
         'Cannot build Atom feed: site configuration has no base_url',
-        error.message
+        error.message,
       )
     end
   end
@@ -163,7 +163,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       end
       assert_equal(
         'Cannot build Atom feed: no title in params, item or site config',
-        error.message
+        error.message,
       )
     end
   end
@@ -188,7 +188,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       end
       assert_equal(
         'Cannot build Atom feed: no author_name in params, item or site config',
-        error.message
+        error.message,
       )
     end
   end
@@ -221,21 +221,21 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       # Still should keep feed level author
       assert_match(
         /#{Regexp.escape('<name>Denis Defreyne</name>')}/, #'
-        result
+        result,
       )
       assert_match(
         /#{Regexp.escape('<uri>http://stoneship.org/</uri>')}/, #'
-        result
+        result,
       )
 
       # Overrides on specific items
       assert_match(
         /#{Regexp.escape('<name>Don Alias</name>')}/, #'
-        result
+        result,
       )
       assert_match(
         /#{Regexp.escape('<uri>http://don.example.com/</uri>')}/, #'
-        result
+        result,
       )
     end
   end
@@ -260,7 +260,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       end
       assert_equal(
         'Cannot build Atom feed: no author_uri in params, item or site config',
-        error.message
+        error.message,
       )
     end
   end
@@ -287,7 +287,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       end
       assert_equal(
         'Cannot build Atom feed: one or more articles lack created_at',
-        error.message
+        error.message,
       )
     end
   end
@@ -312,7 +312,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       atom_feed(
         author_name: 'Bob',
         author_uri: 'http://example.com/~bob/',
-        title: 'My Blog Or Something'
+        title: 'My Blog Or Something',
       )
     end
   end
@@ -328,7 +328,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
         author_name: 'Bob',
         author_uri: 'http://example.com/~bob/',
         title: 'My Blog Or Something',
-        base_url: 'http://example.com'
+        base_url: 'http://example.com',
       })
 
       # Create feed item
@@ -390,11 +390,11 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       result = atom_feed limit: 1, articles: @items
       assert_match(
         Regexp.new('Article 0', Regexp::MULTILINE),
-        result
+        result,
       )
       refute_match(
         Regexp.new('Article 1', Regexp::MULTILINE),
-        result
+        result,
       )
     end
   end
@@ -423,7 +423,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       result = atom_feed
       assert_match(
         Regexp.new('Article 1.*Article 0', Regexp::MULTILINE),
-        result
+        result,
       )
     end
   end
@@ -452,7 +452,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       result = atom_feed(preserve_order: true)
       assert_match(
         Regexp.new('Article 1.*Article 0', Regexp::MULTILINE),
-        result
+        result,
       )
     end
   end

--- a/test/helpers/test_link_to.rb
+++ b/test/helpers/test_link_to.rb
@@ -5,7 +5,7 @@ class Nanoc::Helpers::LinkToTest < Nanoc::TestCase
     # Check
     assert_equal(
       '<a href="/foo/">Foo</a>',
-      link_to('Foo', '/foo/')
+      link_to('Foo', '/foo/'),
     )
   end
 
@@ -17,7 +17,7 @@ class Nanoc::Helpers::LinkToTest < Nanoc::TestCase
     # Check
     assert_equal(
       '<a href="/bar/">Bar</a>',
-      link_to('Bar', rep)
+      link_to('Bar', rep),
     )
   end
 
@@ -29,7 +29,7 @@ class Nanoc::Helpers::LinkToTest < Nanoc::TestCase
     # Check
     assert_equal(
       '<a href="/bar/">Bar</a>',
-      link_to('Bar', item)
+      link_to('Bar', item),
     )
   end
 
@@ -37,7 +37,7 @@ class Nanoc::Helpers::LinkToTest < Nanoc::TestCase
     # Check
     assert_equal(
       '<a title="Dis mai foo!" href="/foo/">Foo</a>',
-      link_to('Foo', '/foo/', title: 'Dis mai foo!')
+      link_to('Foo', '/foo/', title: 'Dis mai foo!'),
     )
   end
 
@@ -45,7 +45,7 @@ class Nanoc::Helpers::LinkToTest < Nanoc::TestCase
     # Check
     assert_equal(
       '<a title="Foo &amp; Bar" href="/foo&amp;bar/">Foo &amp; Bar</a>',
-      link_to('Foo &amp; Bar', '/foo&bar/', title: 'Foo & Bar')
+      link_to('Foo &amp; Bar', '/foo&bar/', title: 'Foo & Bar'),
     )
   end
 
@@ -68,7 +68,7 @@ class Nanoc::Helpers::LinkToTest < Nanoc::TestCase
     # Check
     assert_equal(
       '<span class="active" title="You\'re here.">Bar</span>',
-      link_to_unless_current('Bar', @item_rep)
+      link_to_unless_current('Bar', @item_rep),
     )
   ensure
     @item = nil
@@ -82,7 +82,7 @@ class Nanoc::Helpers::LinkToTest < Nanoc::TestCase
     # Check
     assert_equal(
       '<a href="/abc/xyz/">Bar</a>',
-      link_to_unless_current('Bar', '/abc/xyz/')
+      link_to_unless_current('Bar', '/abc/xyz/'),
     )
   end
 
@@ -94,7 +94,7 @@ class Nanoc::Helpers::LinkToTest < Nanoc::TestCase
     # Test
     assert_equal(
       './',
-      relative_path_to('/foo/bar/baz/')
+      relative_path_to('/foo/bar/baz/'),
     )
   end
 
@@ -106,7 +106,7 @@ class Nanoc::Helpers::LinkToTest < Nanoc::TestCase
     # Test
     assert_equal(
       '../../../',
-      relative_path_to('/')
+      relative_path_to('/'),
     )
   end
 
@@ -118,7 +118,7 @@ class Nanoc::Helpers::LinkToTest < Nanoc::TestCase
     # Test
     assert_equal(
       '../../quux',
-      relative_path_to('/foo/quux')
+      relative_path_to('/foo/quux'),
     )
   end
 
@@ -130,7 +130,7 @@ class Nanoc::Helpers::LinkToTest < Nanoc::TestCase
     # Test
     assert_equal(
       '../../quux/',
-      relative_path_to('/foo/quux/')
+      relative_path_to('/foo/quux/'),
     )
   end
 
@@ -146,7 +146,7 @@ class Nanoc::Helpers::LinkToTest < Nanoc::TestCase
     # Test
     assert_equal(
       '../../quux/',
-      relative_path_to(other_item_rep)
+      relative_path_to(other_item_rep),
     )
   end
 
@@ -162,7 +162,7 @@ class Nanoc::Helpers::LinkToTest < Nanoc::TestCase
     # Test
     assert_equal(
       '../../quux/',
-      relative_path_to(other_item)
+      relative_path_to(other_item),
     )
   end
 

--- a/test/helpers/test_tagging.rb
+++ b/test/helpers/test_tagging.rb
@@ -8,7 +8,7 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
     # Check
     assert_equal(
       '(none)',
-      tags_for(item, base_url: 'http://example.com/tag/')
+      tags_for(item, base_url: 'http://example.com/tag/'),
     )
   end
 
@@ -20,7 +20,7 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
     assert_equal(
       "#{link_for_tag('foo', 'http://stoneship.org/tag/')}, " \
       "#{link_for_tag('bar', 'http://stoneship.org/tag/')}",
-      tags_for(item, base_url: 'http://stoneship.org/tag/')
+      tags_for(item, base_url: 'http://stoneship.org/tag/'),
     )
   end
 
@@ -31,7 +31,7 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
     # Check
     assert_equal(
       'no tags for you, fool',
-      tags_for(item, none_text: 'no tags for you, fool', base_url: 'http://example.com/tag/')
+      tags_for(item, none_text: 'no tags for you, fool', base_url: 'http://example.com/tag/'),
     )
   end
 
@@ -43,7 +43,7 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
     assert_equal(
       "#{link_for_tag('foo', 'http://example.com/tag/')} ++ " \
       "#{link_for_tag('bar', 'http://example.com/tag/')}",
-      tags_for(item, separator: ' ++ ', base_url: 'http://example.com/tag/')
+      tags_for(item, separator: ' ++ ', base_url: 'http://example.com/tag/'),
     )
   end
 
@@ -52,7 +52,7 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
     @items = Nanoc::ItemCollectionView.new([
       Nanoc::Int::Item.new('item 1', { tags: [:foo]       }, '/item1/'),
       Nanoc::Int::Item.new('item 2', { tags: [:bar]       }, '/item2/'),
-      Nanoc::Int::Item.new('item 3', { tags: [:foo, :bar] }, '/item3/')
+      Nanoc::Int::Item.new('item 3', { tags: [:foo, :bar] }, '/item3/'),
     ])
 
     # Find items
@@ -61,21 +61,21 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
     # Check
     assert_equal(
       [@items[0], @items[2]],
-      items_with_foo_tag
+      items_with_foo_tag,
     )
   end
 
   def test_link_for_tag
     assert_equal(
       %(<a href="http://stoneship.org/tags/foobar" rel="tag">foobar</a>),
-      link_for_tag('foobar', 'http://stoneship.org/tags/')
+      link_for_tag('foobar', 'http://stoneship.org/tags/'),
     )
   end
 
   def test_link_for_tag_escape
     assert_equal(
       %(<a href="http://stoneship.org/tags&amp;stuff/foo&amp;bar" rel="tag">foo&amp;bar</a>),
-      link_for_tag('foo&bar', 'http://stoneship.org/tags&stuff/')
+      link_for_tag('foo&bar', 'http://stoneship.org/tags&stuff/'),
     )
   end
 end


### PR DESCRIPTION
Enforcing a trailing comma for multi-line arrays, hashes, calls, … is useful because it makes some diffs easier to read and prevents some merge conflicts.

This PR also fixes some other style issues which I had lying around. Sorry! (I’ll have Rubocop be part of the usual test process some day.)