### PR TITLE
Improve errors

### DIFF
--- a/lib/nanoc/base/services/executor.rb
+++ b/lib/nanoc/base/services/executor.rb
@@ -1,6 +1,12 @@
 module Nanoc
   module Int
     class Executor
+      class OutputNotWrittenError < ::Nanoc::Error
+        def initialize(filter_name, output_filename)
+          super("The #{filter_name.inspect} filter did not write anything to the required output file, #{output_filename}.")
+        end
+      end
+
       def initialize(compiler)
         @compiler = compiler
       end
@@ -36,7 +42,7 @@ module Nanoc
 
           # Check whether file was written
           if klass.to_binary? && !File.file?(filter.output_filename)
-            raise "The #{filter_name.inspect} filter did not write anything to the required output file, #{filter.output_filename}."
+            raise OutputNotWrittenError.new(filter_name, filter.output_filename)
           end
 
           # Create snapshot

--- a/lib/nanoc/base/views/item_rep_collection.rb
+++ b/lib/nanoc/base/views/item_rep_collection.rb
@@ -2,6 +2,12 @@ module Nanoc
   class ItemRepCollectionView
     include Enumerable
 
+    class NoSuchItemRepError < ::Nanoc::Error
+      def initialize(rep_name)
+        super("No rep named #{rep_name.inspect} was found.")
+      end
+    end
+
     # @api private
     def initialize(item_reps)
       @item_reps = item_reps
@@ -58,7 +64,7 @@ module Nanoc
       if res
         Nanoc::ItemRepView.new(res)
       else
-        raise Nanoc::Int::Errors::Generic, "No rep named #{rep_name.inspect} was found."
+        raise NoSuchItemRepError.new(rep_name)
       end
     end
   end

--- a/spec/nanoc/base/entities/content_spec.rb
+++ b/spec/nanoc/base/entities/content_spec.rb
@@ -78,7 +78,7 @@ describe Nanoc::Int::TextualContent do
       let(:content) { described_class.new('foo', filename: 'foo.md') }
 
       it 'errors' do
-        expect { content }.to raise_error
+        expect { content }.to raise_error(ArgumentError)
       end
     end
   end
@@ -120,7 +120,7 @@ describe Nanoc::Int::BinaryContent do
       let(:content) { described_class.new('foo.dat') }
 
       it 'errors' do
-        expect { content }.to raise_error
+        expect { content }.to raise_error(ArgumentError)
       end
     end
   end

--- a/spec/nanoc/base/entities/identifier_spec.rb
+++ b/spec/nanoc/base/entities/identifier_spec.rb
@@ -1,4 +1,36 @@
 describe Nanoc::Identifier do
+  describe '.from' do
+    subject { described_class.from(arg) }
+
+    context 'given an identifier' do
+      let(:arg) { Nanoc::Identifier.new('/foo.md') }
+
+      it 'returns an identifier' do
+        expect(subject).to be_a(Nanoc::Identifier)
+        expect(subject.to_s).to eq('/foo.md')
+        expect(subject).to be_full
+      end
+    end
+
+    context 'given a string' do
+      let(:arg) { '/foo.md' }
+
+      it 'returns an identifier' do
+        expect(subject).to be_a(Nanoc::Identifier)
+        expect(subject.to_s).to eq('/foo.md')
+        expect(subject).to be_full
+      end
+    end
+
+    context 'given something else' do
+      let(:arg) { 12345 }
+
+      it 'raises' do
+        expect { subject }.to raise_error(Nanoc::Identifier::NonCoercibleObjectError)
+      end
+    end
+  end
+
   describe '#initialize' do
     context 'legacy type' do
       it 'does not convert already clean paths' do
@@ -29,7 +61,8 @@ describe Nanoc::Identifier do
 
     context 'full type' do
       it 'refuses string not starting with a slash' do
-        expect { described_class.new('foo') }.to raise_error('Invalid identifier (does not start with a slash): "foo"')
+        expect { described_class.new('foo') }
+          .to raise_error(Nanoc::Identifier::InvalidIdentifierError)
       end
 
       it 'has proper string representation' do
@@ -41,18 +74,25 @@ describe Nanoc::Identifier do
         expect { identifier.to_s << 'bbq' }.to raise_frozen_error
       end
     end
+
+    context 'other type' do
+      it 'errors' do
+        expect { described_class.new('foo', type: :donkey) }
+          .to raise_error(Nanoc::Identifier::InvalidTypeError)
+      end
+    end
   end
 
   describe '#to_s' do
     it 'returns immutable string' do
-      expect { described_class.new('foo/', type: :legacy).to_s << 'lols' }.to raise_error
-      expect { described_class.new('/foo').to_s << 'lols' }.to raise_error
+      expect { described_class.new('foo/', type: :legacy).to_s << 'lols' }.to raise_frozen_error
+      expect { described_class.new('/foo').to_s << 'lols' }.to raise_frozen_error
     end
   end
 
   describe '#to_str' do
     it 'returns immutable string' do
-      expect { described_class.new('/foo/bar').to_str << 'lols' }.to raise_error
+      expect { described_class.new('/foo/bar').to_str << 'lols' }.to raise_frozen_error
     end
   end
 
@@ -171,7 +211,7 @@ describe Nanoc::Identifier do
       let(:prefix) { 'asdf' }
 
       it 'raises an error' do
-        expect { subject }.to raise_error
+        expect { subject }.to raise_error(Nanoc::Identifier::InvalidPrefixError)
       end
     end
 
@@ -179,7 +219,7 @@ describe Nanoc::Identifier do
       let(:prefix) { 'asdf/' }
 
       it 'raises an error' do
-        expect { subject }.to raise_error
+        expect { subject }.to raise_error(Nanoc::Identifier::InvalidPrefixError)
       end
     end
 
@@ -210,7 +250,7 @@ describe Nanoc::Identifier do
       let(:ext) { 'html' }
 
       it 'raises an error' do
-        expect { subject }.to raise_error
+        expect { subject }.to raise_error(Nanoc::Identifier::UnsupportedLegacyOperationError)
       end
     end
 
@@ -278,7 +318,7 @@ describe Nanoc::Identifier do
       let(:identifier) { described_class.new('/foo/', type: :legacy) }
 
       it 'raises an error' do
-        expect { subject }.to raise_error
+        expect { subject }.to raise_error(Nanoc::Identifier::UnsupportedLegacyOperationError)
       end
     end
 
@@ -306,7 +346,7 @@ describe Nanoc::Identifier do
       let(:identifier) { described_class.new('/foo/', type: :legacy) }
 
       it 'raises an error' do
-        expect { subject }.to raise_error
+        expect { subject }.to raise_error(Nanoc::Identifier::UnsupportedLegacyOperationError)
       end
     end
 

--- a/spec/nanoc/base/services/executor_spec.rb
+++ b/spec/nanoc/base/services/executor_spec.rb
@@ -193,7 +193,8 @@ describe Nanoc::Int::Executor do
       end
 
       example do
-        expect { executor.filter(rep, :whatever) }.to raise_error
+        expect { executor.filter(rep, :whatever) }
+          .to raise_error(Nanoc::Int::Executor::OutputNotWrittenError)
       end
     end
 

--- a/spec/nanoc/base/views/item_rep_collection_spec.rb
+++ b/spec/nanoc/base/views/item_rep_collection_spec.rb
@@ -69,7 +69,7 @@ describe Nanoc::ItemRepCollectionView do
       let(:name) { :donkey }
 
       it 'raises' do
-        expect { subject }.to raise_error
+        expect { subject }.to raise_error(Nanoc::ItemRepCollectionView::NoSuchItemRepError)
       end
     end
 

--- a/spec/nanoc/base/views/item_spec.rb
+++ b/spec/nanoc/base/views/item_spec.rb
@@ -130,7 +130,7 @@ describe Nanoc::ItemView do
       let(:params) { { rep: :other } }
 
       it 'raises an error' do
-        expect { subject }.to raise_error
+        expect { subject }.to raise_error(Nanoc::ItemRepCollectionView::NoSuchItemRepError)
       end
     end
   end
@@ -199,7 +199,7 @@ describe Nanoc::ItemView do
       let(:params) { { rep: :other } }
 
       it 'raises an error' do
-        expect { subject }.to raise_error
+        expect { subject }.to raise_error(Nanoc::ItemRepCollectionView::NoSuchItemRepError)
       end
     end
   end


### PR DESCRIPTION
RSpec started complaining about uses of `#raise_error` without argument, and so it guilted me into making this PR.

* Added arguments to `#raise_error` everywhere.

* Added specs for some cases that weren’t tested.

* Created specific error classes (`Nanoc::Error` subclasses) so they are easy to test and also easy to handle, if necessary. This also marks the departure from the monolithic `Nanoc::Errors` module.