### PR TITLE
Remove Inch badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![Build status](http://img.shields.io/travis/nanoc/nanoc.svg)](https://travis-ci.org/nanoc/nanoc)
 [![Code Climate](http://img.shields.io/codeclimate/github/nanoc/nanoc.svg)](https://codeclimate.com/github/nanoc/nanoc)
 [![Code Coverage](http://img.shields.io/coveralls/nanoc/nanoc.svg)](https://coveralls.io/r/nanoc/nanoc)
-[![Documentation Coverage](http://inch-ci.org/github/nanoc/nanoc.svg)](http://inch-ci.org/github/nanoc/nanoc/)
 
 ![nanoc logo](https://avatars1.githubusercontent.com/u/3260163?s=140)
 


### PR DESCRIPTION
nanoc is a tool, not a library. As much as I care about documentation, API documentation is not where it’s at for nanoc. Because of this, I don’t feel that the Inch badge belongs in the nanoc README.

I will continue to use Inch for other projects where it is more appropriate (for instance, [cri](https://github.com/ddfreyne/cri)).

CC @rrrene