### PR TITLE
Check for Gemfile

### DIFF
--- a/bin/nanoc
+++ b/bin/nanoc
@@ -2,4 +2,8 @@
 require 'nanoc'
 require 'nanoc/cli'
 
+if File.file?('Gemfile') && !defined?(Bundler)
+  warn 'A Gemfile was detected, but Bundler is not loaded. This is probably not what you want. To run nanoc with Bundler, use `bundle exec nanoc`.'
+end
+
 Nanoc::CLI.run(ARGV)


### PR DESCRIPTION
This shows the following message when nanoc is invoked without `bundle exec`, and a _Gemfile_ is present:

> A Gemfile was detected, but Bundler is not loaded. This is probably not what you want. To run nanoc with Bundler, use `bundle exec nanoc`.