### PR TITLE
Full site loader

### DIFF
--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -110,13 +110,10 @@ module Nanoc::Int
       return if @loaded || @loading
       @loading = true
 
-      # Load site if necessary
-      site.load
-
       # Preprocess
       rules_collection.load
       preprocess
-      site.setup_child_parent_links
+      Nanoc::Int::SiteLoader.new.setup_child_parent_links(site.items)
       build_reps
       route_reps
 
@@ -143,10 +140,7 @@ module Nanoc::Int
       @stack = []
 
       items.each { |item| item.reps.clear }
-      site.teardown_child_parent_links
       rules_collection.unload
-
-      site.unload
 
       @loaded = false
       @unloading = false

--- a/lib/nanoc/base/repos/site_loader.rb
+++ b/lib/nanoc/base/repos/site_loader.rb
@@ -1,18 +1,74 @@
 module Nanoc::Int
   class SiteLoader
     def new_empty
-      Nanoc::Int::Site.new(Nanoc::Int::Configuration.new.with_defaults)
+      site_from_config(Nanoc::Int::Configuration.new.with_defaults)
     end
 
     def new_with_config(hash)
-      Nanoc::Int::Site.new(Nanoc::Int::Configuration.new(hash).with_defaults)
+      site_from_config(Nanoc::Int::Configuration.new(hash).with_defaults)
     end
 
     def new_from_cwd
-      Nanoc::Int::Site.new(config_from_cwd)
+      site_from_config(config_from_cwd)
+    end
+
+    # @api private
+    def setup_child_parent_links(items)
+      items.each do |item|
+        item.parent = nil
+        item.children = []
+      end
+
+      item_map = {}
+      items.each do |item|
+        next if item.identifier !~ /\/\z/
+        item_map[item.identifier.to_s] = item
+      end
+
+      items.each do |item|
+        parent_id_end = item.identifier.to_s.rindex('/', -2)
+        next unless parent_id_end
+
+        parent_id = item.identifier.to_s[0..parent_id_end]
+        parent = item_map[parent_id]
+        next unless parent
+
+        item.parent = parent
+        parent.children << item
+      end
     end
 
     private
+
+    def site_from_config(config)
+      code_snippets = code_snippets_from_config(config)
+      code_snippets.each(&:load)
+
+      items = Nanoc::Int::IdentifiableCollection.new(config)
+      layouts = Nanoc::Int::IdentifiableCollection.new(config)
+
+      with_data_sources(config) do |data_sources|
+        data_sources.each do |ds|
+          items_in_ds = ds.items
+          layouts_in_ds = ds.layouts
+
+          items_in_ds.each { |i| i.identifier = i.identifier.prefix(ds.items_root) }
+          layouts_in_ds.each { |l| l.identifier = l.identifier.prefix(ds.layouts_root) }
+
+          items.concat(items_in_ds)
+          layouts.concat(layouts_in_ds)
+        end
+      end
+
+      setup_child_parent_links(items)
+
+      Nanoc::Int::Site.new(
+        config: config,
+        code_snippets: code_snippets,
+        items: items,
+        layouts: layouts,
+      )
+    end
 
     class NoConfigFileFoundError < ::Nanoc::Error
       def initialize
@@ -74,6 +130,46 @@ module Nanoc::Int
       parent_config = Nanoc::Int::Configuration.new(YAML.load_file(parent_path))
       full_parent_config = apply_parent_config(parent_config, processed_paths + [parent_path])
       full_parent_config.merge(config.without(:parent_config_file))
+    end
+
+    def with_data_sources(config, &_block)
+      data_sources = create_data_sources(config)
+
+      begin
+        data_sources.each(&:use)
+        yield(data_sources)
+      ensure
+        data_sources.each(&:unuse)
+      end
+    end
+
+    def create_data_sources(config)
+      config[:data_sources].map do |data_source_hash|
+        # Get data source class
+        data_source_class = Nanoc::DataSource.named(data_source_hash[:type])
+        if data_source_class.nil?
+          raise Nanoc::Int::Errors::UnknownDataSource.new(data_source_hash[:type])
+        end
+
+        # Create data source
+        data_source_class.new(
+          config,
+          data_source_hash[:items_root],
+          data_source_hash[:layouts_root],
+          data_source_hash.merge(data_source_hash[:config] || {}),
+        )
+      end
+    end
+
+    def code_snippets_from_config(config)
+      config[:lib_dirs].flat_map do |lib|
+        Dir["#{lib}/**/*.rb"].sort.map do |filename|
+          Nanoc::Int::CodeSnippet.new(
+            File.read(filename),
+            filename,
+          )
+        end
+      end
     end
   end
 end

--- a/lib/nanoc/base/source_data/data_source.rb
+++ b/lib/nanoc/base/source_data/data_source.rb
@@ -29,21 +29,8 @@ module Nanoc
 
     extend Nanoc::Int::PluginRegistry::PluginMethods
 
-    # Creates a new data source for the given site.
-    #
-    # @param [Nanoc::Int::Site] site The site this data source belongs to.
-    #
-    # @param [String] items_root The prefix that should be given to all items
-    #   returned by the #items method (comparable to mount points for
-    #   filesystems in Unix-ish OSes).
-    #
-    # @param [String] layouts_root The prefix that should be given to all
-    #   layouts returned by the #layouts method (comparable to mount points
-    #   for filesystems in Unix-ish OSes).
-    #
-    # @param [Hash] config The configuration for this data source.
-    def initialize(site, items_root, layouts_root, config)
-      @site         = site
+    def initialize(site_config, items_root, layouts_root, config)
+      @site_config  = site_config
       @items_root   = items_root
       @layouts_root = layouts_root
       @config       = config || {}

--- a/lib/nanoc/base/source_data/site.rb
+++ b/lib/nanoc/base/source_data/site.rb
@@ -1,9 +1,17 @@
 module Nanoc::Int
   # @api private
   class Site
-    # @param [Nanoc::Int::Configuration] config
-    def initialize(config)
-      @config = config
+    # @option params [Nanoc::Int::Configuration] :config
+    #
+    # @option params [Enumerable<Nanoc::Int::CodeSnippet>] :code_snippets
+    def initialize(params = {})
+      @config = params.fetch(:config)
+      @code_snippets = params.fetch(:code_snippets)
+      @items = params.fetch(:items)
+      @layouts = params.fetch(:layouts)
+
+      ensure_identifier_uniqueness(@items, 'item')
+      ensure_identifier_uniqueness(@layouts, 'layout')
     end
 
     # Compiles the site.
@@ -23,102 +31,10 @@ module Nanoc::Int
       @compiler ||= Nanoc::Int::Compiler.new(self)
     end
 
-    # Returns the data sources for this site. Will create a new data source if
-    # none exists yet.
-    #
-    # @return [Array<Nanoc::DataSource>] The list of data sources for this
-    #   site
-    #
-    # @raise [Nanoc::Int::Errors::UnknownDataSource] if the site configuration
-    #   specifies an unknown data source
-    def data_sources
-      load_code_snippets
-
-      @data_sources ||= begin
-        @config[:data_sources].map do |data_source_hash|
-          # Get data source class
-          data_source_class = Nanoc::DataSource.named(data_source_hash[:type])
-          raise Nanoc::Int::Errors::UnknownDataSource.new(data_source_hash[:type]) if data_source_class.nil?
-
-          # Create data source
-          data_source_class.new(
-            self,
-            data_source_hash[:items_root],
-            data_source_hash[:layouts_root],
-            data_source_hash.merge(data_source_hash[:config] || {}),
-          )
-        end
-      end
-    end
-
-    # Returns this site’s code snippets.
-    #
-    # @return [Array<Nanoc::Int::CodeSnippet>] The list of code snippets in this
-    #   site
-    def code_snippets
-      load
-      @code_snippets
-    end
-
-    # Returns this site’s items.
-    #
-    # @return [Array<Nanoc::Int::Item>] The list of items in this site
-    def items
-      load
-      @items
-    end
-
-    # Returns this site’s layouts.
-    #
-    # @return [Array<Nanoc::Int::Layouts>] The list of layout in this site
-    def layouts
-      load
-      @layouts
-    end
-
-    # @return [Nanoc::Int::Configuration]
-    def config
-      @config
-    end
-
-    # Fills each item's parent reference and children array with the
-    # appropriate items. It is probably not necessary to call this method
-    # manually; it will be called when appropriate.
-    #
-    # @return [void]
-    def setup_child_parent_links
-      teardown_child_parent_links
-
-      item_map = {}
-      @items.each do |item|
-        next if item.identifier !~ /\/\z/
-        item_map[item.identifier.to_s] = item
-      end
-
-      @items.each do |item|
-        parent_id_end = item.identifier.to_s.rindex('/', -2)
-        next unless parent_id_end
-
-        parent_id = item.identifier.to_s[0..parent_id_end]
-        parent = item_map[parent_id]
-        next unless parent
-
-        item.parent = parent
-        parent.children << item
-      end
-    end
-
-    # Removes all child-parent links.
-    #
-    # @api private
-    #
-    # @return [void]
-    def teardown_child_parent_links
-      @items.each do |item|
-        item.parent = nil
-        item.children = []
-      end
-    end
+    attr_reader :code_snippets
+    attr_reader :config
+    attr_reader :items
+    attr_reader :layouts
 
     # Prevents all further modifications to itself, its items, its layouts etc.
     #
@@ -127,129 +43,6 @@ module Nanoc::Int
       config.__nanoc_freeze_recursively
       items.each(&:freeze)
       layouts.each(&:freeze)
-      code_snippets.each(&:freeze)
-    end
-
-    # Loads the site data. It is not necessary to call this method explicitly;
-    # it will be called when it is necessary.
-    #
-    # @api private
-    #
-    # @return [void]
-    def load
-      return if @loaded || @loading
-      @loading = true
-
-      # Load all data
-      load_code_snippets
-      with_datasources do
-        load_items
-        load_layouts
-      end
-      setup_child_parent_links
-
-      # Ensure unique
-      ensure_identifier_uniqueness(@items, 'item')
-      ensure_identifier_uniqueness(@layouts, 'layout')
-
-      # Load compiler too
-      # FIXME: this should not be necessary
-      compiler.load
-
-      @loaded = true
-    rescue => e
-      unload
-      raise e
-    ensure
-      @loading = false
-    end
-
-    # Undoes the effects of {#load}. Used when {#load} raises an exception.
-    #
-    # @api private
-    def unload
-      return if @unloading
-      @unloading = true
-
-      @items_loaded = false
-      @items = []
-      @layouts_loaded = false
-      @layouts = []
-      @code_snippets_loaded = false
-      @code_snippets = []
-
-      compiler.unload
-
-      @loaded = false
-      @unloading = false
-    end
-
-    private
-
-    # Executes the given block, making sure that the datasources are
-    # available for the duration of the block
-    def with_datasources(&_block)
-      data_sources.each(&:use)
-      yield
-    ensure
-      data_sources.each(&:unuse)
-    end
-
-    # Loads this site’s code and executes it.
-    def load_code_snippets
-      @code_snippets_loaded ||= false
-      return if @code_snippets_loaded
-      @code_snippets_loaded = true
-
-      # Get code snippets
-      @code_snippets = []
-      config[:lib_dirs].each do |lib|
-        code_snippets = Dir["#{lib}/**/*.rb"].sort.map do |filename|
-          Nanoc::Int::CodeSnippet.new(
-            File.read(filename),
-            filename,
-          )
-        end
-        @code_snippets.concat(code_snippets)
-      end
-
-      # Execute code snippets
-      @code_snippets.each(&:load)
-    end
-
-    # Loads this site’s items, sets up item child-parent relationships and
-    # builds each item's list of item representations.
-    def load_items
-      @items_loaded ||= false
-      return if @items_loaded
-      @items_loaded = true
-
-      # Get items
-      @items = Nanoc::Int::IdentifiableCollection.new(@config)
-      data_sources.each do |ds|
-        items_in_ds = ds.items
-        items_in_ds.each do |i|
-          i.identifier = i.identifier.prefix(ds.items_root)
-        end
-        @items.concat(items_in_ds)
-      end
-    end
-
-    # Loads this site’s layouts.
-    def load_layouts
-      @layouts_loaded ||= false
-      return if @layouts_loaded
-      @layouts_loaded = true
-
-      # Get layouts
-      @layouts = Nanoc::Int::IdentifiableCollection.new(@config)
-      data_sources.each do |ds|
-        layouts_in_ds = ds.layouts
-        layouts_in_ds.each do |l|
-          l.identifier = l.identifier.prefix(ds.layouts_root)
-        end
-        @layouts.concat(layouts_in_ds)
-      end
     end
 
     def ensure_identifier_uniqueness(objects, type)

--- a/lib/nanoc/cli/command_runner.rb
+++ b/lib/nanoc/cli/command_runner.rb
@@ -57,9 +57,8 @@ module Nanoc::CLI
     #
     # @return [void]
     def load_site
+      print 'Loading site… '
       require_site
-      print 'Loading site data… '
-      site.load
       puts 'done'
     end
 

--- a/lib/nanoc/cli/commands/prune.rb
+++ b/lib/nanoc/cli/commands/prune.rb
@@ -16,6 +16,7 @@ module Nanoc::CLI::Commands
   class Prune < ::Nanoc::CLI::CommandRunner
     def run
       load_site
+      site.compiler.load
 
       if options.key?(:yes)
         Nanoc::Extra::Pruner.new(site, exclude: prune_config_exclude).run

--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -54,7 +54,7 @@ module Nanoc::DataSources
           content_filename = filename_for(base_filename, content_ext)
 
           # Read content and metadata
-          is_binary = content_filename && !@site.config[:text_extensions].include?(File.extname(content_filename)[1..-1])
+          is_binary = content_filename && !@site_config[:text_extensions].include?(File.extname(content_filename)[1..-1])
           if is_binary && klass == Nanoc::Int::Item
             meta                = (meta_filename && YAML.load_file(meta_filename)) || {}
             content_or_filename = content_filename

--- a/test/base/test_compiler.rb
+++ b/test/base/test_compiler.rb
@@ -190,6 +190,7 @@ class Nanoc::Int::CompilerTest < Nanoc::TestCase
     with_site do |site|
       File.open('content/index.html', 'w') { |io| io.write('o hello') }
 
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
       site.compile
 
       assert Dir['output/*'].size == 1
@@ -203,6 +204,7 @@ class Nanoc::Int::CompilerTest < Nanoc::TestCase
       File.open('content/foo.html', 'w') { |io| io.write('o hai') }
       File.open('content/bar.html', 'w') { |io| io.write('o bai') }
 
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
       site.compile
 
       assert Dir['output/*'].size == 2
@@ -222,6 +224,7 @@ class Nanoc::Int::CompilerTest < Nanoc::TestCase
         io.write('manatee')
       end
 
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
       site.compile
 
       assert Dir['output/*'].size == 2
@@ -241,6 +244,7 @@ class Nanoc::Int::CompilerTest < Nanoc::TestCase
         io.write('<%= @items.find { |i| i.identifier == "/foo/" }.compiled_content %>')
       end
 
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
       assert_raises Nanoc::Int::Errors::RecursiveCompilation do
         site.compile
       end
@@ -574,6 +578,7 @@ class Nanoc::Int::CompilerTest < Nanoc::TestCase
       end
 
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
+      site.compiler.load
       rep = site.items['/a/'].reps[0]
       dt = site.compiler.dependency_tracker
       dt.start

--- a/test/base/test_outdatedness_checker.rb
+++ b/test/base/test_outdatedness_checker.rb
@@ -5,11 +5,14 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       File.open('content/index.html', 'w') { |io| io.write('o hello') }
       File.open('lib/stuff.rb', 'w') { |io| io.write('$foo = 123') }
 
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
       site.compile
     end
 
     # Check
     with_site(name: 'foo') do |site|
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+      site.compiler.load
       outdatedness_checker = site.compiler.send :outdatedness_checker
       rep = site.items['/'].reps[0]
       assert_nil outdatedness_checker.outdatedness_reason_for(rep)
@@ -22,6 +25,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       File.open('content/index.html', 'w') { |io| io.write('o hello') }
       File.open('lib/stuff.rb', 'w') { |io| io.write('$foo = 123') }
 
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
       site.compile
     end
 
@@ -32,6 +36,8 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
 
     # Check
     with_site(name: 'foo') do |site|
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+      site.compiler.load
       outdatedness_checker = site.compiler.send :outdatedness_checker
       rep = site.items.find { |i| i.identifier == '/' }.reps[0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::NotEnoughData,
@@ -45,6 +51,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       File.open('content/index.html', 'w') { |io| io.write('o hello') }
       File.open('lib/stuff.rb', 'w') { |io| io.write('$foo = 123') }
 
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
       site.compile
     end
 
@@ -55,6 +62,8 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
 
     # Check
     with_site(name: 'foo') do |site|
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+      site.compiler.load
       outdatedness_checker = site.compiler.send :outdatedness_checker
       rep = site.items.find { |i| i.identifier == '/' }.reps[0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::NotWritten,
@@ -69,6 +78,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       File.open('content/new.html', 'w') { |io| io.write('o hello too') }
       File.open('lib/stuff.rb', 'w') { |io| io.write('$foo = 123') }
 
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
       site.compile
     end
 
@@ -79,6 +89,8 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
 
     # Check
     with_site(name: 'foo') do |site|
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+      site.compiler.load
       outdatedness_checker = site.compiler.send :outdatedness_checker
       rep = site.items.find { |i| i.identifier == '/new/' }.reps[0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::SourceModified,
@@ -92,6 +104,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       File.open('content/index.html', 'w') { |io| io.write('o hello') }
       File.open('layouts/default.html', 'w') { |io| io.write('!!! <%= yield %> !!!') }
 
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
       site.compile
     end
 
@@ -103,6 +116,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
     # Check
     with_site(name: 'foo') do |site|
       # FIXME: ugly fugly hack
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
       site.compiler.load
 
       outdatedness_checker = site.compiler.send :outdatedness_checker
@@ -122,6 +136,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
         io.write('stuff')
       end
 
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
       site.compile
     end
 
@@ -135,6 +150,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
     # Check
     with_site(name: 'foo') do |site|
       # FIXME: ugly fugly hack
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
       site.compiler.load
 
       outdatedness_checker = site.compiler.send :outdatedness_checker
@@ -157,6 +173,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
         io.write('stuff')
       end
 
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
       site.compile
     end
 
@@ -170,6 +187,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
     # Check
     with_site(name: 'foo') do |site|
       # FIXME: ugly fugly hack
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
       site.compiler.load
 
       outdatedness_checker = site.compiler.send :outdatedness_checker
@@ -191,6 +209,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
         io.write('stuff')
       end
 
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
       site.compile
     end
 
@@ -202,6 +221,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
     # Check
     with_site(name: 'foo') do |site|
       # FIXME: ugly fugly hack
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
       site.compiler.load
 
       outdatedness_checker = site.compiler.send :outdatedness_checker
@@ -223,6 +243,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
         io.write('stuff')
       end
 
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
       site.compile
     end
 
@@ -236,6 +257,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
     # Check
     with_site(name: 'foo') do |site|
       # FIXME: ugly fugly hack
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
       site.compiler.load
 
       outdatedness_checker = site.compiler.send :outdatedness_checker
@@ -252,6 +274,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
     with_site(name: 'foo') do |site|
       File.open('content/index.html', 'w') { |io| io.write('o hello') }
 
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
       site.compile
     end
 
@@ -262,6 +285,8 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
 
     # Check
     with_site(name: 'foo') do |site|
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+      site.compiler.load
       outdatedness_checker = site.compiler.send :outdatedness_checker
       rep = site.items.find { |i| i.identifier == '/' }.reps[0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::CodeSnippetsModified,
@@ -274,6 +299,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
     with_site(name: 'foo') do |site|
       File.open('content/index.html', 'w') { |io| io.write('o hello') }
 
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
       site.compile
     end
 
@@ -291,6 +317,8 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
 
     # Check
     with_site(name: 'foo') do |site|
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+      site.compiler.load
       outdatedness_checker = site.compiler.send :outdatedness_checker
       rep = site.items.find { |i| i.identifier == '/' }.reps[0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::ConfigurationModified,
@@ -303,6 +331,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
     with_site(name: 'foo') do |site|
       File.open('content/index.html', 'w') { |io| io.write('o hello') }
 
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
       site.compile
     end
 
@@ -313,6 +342,8 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
 
     # Check
     with_site(name: 'foo') do |site|
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+      site.compiler.load
       outdatedness_checker = site.compiler.send :outdatedness_checker
       rep = site.items.find { |i| i.identifier == '/' }.reps[0]
       assert_nil outdatedness_checker.outdatedness_reason_for(rep)
@@ -355,6 +386,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
     # Check
     FileUtils.cd('foo') do
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
+      site.compiler.load
       outdatedness_checker = site.compiler.send :outdatedness_checker
       rep = site.items.find { |i| i.identifier == '/' }.reps[0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::RulesModified,

--- a/test/cli/commands/test_create_site.rb
+++ b/test/cli/commands/test_create_site.rb
@@ -75,9 +75,8 @@ class Nanoc::CLI::Commands::CreateSiteTest < Nanoc::TestCase
     FileUtils.cd('foo') do
       # Try with encoding = default encoding = utf-8
       File.open('content/index.html', 'w') { |io| io.write("Hello <\xD6>!\n") }
-      site = Nanoc::Int::SiteLoader.new.new_from_cwd
       exception = assert_raises(RuntimeError) do
-        site.compile
+        Nanoc::Int::SiteLoader.new.new_from_cwd
       end
       assert_equal 'Could not read content/index.html because the file is not valid UTF-8.', exception.message
 

--- a/test/data_sources/test_filesystem_unified.rb
+++ b/test/data_sources/test_filesystem_unified.rb
@@ -4,7 +4,7 @@ class Nanoc::DataSources::FilesystemUnifiedTest < Nanoc::TestCase
     site = Nanoc::Int::SiteLoader.new.new_empty
 
     # Create data source
-    data_source = Nanoc::DataSources::FilesystemUnified.new(site, nil, nil, params)
+    data_source = Nanoc::DataSources::FilesystemUnified.new(site.config, nil, nil, params)
 
     # Done
     data_source

--- a/test/extra/checking/checks/test_stale.rb
+++ b/test/extra/checking/checks/test_stale.rb
@@ -5,6 +5,7 @@ class Nanoc::Extra::Checking::Checks::StaleTest < Nanoc::TestCase
 
   def calc_issues
     site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    site.compiler.load # TODO: remove me
     check = check_class.create(site)
     check.run
     check.issues

--- a/test/helpers/test_rendering.rb
+++ b/test/helpers/test_rendering.rb
@@ -11,6 +11,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
         io.write 'This is the <%= @layout.identifier %> layout.'
       end
 
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+      site.compiler.load
       @site = Nanoc::SiteView.new(site)
       @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
 
@@ -28,6 +30,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
         io.write 'This is the <%= @layout.identifier %> layout.'
       end
 
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+      site.compiler.load
       @site = Nanoc::SiteView.new(site)
       @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
 
@@ -45,6 +49,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
         io.write 'I am the <%= @layout.class %> class.'
       end
 
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+      site.compiler.load
       @site = Nanoc::SiteView.new(site)
       @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
 
@@ -62,6 +68,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
         io.write 'I am the <%= @layout.unwrap.class %> class.'
       end
 
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+      site.compiler.load
       @site = Nanoc::SiteView.new(site)
       @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
 
@@ -71,6 +79,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
 
   def test_render_with_unknown_layout
     with_site do |site|
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+      site.compiler.load
       @site = Nanoc::SiteView.new(site)
       @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
 
@@ -88,6 +98,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
 
       File.open('layouts/foo.erb', 'w').close
 
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+      site.compiler.load
       @site = Nanoc::SiteView.new(site)
       @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
 
@@ -105,6 +117,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
 
       File.open('layouts/foo.erb', 'w').close
 
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+      site.compiler.load
       @site = Nanoc::SiteView.new(site)
       @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
 
@@ -124,6 +138,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
         io.write '[partial-before]<%= yield %>[partial-after]'
       end
 
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+      site.compiler.load
       @site = Nanoc::SiteView.new(site)
       @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
 


### PR DESCRIPTION
**Goal:** Let `Site` be a dumb entity, and decouple state (`Site`) and operations on state (`SiteLoader`).

This lets the site loader provide all data necessary to construct a site.

The `Site` entity is now a lot smaller, and does not interact with outside systems anymore. The site loader itself has become an ugly beast, which is expected. Future refactorings will take care of that.