### PR TITLE
Fix absolute filename check on Windows

### DIFF
--- a/lib/nanoc/base/entities/content.rb
+++ b/lib/nanoc/base/entities/content.rb
@@ -15,7 +15,7 @@ module Nanoc
 
       # @param [String, nil] filename
       def initialize(filename)
-        if filename && !filename.start_with?('/')
+        if filename && Pathname.new(filename).relative?
           raise ArgumentError, 'Content filename is not absolute'
         end
 


### PR DESCRIPTION
Fix for the issue mentioned in [this comment](https://github.com/nanoc/nanoc/pull/622#discussion_r31878466).