### PR TITLE
Load compiler in check

### DIFF
--- a/lib/nanoc/extra/checking/runner.rb
+++ b/lib/nanoc/extra/checking/runner.rb
@@ -62,8 +62,6 @@ module Nanoc::Extra::Checking
       run_check_classes(check_classes_named(check_class_names))
     end
 
-    protected
-
     def load_dsl_if_available
       @dsl_loaded ||= false
       unless @dsl_loaded
@@ -107,6 +105,9 @@ module Nanoc::Extra::Checking
 
     def run_checks(classes)
       return [] if classes.empty?
+
+      # TODO: remove me
+      @site.compiler.load
 
       checks = []
       issues = Set.new

--- a/test/extra/checking/checks/test_stale.rb
+++ b/test/extra/checking/checks/test_stale.rb
@@ -5,10 +5,8 @@ class Nanoc::Extra::Checking::Checks::StaleTest < Nanoc::TestCase
 
   def calc_issues
     site = Nanoc::Int::SiteLoader.new.new_from_cwd
-    site.compiler.load # TODO: remove me
-    check = check_class.create(site)
-    check.run
-    check.issues
+    runner = Nanoc::Extra::Checking::Runner.new(site)
+    issues = runner.run_checks([check_class])
   end
 
   def test_run_ok


### PR DESCRIPTION
The `stale` check requires the compiler to be loaded so that the item reps are available. This wasn’t the case, but this PR fixes that.

The fix is pretty ugly, but hopefully the ugliness will disappear once the item rep building is moved outside of `Compiler#load`.