### PR TITLE
Fix show rules

### DIFF
--- a/lib/nanoc/base/compilation/rule.rb
+++ b/lib/nanoc/base/compilation/rule.rb
@@ -13,6 +13,8 @@ module Nanoc::Int
     # @since 3.2.0
     attr_reader :snapshot_name
 
+    attr_reader :pattern
+
     # Creates a new item compilation rule with the given identifier regex,
     # compiler and block. The block will be called during compilation with the
     # item rep as its argument.

--- a/lib/nanoc/base/entities/pattern.rb
+++ b/lib/nanoc/base/entities/pattern.rb
@@ -41,6 +41,10 @@ module Nanoc::Int
     def captures(_identifier)
       nil
     end
+
+    def to_s
+      @string
+    end
   end
 
   # @api private
@@ -56,6 +60,10 @@ module Nanoc::Int
     def captures(identifier)
       matches = @regexp.match(identifier.to_s)
       matches && matches.captures
+    end
+
+    def to_s
+      @regexp.to_s
     end
   end
 end

--- a/lib/nanoc/cli/command_runner.rb
+++ b/lib/nanoc/cli/command_runner.rb
@@ -27,6 +27,13 @@ module Nanoc::CLI
       @site
     end
 
+    # For debugging purposes.
+    #
+    # @api private
+    def site=(new_site)
+      @site = new_site
+    end
+
     # @return [Boolean] true if the current working directory is a nanoc site
     #   directory, false otherwise
     def in_site_dir?

--- a/lib/nanoc/cli/commands/show-rules.rb
+++ b/lib/nanoc/cli/commands/show-rules.rb
@@ -10,48 +10,39 @@ module Nanoc::CLI::Commands
     def run
       require_site
 
-      @c    = Nanoc::CLI::ANSIStringColorizer
-      @calc = site.compiler.rule_memory_calculator
+      @c = Nanoc::CLI::ANSIStringColorizer
+      @rules = site.compiler.rules_collection
 
-      # TODO: explain /foo/
-      # TODO: explain content/foo.html
-      # TODO: explain output/foo/index.html
-
-      site.items.each   { |i| explain_item(i)   }
-      site.layouts.each { |l| explain_layout(l) }
+      site.items.sort_by(&:identifier).each   { |e| explain_item(e) }
+      site.layouts.sort_by(&:identifier).each { |e| explain_layout(e) }
     end
-
-    protected
 
     def explain_item(item)
       puts "#{@c.c('Item ' + item.identifier, :bold, :yellow)}:"
-      puts "  (from #{item[:filename]})" if item[:filename]
+
       item.reps.each do |rep|
-        puts "  Rep #{rep.name}:"
-        if @calc[rep].empty? && rep.raw_path.nil?
-          puts '    (nothing)'
-        else
-          @calc[rep].each do |mem|
-            puts format('    %s %s',
-              @c.c(format('%-10s', mem[0].to_s), :blue),
-              mem[1..-1].map(&:inspect).join(', '))
-          end
-          if rep.raw_path
-            puts format('    %s %s',
-              @c.c(format('%-10s', 'write to'), :blue),
-              rep.raw_path)
-          end
-        end
+        rule = @rules.compilation_rule_for(rep)
+        puts "  Rep #{rep.name}: #{rule ? rule.pattern : '(none)'}"
       end
+
       puts
     end
 
     def explain_layout(layout)
       puts "#{@c.c('Layout ' + layout.identifier, :bold, :yellow)}:"
-      puts "  (from #{layout[:filename]})" if layout[:filename]
-      puts format('  %s %s',
-        @c.c(format('%-10s', 'filter'), :blue),
-        @calc[layout].map(&:inspect).join(', '))
+
+      found = false
+      @rules.layout_filter_mapping.find do |pattern, _|
+        if pattern.match?(layout.identifier)
+          puts "  #{pattern}"
+          found = true
+          break
+        end
+      end
+      unless found
+        puts '  (none)'
+      end
+
       puts
     end
   end

--- a/spec/nanoc/base/entities/pattern_spec.rb
+++ b/spec/nanoc/base/entities/pattern_spec.rb
@@ -22,10 +22,10 @@ describe Nanoc::Int::Pattern do
 end
 
 describe Nanoc::Int::RegexpPattern do
+  let(:pattern) { described_class.new(/the answer is (\d+)/) }
+
   describe '#match?' do
     it 'matches' do
-      pattern = described_class.new(/the answer is (\d+)/)
-
       expect(pattern.match?('the answer is 42')).to eql(true)
       expect(pattern.match?('the answer is donkey')).to eql(false)
     end
@@ -33,13 +33,19 @@ describe Nanoc::Int::RegexpPattern do
 
   describe '#captures' do
     it 'returns nil if it does not match' do
-      pattern = described_class.new(/the answer is (\d+)/)
       expect(pattern.captures('the answer is donkey')).to be_nil
     end
 
     it 'returns array if it matches' do
-      pattern = described_class.new(/the answer is (\d+)/)
       expect(pattern.captures('the answer is 42')).to eql(['42'])
+    end
+  end
+
+  describe '#to_s' do
+    subject { pattern.to_s }
+
+    it 'returns the regex' do
+      expect(subject).to eq('(?-mix:the answer is (\d+))')
     end
   end
 end
@@ -74,6 +80,16 @@ describe Nanoc::Int::StringPattern do
     it 'returns nil' do
       pattern = described_class.new('d*key')
       expect(pattern.captures('donkey')).to be_nil
+    end
+  end
+
+  describe '#to_s' do
+    let(:pattern) { described_class.new('/foo/*/bar/**/*.animal') }
+
+    subject { pattern.to_s }
+
+    it 'returns the regex' do
+      expect(subject).to eq('/foo/*/bar/**/*.animal')
     end
   end
 end

--- a/spec/nanoc/cli/commands/show_rules_spec.rb
+++ b/spec/nanoc/cli/commands/show_rules_spec.rb
@@ -1,0 +1,97 @@
+describe Nanoc::CLI::Commands::ShowRules do
+  describe '#run' do
+    subject { runner.run }
+
+    let(:runner) do
+      described_class.new(options, arguments, command).tap do |runner|
+        runner.site = site
+      end
+    end
+
+    let(:options) { {} }
+
+    let(:arguments) { [] }
+
+    let(:command) { double(:command) }
+
+    let(:site) do
+      double(
+        :site,
+        items: items,
+        layouts: layouts,
+        compiler: compiler)
+    end
+
+    let(:items) do
+      Nanoc::Int::IdentifiableCollection.new(config).tap do |ic|
+        ic << Nanoc::Int::Item.new('About Me', {}, '/about.md').tap do |i|
+          i.reps << Nanoc::Int::ItemRep.new(i, :default)
+          i.reps << Nanoc::Int::ItemRep.new(i, :text)
+        end
+        ic << Nanoc::Int::Item.new('About My Dog', {}, '/dog.md').tap do |i|
+          i.reps << Nanoc::Int::ItemRep.new(i, :default)
+          i.reps << Nanoc::Int::ItemRep.new(i, :text)
+        end
+        ic << Nanoc::Int::Item.new('Raw Data', {}, '/other.dat').tap do |i|
+          i.reps << Nanoc::Int::ItemRep.new(i, :default)
+        end
+      end
+    end
+
+    let(:layouts) do
+      Nanoc::Int::IdentifiableCollection.new(config).tap do |ic|
+        ic << Nanoc::Int::Layout.new('Default', {}, '/default.erb')
+        ic << Nanoc::Int::Layout.new('Article', {}, '/article.haml')
+        ic << Nanoc::Int::Layout.new('Other', {}, '/other.xyzzy')
+      end
+    end
+
+    let(:config) { double(:config) }
+
+    let(:compiler) { double(:compiler, rules_collection: rules_collection) }
+
+    let(:rules_collection) do
+      Nanoc::Int::RulesCollection.new(nil).tap do |rc|
+        rc.add_item_compilation_rule(
+          Nanoc::Int::Rule.new(Nanoc::Int::Pattern.from('/dog.*'), :default, proc {}))
+        rc.add_item_compilation_rule(
+          Nanoc::Int::Rule.new(Nanoc::Int::Pattern.from('/*.md'), :default, proc {}))
+        rc.add_item_compilation_rule(
+          Nanoc::Int::Rule.new(Nanoc::Int::Pattern.from('/**/*'), :text, proc {}))
+
+        rc.layout_filter_mapping[Nanoc::Int::Pattern.from('/*.haml')] = [:haml, {}]
+        rc.layout_filter_mapping[Nanoc::Int::Pattern.from('/*.erb')] = [:erb, {}]
+      end
+    end
+
+    let(:expected_out) do
+      <<-EOS
+        \e[1m\e[33mItem /about.md\e[0m:
+          Rep default: /*.md
+          Rep text: /**/*
+
+        \e[1m\e[33mItem /dog.md\e[0m:
+          Rep default: /dog.*
+          Rep text: /**/*
+
+        \e[1m\e[33mItem /other.dat\e[0m:
+          Rep default: (none)
+
+        \e[1m\e[33mLayout /article.haml\e[0m:
+          /*.haml
+
+        \e[1m\e[33mLayout /default.erb\e[0m:
+          /*.erb
+
+        \e[1m\e[33mLayout /other.xyzzy\e[0m:
+          (none)
+
+      EOS
+      .gsub(/^ {8}/, '')
+    end
+
+    it 'outputs item and layout rules' do
+      expect { subject }.to output(expected_out).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
Checksumming is used to determine whether rules have changed, and thus it is no longer possible to show the full rules.

What is possible, however, is show which items match against which rules. This PR modifies the command to work that way.

Example output:

```
Item /docs/troubleshooting.md:
  Rep default: /**/*

Item /docs/tutorial.md:
  Rep default: /**/*

Item /favicon.ico:
  Rep default: /favicon.ico

Item /index.html:
  Rep default: /index.*

Item /release-notes:
  Rep default: /**/*

Item /robots.txt.erb:
  Rep default: /robots.*

Item /sitemap.xml.erb:
  Rep default: /sitemap.*

Item /style-guide.md:
  Rep default: /**/*

Layout /autodoc_partial.erb:
  /**/*

Layout /default.html.erb:
  /**/*
```