### PR TITLE
Create item rep repo

### DIFF
--- a/lib/nanoc/base.rb
+++ b/lib/nanoc/base.rb
@@ -34,6 +34,7 @@ module Nanoc::Int
   autoload 'OutdatednessReasons',  'nanoc/base/compilation/outdatedness_reasons'
   autoload 'Rule',                 'nanoc/base/compilation/rule'
   autoload 'RuleContext',          'nanoc/base/compilation/rule_context'
+  autoload 'ItemRepRepo',          'nanoc/base/compilation/item_rep_repo'
 end
 
 require_relative 'base/entities'

--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -135,7 +135,7 @@ module Nanoc::Int
     # @return [void]
     def store(reps)
       # Calculate rule memory
-      (reps + @site.layouts.to_a).each do |obj|
+      (reps.to_a + @site.layouts.to_a).each do |obj|
         rule_memory_store[obj] = rule_memory_calculator[obj]
       end
 
@@ -220,7 +220,7 @@ module Nanoc::Int
       end
 
       # Find item reps to compile and compile them
-      selector = Nanoc::Int::ItemRepSelector.new(reps)
+      selector = Nanoc::Int::ItemRepSelector.new(reps.to_a)
       selector.each do |rep|
         @stack = []
         compile_rep(rep)

--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -100,6 +100,7 @@ module Nanoc::Int
 
       # Build reps
       reps = build_reps
+      @reps = reps
 
       # Compile
       run(reps)
@@ -276,7 +277,7 @@ module Nanoc::Int
       executor.snapshot(rep, :raw)
       executor.snapshot(rep, :pre, final: false)
       rules_collection.compilation_rule_for(rep)
-        .apply_to(rep, executor: executor, site: @site)
+        .apply_to(rep, reps: @reps, executor: executor, site: @site)
       executor.snapshot(rep, :post) if rep.has_snapshot?(:post)
       executor.snapshot(rep, :last)
     end

--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -182,8 +182,8 @@ module Nanoc::Int
         item: Nanoc::ItemView.new(rep.item, @reps),
         rep: Nanoc::ItemRepView.new(rep),
         item_rep: Nanoc::ItemRepView.new(rep),
-        items: Nanoc::ItemCollectionView.new(site.items),
-        layouts: Nanoc::LayoutCollectionView.new(site.layouts),
+        items: Nanoc::ItemCollectionView.new(site.items, @reps),
+        layouts: Nanoc::LayoutCollectionView.new(site.layouts, @reps),
         config: Nanoc::ConfigView.new(site.config),
         site: Nanoc::SiteView.new(site),
       })

--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -102,11 +102,10 @@ module Nanoc::Int
       Nanoc::Int::Preprocessor.new(site: @site, rules_collection: @rules_collection).run
 
       # Build reps
-      reps = build_reps
-      @reps = reps
+      build_reps
 
       # Compile
-      run(reps)
+      run(@reps)
     end
 
     def run(reps)
@@ -164,7 +163,7 @@ module Nanoc::Int
     def build_reps
       builder = Nanoc::Int::ItemRepBuilder.new(site, rules_collection)
       builder.run
-      builder.reps
+      @reps = builder.reps
     end
 
     # @param [Nanoc::Int::ItemRep] rep The item representation for which the

--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -292,7 +292,7 @@ module Nanoc::Int
     # @return [void]
     def forget_dependencies_if_outdated
       @site.items.each do |i|
-        if i.reps.any? { |r| outdatedness_checker.outdated?(r) }
+        if @reps[i].any? { |r| outdatedness_checker.outdated?(r) }
           @dependency_tracker.forget_dependencies_for(i)
         end
       end

--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -70,6 +70,9 @@ module Nanoc::Int
     # @api private
     attr_reader :dependency_tracker
 
+    # @api private
+    attr_reader :reps
+
     # @group Public instance methods
 
     def initialize(site, rules_collection, compiled_content_cache:, checksum_store:, rule_memory_store:, rule_memory_calculator:)

--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -201,6 +201,7 @@ module Nanoc::Int
         rules_collection: @rules_collection,
         rule_memory_store: @rule_memory_store,
         rule_memory_calculator: @rule_memory_calculator,
+        reps: @reps,
       )
     end
     memoize :outdatedness_checker

--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -179,7 +179,7 @@ module Nanoc::Int
 
       # TODO: Do not expose @site (necessary for captures store though…)
       content_or_filename_assigns.merge({
-        item: Nanoc::ItemView.new(rep.item),
+        item: Nanoc::ItemView.new(rep.item, @reps),
         rep: Nanoc::ItemRepView.new(rep),
         item_rep: Nanoc::ItemRepView.new(rep),
         items: Nanoc::ItemCollectionView.new(site.items),

--- a/lib/nanoc/base/compilation/filter.rb
+++ b/lib/nanoc/base/compilation/filter.rb
@@ -195,7 +195,8 @@ module Nanoc
 
       # Raise unmet dependency error if necessary
       items.each do |item|
-        rep = item.reps.find { |r| !r.compiled? }
+        reps = assigns[:site].unwrap.compiler.reps[item]
+        rep = reps.find { |r| !r.compiled? }
         raise Nanoc::Int::Errors::UnmetDependency.new(rep) if rep
       end
     end

--- a/lib/nanoc/base/compilation/item_rep_repo.rb
+++ b/lib/nanoc/base/compilation/item_rep_repo.rb
@@ -24,7 +24,7 @@ module Nanoc::Int
       self
     end
 
-    def reps_for(item)
+    def [](item)
       @reps_by_item.fetch(item, [])
     end
   end

--- a/lib/nanoc/base/compilation/item_rep_repo.rb
+++ b/lib/nanoc/base/compilation/item_rep_repo.rb
@@ -3,6 +3,8 @@ module Nanoc::Int
   #
   # @api private
   class ItemRepRepo
+    include Enumerable
+
     def initialize
       @reps = []
       @reps_by_item = {}

--- a/lib/nanoc/base/compilation/item_rep_repo.rb
+++ b/lib/nanoc/base/compilation/item_rep_repo.rb
@@ -1,0 +1,31 @@
+module Nanoc::Int
+  # Stores item reps (in memory).
+  #
+  # @api private
+  class ItemRepRepo
+    def initialize
+      @reps = []
+      @reps_by_item = {}
+    end
+
+    def <<(rep)
+      @reps << rep
+
+      @reps_by_item[rep.item] ||= []
+      @reps_by_item[rep.item] << rep
+    end
+
+    def to_a
+      @reps
+    end
+
+    def each(&block)
+      @reps.each(&block)
+      self
+    end
+
+    def reps_for(item)
+      @reps_by_item.fetch(item, [])
+    end
+  end
+end

--- a/lib/nanoc/base/compilation/outdatedness_checker.rb
+++ b/lib/nanoc/base/compilation/outdatedness_checker.rb
@@ -20,13 +20,15 @@ module Nanoc::Int
     # @param [Nanoc::Int::RulesCollection] rules_collection
     # @param [Nanoc::Int::RuleMemoryStore] rule_memory_store
     # @param [Nanoc::Int::RuleMemoryCalculator] rule_memory_calculator
-    def initialize(site:, checksum_store:, dependency_tracker:, rules_collection:, rule_memory_store:, rule_memory_calculator:)
+    # @param [Nanoc::Int::ItemRepRepo] reps
+    def initialize(site:, checksum_store:, dependency_tracker:, rules_collection:, rule_memory_store:, rule_memory_calculator:, reps:)
       @site = site
       @checksum_store = checksum_store
       @dependency_tracker = dependency_tracker
       @rules_collection = rules_collection
       @rule_memory_store = rule_memory_store
       @rule_memory_calculator = rule_memory_calculator
+      @reps = reps
 
       @basic_outdatedness_reasons = {}
       @outdatedness_reasons = {}
@@ -109,7 +111,7 @@ module Nanoc::Int
         # Not outdated
         return nil
       when Nanoc::Int::Item
-        obj.reps.find { |rep| basic_outdatedness_reason_for(rep) }
+        @reps[obj].find { |rep| basic_outdatedness_reason_for(rep) }
       when Nanoc::Int::Layout
         # Outdated if rules outdated
         return Reasons::RulesModified if

--- a/lib/nanoc/base/compilation/rule.rb
+++ b/lib/nanoc/base/compilation/rule.rb
@@ -59,8 +59,7 @@ module Nanoc::Int
     # @param [Nanoc::Int::Executor, Nanoc::Int::RecordingExecutor] executor
     #
     # @return [void]
-    def apply_to(rep, site:, executor:, reps: nil)
-      # TODO: make reps mandatory
+    def apply_to(rep, site:, executor:, reps:)
       context = Nanoc::Int::RuleContext.new(
         reps: reps, rep: rep, executor: executor, site: site)
       context.instance_exec(matches(rep.item.identifier), &@block)

--- a/lib/nanoc/base/compilation/rule.rb
+++ b/lib/nanoc/base/compilation/rule.rb
@@ -59,8 +59,10 @@ module Nanoc::Int
     # @param [Nanoc::Int::Executor, Nanoc::Int::RecordingExecutor] executor
     #
     # @return [void]
-    def apply_to(rep, site:, executor:)
-      context = Nanoc::Int::RuleContext.new(rep: rep, executor: executor, site: site)
+    def apply_to(rep, site:, executor:, reps: nil)
+      # TODO: make reps mandatory
+      context = Nanoc::Int::RuleContext.new(
+        reps: reps, rep: rep, executor: executor, site: site)
       context.instance_exec(matches(rep.item.identifier), &@block)
     end
 

--- a/lib/nanoc/base/compilation/rule_context.rb
+++ b/lib/nanoc/base/compilation/rule_context.rb
@@ -15,8 +15,8 @@ module Nanoc::Int
         item: Nanoc::ItemView.new(rep.item, nil),
         rep: Nanoc::ItemRepView.new(rep),
         item_rep: Nanoc::ItemRepView.new(rep),
-        items: Nanoc::ItemCollectionView.new(site.items),
-        layouts: Nanoc::LayoutCollectionView.new(site.layouts),
+        items: Nanoc::ItemCollectionView.new(site.items, nil),
+        layouts: Nanoc::LayoutCollectionView.new(site.layouts, nil),
         config: Nanoc::ConfigView.new(site.config),
         site: Nanoc::SiteView.new(site),
       })

--- a/lib/nanoc/base/compilation/rule_context.rb
+++ b/lib/nanoc/base/compilation/rule_context.rb
@@ -5,18 +5,21 @@ module Nanoc::Int
   #
   # @api private
   class RuleContext < Nanoc::Int::Context
+<<<<<<< HEAD
     # @param [Nanoc::Int::ItemRep] rep
     # @param [Nanoc::Int::Site] site
     # @param [Nanoc::Int::Executor, Nanoc::Int::RecordingExecutor] executor
-    def initialize(rep:, site:, executor:)
+    # @param reps
+    def initialize(rep:, site:, executor:, reps: nil)
+      #  TODO: make reps mandatory
       @_executor = executor
 
       super({
-        item: Nanoc::ItemView.new(rep.item, nil),
+        item: Nanoc::ItemView.new(rep.item, reps),
         rep: Nanoc::ItemRepView.new(rep),
         item_rep: Nanoc::ItemRepView.new(rep),
-        items: Nanoc::ItemCollectionView.new(site.items, nil),
-        layouts: Nanoc::LayoutCollectionView.new(site.layouts, nil),
+        items: Nanoc::ItemCollectionView.new(site.items, reps),
+        layouts: Nanoc::LayoutCollectionView.new(site.layouts, reps),
         config: Nanoc::ConfigView.new(site.config),
         site: Nanoc::SiteView.new(site),
       })

--- a/lib/nanoc/base/compilation/rule_context.rb
+++ b/lib/nanoc/base/compilation/rule_context.rb
@@ -12,7 +12,7 @@ module Nanoc::Int
       @_executor = executor
 
       super({
-        item: Nanoc::ItemView.new(rep.item),
+        item: Nanoc::ItemView.new(rep.item, nil),
         rep: Nanoc::ItemRepView.new(rep),
         item_rep: Nanoc::ItemRepView.new(rep),
         items: Nanoc::ItemCollectionView.new(site.items),

--- a/lib/nanoc/base/compilation/rule_context.rb
+++ b/lib/nanoc/base/compilation/rule_context.rb
@@ -5,13 +5,11 @@ module Nanoc::Int
   #
   # @api private
   class RuleContext < Nanoc::Int::Context
-<<<<<<< HEAD
     # @param [Nanoc::Int::ItemRep] rep
     # @param [Nanoc::Int::Site] site
     # @param [Nanoc::Int::Executor, Nanoc::Int::RecordingExecutor] executor
     # @param reps
-    def initialize(rep:, site:, executor:, reps: nil)
-      #  TODO: make reps mandatory
+    def initialize(rep:, site:, executor:, reps:)
       @_executor = executor
 
       super({

--- a/lib/nanoc/base/services/item_rep_builder.rb
+++ b/lib/nanoc/base/services/item_rep_builder.rb
@@ -7,7 +7,7 @@ module Nanoc::Int
       @site = site
       @rules_collection = rules_collection
 
-      @reps = []
+      @reps = Nanoc::Int::ItemRepRepo.new
     end
 
     def run

--- a/lib/nanoc/base/services/item_rep_builder.rb
+++ b/lib/nanoc/base/services/item_rep_builder.rb
@@ -15,7 +15,7 @@ module Nanoc::Int
         rep_names_for(item).each do |rep_name|
           rep = Nanoc::Int::ItemRep.new(item, rep_name)
 
-          item.reps << rep
+          #item.reps << rep
           @reps << rep
         end
       end

--- a/lib/nanoc/base/services/item_rep_builder.rb
+++ b/lib/nanoc/base/services/item_rep_builder.rb
@@ -15,7 +15,6 @@ module Nanoc::Int
         rep_names_for(item).each do |rep_name|
           rep = Nanoc::Int::ItemRep.new(item, rep_name)
 
-          #item.reps << rep
           @reps << rep
         end
       end

--- a/lib/nanoc/base/services/item_rep_router.rb
+++ b/lib/nanoc/base/services/item_rep_router.rb
@@ -29,7 +29,7 @@ module Nanoc::Int
     end
 
     def basic_path_for(rep, rule)
-      basic_path = rule.apply_to(rep, executor: nil, site: @site)
+      basic_path = rule.apply_to(rep, reps: nil, executor: nil, site: @site)
 
       if basic_path && basic_path !~ %r{^/}
         raise "The path returned for the #{rep.inspect} item representation, “#{basic_path}”, does not start with a slash. Please ensure that all routing rules return a path that starts with a slash."

--- a/lib/nanoc/base/services/preprocessor.rb
+++ b/lib/nanoc/base/services/preprocessor.rb
@@ -20,8 +20,8 @@ module Nanoc::Int
     def new_preprocessor_context
       Nanoc::Int::Context.new({
         config: Nanoc::MutableConfigView.new(@site.config),
-        items: Nanoc::MutableItemCollectionView.new(@site.items),
-        layouts: Nanoc::MutableLayoutCollectionView.new(@site.layouts),
+        items: Nanoc::MutableItemCollectionView.new(@site.items, nil),
+        layouts: Nanoc::MutableLayoutCollectionView.new(@site.layouts, nil),
       })
     end
   end

--- a/lib/nanoc/base/services/rule_memory_calculator.rb
+++ b/lib/nanoc/base/services/rule_memory_calculator.rb
@@ -56,7 +56,7 @@ module Nanoc::Int
       executor = Nanoc::Int::RecordingExecutor.new
       @rules_collection
         .compilation_rule_for(rep)
-        .apply_to(rep, executor: executor, site: @site)
+        .apply_to(rep, reps: nil, executor: executor, site: @site)
       executor.record_write(rep, rep.path)
       make_rule_memory_serializable(executor.rule_memory)
     end

--- a/lib/nanoc/base/source_data/item.rb
+++ b/lib/nanoc/base/source_data/item.rb
@@ -2,7 +2,7 @@ module Nanoc::Int
   # @api private
   class Item < ::Nanoc::Int::Document
     # @return [Array<Nanoc::Int::ItemRep>] This item’s list of item reps
-    attr_reader :reps
+    #attr_reader :reps
 
     # @return [Nanoc::Int::Item, nil] The parent item of this item. This can be
     #   nil even for non-root items.

--- a/lib/nanoc/base/views/identifiable_collection_view.rb
+++ b/lib/nanoc/base/views/identifiable_collection_view.rb
@@ -3,8 +3,9 @@ module Nanoc
     include Enumerable
 
     # @api private
-    def initialize(objects)
+    def initialize(objects, reps)
       @objects = objects
+      @reps = reps
     end
 
     # @api private

--- a/lib/nanoc/base/views/identifiable_collection_view.rb
+++ b/lib/nanoc/base/views/identifiable_collection_view.rb
@@ -13,6 +13,11 @@ module Nanoc
       @objects
     end
 
+    # @api private
+    def unwrap_reps
+      @reps
+    end
+
     # @abstract
     #
     # @api private
@@ -28,7 +33,7 @@ module Nanoc
     #
     # @return [self]
     def each
-      @objects.each { |i| yield view_class.new(i, @reps) }
+      @objects.each { |i| yield view_class.new(i, unwrap_reps) }
       self
     end
 
@@ -71,7 +76,7 @@ module Nanoc
     #   @return [#identifier] if an object was found
     def [](arg)
       res = @objects[arg]
-      res && view_class.new(res, @reps)
+      res && view_class.new(res, unwrap_reps)
     end
   end
 end

--- a/lib/nanoc/base/views/identifiable_collection_view.rb
+++ b/lib/nanoc/base/views/identifiable_collection_view.rb
@@ -27,7 +27,7 @@ module Nanoc
     #
     # @return [self]
     def each
-      @objects.each { |i| yield view_class.new(i) }
+      @objects.each { |i| yield view_class.new(i, nil) }
       self
     end
 
@@ -70,7 +70,7 @@ module Nanoc
     #   @return [#identifier] if an object was found
     def [](arg)
       res = @objects[arg]
-      res && view_class.new(res)
+      res && view_class.new(res, nil)
     end
   end
 end

--- a/lib/nanoc/base/views/identifiable_collection_view.rb
+++ b/lib/nanoc/base/views/identifiable_collection_view.rb
@@ -28,7 +28,7 @@ module Nanoc
     #
     # @return [self]
     def each
-      @objects.each { |i| yield view_class.new(i, nil) }
+      @objects.each { |i| yield view_class.new(i, @reps) }
       self
     end
 
@@ -71,7 +71,7 @@ module Nanoc
     #   @return [#identifier] if an object was found
     def [](arg)
       res = @objects[arg]
-      res && view_class.new(res, nil)
+      res && view_class.new(res, @reps)
     end
   end
 end

--- a/lib/nanoc/base/views/item_rep_view.rb
+++ b/lib/nanoc/base/views/item_rep_view.rb
@@ -61,7 +61,8 @@ module Nanoc
     #
     # @return [Nanoc::ItemView]
     def item
-      Nanoc::ItemView.new(@item_rep.item)
+      # FIXME: pass reps
+      Nanoc::ItemView.new(@item_rep.item, nil)
     end
 
     # @api private

--- a/lib/nanoc/base/views/item_view.rb
+++ b/lib/nanoc/base/views/item_view.rb
@@ -62,7 +62,7 @@ module Nanoc
     #
     # @return [Nanoc::ItemRepCollectionView]
     def reps
-      Nanoc::ItemRepCollectionView.new(unwrap_reps.reps_for(unwrap))
+      Nanoc::ItemRepCollectionView.new(unwrap_reps[unwrap])
     end
 
     # @api private

--- a/lib/nanoc/base/views/item_view.rb
+++ b/lib/nanoc/base/views/item_view.rb
@@ -40,7 +40,7 @@ module Nanoc
     #
     # @return [Enumerable<Nanoc::ItemView>]
     def children
-      unwrap.children.map { |i| Nanoc::ItemView.new(i, @reps) }
+      unwrap.children.map { |i| Nanoc::ItemView.new(i, unwrap_reps) }
     end
 
     # Returns the parent of this item, if one exists. For items with identifiers
@@ -50,7 +50,7 @@ module Nanoc
     #
     # @return [nil] if the item has no parent
     def parent
-      unwrap.parent && Nanoc::ItemView.new(unwrap.parent, @reps)
+      unwrap.parent && Nanoc::ItemView.new(unwrap.parent, unwrap_reps)
     end
 
     # @return [Boolean] True if the item is binary, false otherwise
@@ -62,7 +62,7 @@ module Nanoc
     #
     # @return [Nanoc::ItemRepCollectionView]
     def reps
-      Nanoc::ItemRepCollectionView.new(@reps.reps_for(unwrap))
+      Nanoc::ItemRepCollectionView.new(unwrap_reps.reps_for(unwrap))
     end
 
     # @api private

--- a/lib/nanoc/base/views/item_view.rb
+++ b/lib/nanoc/base/views/item_view.rb
@@ -40,7 +40,7 @@ module Nanoc
     #
     # @return [Enumerable<Nanoc::ItemView>]
     def children
-      unwrap.children.map { |i| Nanoc::ItemView.new(i) }
+      unwrap.children.map { |i| Nanoc::ItemView.new(i, @reps) }
     end
 
     # Returns the parent of this item, if one exists. For items with identifiers
@@ -50,7 +50,7 @@ module Nanoc
     #
     # @return [nil] if the item has no parent
     def parent
-      unwrap.parent && Nanoc::ItemView.new(unwrap.parent)
+      unwrap.parent && Nanoc::ItemView.new(unwrap.parent, @reps)
     end
 
     # @return [Boolean] True if the item is binary, false otherwise

--- a/lib/nanoc/base/views/item_view.rb
+++ b/lib/nanoc/base/views/item_view.rb
@@ -62,7 +62,7 @@ module Nanoc
     #
     # @return [Nanoc::ItemRepCollectionView]
     def reps
-      Nanoc::ItemRepCollectionView.new(unwrap.reps)
+      Nanoc::ItemRepCollectionView.new(@reps.reps_for(unwrap))
     end
 
     # @api private

--- a/lib/nanoc/base/views/mixins/document_view_mixin.rb
+++ b/lib/nanoc/base/views/mixins/document_view_mixin.rb
@@ -14,6 +14,11 @@ module Nanoc
       @document
     end
 
+    # @api private
+    def unwrap_reps
+      @reps
+    end
+
     # @see Object#==
     def ==(other)
       identifier == other.identifier

--- a/lib/nanoc/base/views/mixins/document_view_mixin.rb
+++ b/lib/nanoc/base/views/mixins/document_view_mixin.rb
@@ -4,8 +4,9 @@ module Nanoc
     NONE = Object.new
 
     # @api private
-    def initialize(document)
+    def initialize(document, reps)
       @document = document
+      @reps = reps
     end
 
     # @api private

--- a/lib/nanoc/base/views/mutable_identifiable_collection_view.rb
+++ b/lib/nanoc/base/views/mutable_identifiable_collection_view.rb
@@ -8,7 +8,7 @@ module Nanoc
     #
     # @return [self]
     def delete_if(&_block)
-      @objects.delete_if { |o| yield(view_class.new(o)) }
+      @objects.delete_if { |o| yield(view_class.new(o, nil)) }
       self
     end
   end

--- a/lib/nanoc/base/views/mutable_identifiable_collection_view.rb
+++ b/lib/nanoc/base/views/mutable_identifiable_collection_view.rb
@@ -8,7 +8,7 @@ module Nanoc
     #
     # @return [self]
     def delete_if(&_block)
-      @objects.delete_if { |o| yield(view_class.new(o, @reps)) }
+      @objects.delete_if { |o| yield(view_class.new(o, unwrap_reps)) }
       self
     end
   end

--- a/lib/nanoc/base/views/mutable_identifiable_collection_view.rb
+++ b/lib/nanoc/base/views/mutable_identifiable_collection_view.rb
@@ -8,7 +8,7 @@ module Nanoc
     #
     # @return [self]
     def delete_if(&_block)
-      @objects.delete_if { |o| yield(view_class.new(o, nil)) }
+      @objects.delete_if { |o| yield(view_class.new(o, @reps)) }
       self
     end
   end

--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -429,7 +429,8 @@ module Nanoc::CLI::Commands
     end
 
     def reps
-      site.items.map(&:reps).flatten
+      site.compiler.reps.to_a
+      # site.items.map(&:reps).flatten
     end
     memoize :reps
 

--- a/lib/nanoc/cli/commands/shell.rb
+++ b/lib/nanoc/cli/commands/shell.rb
@@ -23,8 +23,8 @@ module Nanoc::CLI::Commands
 
     def self.env_for(site)
       {
-        items: Nanoc::ItemCollectionView.new(site.items),
-        layouts: Nanoc::LayoutCollectionView.new(site.layouts),
+        items: Nanoc::ItemCollectionView.new(site.items, nil),
+        layouts: Nanoc::LayoutCollectionView.new(site.layouts, nil),
         config: Nanoc::ConfigView.new(site.config),
       }
     end

--- a/lib/nanoc/cli/commands/show-rules.rb
+++ b/lib/nanoc/cli/commands/show-rules.rb
@@ -9,18 +9,21 @@ module Nanoc::CLI::Commands
   class ShowRules < ::Nanoc::CLI::CommandRunner
     def run
       require_site
+      site.compiler.build_reps
 
       @c = Nanoc::CLI::ANSIStringColorizer
       @rules = site.compiler.rules_collection
 
-      site.items.sort_by(&:identifier).each   { |e| explain_item(e) }
+      reps = site.compiler.reps
+
+      site.items.sort_by(&:identifier).each   { |e| explain_item(e, reps) }
       site.layouts.sort_by(&:identifier).each { |e| explain_layout(e) }
     end
 
-    def explain_item(item)
+    def explain_item(item, reps)
       puts "#{@c.c('Item ' + item.identifier, :bold, :yellow)}:"
 
-      item.reps.each do |rep|
+      reps[item].each do |rep|
         rule = @rules.compilation_rule_for(rep)
         puts "  Rep #{rep.name}: #{rule ? rule.pattern : '(none)'}"
       end

--- a/lib/nanoc/extra/checking/check.rb
+++ b/lib/nanoc/extra/checking/check.rb
@@ -20,9 +20,8 @@ module Nanoc::Extra::Checking
       output_filenames = Dir[output_dir + '/**/*'].select { |f| File.file?(f) }
 
       context = {
-        # FIXME: pass real reps
-        items: Nanoc::ItemCollectionView.new(site.items, nil),
-        layouts: Nanoc::LayoutCollectionView.new(site.layouts, nil),
+        items: Nanoc::ItemCollectionView.new(site.items, site.compiler.reps),
+        layouts: Nanoc::LayoutCollectionView.new(site.layouts, site.compiler.reps),
         config: Nanoc::ConfigView.new(site.config),
         site: Nanoc::SiteView.new(site), # TODO: remove me
         output_filenames: output_filenames,

--- a/lib/nanoc/extra/checking/check.rb
+++ b/lib/nanoc/extra/checking/check.rb
@@ -20,8 +20,9 @@ module Nanoc::Extra::Checking
       output_filenames = Dir[output_dir + '/**/*'].select { |f| File.file?(f) }
 
       context = {
-        items: Nanoc::ItemCollectionView.new(site.items),
-        layouts: Nanoc::LayoutCollectionView.new(site.layouts),
+        # FIXME: pass real reps
+        items: Nanoc::ItemCollectionView.new(site.items, nil),
+        layouts: Nanoc::LayoutCollectionView.new(site.layouts, nil),
         config: Nanoc::ConfigView.new(site.config),
         site: Nanoc::SiteView.new(site), # TODO: remove me
         output_filenames: output_filenames,

--- a/lib/nanoc/extra/pruner.rb
+++ b/lib/nanoc/extra/pruner.rb
@@ -28,9 +28,7 @@ module Nanoc::Extra
 
       # Get compiled files
       # FIXME: requires #build_reps to have been called
-      all_raw_paths = site.items.map do |item|
-        item.reps.map(&:raw_path)
-      end
+      site.compiler.reps.map(&:raw_path)
       compiled_files = all_raw_paths.flatten.compact.select { |f| File.file?(f) }
 
       # Get present files and dirs

--- a/spec/nanoc/base/checksummer_spec.rb
+++ b/spec/nanoc/base/checksummer_spec.rb
@@ -207,14 +207,14 @@ describe Nanoc::Int::Checksummer do
   end
 
   context 'Nanoc::ItemView' do
-    let(:obj) { Nanoc::ItemView.new(item) }
+    let(:obj) { Nanoc::ItemView.new(item, nil) }
     let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo.md') }
 
     it { is_expected.to eql('Nanoc::ItemView<Nanoc::Int::Item<content=Nanoc::Int::TextualContent<String<asdf>>,attributes=Hash<>,identifier=Nanoc::Identifier<String</foo.md>>>>') }
   end
 
   context 'Nanoc::LayoutView' do
-    let(:obj) { Nanoc::LayoutView.new(layout) }
+    let(:obj) { Nanoc::LayoutView.new(layout, nil) }
     let(:layout) { Nanoc::Int::Layout.new('asdf', {}, '/foo.md') }
 
     it { is_expected.to eql('Nanoc::LayoutView<Nanoc::Int::Layout<content=Nanoc::Int::TextualContent<String<asdf>>,attributes=Hash<>,identifier=Nanoc::Identifier<String</foo.md>>>>') }

--- a/spec/nanoc/base/checksummer_spec.rb
+++ b/spec/nanoc/base/checksummer_spec.rb
@@ -228,7 +228,7 @@ describe Nanoc::Int::Checksummer do
   end
 
   context 'Nanoc::ItemCollectionView' do
-    let(:obj) { Nanoc::ItemCollectionView.new(wrapped) }
+    let(:obj) { Nanoc::ItemCollectionView.new(wrapped, nil) }
 
     let(:config) { Nanoc::Int::Configuration.new({ 'foo' => 'bar' }) }
 

--- a/spec/nanoc/base/views/document_view_spec.rb
+++ b/spec/nanoc/base/views/document_view_spec.rb
@@ -1,7 +1,10 @@
 shared_examples 'a document view' do
+  let(:reps) { double(:reps) }
+
+  let(:view) { described_class.new(document, reps) }
+
   describe '#== and #eql?' do
     let(:document) { entity_class.new('content', {}, '/asdf/') }
-    let(:view) { described_class.new(document) }
 
     context 'comparing with document with same identifier' do
       let(:other) { entity_class.new('content', {}, '/asdf/') }
@@ -22,7 +25,7 @@ shared_examples 'a document view' do
     end
 
     context 'comparing with document view with same identifier' do
-      let(:other) { Nanoc::LayoutView.new(entity_class.new('content', {}, '/asdf/')) }
+      let(:other) { described_class.new(entity_class.new('content', {}, '/asdf/'), reps) }
 
       it 'is equal' do
         expect(view).to eq(other)
@@ -31,7 +34,7 @@ shared_examples 'a document view' do
     end
 
     context 'comparing with document view with different identifier' do
-      let(:other) { Nanoc::LayoutView.new(entity_class.new('content', {}, '/fdsa/')) }
+      let(:other) { described_class.new(entity_class.new('content', {}, '/fdsa/'), reps) }
 
       it 'is not equal' do
         expect(view).not_to eq(other)
@@ -42,7 +45,6 @@ shared_examples 'a document view' do
 
   describe '#[]' do
     let(:document) { entity_class.new('stuff', { animal: 'donkey' }, '/foo/') }
-    let(:view) { described_class.new(document) }
 
     subject { view[key] }
 
@@ -63,12 +65,11 @@ shared_examples 'a document view' do
   end
 
   describe '#fetch' do
-    let(:item) { entity_class.new('stuff', { animal: 'donkey' }, '/foo/') }
-    let(:view) { described_class.new(item) }
+    let(:document) { entity_class.new('stuff', { animal: 'donkey' }, '/foo/') }
 
     before do
-      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:visit_started, item).ordered
-      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:visit_ended, item).ordered
+      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:visit_started, document).ordered
+      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:visit_ended, document).ordered
     end
 
     context 'with existant key' do
@@ -104,7 +105,6 @@ shared_examples 'a document view' do
 
   describe '#key?' do
     let(:document) { entity_class.new('stuff', { animal: 'donkey' }, '/foo/') }
-    let(:view) { described_class.new(document) }
 
     before do
       expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:visit_started, document).ordered
@@ -126,7 +126,6 @@ shared_examples 'a document view' do
 
   describe '#hash' do
     let(:document) { double(:document, identifier: '/foo/') }
-    let(:view) { described_class.new(document) }
 
     subject { view.hash }
 

--- a/spec/nanoc/base/views/identifiable_collection_spec.rb
+++ b/spec/nanoc/base/views/identifiable_collection_spec.rb
@@ -1,6 +1,8 @@
 # Needs :view_class
 shared_examples 'an identifiable collection' do
-  let(:view) { described_class.new(wrapped) }
+  let(:view) { described_class.new(wrapped, reps) }
+
+  let(:reps) { double(:reps) }
 
   let(:config) do
     { string_pattern_type: 'glob' }

--- a/spec/nanoc/base/views/item_spec.rb
+++ b/spec/nanoc/base/views/item_spec.rb
@@ -2,9 +2,11 @@ describe Nanoc::ItemView do
   let(:entity_class) { Nanoc::Int::Item }
   it_behaves_like 'a document view'
 
+  let(:reps) { double(:reps) }
+
   describe '#raw_content' do
     let(:item) { Nanoc::Int::Item.new('content', {}, '/asdf/') }
-    let(:view) { described_class.new(item) }
+    let(:view) { described_class.new(item, reps) }
 
     subject { view.raw_content }
 
@@ -16,7 +18,7 @@ describe Nanoc::ItemView do
       Nanoc::Int::Item.new('me', {}, '/me/').tap { |i| i.parent = parent_item }
     end
 
-    let(:view) { described_class.new(item) }
+    let(:view) { described_class.new(item, reps) }
 
     subject { view.parent }
 
@@ -51,7 +53,7 @@ describe Nanoc::ItemView do
     let(:rep_a) { double(:rep_a) }
     let(:rep_b) { double(:rep_b) }
 
-    let(:view) { described_class.new(item) }
+    let(:view) { described_class.new(item, reps) }
 
     subject { view.reps }
 
@@ -64,7 +66,7 @@ describe Nanoc::ItemView do
   describe '#compiled_content' do
     subject { view.compiled_content(params) }
 
-    let(:view) { described_class.new(item) }
+    let(:view) { described_class.new(item, reps) }
 
     let(:item) do
       Nanoc::Int::Item.new('content', {}, '/asdf/')
@@ -138,7 +140,7 @@ describe Nanoc::ItemView do
   describe '#path' do
     subject { view.path(params) }
 
-    let(:view) { described_class.new(item) }
+    let(:view) { described_class.new(item, reps) }
 
     let(:item) do
       Nanoc::Int::Item.new('content', {}, '/asdf.md')

--- a/spec/nanoc/base/views/item_spec.rb
+++ b/spec/nanoc/base/views/item_spec.rb
@@ -49,13 +49,20 @@ describe Nanoc::ItemView do
   end
 
   describe '#reps' do
-    let(:item) { double(:item, reps: [rep_a, rep_b]) }
-    let(:rep_a) { double(:rep_a) }
-    let(:rep_b) { double(:rep_b) }
+    let(:item) { Nanoc::Int::Item.new('content', {}, '/asdf/') }
+    let(:rep_a) { Nanoc::Int::ItemRep.new(item, :a) }
+    let(:rep_b) { Nanoc::Int::ItemRep.new(item, :b) }
 
     let(:view) { described_class.new(item, reps) }
 
+    let(:reps) { Nanoc::Int::ItemRepRepo.new }
+
     subject { view.reps }
+
+    before do
+      reps << rep_a
+      reps << rep_b
+    end
 
     it 'returns a proper item rep collection' do
       expect(subject.size).to eq(2)
@@ -86,8 +93,10 @@ describe Nanoc::ItemView do
       end
     end
 
+    let(:reps) { Nanoc::Int::ItemRepRepo.new }
+
     before do
-      item.reps << rep
+      reps << rep
     end
 
     context 'requesting implicit default rep' do
@@ -155,8 +164,10 @@ describe Nanoc::ItemView do
       end
     end
 
+    let(:reps) { Nanoc::Int::ItemRepRepo.new }
+
     before do
-      item.reps << rep
+      reps << rep
     end
 
     context 'requesting implicit default rep' do

--- a/spec/nanoc/base/views/mutable_document_view_spec.rb
+++ b/spec/nanoc/base/views/mutable_document_view_spec.rb
@@ -1,7 +1,10 @@
 shared_examples 'a mutable document view' do
+  let(:view) { described_class.new(document, reps) }
+
+  let(:reps) { double(:reps) }
+
   describe '#[]=' do
-    let(:item) { entity_class.new('content', {}, '/asdf/') }
-    let(:view) { described_class.new(item) }
+    let(:document) { entity_class.new('content', {}, '/asdf/') }
 
     it 'sets attributes' do
       view[:title] = 'Donkey'
@@ -10,8 +13,7 @@ shared_examples 'a mutable document view' do
   end
 
   describe '#update_attributes' do
-    let(:item) { entity_class.new('content', {}, '/asdf/') }
-    let(:view) { described_class.new(item) }
+    let(:document) { entity_class.new('content', {}, '/asdf/') }
 
     let(:update) { { friend: 'Giraffe' } }
 

--- a/spec/nanoc/base/views/mutable_identifiable_collection_spec.rb
+++ b/spec/nanoc/base/views/mutable_identifiable_collection_spec.rb
@@ -1,5 +1,7 @@
 shared_examples 'a mutable identifiable collection' do
-  let(:view) { described_class.new(wrapped) }
+  let(:view) { described_class.new(wrapped, reps) }
+
+  let(:reps) { double(:reps) }
 
   let(:config) do
     {}

--- a/spec/nanoc/base/views/mutable_item_collection_spec.rb
+++ b/spec/nanoc/base/views/mutable_item_collection_spec.rb
@@ -18,7 +18,9 @@ describe Nanoc::MutableItemCollectionView do
       end
     end
 
-    let(:view) { described_class.new(wrapped) }
+    let(:view) { described_class.new(wrapped, reps) }
+
+    let(:reps) { double(:reps) }
 
     it 'creates an object' do
       view.create('new content', { title: 'New Page' }, '/new/')

--- a/spec/nanoc/base/views/mutable_layout_collection_spec.rb
+++ b/spec/nanoc/base/views/mutable_layout_collection_spec.rb
@@ -18,7 +18,9 @@ describe Nanoc::MutableLayoutCollectionView do
       end
     end
 
-    let(:view) { described_class.new(wrapped) }
+    let(:view) { described_class.new(wrapped, reps) }
+
+    let(:reps) { double(:reps) }
 
     it 'creates an object' do
       view.create('new content', { title: 'New Page' }, '/new/')

--- a/spec/nanoc/cli/commands/show_rules_spec.rb
+++ b/spec/nanoc/cli/commands/show_rules_spec.rb
@@ -24,17 +24,9 @@ describe Nanoc::CLI::Commands::ShowRules do
 
     let(:items) do
       Nanoc::Int::IdentifiableCollection.new(config).tap do |ic|
-        ic << Nanoc::Int::Item.new('About Me', {}, '/about.md').tap do |i|
-          i.reps << Nanoc::Int::ItemRep.new(i, :default)
-          i.reps << Nanoc::Int::ItemRep.new(i, :text)
-        end
-        ic << Nanoc::Int::Item.new('About My Dog', {}, '/dog.md').tap do |i|
-          i.reps << Nanoc::Int::ItemRep.new(i, :default)
-          i.reps << Nanoc::Int::ItemRep.new(i, :text)
-        end
-        ic << Nanoc::Int::Item.new('Raw Data', {}, '/other.dat').tap do |i|
-          i.reps << Nanoc::Int::ItemRep.new(i, :default)
-        end
+        ic << Nanoc::Int::Item.new('About Me', {}, '/about.md')
+        ic << Nanoc::Int::Item.new('About My Dog', {}, '/dog.md')
+        ic << Nanoc::Int::Item.new('Raw Data', {}, '/other.dat')
       end
     end
 
@@ -48,7 +40,17 @@ describe Nanoc::CLI::Commands::ShowRules do
 
     let(:config) { double(:config) }
 
-    let(:compiler) { double(:compiler, rules_collection: rules_collection) }
+    let(:compiler) { double(:compiler, reps: reps, rules_collection: rules_collection) }
+
+    let(:reps) do
+      Nanoc::Int::ItemRepRepo.new.tap do |r|
+        r << Nanoc::Int::ItemRep.new(items['/about.md'], :default)
+        r << Nanoc::Int::ItemRep.new(items['/about.md'], :text)
+        r << Nanoc::Int::ItemRep.new(items['/dog.md'], :default)
+        r << Nanoc::Int::ItemRep.new(items['/dog.md'], :text)
+        r << Nanoc::Int::ItemRep.new(items['/other.dat'], :default)
+      end
+    end
 
     let(:rules_collection) do
       Nanoc::Int::RulesCollection.new.tap do |rc|
@@ -88,6 +90,10 @@ describe Nanoc::CLI::Commands::ShowRules do
 
       EOS
         .gsub(/^ {8}/, '')
+    end
+
+    before do
+      expect(compiler).to receive(:build_reps)
     end
 
     it 'outputs item and layout rules' do

--- a/spec/nanoc/helpers/blogging_spec.rb
+++ b/spec/nanoc/helpers/blogging_spec.rb
@@ -108,7 +108,7 @@ describe Nanoc::Helpers::Blogging do
     end
 
     let(:item_view) do
-      Nanoc::ItemView.new(item)
+      Nanoc::ItemView.new(item, nil)
     end
 
     let(:item_attributes) do
@@ -174,7 +174,7 @@ describe Nanoc::Helpers::Blogging do
     end
 
     let(:item_view) do
-      Nanoc::ItemView.new(item)
+      Nanoc::ItemView.new(item, nil)
     end
 
     let(:item_attributes) do
@@ -231,7 +231,7 @@ describe Nanoc::Helpers::Blogging do
     let(:item_rep_path) { '/stuff.xml' }
 
     let(:item_view) do
-      Nanoc::ItemView.new(item)
+      Nanoc::ItemView.new(item, nil)
     end
 
     let(:item_attributes) do

--- a/spec/nanoc/helpers/blogging_spec.rb
+++ b/spec/nanoc/helpers/blogging_spec.rb
@@ -87,7 +87,6 @@ describe Nanoc::Helpers::Blogging do
       items << item_b
       items << item_c
 
-      # FIXME: pass real reps
       { items: Nanoc::ItemCollectionView.new(items, nil) }
     end
 
@@ -102,15 +101,11 @@ describe Nanoc::Helpers::Blogging do
     subject { mod.url_for(item_view) }
 
     let(:item) do
-      Nanoc::Int::Item.new('Stuff', item_attributes, '/stuff/').tap do |item|
-        item.reps << Nanoc::Int::ItemRep.new(item, :default).tap do |rep|
-          rep.paths[:last] = '/rep/path/stuff.html'
-        end
-      end
+      Nanoc::Int::Item.new('Stuff', item_attributes, '/stuff/')
     end
 
     let(:item_view) do
-      Nanoc::ItemView.new(item, nil)
+      Nanoc::ItemView.new(item, reps)
     end
 
     let(:item_attributes) do
@@ -121,6 +116,15 @@ describe Nanoc::Helpers::Blogging do
       {
         config: { base_url: base_url },
       }
+    end
+
+    let(:reps) { Nanoc::Int::ItemRepRepo.new }
+
+    before do
+      rep = Nanoc::Int::ItemRep.new(item, :default)
+      rep.paths[:last] = '/rep/path/stuff.html'
+      item.reps << rep
+      reps << rep
     end
 
     context 'without base_url' do
@@ -168,15 +172,11 @@ describe Nanoc::Helpers::Blogging do
     subject { mod.feed_url }
 
     let(:item) do
-      Nanoc::Int::Item.new('Feed', item_attributes, '/feed/').tap do |item|
-        item.reps << Nanoc::Int::ItemRep.new(item, :default).tap do |rep|
-          rep.paths[:last] = '/feed.xml'
-        end
-      end
+      Nanoc::Int::Item.new('Feed', item_attributes, '/feed/')
     end
 
     let(:item_view) do
-      Nanoc::ItemView.new(item, nil)
+      Nanoc::ItemView.new(item, reps)
     end
 
     let(:item_attributes) do
@@ -188,6 +188,15 @@ describe Nanoc::Helpers::Blogging do
         config: { base_url: base_url },
         item: item_view,
       }
+    end
+
+    let(:reps) { Nanoc::Int::ItemRepRepo.new }
+
+    before do
+      rep = Nanoc::Int::ItemRep.new(item, :default)
+      rep.paths[:last] = '/feed.xml'
+      item.reps << rep
+      reps << rep
     end
 
     context 'without base_url' do
@@ -223,17 +232,13 @@ describe Nanoc::Helpers::Blogging do
     subject { mod.atom_tag_for(item_view) }
 
     let(:item) do
-      Nanoc::Int::Item.new('Stuff', item_attributes, '/stuff/').tap do |item|
-        item.reps << Nanoc::Int::ItemRep.new(item, :default).tap do |rep|
-          rep.paths[:last] = item_rep_path
-        end
-      end
+      Nanoc::Int::Item.new('Stuff', item_attributes, '/stuff/')
     end
 
     let(:item_rep_path) { '/stuff.xml' }
 
     let(:item_view) do
-      Nanoc::ItemView.new(item, nil)
+      Nanoc::ItemView.new(item, reps)
     end
 
     let(:item_attributes) do
@@ -248,6 +253,15 @@ describe Nanoc::Helpers::Blogging do
     end
 
     let(:base_url) { 'http://url.base' }
+
+    let(:reps) { Nanoc::Int::ItemRepRepo.new }
+
+    before do
+      rep = Nanoc::Int::ItemRep.new(item, :default)
+      rep.paths[:last] = item_rep_path
+      item.reps << rep
+      reps << rep
+    end
 
     context 'item with path' do
       let(:item_rep_path) { '/stuff.xml' }

--- a/spec/nanoc/helpers/blogging_spec.rb
+++ b/spec/nanoc/helpers/blogging_spec.rb
@@ -123,7 +123,6 @@ describe Nanoc::Helpers::Blogging do
     before do
       rep = Nanoc::Int::ItemRep.new(item, :default)
       rep.paths[:last] = '/rep/path/stuff.html'
-      item.reps << rep
       reps << rep
     end
 
@@ -195,7 +194,6 @@ describe Nanoc::Helpers::Blogging do
     before do
       rep = Nanoc::Int::ItemRep.new(item, :default)
       rep.paths[:last] = '/feed.xml'
-      item.reps << rep
       reps << rep
     end
 
@@ -259,7 +257,6 @@ describe Nanoc::Helpers::Blogging do
     before do
       rep = Nanoc::Int::ItemRep.new(item, :default)
       rep.paths[:last] = item_rep_path
-      item.reps << rep
       reps << rep
     end
 

--- a/spec/nanoc/helpers/blogging_spec.rb
+++ b/spec/nanoc/helpers/blogging_spec.rb
@@ -42,7 +42,8 @@ describe Nanoc::Helpers::Blogging do
       items << item_b
       items << item_c
 
-      { items: Nanoc::ItemCollectionView.new(items) }
+      # FIXME: pass real reps
+      { items: Nanoc::ItemCollectionView.new(items, nil) }
     end
 
     it 'returns the two articles' do
@@ -86,7 +87,8 @@ describe Nanoc::Helpers::Blogging do
       items << item_b
       items << item_c
 
-      { items: Nanoc::ItemCollectionView.new(items) }
+      # FIXME: pass real reps
+      { items: Nanoc::ItemCollectionView.new(items, nil) }
     end
 
     it 'returns the two articles' do

--- a/test/base/test_compiler.rb
+++ b/test/base/test_compiler.rb
@@ -526,42 +526,6 @@ class Nanoc::Int::CompilerTest < Nanoc::TestCase
     end
   end
 
-  def test_compiler_dependency_on_unmet_dependency
-    with_site do
-      File.open('content/a.html', 'w') do |io|
-        io.write('<% @items["/b/"].compiled_content %>')
-      end
-      File.open('content/b.html', 'w') do |io|
-        io.write('I am feeling so dependent!')
-      end
-      File.open('Rules', 'w') do |io|
-        io.write "compile '*' do\n"
-        io.write "  filter :erb\n"
-        io.write "end\n"
-        io.write "\n"
-        io.write "route '*' do\n"
-        io.write "  item.identifier.chop + '.' + item[:extension]\n"
-        io.write "end\n"
-        io.write "\n"
-        io.write "layout '*', :erb\n"
-      end
-
-      site = Nanoc::Int::SiteLoader.new.new_from_cwd
-      site.compiler.build_reps
-      site.compiler.load_stores
-      rep = site.items['/a/'].reps[0]
-      dt = site.compiler.dependency_tracker
-      dt.start
-      assert_raises Nanoc::Int::Errors::UnmetDependency do
-        site.compiler.send :compile_rep, rep
-      end
-      dt.stop
-
-      stack = dt.instance_eval { @stack }
-      assert_empty stack
-    end
-  end
-
   def test_find_layouts_by_glob
     Nanoc::CLI.run %w( create_site bar )
     FileUtils.cd('bar') do

--- a/test/base/test_outdatedness_checker.rb
+++ b/test/base/test_outdatedness_checker.rb
@@ -41,7 +41,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.build_reps
       site.compiler.load_stores
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items.find { |i| i.identifier == '/' }.reps[0]
+      rep = site.compiler.reps[site.items.find { |i| i.identifier == '/' }][0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::NotEnoughData,
         outdatedness_checker.outdatedness_reason_for(rep)
     end
@@ -68,7 +68,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.build_reps
       site.compiler.load_stores
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items.find { |i| i.identifier == '/' }.reps[0]
+      rep = site.compiler.reps[site.items.find { |i| i.identifier == '/' }][0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::NotWritten,
         outdatedness_checker.outdatedness_reason_for(rep)
     end
@@ -96,7 +96,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.build_reps
       site.compiler.load_stores
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items.find { |i| i.identifier == '/new/' }.reps[0]
+      rep = site.compiler.reps[site.items.find { |i| i.identifier == '/new/' }][0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::SourceModified,
         outdatedness_checker.outdatedness_reason_for(rep)
     end
@@ -125,7 +125,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.load_stores
 
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items.find { |i| i.identifier == '/' }.reps[0]
+      rep = site.compiler.reps[site.items.find { |i| i.identifier == '/' }][0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::DependenciesOutdated,
         outdatedness_checker.outdatedness_reason_for(rep)
     end
@@ -160,7 +160,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.load_stores
 
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items.find { |i| i.identifier == '/a/' }.reps[0]
+      rep = site.compiler.reps[site.items.find { |i| i.identifier == '/a/' }][0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::DependenciesOutdated,
         outdatedness_checker.outdatedness_reason_for(rep)
     end
@@ -198,7 +198,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.load_stores
 
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items.find { |i| i.identifier == '/a/' }.reps[0]
+      rep = site.compiler.reps[site.items.find { |i| i.identifier == '/a/' }][0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::DependenciesOutdated,
         outdatedness_checker.outdatedness_reason_for(rep)
     end
@@ -233,7 +233,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.load_stores
 
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items.find { |i| i.identifier == '/a/' }.reps[0]
+      rep = site.compiler.reps[site.items.find { |i| i.identifier == '/a/' }][0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::DependenciesOutdated,
         outdatedness_checker.outdatedness_reason_for(rep)
     end
@@ -270,7 +270,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.load_stores
 
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items.find { |i| i.identifier == '/a/' }.reps[0]
+      rep = site.compiler.reps[site.items.find { |i| i.identifier == '/a/' }][0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::DependenciesOutdated,
         outdatedness_checker.outdatedness_reason_for(rep)
     end
@@ -298,7 +298,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.build_reps
       site.compiler.load_stores
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items.find { |i| i.identifier == '/' }.reps[0]
+      rep = site.compiler.reps[site.items.find { |i| i.identifier == '/' }][0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::CodeSnippetsModified,
         outdatedness_checker.outdatedness_reason_for(rep)
     end
@@ -331,7 +331,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.build_reps
       site.compiler.load_stores
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items.find { |i| i.identifier == '/' }.reps[0]
+      rep = site.compiler.reps[site.items.find { |i| i.identifier == '/' }][0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::ConfigurationModified,
         outdatedness_checker.outdatedness_reason_for(rep)
     end
@@ -357,7 +357,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.build_reps
       site.compiler.load_stores
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items.find { |i| i.identifier == '/' }.reps[0]
+      rep = site.compiler.reps[site.items.find { |i| i.identifier == '/' }][0]
       assert_nil outdatedness_checker.outdatedness_reason_for(rep)
     end
   end
@@ -401,7 +401,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.build_reps
       site.compiler.load_stores
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items.find { |i| i.identifier == '/' }.reps[0]
+      rep = site.compiler.reps[site.items.find { |i| i.identifier == '/' }][0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::RulesModified,
         outdatedness_checker.outdatedness_reason_for(rep)
     end
@@ -431,6 +431,8 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
     # Assert not outdated
     FileUtils.cd('foo') do
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
+      site.compiler.build_reps
+      site.compiler.load_stores
       outdatedness_checker = site.compiler.outdatedness_checker
       site.items.each do |item|
         refute outdatedness_checker.outdated?(item), 'item should not be outdated'
@@ -464,6 +466,8 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
     # Assert not outdated
     FileUtils.cd('foo') do
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
+      site.compiler.build_reps
+      site.compiler.load_stores
       outdatedness_checker = site.compiler.outdatedness_checker
       site.items.each do |item|
         refute outdatedness_checker.outdated?(item), 'item should not be outdated'

--- a/test/base/test_rule_context.rb
+++ b/test/base/test_rule_context.rb
@@ -12,10 +12,12 @@ class Nanoc::Int::RuleContextTest < Nanoc::TestCase
     item.stubs(:site).returns(site)
     rep = mock
     rep.stubs(:item).returns(item)
+    reps = mock
 
     # Create context
     executor = nil
-    rule_context = Nanoc::Int::RuleContext.new(rep: rep, executor: executor, site: site)
+    rule_context = Nanoc::Int::RuleContext.new(
+      reps: reps, rep: rep, executor: executor, site: site)
 
     # Check classes
     assert_equal Nanoc::ItemRepView,          rule_context.rep.class
@@ -32,6 +34,11 @@ class Nanoc::Int::RuleContextTest < Nanoc::TestCase
     assert_equal config,  rule_context.config.unwrap
     assert_equal layouts, rule_context.layouts.unwrap
     assert_equal items,   rule_context.items.unwrap
+
+    # Check reps
+    assert_equal reps, rule_context.item.unwrap_reps
+    assert_equal reps, rule_context.layouts.unwrap_reps
+    assert_equal reps, rule_context.items.unwrap_reps
   end
 
   def test_actions
@@ -45,6 +52,7 @@ class Nanoc::Int::RuleContextTest < Nanoc::TestCase
     site.stubs(:layouts).returns(layouts)
     item = mock
     item.stubs(:site).returns(site)
+    reps = mock
 
     # Mock rep
     rep = mock
@@ -52,7 +60,8 @@ class Nanoc::Int::RuleContextTest < Nanoc::TestCase
 
     # Create context
     executor = nil
-    rule_context = Nanoc::Int::RuleContext.new(rep: rep, executor: executor, site: site)
+    rule_context = Nanoc::Int::RuleContext.new(
+      reps: reps, rep: rep, executor: executor, site: site)
 
     # Check
     assert_raises(NoMethodError) do

--- a/test/extra/checking/checks/test_stale.rb
+++ b/test/extra/checking/checks/test_stale.rb
@@ -5,6 +5,7 @@ class Nanoc::Extra::Checking::Checks::StaleTest < Nanoc::TestCase
 
   def calc_issues
     site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    site.compiler.build_reps
     runner = Nanoc::Extra::Checking::Runner.new(site)
     issues = runner.run_checks([check_class])
   end

--- a/test/filters/test_less.rb
+++ b/test/filters/test_less.rb
@@ -2,7 +2,9 @@ class Nanoc::Filters::LessTest < Nanoc::TestCase
   def test_filter
     if_have 'less' do
       # Create item
-      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'))
+      @item = Nanoc::ItemView.new(
+        Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'),
+        nil)
 
       # Create filter
       filter = ::Nanoc::Filters::Less.new(item: @item, items: [@item])
@@ -20,7 +22,9 @@ class Nanoc::Filters::LessTest < Nanoc::TestCase
       File.open('content/foo/bar/imported_file.less', 'w') { |io| io.write('p { color: red; }') }
 
       # Create item
-      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'))
+      @item = Nanoc::ItemView.new(
+        Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'),
+        nil)
 
       # Create filter
       filter = ::Nanoc::Filters::Less.new(item: @item, items: [@item])
@@ -39,7 +43,9 @@ class Nanoc::Filters::LessTest < Nanoc::TestCase
 
       # Create item
       File.open('content/foo/bar.txt', 'w') { |io| io.write('meh') }
-      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'))
+      @item = Nanoc::ItemView.new(
+        Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'),
+        nil)
 
       # Create filter
       filter = ::Nanoc::Filters::Less.new(item: @item, items: [@item])
@@ -108,7 +114,9 @@ class Nanoc::Filters::LessTest < Nanoc::TestCase
   def test_compression
     if_have 'less' do
       # Create item
-      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'))
+      @item = Nanoc::ItemView.new(
+        Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'),
+        nil)
 
       # Create filter
       filter = ::Nanoc::Filters::Less.new(item: @item, items: [@item])

--- a/test/filters/test_sass.rb
+++ b/test/filters/test_sass.rb
@@ -292,6 +292,7 @@ class Nanoc::Filters::SassTest < Nanoc::TestCase
           { content_filename: 'content/xyzzy.sass' },
           '/blah/',
         ),
+        nil,
       ),
     ]
     params = { item: items[0], items: items }.merge(params)

--- a/test/filters/test_xsl.rb
+++ b/test/filters/test_xsl.rb
@@ -87,11 +87,11 @@ EOS
       item = Nanoc::Int::Item.new(SAMPLE_XML_IN,
                              {},
                              '/content/')
-      item = Nanoc::ItemView.new(item)
+      item = Nanoc::ItemView.new(item, nil)
       layout = Nanoc::Int::Layout.new(SAMPLE_XSL,
                                  {},
                                  '/layout/')
-      layout = Nanoc::LayoutView.new(layout)
+      layout = Nanoc::LayoutView.new(layout, nil)
 
       # Create an instance of the filter
       assigns = {
@@ -113,11 +113,11 @@ EOS
       item = Nanoc::Int::Item.new(SAMPLE_XML_IN_WITH_PARAMS,
                              {},
                              '/content/')
-      item = Nanoc::ItemView.new(item)
+      item = Nanoc::ItemView.new(item, nil)
       layout = Nanoc::Int::Layout.new(SAMPLE_XSL_WITH_PARAMS,
                                  {},
                                  '/layout/')
-      layout = Nanoc::LayoutView.new(layout)
+      layout = Nanoc::LayoutView.new(layout, nil)
 
       # Create an instance of the filter
       assigns = {
@@ -140,11 +140,11 @@ EOS
       item = Nanoc::Int::Item.new(SAMPLE_XML_IN_WITH_OMIT_XML_DECL,
                              {},
                              '/content/')
-      item = Nanoc::ItemView.new(item)
+      item = Nanoc::ItemView.new(item, nil)
       layout = Nanoc::Int::Layout.new(SAMPLE_XSL_WITH_OMIT_XML_DECL,
                                  {},
                                  '/layout/')
-      layout = Nanoc::LayoutView.new(layout)
+      layout = Nanoc::LayoutView.new(layout, nil)
 
       # Create an instance of the filter
       assigns = {

--- a/test/helpers/test_capturing.rb
+++ b/test/helpers/test_capturing.rb
@@ -18,7 +18,7 @@ class Nanoc::Helpers::CapturingTest < Nanoc::TestCase
     site = Nanoc::Int::SiteLoader.new.new_empty
     item = Nanoc::Int::Item.new('moo', {}, '/blah/')
     @site = Nanoc::SiteView.new(Nanoc::Int::SiteLoader.new.new_empty)
-    @item = Nanoc::ItemView.new(item)
+    @item = Nanoc::ItemView.new(item, nil)
 
     # Evaluate content
     result = ::ERB.new(content).result(binding)
@@ -33,7 +33,7 @@ class Nanoc::Helpers::CapturingTest < Nanoc::TestCase
 
     # Build site
     @site = Nanoc::SiteView.new(Nanoc::Int::SiteLoader.new.new_empty)
-    @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('moo', {}, '/blah/'))
+    @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('moo', {}, '/blah/'), nil)
 
     # Capture
     _erbout = 'foo'
@@ -67,7 +67,7 @@ foot
 EOS
 
     @site = Nanoc::SiteView.new(Nanoc::Int::SiteLoader.new.new_empty)
-    @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', {}, '/'))
+    @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', {}, '/'), nil)
 
     result = ::ERB.new(content).result(binding)
 
@@ -85,7 +85,7 @@ EOS
     end
 
     @site = Nanoc::SiteView.new(Nanoc::Int::SiteLoader.new.new_empty)
-    @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', {}, '/'))
+    @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', {}, '/'), nil)
     content = '<% content_for :a do %>Content One<% end %>'
     ::ERB.new(content).result(binding)
 
@@ -93,7 +93,7 @@ EOS
     assert_equal nil,           content_for(@item, :b)
 
     @site = Nanoc::SiteView.new(Nanoc::Int::SiteLoader.new.new_empty)
-    @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', {}, '/'))
+    @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', {}, '/'), nil)
     content = '<% content_for :b do %>Content Two<% end %>'
     ::ERB.new(content).result(binding)
 

--- a/test/helpers/test_filtering.rb
+++ b/test/helpers/test_filtering.rb
@@ -32,7 +32,7 @@ class Nanoc::Helpers::FilteringTest < Nanoc::TestCase
       item = Nanoc::Int::Item.new('stuff', { title: 'Bar...' }, '/foo.md')
       item_rep = Nanoc::Int::ItemRep.new(item, :default)
 
-      @item = Nanoc::ItemView.new(item)
+      @item = Nanoc::ItemView.new(item, nil)
       @item_rep = Nanoc::ItemRepView.new(item_rep)
 
       result = ::ERB.new(content).result(binding)

--- a/test/helpers/test_rendering.rb
+++ b/test/helpers/test_rendering.rb
@@ -13,7 +13,7 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
 
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
       @site = Nanoc::SiteView.new(site)
-      @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, nil)
 
       assert_equal('This is the /foo/ layout.', render('/foo/'))
     end
@@ -31,7 +31,7 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
 
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
       @site = Nanoc::SiteView.new(site)
-      @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, nil)
 
       assert_equal('This is the /foo/ layout.', render('/foo'))
     end
@@ -49,7 +49,7 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
 
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
       @site = Nanoc::SiteView.new(site)
-      @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, nil)
 
       assert_equal('I am the Nanoc::LayoutView class.', render('/foo/'))
     end
@@ -67,7 +67,7 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
 
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
       @site = Nanoc::SiteView.new(site)
-      @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, nil)
 
       assert_equal('I am the Nanoc::Int::Layout class.', render('/foo/'))
     end
@@ -77,7 +77,7 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
     with_site do |site|
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
       @site = Nanoc::SiteView.new(site)
-      @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, nil)
 
       assert_raises(Nanoc::Int::Errors::UnknownLayout) do
         render '/dsfghjkl/'
@@ -95,7 +95,7 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
 
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
       @site = Nanoc::SiteView.new(site)
-      @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, nil)
 
       assert_raises(Nanoc::Int::Errors::CannotDetermineFilter) do
         render '/foo/'
@@ -113,7 +113,7 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
 
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
       @site = Nanoc::SiteView.new(site)
-      @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, nil)
 
       assert_raises(Nanoc::Int::Errors::UnknownFilter) do
         render '/foo/'
@@ -133,7 +133,7 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
 
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
       @site = Nanoc::SiteView.new(site)
-      @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, nil)
 
       _erbout = '[erbout-before]'
       result = render '/foo/' do

--- a/test/helpers/test_tagging.rb
+++ b/test/helpers/test_tagging.rb
@@ -3,7 +3,8 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
 
   def test_tags_for_without_tags
     # Create item
-    item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', {}, '/path/'))
+    item = Nanoc::ItemView.new(
+      Nanoc::Int::Item.new('content', {}, '/path/'), nil)
 
     # Check
     assert_equal(
@@ -14,7 +15,8 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
 
   def test_tags_for_with_custom_base_url
     # Create item
-    item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', { tags: %w(foo bar) }, '/path/'))
+    item = Nanoc::ItemView.new(
+      Nanoc::Int::Item.new('content', { tags: %w(foo bar) }, '/path/'), nil)
 
     # Check
     assert_equal(
@@ -26,7 +28,8 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
 
   def test_tags_for_with_custom_none_text
     # Create item
-    item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', { tags: [] }, '/path/'))
+    item = Nanoc::ItemView.new(
+      Nanoc::Int::Item.new('content', { tags: [] }, '/path/'), nil)
 
     # Check
     assert_equal(
@@ -37,7 +40,8 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
 
   def test_tags_for_with_custom_separator
     # Create item
-    item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', { tags: %w(foo bar) }, '/path/'))
+    item = Nanoc::ItemView.new(
+      Nanoc::Int::Item.new('content', { tags: %w(foo bar) }, '/path/'), nil)
 
     # Check
     assert_equal(

--- a/test/helpers/test_tagging.rb
+++ b/test/helpers/test_tagging.rb
@@ -57,7 +57,7 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
       Nanoc::Int::Item.new('item 1', { tags: [:foo]       }, '/item1/'),
       Nanoc::Int::Item.new('item 2', { tags: [:bar]       }, '/item2/'),
       Nanoc::Int::Item.new('item 3', { tags: [:foo, :bar] }, '/item3/'),
-    ])
+    ], nil)
 
     # Find items
     items_with_foo_tag = items_with_tag(:foo)

--- a/test/helpers/test_xml_sitemap.rb
+++ b/test/helpers/test_xml_sitemap.rb
@@ -11,33 +11,35 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
 
   def test_xml_sitemap
     if_have 'builder', 'nokogiri' do
+      reps = Nanoc::Int::ItemRepRepo.new
+
       # Create items
       @items = Nanoc::Int::IdentifiableCollection.new({})
 
       # Create item 1
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'), nil)
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'), reps)
       @items << item
-      create_item_rep(item.unwrap, :one_a, '/item-one/a/')
-      create_item_rep(item.unwrap, :one_b, '/item-one/b/')
+      reps << create_item_rep(item.unwrap, :one_a, '/item-one/a/')
+      reps << create_item_rep(item.unwrap, :one_b, '/item-one/b/')
 
       # Create item 2
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 2', { is_hidden: true }, '/item-two/'), nil)
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 2', { is_hidden: true }, '/item-two/'), reps)
       @items << item
 
       # Create item 3
       attrs = { mtime: Time.parse('2004-07-12'), changefreq: 'daily', priority: 0.5 }
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 3', attrs, '/item-three/'), nil)
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 3', attrs, '/item-three/'), reps)
       @items << item
-      create_item_rep(item.unwrap, :three_a, '/item-three/a/')
-      create_item_rep(item.unwrap, :three_b, '/item-three/b/')
+      reps << create_item_rep(item.unwrap, :three_a, '/item-three/a/')
+      reps << create_item_rep(item.unwrap, :three_b, '/item-three/b/')
 
       # Create item 4
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 4', {}, '/item-four/'), nil)
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 4', {}, '/item-four/'), reps)
       @items << item
-      create_item_rep(item.unwrap, :four_a, nil)
+      reps << create_item_rep(item.unwrap, :four_a, nil)
 
       # Create sitemap item
-      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), nil)
+      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), reps)
 
       # Create site
       @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
@@ -72,13 +74,15 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
 
   def test_sitemap_with_items_as_param
     if_have 'builder', 'nokogiri' do
+      reps = Nanoc::Int::ItemRepRepo.new
+
       # Create items
       @items = Nanoc::Int::IdentifiableCollection.new({})
       @items << nil
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'), nil)
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'), reps)
       @items << item
-      create_item_rep(item.unwrap, :one_a, '/item-one/a/')
-      create_item_rep(item.unwrap, :one_b, '/item-one/b/')
+      reps << create_item_rep(item.unwrap, :one_a, '/item-one/a/')
+      reps << create_item_rep(item.unwrap, :one_b, '/item-one/b/')
       @items << nil
 
       # Create sitemap item
@@ -109,15 +113,17 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
 
   def test_filter
     if_have 'builder', 'nokogiri' do
+      reps = Nanoc::Int::ItemRepRepo.new
+
       # Create items
       @items = Nanoc::Int::IdentifiableCollection.new({})
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'), nil)
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'), reps)
       @items << item
-      create_item_rep(item.unwrap, :one_a, '/item-one/a/')
-      create_item_rep(item.unwrap, :one_b, '/item-one/b/')
+      reps << create_item_rep(item.unwrap, :one_a, '/item-one/a/')
+      reps << create_item_rep(item.unwrap, :one_b, '/item-one/b/')
 
       # Create sitemap item
-      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), nil)
+      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), reps)
 
       # Create site
       @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
@@ -140,23 +146,25 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
 
   def test_sorted
     if_have 'builder', 'nokogiri' do
+      reps = Nanoc::Int::ItemRepRepo.new
+
       # Create items
       @items = Nanoc::Int::IdentifiableCollection.new({})
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/george/'), nil)
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/george/'), reps)
       @items << item
-      create_item_rep(item.unwrap, :a_alice,   '/george/alice/')
-      create_item_rep(item.unwrap, :b_zoey,    '/george/zoey/')
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/walton/'), nil)
+      reps << create_item_rep(item.unwrap, :a_alice,   '/george/alice/')
+      reps << create_item_rep(item.unwrap, :b_zoey,    '/george/zoey/')
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/walton/'), reps)
       @items << item
-      create_item_rep(item.unwrap, :a_eve,     '/walton/eve/')
-      create_item_rep(item.unwrap, :b_bob,     '/walton/bob/')
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/lucas/'), nil)
+      reps << create_item_rep(item.unwrap, :a_eve,     '/walton/eve/')
+      reps << create_item_rep(item.unwrap, :b_bob,     '/walton/bob/')
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/lucas/'), reps)
       @items << item
-      create_item_rep(item.unwrap, :a_trudy,   '/lucas/trudy/')
-      create_item_rep(item.unwrap, :b_mallory, '/lucas/mallory/')
+      reps << create_item_rep(item.unwrap, :a_trudy,   '/lucas/trudy/')
+      reps << create_item_rep(item.unwrap, :b_mallory, '/lucas/mallory/')
 
       # Create sitemap item
-      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), nil)
+      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), reps)
 
       # Create site
       @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })

--- a/test/helpers/test_xml_sitemap.rb
+++ b/test/helpers/test_xml_sitemap.rb
@@ -15,29 +15,29 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
       @items = Nanoc::Int::IdentifiableCollection.new({})
 
       # Create item 1
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'))
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'), nil)
       @items << item
       create_item_rep(item.unwrap, :one_a, '/item-one/a/')
       create_item_rep(item.unwrap, :one_b, '/item-one/b/')
 
       # Create item 2
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 2', { is_hidden: true }, '/item-two/'))
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 2', { is_hidden: true }, '/item-two/'), nil)
       @items << item
 
       # Create item 3
       attrs = { mtime: Time.parse('2004-07-12'), changefreq: 'daily', priority: 0.5 }
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 3', attrs, '/item-three/'))
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 3', attrs, '/item-three/'), nil)
       @items << item
       create_item_rep(item.unwrap, :three_a, '/item-three/a/')
       create_item_rep(item.unwrap, :three_b, '/item-three/b/')
 
       # Create item 4
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 4', {}, '/item-four/'))
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 4', {}, '/item-four/'), nil)
       @items << item
       create_item_rep(item.unwrap, :four_a, nil)
 
       # Create sitemap item
-      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'))
+      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), nil)
 
       # Create site
       @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
@@ -75,7 +75,7 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
       # Create items
       @items = Nanoc::Int::IdentifiableCollection.new({})
       @items << nil
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'))
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'), nil)
       @items << item
       create_item_rep(item.unwrap, :one_a, '/item-one/a/')
       create_item_rep(item.unwrap, :one_b, '/item-one/b/')
@@ -111,13 +111,13 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
     if_have 'builder', 'nokogiri' do
       # Create items
       @items = Nanoc::Int::IdentifiableCollection.new({})
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'))
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'), nil)
       @items << item
       create_item_rep(item.unwrap, :one_a, '/item-one/a/')
       create_item_rep(item.unwrap, :one_b, '/item-one/b/')
 
       # Create sitemap item
-      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'))
+      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), nil)
 
       # Create site
       @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
@@ -142,21 +142,21 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
     if_have 'builder', 'nokogiri' do
       # Create items
       @items = Nanoc::Int::IdentifiableCollection.new({})
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/george/'))
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/george/'), nil)
       @items << item
       create_item_rep(item.unwrap, :a_alice,   '/george/alice/')
       create_item_rep(item.unwrap, :b_zoey,    '/george/zoey/')
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/walton/'))
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/walton/'), nil)
       @items << item
       create_item_rep(item.unwrap, :a_eve,     '/walton/eve/')
       create_item_rep(item.unwrap, :b_bob,     '/walton/bob/')
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/lucas/'))
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/lucas/'), nil)
       @items << item
       create_item_rep(item.unwrap, :a_trudy,   '/lucas/trudy/')
       create_item_rep(item.unwrap, :b_mallory, '/lucas/mallory/')
 
       # Create sitemap item
-      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'))
+      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), nil)
 
       # Create site
       @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })

--- a/test/helpers/test_xml_sitemap.rb
+++ b/test/helpers/test_xml_sitemap.rb
@@ -193,7 +193,6 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
     rep = Nanoc::Int::ItemRep.new(item, name)
     rep.paths     = { last: path }
     rep.raw_paths = { last: path }
-    item.reps << rep
     rep
   end
 end


### PR DESCRIPTION
This is an attempt at removing the item reps collection from `ItemRep`. This should make it easier to move to streaming data sources (hopefully).