### PR TITLE
Extract config loader

### DIFF
--- a/lib/nanoc/base/repos.rb
+++ b/lib/nanoc/base/repos.rb
@@ -2,5 +2,6 @@ require_relative 'repos/store'
 
 require_relative 'repos/checksum_store'
 require_relative 'repos/compiled_content_cache'
+require_relative 'repos/config_loader'
 require_relative 'repos/rule_memory_store'
 require_relative 'repos/site_loader'

--- a/lib/nanoc/base/repos/config_loader.rb
+++ b/lib/nanoc/base/repos/config_loader.rb
@@ -30,7 +30,7 @@ module Nanoc::Int
       candidate && File.expand_path(candidate)
     end
 
-    def config_from_cwd
+    def new_from_cwd
       # Determine path
       filename = self.class.config_filename_for_cwd
       raise NoConfigFileFoundError if filename.nil?

--- a/lib/nanoc/base/repos/config_loader.rb
+++ b/lib/nanoc/base/repos/config_loader.rb
@@ -1,0 +1,65 @@
+module Nanoc::Int
+  class ConfigLoader
+    class NoConfigFileFoundError < ::Nanoc::Error
+      def initialize
+        super('No configuration file found')
+      end
+    end
+
+    class NoParentConfigFileFoundError < ::Nanoc::Error
+      def initialize(filename)
+        super("There is no parent configuration file at #{filename}")
+      end
+    end
+
+    class CyclicalConfigFileError < ::Nanoc::Error
+      def initialize(filename)
+        super("The parent configuration file at #{filename} includes one of its descendants")
+      end
+    end
+
+    # @return [Boolean]
+    def self.cwd_is_nanoc_site?
+      !config_filename_for_cwd.nil?
+    end
+
+    # @return [String]
+    def self.config_filename_for_cwd
+      filenames = %w( nanoc.yaml config.yaml )
+      candidate = filenames.find { |f| File.file?(f) }
+      candidate && File.expand_path(candidate)
+    end
+
+    def config_from_cwd
+      # Determine path
+      filename = self.class.config_filename_for_cwd
+      raise NoConfigFileFoundError if filename.nil?
+
+      # Read
+      apply_parent_config(
+        Nanoc::Int::Configuration.new(YAML.load_file(filename)),
+        [filename]).with_defaults
+    end
+
+    def apply_parent_config(config, processed_paths = Set.new)
+      parent_path = config[:parent_config_file]
+      return config if parent_path.nil?
+
+      # Get absolute path
+      parent_path = File.absolute_path(parent_path, File.dirname(processed_paths.last))
+      unless File.file?(parent_path)
+        raise NoParentConfigFileFoundError.new(parent_path)
+      end
+
+      # Check recursion
+      if processed_paths.include?(parent_path)
+        raise CyclicalConfigFileError.new(parent_path)
+      end
+
+      # Load
+      parent_config = Nanoc::Int::Configuration.new(YAML.load_file(parent_path))
+      full_parent_config = apply_parent_config(parent_config, processed_paths + [parent_path])
+      full_parent_config.merge(config.without(:parent_config_file))
+    end
+  end
+end

--- a/lib/nanoc/base/repos/config_loader.rb
+++ b/lib/nanoc/base/repos/config_loader.rb
@@ -1,4 +1,5 @@
 module Nanoc::Int
+  # @api private
   class ConfigLoader
     class NoConfigFileFoundError < ::Nanoc::Error
       def initialize
@@ -41,7 +42,8 @@ module Nanoc::Int
         [filename]).with_defaults
     end
 
-    def apply_parent_config(config, processed_paths = Set.new)
+    # @api private
+    def apply_parent_config(config, processed_paths = [])
       parent_path = config[:parent_config_file]
       return config if parent_path.nil?
 

--- a/lib/nanoc/base/repos/site_loader.rb
+++ b/lib/nanoc/base/repos/site_loader.rb
@@ -9,7 +9,7 @@ module Nanoc::Int
     end
 
     def new_from_cwd
-      site_from_config(config_from_cwd)
+      site_from_config(Nanoc::Int::ConfigLoader.new.config_from_cwd)
     end
 
     # @api private
@@ -70,66 +70,9 @@ module Nanoc::Int
       )
     end
 
-    class NoConfigFileFoundError < ::Nanoc::Error
-      def initialize
-        super('No configuration file found')
-      end
-    end
-
-    class NoParentConfigFileFoundError < ::Nanoc::Error
-      def initialize(filename)
-        super("There is no parent configuration file at #{filename}")
-      end
-    end
-
-    class CyclicalConfigFileError < ::Nanoc::Error
-      def initialize(filename)
-        super("The parent configuration file at #{filename} includes one of its descendants")
-      end
-    end
-
     # @return [Boolean]
     def self.cwd_is_nanoc_site?
-      !config_filename_for_cwd.nil?
-    end
-
-    # @return [String]
-    def self.config_filename_for_cwd
-      filenames = %w( nanoc.yaml config.yaml )
-      candidate = filenames.find { |f| File.file?(f) }
-      candidate && File.expand_path(candidate)
-    end
-
-    def config_from_cwd
-      # Determine path
-      filename = self.class.config_filename_for_cwd
-      raise NoConfigFileFoundError if filename.nil?
-
-      # Read
-      apply_parent_config(
-        Nanoc::Int::Configuration.new(YAML.load_file(filename)),
-        [filename]).with_defaults
-    end
-
-    def apply_parent_config(config, processed_paths = Set.new)
-      parent_path = config[:parent_config_file]
-      return config if parent_path.nil?
-
-      # Get absolute path
-      parent_path = File.absolute_path(parent_path, File.dirname(processed_paths.last))
-      unless File.file?(parent_path)
-        raise NoParentConfigFileFoundError.new(parent_path)
-      end
-
-      # Check recursion
-      if processed_paths.include?(parent_path)
-        raise CyclicalConfigFileError.new(parent_path)
-      end
-
-      # Load
-      parent_config = Nanoc::Int::Configuration.new(YAML.load_file(parent_path))
-      full_parent_config = apply_parent_config(parent_config, processed_paths + [parent_path])
-      full_parent_config.merge(config.without(:parent_config_file))
+      Nanoc::Int::ConfigLoader.cwd_is_nanoc_site?
     end
 
     def with_data_sources(config, &_block)

--- a/lib/nanoc/base/repos/site_loader.rb
+++ b/lib/nanoc/base/repos/site_loader.rb
@@ -9,7 +9,7 @@ module Nanoc::Int
     end
 
     def new_from_cwd
-      site_from_config(Nanoc::Int::ConfigLoader.new.config_from_cwd)
+      site_from_config(Nanoc::Int::ConfigLoader.new.new_from_cwd)
     end
 
     # @api private

--- a/lib/nanoc/cli.rb
+++ b/lib/nanoc/cli.rb
@@ -117,8 +117,8 @@ module Nanoc::CLI
   # @return [void]
   def self.load_custom_commands
     if Nanoc::Int::SiteLoader.cwd_is_nanoc_site?
-      site = Nanoc::Int::SiteLoader.new.new_from_cwd
-      site.config[:commands_dirs].each do |path|
+      config = Nanoc::Int::ConfigLoader.new.new_from_cwd
+      config[:commands_dirs].each do |path|
         load_commands_at(path)
       end
     end

--- a/spec/nanoc/base/repos/config_loader_spec.rb
+++ b/spec/nanoc/base/repos/config_loader_spec.rb
@@ -1,0 +1,199 @@
+describe Nanoc::Int::ConfigLoader do
+  let(:loader) { described_class.new }
+
+  describe '#new_from_cwd' do
+    subject { loader.new_from_cwd }
+
+    context 'no config file present' do
+      it 'errors' do
+        expect { subject }.to raise_error(
+          Nanoc::Int::ConfigLoader::NoConfigFileFoundError)
+      end
+    end
+
+    context 'config file present' do
+      before do
+        File.write('nanoc.yaml', YAML.dump(foo: 'bar'))
+      end
+
+      it 'returns a configuration' do
+        expect(subject).to be_a(Nanoc::Int::Configuration)
+      end
+
+      it 'has the defaults' do
+        expect(subject[:output_dir]).to eq('output')
+      end
+
+      it 'has the custom option' do
+        expect(subject[:foo]).to eq('bar')
+      end
+    end
+
+    context 'config file and parent present' do
+      before do
+        File.write('nanoc.yaml', YAML.dump(parent_config_file: 'parent.yaml'))
+        File.write('parent.yaml', YAML.dump(foo: 'bar'))
+      end
+
+      it 'returns the configuration' do
+        expect(subject).to be_a(Nanoc::Int::Configuration)
+      end
+
+      it 'has the defaults' do
+        expect(subject[:output_dir]).to eq('output')
+      end
+
+      it 'has the custom option' do
+        expect(subject[:foo]).to eq('bar')
+      end
+
+      it 'does not include parent config option' do
+        expect(subject[:parent_config_file]).to be_nil
+      end
+    end
+  end
+
+  describe '.cwd_is_nanoc_site? + .config_filename_for_cwd' do
+    context 'no config files' do
+      it 'is not considered a nanoc site dir' do
+        expect(described_class.cwd_is_nanoc_site?).to eq(false)
+        expect(described_class.config_filename_for_cwd).to be_nil
+      end
+    end
+
+    context 'nanoc.yaml config file' do
+      before do
+        File.write('nanoc.yaml', 'stuff')
+      end
+
+      it 'is considered a nanoc site dir' do
+        expect(described_class.cwd_is_nanoc_site?).to eq(true)
+        expect(described_class.config_filename_for_cwd).to eq(File.expand_path('nanoc.yaml'))
+      end
+    end
+
+    context 'config.yaml config file' do
+      before do
+        File.write('config.yaml', 'stuff')
+      end
+
+      it 'is considered a nanoc site dir' do
+        expect(described_class.cwd_is_nanoc_site?).to eq(true)
+        expect(described_class.config_filename_for_cwd).to eq(File.expand_path('config.yaml'))
+      end
+    end
+  end
+
+  describe '#apply_parent_config' do
+    subject { loader.apply_parent_config(config, processed_paths) }
+
+    let(:config) { Nanoc::Int::Configuration.new(foo: 'bar') }
+
+    let(:processed_paths) { ['nanoc.yaml'] }
+
+    context 'no parent_config_file' do
+      it 'returns self' do
+        expect(subject).to eq(config)
+      end
+    end
+
+    context 'parent config file is set' do
+      let(:config) do
+        Nanoc::Int::Configuration.new(
+          parent_config_file: 'foo.yaml',
+          foo: 'bar',
+        )
+      end
+
+      context 'parent config file is not present' do
+        it 'errors' do
+          expect { subject }.to raise_error(
+            Nanoc::Int::ConfigLoader::NoParentConfigFileFoundError)
+        end
+      end
+
+      context 'parent config file is present' do
+        context 'parent-child cycle' do
+          before do
+            File.write('foo.yaml', 'parent_config_file: bar.yaml')
+            File.write('bar.yaml', 'parent_config_file: foo.yaml')
+          end
+
+          it 'errors' do
+            expect { subject }.to raise_error(
+              Nanoc::Int::ConfigLoader::CyclicalConfigFileError)
+          end
+        end
+
+        context 'self parent-child cycle' do
+          before do
+            File.write('foo.yaml', 'parent_config_file: foo.yaml')
+          end
+
+          it 'errors' do
+            expect { subject }.to raise_error(
+              Nanoc::Int::ConfigLoader::CyclicalConfigFileError)
+          end
+        end
+
+        context 'no parent-child cycle' do
+          before do
+            File.write('foo.yaml', 'animal: giraffe')
+          end
+
+          it 'returns a configuration' do
+            expect(subject).to be_a(Nanoc::Int::Configuration)
+          end
+
+          it 'has no defaults (added in #new_from_cwd only)' do
+            expect(subject[:output_dir]).to be_nil
+          end
+
+          it 'inherits options from parent' do
+            expect(subject[:animal]).to eq('giraffe')
+          end
+
+          it 'takes options from child' do
+            expect(subject[:foo]).to eq('bar')
+          end
+
+          it 'does not include parent config option' do
+            expect(subject[:parent_config_file]).to be_nil
+          end
+        end
+
+        context 'long parent chain' do
+          before do
+            File.write('foo.yaml', "parrots: 43\nparent_config_file: bar.yaml\n")
+            File.write('bar.yaml', "day_one: lasers\nslugs: false\n")
+          end
+
+          it 'returns a configuration' do
+            expect(subject).to be_a(Nanoc::Int::Configuration)
+          end
+
+          it 'has no defaults (added in #new_from_cwd only)' do
+            expect(subject[:output_dir]).to be_nil
+          end
+
+          it 'inherits options from grandparent' do
+            expect(subject[:day_one]).to eq('lasers')
+            expect(subject[:slugs]).to eq(false)
+          end
+
+          it 'inherits options from parent' do
+            expect(subject[:parrots]).to eq(43)
+          end
+
+          it 'takes options from child' do
+            expect(subject[:foo]).to eq('bar')
+          end
+
+          it 'does not include parent config option' do
+            expect(subject[:parent_config_file]).to be_nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/nanoc/base/repos/site_loader_spec.rb
+++ b/spec/nanoc/base/repos/site_loader_spec.rb
@@ -52,7 +52,7 @@ describe Nanoc::Int::SiteLoader do
     context 'no config file' do
       it 'errors' do
         expect { subject }.to raise_error(
-          Nanoc::Int::SiteLoader::NoConfigFileFoundError)
+          Nanoc::Int::ConfigLoader::NoConfigFileFoundError)
       end
     end
 

--- a/test/base/test_site.rb
+++ b/test/base/test_site.rb
@@ -1,6 +1,6 @@
 class Nanoc::Int::SiteTest < Nanoc::TestCase
   def test_initialize_with_dir_without_config_yaml
-    assert_raises(Nanoc::Int::SiteLoader::NoConfigFileFoundError) do
+    assert_raises(Nanoc::Int::ConfigLoader::NoConfigFileFoundError) do
       Nanoc::Int::SiteLoader.new.new_from_cwd
     end
   end
@@ -70,7 +70,7 @@ parent_config_file: foo/foo.yaml
 EOF
     end
 
-    assert_raises(Nanoc::Int::SiteLoader::NoParentConfigFileFoundError) do
+    assert_raises(Nanoc::Int::ConfigLoader::NoParentConfigFileFoundError) do
       Nanoc::Int::SiteLoader.new.new_from_cwd
     end
   end
@@ -90,7 +90,7 @@ EOF
       end
     end
 
-    assert_raises(Nanoc::Int::SiteLoader::CyclicalConfigFileError) do
+    assert_raises(Nanoc::Int::ConfigLoader::CyclicalConfigFileError) do
       Nanoc::Int::SiteLoader.new.new_from_cwd
     end
   end


### PR DESCRIPTION
Fixes #644.

Having a separate config loader prevents having to load the site twice, and thus all its code snippets, removing the “constant already defined” warnings. It also leads to a speedup, but it doesn’t make it faster than nanoc 3.x. It’s also cleaner to not have all config-loading functionality in the site loader.

It probably makes sense to test the config loader separately; I’m relying on the site loader tests to ensure the config loader works at the moment.