### PR TITLE
Rename nanoc to Nanoc

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,7 +48,7 @@ Lint/NonLocalExitFromIterator:
 BracesAroundHashParameters:
   Enabled: false
 
-# nanoc relies on eval in several cases (code snippets and some helpers).
+# Nanoc relies on eval in several cases (code snippets and some helpers).
 Eval:
   Enabled: false
 
@@ -118,7 +118,7 @@ AsciiComments:
 Documentation:
   Enabled: false
 
-# nanoc suppresses exceptions for valid reasons in a few cases.
+# Nanoc suppresses exceptions for valid reasons in a few cases.
 HandleExceptions:
   Enabled: false
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Contributing
 Reporting bugs
 --------------
 
-If you find a bug in nanoc, you should report it! Some information that you should include in your bug report is the nanoc version (`nanoc --version`) and, if relevant, the crash log (`crash.log`).
+If you find a bug in Nanoc, you should report it! Some information that you should include in your bug report is the Nanoc version (`nanoc --version`) and, if relevant, the crash log (`crash.log`).
 
 For details, check the [*bug reporting* section of the development guide](http://nanoc.ws/development/#reporting-bugs).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,10 @@
-# nanoc news
+# Nanoc news
+
+## 4.0.0rc2 (???)
+
+Changes:
+
+* nanoc is now called Nanoc
 
 ## 4.0.0rc1 (2015-06-21)
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 [![Code Climate](http://img.shields.io/codeclimate/github/nanoc/nanoc.svg)](https://codeclimate.com/github/nanoc/nanoc)
 [![Code Coverage](http://img.shields.io/coveralls/nanoc/nanoc.svg)](https://coveralls.io/r/nanoc/nanoc)
 
-![nanoc logo](https://avatars1.githubusercontent.com/u/3260163?s=140)
+![Nanoc logo](https://avatars1.githubusercontent.com/u/3260163?s=140)
 
-# nanoc
+# Nanoc
 
-nanoc is a flexible static-site generator written in Ruby. See the [nanoc web site](http://nanoc.ws) for more information.
+Nanoc is a flexible static-site generator written in Ruby. See the [Nanoc web site](http://nanoc.ws) for more information.
 
-**Please take a moment and [donate](http://pledgie.com/campaigns/9282) to nanoc. A lot of time has gone into developing nanoc, and I would like to keep it going. Your support will ensure that nanoc will continue to improve.**
+**Please take a moment and [donate](http://pledgie.com/campaigns/9282) to Nanoc. A lot of time has gone into developing Nanoc, and I would like to keep it going. Your support will ensure that Nanoc will continue to improve.**
 
 ## Contributing
 
@@ -17,6 +17,6 @@ Contributions are greatly appreciated! Consult the [Development guidelines](http
 
 ### Contributors
 
-Many thanks to everyone who has contributed to nanoc in one way or another:
+Many thanks to everyone who has contributed to Nanoc in one way or another:
 
 Ale Muñoz, Alexander Mankuta, Arnau Siches, Ben Armston, Bil Bas, Brian Candler, Bruno Dufour, Chris Eppstein, Christian Plessl, Colin Barrett, Damien Pollet, Dan Callahan, Daniel Hofstetter, Daniel Mendler, Daniel Wollschlaeger, David Alexander, David Everitt, Dennis Sutch, Devon Luke Buchanan, Dmitry Bilunov, Eric Sunshine, Erik Hollensbe, Fabian Buch, Felix Hanley, Go Maeda, Gregory Pakosz, Grégory Karékinian, Guilherme Garnier, Jack Chu, Jake Benilov, Jasper Van der Jeugt, Jeff Forcier, John Nishinaga, Justin Clift, Justin Hileman, Kevin Lynagh, Louis T., Mathias Bynens, Matt Keveney, Matthew Frazier, Matthias Beyer, Matthias Reitinger, Matthias Vallentin, Michal Cichra, Nelson Chen, Nicky Peeters, Nikhil Marathe, Oliver Byford, Peter Aronoff, Raphael von der Grün, Remko Tronçon, Riley Goodside, Ruben Verborgh, Scott Vokes, Simon South, Spencer Whitt, Stanley Rost, Starr Horne, Stefan Bühler, Stuart Montgomery, Takashi Uchibe, Toon Willems, Tuomas Kareinen, Ursula Kallio, Vincent Driessen, Xavier Shay, Zaiste de Grengolada, Šime Ramov

--- a/bin/nanoc
+++ b/bin/nanoc
@@ -3,7 +3,7 @@ require 'nanoc'
 require 'nanoc/cli'
 
 if File.file?('Gemfile') && !defined?(Bundler)
-  warn 'A Gemfile was detected, but Bundler is not loaded. This is probably not what you want. To run nanoc with Bundler, use `bundle exec nanoc`.'
+  warn 'A Gemfile was detected, but Bundler is not loaded. This is probably not what you want. To run Nanoc with Bundler, use `bundle exec nanoc`.'
 end
 
 Nanoc::CLI.run(ARGV)

--- a/lib/nanoc.rb
+++ b/lib/nanoc.rb
@@ -1,5 +1,5 @@
 module Nanoc
-  # @return [String] A string containing information about this nanoc version
+  # @return [String] A string containing information about this Nanoc version
   #   and its environment (Ruby engine and version, Rubygems version if any).
   #
   # @api private
@@ -7,7 +7,7 @@ module Nanoc
     gem_info = defined?(Gem) ? "with RubyGems #{Gem::VERSION}" : 'without RubyGems'
     engine   = defined?(RUBY_ENGINE) ? RUBY_ENGINE : 'ruby'
     res = ''
-    res << "nanoc #{Nanoc::VERSION} © 2007-2015 Denis Defreyne.\n"
+    res << "Nanoc #{Nanoc::VERSION} © 2007-2015 Denis Defreyne.\n"
     res << "Running #{engine} #{RUBY_VERSION} (#{RUBY_RELEASE_DATE}) on #{RUBY_PLATFORM} #{gem_info}.\n"
     res
   end
@@ -34,7 +34,7 @@ require 'time'
 require 'yaml'
 require 'English'
 
-# Load nanoc
+# Load Nanoc
 require 'nanoc/version'
 require 'nanoc/base'
 require 'nanoc/extra'

--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -65,9 +65,9 @@ module Nanoc::Int
 
     # Compiles the site and writes out the compiled item representations.
     #
-    # Previous versions of nanoc (< 3.2) allowed passing items to compile, and
+    # Previous versions of Nanoc (< 3.2) allowed passing items to compile, and
     # had a “force” option to make the compiler recompile all pages, even
-    # when not outdated. These arguments and options are, as of nanoc 3.2, no
+    # when not outdated. These arguments and options are, as of Nanoc 3.2, no
     # longer used, and will simply be ignored when passed to {#run}.
     #
     # @overload run

--- a/lib/nanoc/base/error.rb
+++ b/lib/nanoc/base/error.rb
@@ -1,5 +1,5 @@
 module Nanoc
-  # Generic error. Superclass for all nanoc-specific errors.
+  # Generic error. Superclass for all Nanoc-specific errors.
   class Error < ::StandardError
   end
 end

--- a/lib/nanoc/base/errors.rb
+++ b/lib/nanoc/base/errors.rb
@@ -1,11 +1,11 @@
 module Nanoc::Int
-  # Module that contains all nanoc-specific errors.
+  # Module that contains all Nanoc-specific errors.
   #
   # @api private
   module Errors
     Generic = ::Nanoc::Error
 
-    # Generic trivial error. Superclass for all nanoc-specific errors that are
+    # Generic trivial error. Superclass for all Nanoc-specific errors that are
     # considered "trivial", i.e. errors that do not require a full crash report.
     class GenericTrivial < Generic
     end
@@ -66,7 +66,7 @@ module Nanoc::Int
     # working directory.
     class NoRulesFileFound < Generic
       def initialize
-        super('This site does not have a rules file, which is required for nanoc sites.')
+        super('This site does not have a rules file, which is required for Nanoc sites.')
       end
     end
 

--- a/lib/nanoc/base/source_data/code_snippet.rb
+++ b/lib/nanoc/base/source_data/code_snippet.rb
@@ -1,5 +1,5 @@
 module Nanoc::Int
-  # Nanoc::Int::CodeSnippet represent a piece of custom code of a nanoc site.
+  # Nanoc::Int::CodeSnippet represent a piece of custom code of a Nanoc site.
   #
   # @api private
   class CodeSnippet
@@ -20,7 +20,7 @@ module Nanoc::Int
     #
     # @param [String] filename The filename corresponding to this code snippet
     #
-    # @param [Time, Hash] _params Extra parameters. Ignored by nanoc; it is
+    # @param [Time, Hash] _params Extra parameters. Ignored by Nanoc; it is
     #   only included for backwards compatibility.
     def initialize(data, filename, _params = nil)
       @data     = data

--- a/lib/nanoc/cli.rb
+++ b/lib/nanoc/cli.rb
@@ -2,7 +2,7 @@ begin
   require 'cri'
 rescue LoadError => e
   $stderr.puts e
-  $stderr.puts "If you are using a Gemfile, make sure that the Gemfile contains nanoc ('gem \"nanoc\"')."
+  $stderr.puts "If you are using a Gemfile, make sure that the Gemfile contains Nanoc ('gem \"nanoc\"')."
   exit 1
 end
 
@@ -42,7 +42,7 @@ module Nanoc::CLI
     @debug = boolean
   end
 
-  # Invokes the nanoc command-line tool with the given arguments.
+  # Invokes the Nanoc command-line tool with the given arguments.
   #
   # @param [Array<String>] args An array of command-line arguments
   #

--- a/lib/nanoc/cli/command_runner.rb
+++ b/lib/nanoc/cli/command_runner.rb
@@ -1,5 +1,5 @@
 module Nanoc::CLI
-  # A command runner subclass for nanoc commands that adds nanoc-specific
+  # A command runner subclass for Nanoc commands that adds Nanoc-specific
   # convenience methods and error handling.
   #
   # @api private
@@ -34,7 +34,7 @@ module Nanoc::CLI
       @site = new_site
     end
 
-    # @return [Boolean] true if the current working directory is a nanoc site
+    # @return [Boolean] true if the current working directory is a Nanoc site
     #   directory, false otherwise
     def in_site_dir?
       Nanoc::Int::SiteLoader.cwd_is_nanoc_site?
@@ -48,7 +48,7 @@ module Nanoc::CLI
     # @return [void]
     def require_site
       if site.nil?
-        raise ::Nanoc::Int::Errors::GenericTrivial, 'The current working directory does not seem to be a nanoc site.'
+        raise ::Nanoc::Int::Errors::GenericTrivial, 'The current working directory does not seem to be a Nanoc site.'
       end
     end
 

--- a/lib/nanoc/cli/commands/create-site.rb
+++ b/lib/nanoc/cli/commands/create-site.rb
@@ -18,10 +18,10 @@ module Nanoc::CLI::Commands
     DEFAULT_CONFIG = <<EOS unless defined? DEFAULT_CONFIG
 # The syntax to use for patterns in the Rules file. Can be either `"glob"`
 # (default) or `"legacy"`. The former will enable glob patterns, which behave
-# like Ruby’s File.fnmatch. The latter will enable nanoc 3.x-style patterns.
+# like Ruby’s File.fnmatch. The latter will enable Nanoc 3.x-style patterns.
 string_pattern_type: glob
 
-# A list of file extensions that nanoc will consider to be textual rather than
+# A list of file extensions that Nanoc will consider to be textual rather than
 # binary. If an item with an extension not in this list is found,  the file
 # will be considered as binary.
 text_extensions: #{array_to_yaml(Nanoc::Int::Configuration::DEFAULT_CONFIG[:text_extensions])}
@@ -34,7 +34,7 @@ output_dir: #{Nanoc::Int::Configuration::DEFAULT_CONFIG[:output_dir]}
 # A list of index filenames, i.e. names of files that will be served by a web
 # server when a directory is requested. Usually, index files are named
 # “index.html”, but depending on the web server, this may be something else,
-# such as “default.htm”. This list is used by nanoc to generate pretty URLs.
+# such as “default.htm”. This list is used by Nanoc to generate pretty URLs.
 index_filenames: #{array_to_yaml(Nanoc::Int::Configuration::DEFAULT_CONFIG[:index_filenames])}
 
 # Whether or not to generate a diff of the compiled content when compiling a
@@ -43,7 +43,7 @@ index_filenames: #{array_to_yaml(Nanoc::Int::Configuration::DEFAULT_CONFIG[:inde
 enable_output_diff: false
 
 prune:
-  # Whether to automatically remove files not managed by nanoc from the output
+  # Whether to automatically remove files not managed by Nanoc from the output
   # directory.
   auto_prune: true
 
@@ -52,7 +52,7 @@ prune:
   # .git, .svn etc.
   exclude: [ '.git', '.hg', '.svn', 'CVS' ]
 
-# The data sources where nanoc loads its data from. This is an array of
+# The data sources where Nanoc loads its data from. This is an array of
 # hashes; each array element represents a single data source. By default,
 # there is only a single data source that reads data from the “content/” and
 # “layout/” directories in the site directory.
@@ -78,7 +78,7 @@ data_sources:
 
     # The kind of identifier to use for items and layouts. The default is
     # “full”, meaning that identifiers include file extensions. This can also
-    # be “legacy”, primarily used by older nanoc sites.
+    # be “legacy”, primarily used by older Nanoc sites.
     identifier_type: full
 
 # Configuration for the “check” command, which run unit tests on the site.
@@ -102,7 +102,7 @@ end
 
 # This is an example rule that matches Markdown (.md) files, and filters them
 # using the :kramdown filter. It is commented out by default, because kramdown
-# is not bundled with nanoc or Ruby.
+# is not bundled with Nanoc or Ruby.
 #
 #compile '/**/*.md' do
 #  filter :kramdown
@@ -132,16 +132,16 @@ EOS
 title: Home
 ---
 
-<h1>A Brand New nanoc Site</h1>
+<h1>A Brand New Nanoc Site</h1>
 
-<p>You’ve just created a new nanoc site. The page you are looking at right now is the home page for your site. To get started, consider replacing this default homepage with your own customized homepage. Some pointers on how to do so:</p>
+<p>You’ve just created a new Nanoc site. The page you are looking at right now is the home page for your site. To get started, consider replacing this default homepage with your own customized homepage. Some pointers on how to do so:</p>
 
 <ul>
   <li><p><strong>Change this page’s content</strong> by editing the “index.html” file in the “content” directory. This is the actual page content, and therefore doesn’t include the header, sidebar or style information (those are part of the layout).</p></li>
   <li><p><strong>Change the layout</strong>, which is the “default.html” file in the “layouts” directory, and create something unique (and hopefully less bland).</p></li>
 </ul>
 
-<p>If you need any help with customizing your nanoc web site, be sure to check out the documentation (see sidebar), and be sure to subscribe to the discussion group (also see sidebar). Enjoy!</p>
+<p>If you need any help with customizing your Nanoc web site, be sure to check out the documentation (see sidebar), and be sure to subscribe to the discussion group (also see sidebar). Enjoy!</p>
 EOS
 
     DEFAULT_STYLESHEET = <<EOS unless defined? DEFAULT_STYLESHEET
@@ -253,11 +253,11 @@ EOS
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>A Brand New nanoc Site - <%= @item[:title] %></title>
+    <title>A Brand New Nanoc Site - <%= @item[:title] %></title>
     <link rel="stylesheet" href="<%= @items['/stylesheet.*'].path %>">
 
     <!-- you don't need to keep this, but it's cool for stats! -->
-    <meta name="generator" content="nanoc <%= Nanoc::VERSION %>">
+    <meta name="generator" content="Nanoc <%= Nanoc::VERSION %>">
   </head>
   <body>
     <div id="main">

--- a/lib/nanoc/cli/commands/nanoc.rb
+++ b/lib/nanoc/cli/commands/nanoc.rb
@@ -1,5 +1,5 @@
 usage 'nanoc command [options] [arguments]'
-summary 'nanoc, a static site compiler written in Ruby'
+summary 'Nanoc, a static site compiler written in Ruby'
 
 opt :l, :color, 'enable color' do
   $stdout.remove_stream_cleaner(Nanoc::CLI::StreamCleaners::ANSIColors)
@@ -20,7 +20,7 @@ opt :C, :'no-color', 'disable color' do
   $stderr.add_stream_cleaner(Nanoc::CLI::StreamCleaners::ANSIColors)
 end
 
-opt :V, :verbose, 'make nanoc output more detailed' do
+opt :V, :verbose, 'make output more detailed' do
   Nanoc::CLI::Logger.instance.level = :low
 end
 

--- a/lib/nanoc/cli/commands/prune.rb
+++ b/lib/nanoc/cli/commands/prune.rb
@@ -1,12 +1,12 @@
 usage 'prune'
-summary 'remove files not managed by nanoc from the output directory'
+summary 'remove files not managed by Nanoc from the output directory'
 description <<-EOS
 Find all files in the output directory that do not correspond to an item
-managed by nanoc and remove them. Since this is a hazardous operation, an
+managed by Nanoc and remove them. Since this is a hazardous operation, an
 additional `--yes` flag is needed as confirmation.
 
 Also see the `auto_prune` configuration option in `nanoc.yaml` (`config.yaml`
-for older nanoc sites), which will automatically prune after compilation.
+for older Nanoc sites), which will automatically prune after compilation.
 EOS
 
 flag :y, :yes,       'confirm deletion'
@@ -25,7 +25,7 @@ module Nanoc::CLI::Commands
       else
         $stderr.puts 'WARNING: Since the prune command is a destructive command, it requires an additional --yes flag in order to work.'
         $stderr.puts
-        $stderr.puts 'Please ensure that the output directory does not contain any files (such as images or stylesheets) that are necessary but are not managed by nanoc. If you want to get a list of all files that would be removed, pass --dry-run.'
+        $stderr.puts 'Please ensure that the output directory does not contain any files (such as images or stylesheets) that are necessary but are not managed by Nanoc. If you want to get a list of all files that would be removed, pass --dry-run.'
         exit 1
       end
     end

--- a/lib/nanoc/cli/commands/shell.rb
+++ b/lib/nanoc/cli/commands/shell.rb
@@ -1,5 +1,5 @@
 usage 'shell'
-summary 'open a shell on the nanoc environment'
+summary 'open a shell on the Nanoc environment'
 aliases 'console'
 description "
 Open an IRB shell on a context that contains @items, @layouts, and @config.

--- a/lib/nanoc/cli/commands/show-plugins.rb
+++ b/lib/nanoc/cli/commands/show-plugins.rb
@@ -3,7 +3,7 @@ aliases :info
 usage 'show-plugins [options]'
 description <<-EOS
 Show a list of available plugins, including filters and data sources.
-If the current directory contains a nanoc web site, the plugins defined in this site will be shown as well.
+If the current directory contains a Nanoc web site, the plugins defined in this site will be shown as well.
 EOS
 
 module Nanoc::CLI::Commands

--- a/lib/nanoc/cli/commands/view.rb
+++ b/lib/nanoc/cli/commands/view.rb
@@ -18,7 +18,6 @@ module Nanoc::CLI::Commands
       load_adsf
       require 'rack'
 
-      # Make sure we are in a nanoc site directory
       require_site
 
       # Set options

--- a/lib/nanoc/cli/error_handler.rb
+++ b/lib/nanoc/cli/error_handler.rb
@@ -297,7 +297,7 @@ module Nanoc::CLI
 
     def write_issue_link(stream, _params = {})
       stream.puts
-      stream.puts 'If you believe this is a bug in nanoc, please do report it at'
+      stream.puts 'If you believe this is a bug in Nanoc, please do report it at'
       stream.puts '-> https://github.com/nanoc/nanoc/issues/new <-'
       stream.puts
       stream.puts 'A detailed crash log has been written to ./crash.log.'

--- a/lib/nanoc/data_sources/filesystem_unified.rb
+++ b/lib/nanoc/data_sources/filesystem_unified.rb
@@ -44,7 +44,7 @@ module Nanoc::DataSources
   #     (`allow_periods_in_identifiers` set to false)
   #     foo.html.erb → /foo/
   #
-  # Note that each item must have an unique identifier. nanoc will display an
+  # Note that each item must have an unique identifier. Nanoc will display an
   # error if two items with the same identifier are found.
   #
   # Some more examples:

--- a/lib/nanoc/extra/checking/runner.rb
+++ b/lib/nanoc/extra/checking/runner.rb
@@ -5,7 +5,7 @@ module Nanoc::Extra::Checking
   class Runner
     CHECKS_FILENAMES = ['Checks', 'Checks.rb', 'checks', 'checks.rb']
 
-    # @param [Nanoc::Int::Site] site The nanoc site this runner is for
+    # @param [Nanoc::Int::Site] site The Nanoc site this runner is for
     def initialize(site)
       @site = site
     end

--- a/lib/nanoc/extra/jruby_nokogiri_warner.rb
+++ b/lib/nanoc/extra/jruby_nokogiri_warner.rb
@@ -12,12 +12,12 @@ Note:
 The behavior of Pure Java Nokogiri differs from the Nokogiri used on the
 standard Ruby interpreter (MRI) due to differences in underlying libraries.
 
-These sometimes problematic behavioral differences can cause nanoc filters not
+These sometimes problematic behavioral differences can cause Nanoc filters not
 to function properly, if at all. If you need reliable (X)HTML and XML handling
 functionality, consider not using Nokogiri on JRuby for the time being.
 
-These issues are being worked on both from the Nokogiri and the nanoc side. Keep
-your Nokogiri and nanoc versions up to date!
+These issues are being worked on both from the Nokogiri and the Nanoc side. Keep
+your Nokogiri and Nanoc versions up to date!
 
 For details, see https://github.com/nanoc/nanoc/pull/422.
 --------------------------------------------------------------------------------

--- a/lib/nanoc/extra/pruner.rb
+++ b/lib/nanoc/extra/pruner.rb
@@ -1,6 +1,6 @@
 module Nanoc::Extra
   # Responsible for finding and deleting files in the site’s output directory
-  # that are not managed by nanoc.
+  # that are not managed by Nanoc.
   #
   # @api private
   class Pruner
@@ -18,7 +18,7 @@ module Nanoc::Extra
       @exclude = params.fetch(:exclude) { [] }
     end
 
-    # Prunes all output files not managed by nanoc.
+    # Prunes all output files not managed by Nanoc.
     #
     # @return [void]
     def run

--- a/lib/nanoc/filters/erubis.rb
+++ b/lib/nanoc/filters/erubis.rb
@@ -4,7 +4,7 @@ module Nanoc::Filters
     requires 'erubis'
 
     # The same as `::Erubis::Eruby` but adds `_erbout` as an alias for the
-    # `_buf` variable, making it compatible with nanoc’s helpers that rely
+    # `_buf` variable, making it compatible with Nanoc’s helpers that rely
     # on `_erbout`, such as {Nanoc::Helpers::Capturing}.
     class ErubisWithErbout < ::Erubis::Eruby
       include ::Erubis::ErboutEnhancer

--- a/lib/nanoc/filters/slim.rb
+++ b/lib/nanoc/filters/slim.rb
@@ -13,8 +13,8 @@ module Nanoc::Filters
     # @return [String] The filtered content
     def run(content, params = {})
       params = {
-        disable_capture: true,      # Capture managed by nanoc
-        buffer: '_erbout', # Force slim to output to the buffer used by nanoc
+        disable_capture: true,      # Capture managed by Nanoc
+        buffer: '_erbout', # Force slim to output to the buffer used by Nanoc
       }.merge params
 
       # Create context

--- a/lib/nanoc/helpers/capturing.rb
+++ b/lib/nanoc/helpers/capturing.rb
@@ -15,7 +15,7 @@ module Nanoc::Helpers
   # @example Capturing content for a summary
   #
   #   <% content_for :summary do %>
-  #     <p>On this item, nanoc is introduced, blah blah.</p>
+  #     <p>On this item, Nanoc is introduced, blah blah.</p>
   #   <% end %>
   #
   # @example Showing captured content in a sidebar

--- a/lib/nanoc/version.rb
+++ b/lib/nanoc/version.rb
@@ -1,4 +1,4 @@
 module Nanoc
-  # The current nanoc version.
+  # The current Nanoc version.
   VERSION = '4.0.0rc1'
 end

--- a/nanoc.gemspec
+++ b/nanoc.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.version     = Nanoc::VERSION
   s.homepage    = 'http://nanoc.ws/'
   s.summary     = 'A static-site generator with a focus on flexibility.'
-  s.description = 'nanoc is a static-site generator focused on flexibility. It transforms content from a format such as Markdown or AsciiDoc into another format, usually HTML, and lays out pages consistently to retain the site’s look and feel throughout. Static sites built with nanoc can be deployed to any web server.'
+  s.description = 'Nanoc is a static-site generator focused on flexibility. It transforms content from a format such as Markdown or AsciiDoc into another format, usually HTML, and lays out pages consistently to retain the site’s look and feel throughout. Static sites built with Nanoc can be deployed to any web server.'
 
   s.author  = 'Denis Defreyne'
   s.email   = 'denis.defreyne@stoneship.org'


### PR DESCRIPTION
Fix for #596.

The product name becomes _Nanoc_ (used to be _nanoc_). The following items are not affected:

* The command-line tool
* The library name
* The gem name