### PR TITLE
Fix RuboCop and Coveralls integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem 'rspec'
 gem 'rubocop', '~> 0.31.0'
 gem 'rubypants'
 gem 'sass', '~> 3.2.2'
+gem 'simplecov', require: false
 gem 'slim'
 gem 'typogruby'
 gem 'uglifier'

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,3 @@
-# Set up env
-$LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__) + '/lib'))
-require './test/gem_loader.rb'
+Rake.add_rakelib 'tasks'
 
-# Load nanoc
-require 'nanoc'
-
-# Load tasks
-Dir.glob('tasks/**/*.rake').each { |r| Rake.application.add_import r }
-
-# Set default task
-task default: :test
+task default: [:test, :rubocop]

--- a/lib/nanoc/base/source_data/configuration.rb
+++ b/lib/nanoc/base/source_data/configuration.rb
@@ -76,7 +76,7 @@ module Nanoc::Int
     end
 
     def without(key)
-      self.class.new(@wrapped.reject { |k, v| k == key })
+      self.class.new(@wrapped.reject { |k, _v| k == key })
     end
 
     def update(hash)

--- a/lib/nanoc/cli/cleaning_stream.rb
+++ b/lib/nanoc/cli/cleaning_stream.rb
@@ -132,6 +132,11 @@ module Nanoc::CLI
       @stream.external_encoding
     end
 
+    # @see ARGF.set_encoding
+    def set_encoding(*args)
+      @stream.set_encoding(*args)
+    end
+
     protected
 
     def _nanoc_clean(s)

--- a/nanoc.gemspec
+++ b/nanoc.gemspec
@@ -1,5 +1,4 @@
-$LOAD_PATH.unshift(File.expand_path('../lib/', __FILE__))
-require 'nanoc/version'
+require_relative 'lib/nanoc/version'
 
 Gem::Specification.new do |s|
   s.name        = 'nanoc'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,15 @@
-$LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__) + '/../lib'))
+require 'simplecov'
+SimpleCov.start
+
 require 'nanoc'
 require 'nanoc/cli'
+
+# FIXME: This should not be necessary (breaks SimpleCov)
+module Nanoc::CLI
+  def self.setup_cleaning_streams
+  end
+end
+
 Nanoc::CLI.setup
 
 RSpec.configure do |c|

--- a/tasks/rubocop.rake
+++ b/tasks/rubocop.rake
@@ -1,10 +1,6 @@
-begin
-  require 'rubocop/rake_task'
+require 'rubocop/rake_task'
 
-  RuboCop::RakeTask.new(:rubocop) do |task|
-    task.options  = %w( --display-cop-names --format simple )
-    task.patterns = ['lib/**/*.rb']
-  end
-rescue LoadError
-  warn 'Could not load RuboCop. RuboCop rake tasks will be unavailable.'
+RuboCop::RakeTask.new(:rubocop) do |task|
+  task.options  = %w( --display-cop-names --format simple )
+  task.patterns = ['lib/**/*.rb']
 end

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -1,33 +1,17 @@
 require 'rspec/core/rake_task'
+require 'rake/testtask'
+require 'coveralls/rake/task'
 
-def run_tests(dir_glob)
-  ENV['ARGS'] ||= ''
-  ENV['QUIET'] ||= 'true'
+Coveralls::RakeTask.new
 
-  $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__) + '/..'))
-
-  # require our test helper so we don't have to in each individual test
-  require 'test/helper'
-
-  test_files = Dir["#{dir_glob}*_spec.rb"] + Dir["#{dir_glob}test_*.rb"]
-  test_files.each { |f| require f }
-
-  res = Minitest.run(ENV['ARGS'].split)
-  exit(res) if res != 0
-end
+SUBDIRS = %w( * base cli data_sources extra filters helpers )
 
 namespace :test do
-  # test:all
-  desc 'Run all tests'
-  task :all do
-    run_tests 'test/**/'
-  end
-
-  # test:...
-  %w( base cli data_sources extra filters helpers ).each do |dir|
-    desc "Run all #{dir} tests"
-    task dir.to_sym do |_task|
-      run_tests "test/#{dir}/**/"
+  SUBDIRS.each do |dir|
+    Rake::TestTask.new(dir == '*' ? 'all' : dir) do |t|
+      t.test_files = Dir["test/#{dir}/**/*_spec.rb"] + Dir["test/#{dir}/**/test_*.rb"]
+      t.libs = ['./lib', '.']
+      t.ruby_opts = ['-r./test/helper']
     end
   end
 end
@@ -37,5 +21,5 @@ RSpec::Core::RakeTask.new(:spec) do |t|
   t.verbose = false
 end
 
-desc 'Alias for test:all + rubocop'
-task test: [:spec, :'test:all', :rubocop]
+desc 'Run all tests and specs'
+task test: [:spec, :'test:all', :'coveralls:push']

--- a/test/gem_loader.rb
+++ b/test/gem_loader.rb
@@ -1,9 +1,0 @@
-begin
-  require 'rubygems'
-
-  gemspec = File.expand_path('nanoc.gemspec', Dir.pwd)
-  Gem::Specification.load(gemspec).dependencies.each do |dep|
-    gem dep.name, *dep.requirement.as_list
-  end
-rescue LoadError
-end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,31 +1,26 @@
-# Set up gem loading (necessary for cri dependency)
-require File.dirname(__FILE__) + '/gem_loader.rb'
+require 'simplecov'
+SimpleCov.start
 
-# Load unit testing stuff
 require 'minitest/test'
 require 'minitest/spec'
 require 'minitest/mock'
+require 'minitest/autorun'
 require 'mocha/setup'
 require 'vcr'
 
-# Setup coverage
-require 'coveralls'
-Coveralls.wear!
-
-# Load nanoc
-$LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__) + '/../lib'))
-require 'nanoc'
-require 'nanoc/cli'
-Nanoc::CLI.setup
-
-# Load miscellaneous requirements
 require 'tmpdir'
 require 'stringio'
+require 'yard'
 
 VCR.configure do |c|
   c.cassette_library_dir = 'test/fixtures/vcr_cassettes'
   c.hook_into :webmock
 end
+
+require 'nanoc'
+require 'nanoc/cli'
+
+Nanoc::CLI.setup
 
 module Nanoc::TestHelpers
   LIB_DIR = File.expand_path(File.dirname(__FILE__) + '/../lib')


### PR DESCRIPTION
The Rubocop integration was failing because because of the call to `#exit`. SimpleCov/Coveralls should now also work properly.

Additionally, this PR simplifies the Rakefiles. It also removes `LOAD_PATH` magic.