### PR TITLE
Fix sidebar links in default site

### DIFF
--- a/lib/nanoc/cli/commands/create-site.rb
+++ b/lib/nanoc/cli/commands/create-site.rb
@@ -266,14 +266,15 @@ EOS
     <div id="sidebar">
       <h2>Documentation</h2>
       <ul>
-        <li><a href="http://nanoc.ws/docs/">Documentation</a></li>
-        <li><a href="http://nanoc.ws/docs/tutorial/">Getting Started</a></li>
+        <li><a href="http://v4.nanoc.ws/about/">About</a></li>
+        <li><a href="http://v4.nanoc.ws/doc/">Documentation</a></li>
+        <li><a href="http://v4.nanoc.ws/doc/tutorial/">Tutorial</a></li>
       </ul>
       <h2>Community</h2>
       <ul>
-        <li><a href="http://groups.google.com/group/nanoc/">Discussion Group</a></li>
-        <li><a href="irc://chat.freenode.net/#nanoc">IRC Channel</a></li>
-        <li><a href="http://github.com/nanoc/nanoc/wiki/">Wiki</a></li>
+        <li><a href="http://groups.google.com/group/nanoc/">Discussion group</a></li>
+        <li><a href="irc://chat.freenode.net/#nanoc">IRC channel</a></li>
+        <li><a href="http://v4.nanoc.ws/contributing/">Contributing</a></li>
       </ul>
     </div>
   </body>


### PR DESCRIPTION
* Added a link to the about page.

* Removed the link to the wiki. The wiki is not particularly useful, and linking to it makes it feel like it is an important part of the documentation or community.

* Pointed all links to `v4.nanoc.ws` rather than `nanoc.ws`. This is necessary because the links otherwise point to old documentation. This is temporary and needs to be changed before the v4 final release.