### PR TITLE
Use keyword arguments

### DIFF
--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -72,14 +72,14 @@ module Nanoc::Int
 
     # @group Public instance methods
 
-    def initialize(site, rules_collection, params = {})
+    def initialize(site, rules_collection, compiled_content_cache:, checksum_store:, rule_memory_store:, rule_memory_calculator:)
       @site = site
       @rules_collection = rules_collection
 
-      @compiled_content_cache = params.fetch(:compiled_content_cache)
-      @checksum_store         = params.fetch(:checksum_store)
-      @rule_memory_store      = params.fetch(:rule_memory_store)
-      @rule_memory_calculator = params.fetch(:rule_memory_calculator)
+      @compiled_content_cache = compiled_content_cache
+      @checksum_store         = checksum_store
+      @rule_memory_store      = rule_memory_store
+      @rule_memory_calculator = rule_memory_calculator
 
       @dependency_tracker =
         Nanoc::Int::DependencyTracker.new(@site.items.to_a + @site.layouts.to_a)

--- a/lib/nanoc/base/compilation/compiler_dsl.rb
+++ b/lib/nanoc/base/compilation/compiler_dsl.rb
@@ -50,8 +50,7 @@ module Nanoc::Int
     # @param [String] identifier A pattern matching identifiers of items that
     #   should be compiled using this rule
     #
-    # @option params [Symbol] :rep (:default) The name of the representation
-    #   that should be compiled using this rule
+    # @param [Symbol] rep The name of the representation
     #
     # @yield The block that will be executed when an item matching this
     #   compilation rule needs to be compiled
@@ -69,15 +68,10 @@ module Nanoc::Int
     #     compile '/bar/', :rep => :raw do
     #       # do nothing
     #     end
-    def compile(identifier, params = {}, &block)
-      # Require block
+    def compile(identifier, rep: :default, &block)
       raise ArgumentError.new('#compile requires a block') unless block_given?
 
-      # Get rep name
-      rep_name = params[:rep] || :default
-
-      # Create rule
-      rule = Nanoc::Int::Rule.new(create_pattern(identifier), rep_name, block)
+      rule = Nanoc::Int::Rule.new(create_pattern(identifier), rep, block)
       @rules_collection.add_item_compilation_rule(rule)
     end
 
@@ -94,8 +88,7 @@ module Nanoc::Int
     # @param [String] identifier A pattern matching identifiers of items that
     #   should be routed using this rule
     #
-    # @option params [Symbol] :rep (:default) The name of the representation
-    #   that should be routed using this rule
+    # @param [Symbol] :rep The name of the representation
     #
     # @yield The block that will be executed when an item matching this
     #   compilation rule needs to be routed
@@ -113,16 +106,10 @@ module Nanoc::Int
     #     route '/bar/', :rep => :raw do
     #       '/raw' + item.identifier + 'index.txt'
     #     end
-    def route(identifier, params = {}, &block)
-      # Require block
+    def route(identifier, rep: :default, snapshot: :last, &block)
       raise ArgumentError.new('#route requires a block') unless block_given?
 
-      # Get rep name
-      rep_name      = params[:rep] || :default
-      snapshot_name = params[:snapshot] || :last
-
-      # Create rule
-      rule = Nanoc::Int::Rule.new(create_pattern(identifier), rep_name, block, snapshot_name: snapshot_name)
+      rule = Nanoc::Int::Rule.new(create_pattern(identifier), rep, block, snapshot_name: snapshot)
       @rules_collection.add_item_routing_rule(rule)
     end
 
@@ -166,8 +153,7 @@ module Nanoc::Int
     # @param [String] identifier A pattern matching identifiers of items that
     #   should be processed using this meta-rule
     #
-    # @option params [Symbol] :rep (:default) The name of the representation
-    #   that should be routed using this rule
+    # @param [Symbol] rep The name of the representation
     #
     # @return [void]
     #
@@ -180,16 +166,11 @@ module Nanoc::Int
     # @example Copying the `:raw` rep of the `/bar/` item as-is
     #
     #     passthrough '/bar/', :rep => :raw
-    def passthrough(identifier, params = {})
-      # Require no block
+    def passthrough(identifier, rep: :default)
       raise ArgumentError.new('#passthrough does not require a block') if block_given?
 
-      # Get rep name
-      rep_name = params[:rep] || :default
-
-      # Create compilation rule
       compilation_block = proc {}
-      compilation_rule = Nanoc::Int::Rule.new(create_pattern(identifier), rep_name, compilation_block)
+      compilation_rule = Nanoc::Int::Rule.new(create_pattern(identifier), rep, compilation_block)
       @rules_collection.add_item_compilation_rule(compilation_rule)
 
       # Create routing rule
@@ -204,7 +185,7 @@ module Nanoc::Int
           item[:extension].nil? || (item[:content_filename].nil? && item.identifier =~ %r{#{item[:extension]}/$}) ? item.identifier.chop : item.identifier.chop + '.' + item[:extension]
         end
       end
-      routing_rule = Nanoc::Int::Rule.new(create_pattern(identifier), rep_name, routing_block, snapshot_name: :last)
+      routing_rule = Nanoc::Int::Rule.new(create_pattern(identifier), rep, routing_block, snapshot_name: :last)
       @rules_collection.add_item_routing_rule(routing_rule)
     end
 
@@ -219,23 +200,20 @@ module Nanoc::Int
     # @param [String] identifier A pattern matching identifiers of items that
     #   should be processed using this meta-rule
     #
-    # @option params [Symbol] :rep (:default) The name of the representation
-    #   that should be routed using this rule
+    # @param [Symbol] rep The name of the representation
     #
     # @return [void]
     #
     # @example Suppressing compilation and output for all all `/foo/*` items.
     #
     #     ignore '/foo/*'
-    def ignore(identifier, params = {})
+    def ignore(identifier, rep: :default)
       raise ArgumentError.new('#ignore does not require a block') if block_given?
 
-      rep_name = params[:rep] || :default
-
-      compilation_rule = Nanoc::Int::Rule.new(create_pattern(identifier), rep_name, proc {})
+      compilation_rule = Nanoc::Int::Rule.new(create_pattern(identifier), rep, proc {})
       @rules_collection.add_item_compilation_rule(compilation_rule)
 
-      routing_rule = Nanoc::Int::Rule.new(create_pattern(identifier), rep_name, proc {}, snapshot_name: :last)
+      routing_rule = Nanoc::Int::Rule.new(create_pattern(identifier), rep, proc {}, snapshot_name: :last)
       @rules_collection.add_item_routing_rule(routing_rule)
     end
 

--- a/lib/nanoc/base/compilation/outdatedness_checker.rb
+++ b/lib/nanoc/base/compilation/outdatedness_checker.rb
@@ -14,18 +14,19 @@ module Nanoc::Int
 
     Reasons = Nanoc::Int::OutdatednessReasons
 
-    # @option params [Nanoc::Int::Site] :site
-    #
-    # @option params [Nanoc::Int::ChecksumStore] :checksum_store
-    #
-    # @option params [Nanoc::Int::DependencyTracker] :dependency_tracker
-    def initialize(params = {})
-      @site = params.fetch(:site)
-      @checksum_store = params.fetch(:checksum_store)
-      @dependency_tracker = params.fetch(:dependency_tracker)
-      @rules_collection = params.fetch(:rules_collection)
-      @rule_memory_store = params.fetch(:rule_memory_store)
-      @rule_memory_calculator = params.fetch(:rule_memory_calculator)
+    # @param [Nanoc::Int::Site] site
+    # @param [Nanoc::Int::ChecksumStore] checksum_store
+    # @param [Nanoc::Int::DependencyTracker] dependency_tracker
+    # @param [Nanoc::Int::RulesCollection] rules_collection
+    # @param [Nanoc::Int::RuleMemoryStore] rule_memory_store
+    # @param [Nanoc::Int::RuleMemoryCalculator] rule_memory_calculator
+    def initialize(site:, checksum_store:, dependency_tracker:, rules_collection:, rule_memory_store:, rule_memory_calculator:)
+      @site = site
+      @checksum_store = checksum_store
+      @dependency_tracker = dependency_tracker
+      @rules_collection = rules_collection
+      @rule_memory_store = rule_memory_store
+      @rule_memory_calculator = rule_memory_calculator
 
       @basic_outdatedness_reasons = {}
       @outdatedness_reasons = {}

--- a/lib/nanoc/base/compilation/rule.rb
+++ b/lib/nanoc/base/compilation/rule.rb
@@ -27,10 +27,9 @@ module Nanoc::Int
     # @param [Proc] block A block that will be called when matching items are
     #   compiled
     #
-    # @option params [Symbol, nil] :snapshot (nil) The name of the snapshot
-    #   this rule will apply to. Ignored for compilation rules, but used for
-    #   routing rules.
-    def initialize(pattern, rep_name, block, params = {})
+    # @param [Symbol, nil] :snapshot The name of the snapshot this rule will
+    #   apply to. Ignored for compilation rules, but used for routing rules.
+    def initialize(pattern, rep_name, block, snapshot_name: nil)
       # TODO: remove me
       unless pattern.is_a?(Nanoc::Int::StringPattern) || pattern.is_a?(Nanoc::Int::RegexpPattern)
         raise 'Can only create rules with patterns'
@@ -38,7 +37,7 @@ module Nanoc::Int
 
       @pattern          = pattern
       @rep_name         = rep_name.to_sym
-      @snapshot_name    = params[:snapshot_name]
+      @snapshot_name    = snapshot_name
 
       @block = block
     end
@@ -55,15 +54,12 @@ module Nanoc::Int
     #
     # @param [Nanoc::Int::ItemRep] rep
     #
-    # @option params [Nanoc::Int::Site] :site
+    # @param [Nanoc::Int::Site] site
     #
-    # @option params [Nanoc::Int::Executor, Nanoc::Int::RecordingExecutor] :executor
+    # @param [Nanoc::Int::Executor, Nanoc::Int::RecordingExecutor] executor
     #
     # @return [void]
-    def apply_to(rep, params = {})
-      site = params.fetch(:site)
-      executor = params.fetch(:executor)
-
+    def apply_to(rep, site:, executor:)
       context = Nanoc::Int::RuleContext.new(rep: rep, executor: executor, site: site)
       context.instance_exec(matches(rep.item.identifier), &@block)
     end

--- a/lib/nanoc/base/compilation/rule_context.rb
+++ b/lib/nanoc/base/compilation/rule_context.rb
@@ -5,12 +5,11 @@ module Nanoc::Int
   #
   # @api private
   class RuleContext < Nanoc::Int::Context
-    # @option params [Nanoc::Int::ItemRep] :rep
-    # @option params [Nanoc::Int::Site] :site
-    def initialize(params = {})
-      rep = params.fetch(:rep)
-      site = params.fetch(:site)
-      @_executor = params.fetch(:executor)
+    # @param [Nanoc::Int::ItemRep] rep
+    # @param [Nanoc::Int::Site] site
+    # @param [Nanoc::Int::Executor, Nanoc::Int::RecordingExecutor] executor
+    def initialize(rep:, site:, executor:)
+      @_executor = executor
 
       super({
         item: Nanoc::ItemView.new(rep.item),

--- a/lib/nanoc/base/entities/content.rb
+++ b/lib/nanoc/base/entities/content.rb
@@ -31,20 +31,19 @@ module Nanoc
       #   content) or the path to the filename containing the content (if this
       #   is binary content).
       #
-      # @option params [Boolean] :binary (false) Whether or not this item is
-      #   binary
+      # @param [Boolean] binary Whether or not this item is binary
       #
-      # @option params [String] :filename (nil) Absolute path to the file
-      #   containing this content (if any)
-      def self.create(content, params = {})
+      # @param [String] filename Absolute path to the file containing this
+      #   content (if any)
+      def self.create(content, binary: false, filename: nil)
         if content.nil?
           raise ArgumentError, 'Cannot create nil content'
         elsif content.is_a?(Nanoc::Int::Content)
           content
-        elsif params.fetch(:binary, false)
+        elsif binary
           Nanoc::Int::BinaryContent.new(content)
         else
-          Nanoc::Int::TextualContent.new(content, filename: params[:filename])
+          Nanoc::Int::TextualContent.new(content, filename: filename)
         end
       end
 
@@ -61,8 +60,8 @@ module Nanoc
       # @return [String]
       attr_reader :string
 
-      def initialize(string, params = {})
-        super(params[:filename])
+      def initialize(string, filename: nil)
+        super(filename)
         @string = string
       end
 

--- a/lib/nanoc/base/entities/identifier.rb
+++ b/lib/nanoc/base/entities/identifier.rb
@@ -48,8 +48,8 @@ module Nanoc
       end
     end
 
-    def initialize(string, params = {})
-      @type = params.fetch(:type, :full)
+    def initialize(string, type: :full)
+      @type = type
 
       case @type
       when :legacy

--- a/lib/nanoc/base/repos/checksum_store.rb
+++ b/lib/nanoc/base/repos/checksum_store.rb
@@ -4,12 +4,11 @@ module Nanoc::Int
   #
   # @api private
   class ChecksumStore < ::Nanoc::Int::Store
-    # @option params [Nanoc::Int::Site] site The site where this checksum store
-    #   belongs to
-    def initialize(params = {})
+    # @param [Nanoc::Int::Site] site
+    def initialize(site: nil)
       super('tmp/checksums', 1)
 
-      @site = params[:site] if params.key?(:site)
+      @site = site
 
       @checksums = {}
     end

--- a/lib/nanoc/base/result_data/item_rep.rb
+++ b/lib/nanoc/base/result_data/item_rep.rb
@@ -47,21 +47,21 @@ module Nanoc::Int
 
     # Returns the compiled content from a given snapshot.
     #
-    # @option params [String] :snapshot The name of the snapshot from which to
+    # @param [Symbol] snapshot The name of the snapshot from which to
     #   fetch the compiled content. By default, the returned compiled content
     #   will be the content compiled right before the first layout call (if
     #   any).
     #
     # @return [String] The compiled content at the given snapshot (or the
     #   default snapshot if no snapshot is specified)
-    def compiled_content(params = {})
+    def compiled_content(snapshot: nil)
       # Make sure we're not binary
       if binary?
         raise Nanoc::Int::Errors::CannotGetCompiledContentOfBinaryItem.new(self)
       end
 
       # Get name of last pre-layout snapshot
-      snapshot_name = params.fetch(:snapshot) { @snapshot_contents[:pre] ? :pre : :last }
+      snapshot_name = snapshot || (@snapshot_contents[:pre] ? :pre : :last)
       is_moving = [:pre, :post, :last].include?(snapshot_name)
 
       # Check existance of snapshot
@@ -100,13 +100,12 @@ module Nanoc::Int
     # Returns the item rep’s raw path. It includes the path to the output
     # directory and the full filename.
     #
-    # @option params [Symbol] :snapshot (:last) The snapshot for which the
-    #   path should be returned
+    # @param [Symbol] snapshot The snapshot for which the path should be
+    #   returned
     #
     # @return [String] The item rep’s path
-    def raw_path(params = {})
-      snapshot_name = params[:snapshot] || :last
-      @raw_paths[snapshot_name]
+    def raw_path(snapshot: :last)
+      @raw_paths[snapshot]
     end
 
     # Returns the item rep’s path, as used when being linked to. It starts
@@ -114,13 +113,12 @@ module Nanoc::Int
     # include the path to the output directory. It will not include the
     # filename if the filename is an index filename.
     #
-    # @option params [Symbol] :snapshot (:last) The snapshot for which the
-    #   path should be returned
+    # @param [Symbol] snapshot The snapshot for which the path should be
+    #   returned
     #
     # @return [String] The item rep’s path
-    def path(params = {})
-      snapshot_name = params[:snapshot] || :last
-      @paths[snapshot_name]
+    def path(snapshot: :last)
+      @paths[snapshot]
     end
 
     # Resets the compilation progress for this item representation. This is

--- a/lib/nanoc/base/services/executor.rb
+++ b/lib/nanoc/base/services/executor.rb
@@ -98,18 +98,16 @@ module Nanoc
         end
       end
 
-      def snapshot(rep, snapshot_name, params = {})
-        is_final = params.fetch(:final, true)
-
+      def snapshot(rep, snapshot_name, final: true)
         unless rep.binary?
           rep.snapshot_contents[snapshot_name] = rep.snapshot_contents[:last]
         end
 
-        if snapshot_name == :pre && is_final
+        if snapshot_name == :pre && final
           rep.snapshot_defs << Nanoc::Int::SnapshotDef.new(:pre, true)
         end
 
-        if is_final
+        if final
           raw_path = rep.raw_path(snapshot: snapshot_name)
           if raw_path
             ItemRepWriter.new.write(rep, raw_path)

--- a/lib/nanoc/base/services/preprocessor.rb
+++ b/lib/nanoc/base/services/preprocessor.rb
@@ -1,9 +1,9 @@
 module Nanoc::Int
   # @api private
   class Preprocessor
-    def initialize(params = {})
-      @site = params.fetch(:site)
-      @rules_collection = params.fetch(:rules_collection)
+    def initialize(site:, rules_collection:)
+      @site = site
+      @rules_collection = rules_collection
     end
 
     def run

--- a/lib/nanoc/base/services/recording_executor.rb
+++ b/lib/nanoc/base/services/recording_executor.rb
@@ -19,8 +19,8 @@ module Nanoc
         end
       end
 
-      def snapshot(_rep, snapshot_name, params = {})
-        @rule_memory << [:snapshot, snapshot_name, params]
+      def snapshot(_rep, snapshot_name, final: true)
+        @rule_memory << [:snapshot, snapshot_name, final: final]
 
         # Count
         existing = Set.new

--- a/lib/nanoc/base/services/rule_memory_calculator.rb
+++ b/lib/nanoc/base/services/rule_memory_calculator.rb
@@ -9,10 +9,11 @@ module Nanoc::Int
     # @api private
     attr_accessor :rules_collection
 
-    # @option params [Nanoc::Int::RulesCollection] rules_collection
-    def initialize(params = {})
-      @rules_collection = params.fetch(:rules_collection)
-      @site = params.fetch(:site)
+    # @param [Nanoc::Int::Site] site
+    # @param [Nanoc::Int::RulesCollection] rules_collection
+    def initialize(site:, rules_collection:)
+      @site = site
+      @rules_collection = rules_collection
     end
 
     # @param [#reference] obj The object to calculate the rule memory for

--- a/lib/nanoc/base/source_data/code_snippet.rb
+++ b/lib/nanoc/base/source_data/code_snippet.rb
@@ -19,12 +19,7 @@ module Nanoc::Int
     #   compilation
     #
     # @param [String] filename The filename corresponding to this code snippet
-    #
-    # @param [Time, Hash] _params Extra parameters. Ignored by nanoc; it is
-    #   only included for backwards compatibility.
-    def initialize(data, filename, _params = nil)
-      # TODO: remove _params
-
+    def initialize(data, filename)
       @data     = data
       @filename = filename
     end

--- a/lib/nanoc/base/source_data/code_snippet.rb
+++ b/lib/nanoc/base/source_data/code_snippet.rb
@@ -23,6 +23,8 @@ module Nanoc::Int
     # @param [Time, Hash] _params Extra parameters. Ignored by nanoc; it is
     #   only included for backwards compatibility.
     def initialize(data, filename, _params = nil)
+      # TODO: remove _params
+
       @data     = data
       @filename = filename
     end

--- a/lib/nanoc/base/source_data/data_source.rb
+++ b/lib/nanoc/base/source_data/data_source.rb
@@ -138,12 +138,9 @@ module Nanoc
     #
     # @param [String] identifier This item's identifier.
     #
-    # @param [Hash] params Extra parameters.
-    #
-    # @option params [Symbol, nil] :binary (true) Whether or not this item is
-    #   binary
-    def new_item(content, attributes, identifier, params = {})
-      content = Nanoc::Int::Content.create(content, params)
+    # @param [Boolean] :binary Whether or not this item is binary
+    def new_item(content, attributes, identifier, binary: false)
+      content = Nanoc::Int::Content.create(content, binary: binary)
       Nanoc::Int::Item.new(content, attributes, identifier)
     end
 

--- a/lib/nanoc/base/source_data/site.rb
+++ b/lib/nanoc/base/source_data/site.rb
@@ -1,14 +1,15 @@
 module Nanoc::Int
   # @api private
   class Site
-    # @option params [Nanoc::Int::Configuration] :config
-    #
-    # @option params [Enumerable<Nanoc::Int::CodeSnippet>] :code_snippets
-    def initialize(params = {})
-      @config = params.fetch(:config)
-      @code_snippets = params.fetch(:code_snippets)
-      @items = params.fetch(:items)
-      @layouts = params.fetch(:layouts)
+    # @param [Nanoc::Int::Configuration] config
+    # @param [Enumerable<Nanoc::Int::CodeSnippet>] code_snippets
+    # @param [Enumerable<Nanoc::Int::Item>] items
+    # @param [Enumerable<Nanoc::Int::Layout>] layouts
+    def initialize(config:, code_snippets:, items:, layouts:)
+      @config = config
+      @code_snippets = code_snippets
+      @items = items
+      @layouts = layouts
 
       ensure_identifier_uniqueness(@items, 'item')
       ensure_identifier_uniqueness(@layouts, 'layout')

--- a/lib/nanoc/base/views/item_rep_view.rb
+++ b/lib/nanoc/base/views/item_rep_view.rb
@@ -28,17 +28,17 @@ module Nanoc
 
     # Returns the compiled content.
     #
-    # @option params [String] :snapshot The name of the snapshot from which to
+    # @param [String] snapshot The name of the snapshot from which to
     #   fetch the compiled content. By default, the returned compiled content
     #   will be the content compiled right before the first layout call (if
     #   any).
     #
     # @return [String] The content at the given snapshot.
-    def compiled_content(params = {})
+    def compiled_content(snapshot: nil)
       Nanoc::Int::NotificationCenter.post(:visit_started, unwrap.item)
       Nanoc::Int::NotificationCenter.post(:visit_ended,   unwrap.item)
 
-      @item_rep.compiled_content(params)
+      @item_rep.compiled_content(snapshot: snapshot)
     end
 
     # Returns the item rep’s path, as used when being linked to. It starts
@@ -46,15 +46,15 @@ module Nanoc
     # include the path to the output directory. It will not include the
     # filename if the filename is an index filename.
     #
-    # @option params [Symbol] :snapshot (:last) The snapshot for which the
-    #   path should be returned.
+    # @param [Symbol] snapshot The snapshot for which the path should be
+    #   returned.
     #
     # @return [String] The item rep’s path.
-    def path(params = {})
+    def path(snapshot: :last)
       Nanoc::Int::NotificationCenter.post(:visit_started, unwrap.item)
       Nanoc::Int::NotificationCenter.post(:visit_ended,   unwrap.item)
 
-      @item_rep.path(params)
+      @item_rep.path(snapshot: snapshot)
     end
 
     # Returns the item that this item rep belongs to.
@@ -65,11 +65,11 @@ module Nanoc
     end
 
     # @api private
-    def raw_path(params = {})
+    def raw_path(snapshot: :last)
       Nanoc::Int::NotificationCenter.post(:visit_started, unwrap.item)
       Nanoc::Int::NotificationCenter.post(:visit_ended,   unwrap.item)
 
-      @item_rep.raw_path(params)
+      @item_rep.raw_path(snapshot: snapshot)
     end
 
     # @api private

--- a/lib/nanoc/base/views/item_view.rb
+++ b/lib/nanoc/base/views/item_view.rb
@@ -4,18 +4,18 @@ module Nanoc
 
     # Returns the compiled content.
     #
-    # @option params [String] :rep (:default) The name of the representation
+    # @param [String] rep The name of the representation
     #   from which the compiled content should be fetched. By default, the
     #   compiled content will be fetched from the default representation.
     #
-    # @option params [String] :snapshot The name of the snapshot from which to
+    # @param [String] snapshot The name of the snapshot from which to
     #   fetch the compiled content. By default, the returned compiled content
     #   will be the content compiled right before the first layout call (if
     #   any).
     #
     # @return [String] The content of the given rep at the given snapshot.
-    def compiled_content(params = {})
-      reps.fetch(params.fetch(:rep, :default)).compiled_content(params)
+    def compiled_content(rep: :default, snapshot: :last)
+      reps.fetch(rep).compiled_content(snapshot: snapshot)
     end
 
     # Returns the item path, as used when being linked to. It starts
@@ -23,16 +23,16 @@ module Nanoc
     # include the path to the output directory. It will not include the
     # filename if the filename is an index filename.
     #
-    # @option params [String] :rep (:default) The name of the representation
+    # @param [String] rep The name of the representation
     #   from which the path should be fetched. By default, the path will be
     #   fetched from the default representation.
     #
-    # @option params [Symbol] :snapshot (:last) The snapshot for which the
+    # @param [Symbol] snapshot The snapshot for which the
     #   path should be returned.
     #
     # @return [String] The item’s path.
-    def path(params = {})
-      reps.fetch(params.fetch(:rep, :default)).path(params)
+    def path(rep: :default, snapshot: :last)
+      reps.fetch(rep).path(snapshot: snapshot)
     end
 
     # Returns the children of this item. For items with identifiers that have

--- a/lib/nanoc/base/views/mutable_item_collection_view.rb
+++ b/lib/nanoc/base/views/mutable_item_collection_view.rb
@@ -15,17 +15,14 @@ module Nanoc
     #
     # @param [Nanoc::Identifier, String] identifier This item's identifier.
     #
-    # @param [Hash] params Extra parameters.
+    # @param [Boolean] binary Whether or not this item is binary
     #
-    # @option params [Boolean] :binary (false) Whether or not this item is
-    #   binary
-    #
-    # @option params [String] :filename (nil) Absolute path to the file
+    # @param [String] filename Absolute path to the file
     #   containing this content (if any)
     #
     # @return [self]
-    def create(content, attributes, identifier, params = {})
-      content = Nanoc::Int::Content.create(content, params)
+    def create(content, attributes, identifier, binary: false, filename: nil)
+      content = Nanoc::Int::Content.create(content, binary: binary, filename: filename)
       @objects << Nanoc::Int::Item.new(content, attributes, identifier)
       self
     end

--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -25,7 +25,7 @@ module Nanoc::CLI::Commands
     #
     # @abstract Subclasses must override {#start} and may override {#stop}.
     class Listener
-      def initialize(_params = {})
+      def initialize(*)
       end
 
       # @param [Nanoc::CLI::CommandRunner] command_runner The command runner for this listener
@@ -147,11 +147,11 @@ module Nanoc::CLI::Commands
         command_runner.options.fetch(:verbose, false)
       end
 
-      # @option params [Array<Nanoc::Int::ItemRep>] :reps The list of item representations in the site
-      def initialize(params = {})
+      # @param [Enumerable<Nanoc::Int::ItemRep>] reps
+      def initialize(reps:)
         @times = {}
 
-        @reps = params.fetch(:reps)
+        @reps = reps
       end
 
       # @see Listener#start
@@ -249,7 +249,7 @@ module Nanoc::CLI::Commands
         !ENV.key?('TRAVIS')
       end
 
-      def initialize(_params = {})
+      def initialize(*)
         @gc_count = 0
       end
 
@@ -314,11 +314,10 @@ module Nanoc::CLI::Commands
 
     # Prints file actions (created, updated, deleted, identical, skipped)
     class FileActionPrinter < Listener
-      # @option params [Array<Nanoc::Int::ItemRep>] :reps The list of item representations in the site
-      def initialize(params = {})
+      def initialize(reps:)
         @start_times = {}
 
-        @reps = params.fetch(:reps)
+        @reps = reps
       end
 
       # @see Listener#start
@@ -361,9 +360,11 @@ module Nanoc::CLI::Commands
       end
     end
 
-    def initialize(options, arguments, command, params = {})
-      super(options, arguments, command)
-      @listener_classes = params.fetch(:listener_classes, default_listener_classes)
+    attr_accessor :listener_classes
+
+    def initialize(options, arguments, command)
+      super
+      @listener_classes = default_listener_classes
     end
 
     def run
@@ -416,6 +417,9 @@ module Nanoc::CLI::Commands
     def run_listeners_while
       setup_listeners
       yield
+    rescue => e
+      STDOUT.puts e
+      STDOUT.puts e.backtrace.join("\n")
     ensure
       teardown_listeners
     end

--- a/lib/nanoc/extra/checking/check.rb
+++ b/lib/nanoc/extra/checking/check.rb
@@ -40,9 +40,7 @@ module Nanoc::Extra::Checking
       raise NotImplementedError.new('Nanoc::Extra::Checking::Check subclasses must implement #run')
     end
 
-    def add_issue(desc, params = {})
-      subject = params.fetch(:subject, nil)
-
+    def add_issue(desc, subject: nil)
       @issues << Issue.new(desc, subject, self.class)
     end
   end

--- a/lib/nanoc/extra/deployer.rb
+++ b/lib/nanoc/extra/deployer.rb
@@ -25,12 +25,12 @@ module Nanoc::Extra
     #
     # @return [Hash] config The deployer configuration
     #
-    # @option params [Boolean] :dry_run (false) true if the deployer should
+    # @param [Boolean] dry_run true if the deployer should
     #   only show what would be deployed instead actually deploying
-    def initialize(source_path, config, params = {})
+    def initialize(source_path, config, dry_run: false)
       @source_path  = source_path
       @config       = config
-      @dry_run      = params.fetch(:dry_run) { false }
+      @dry_run      = dry_run
     end
 
     # Performs the actual deployment.

--- a/lib/nanoc/extra/piper.rb
+++ b/lib/nanoc/extra/piper.rb
@@ -14,11 +14,11 @@ module Nanoc::Extra
       end
     end
 
-    # @option [IO] :stdout ($stdout)
-    # @option [IO] :stderr ($stderr)
-    def initialize(params = {})
-      @stdout = params.fetch(:stdout, $stdout)
-      @stderr = params.fetch(:stderr, $stderr)
+    # @param [IO] stdout
+    # @param [IO] stderr
+    def initialize(stdout: $stdout, stderr: $stderr)
+      @stdout = stdout
+      @stderr = stderr
     end
 
     # @param [Array<String>] cmd

--- a/lib/nanoc/extra/pruner.rb
+++ b/lib/nanoc/extra/pruner.rb
@@ -9,13 +9,15 @@ module Nanoc::Extra
 
     # @param [Nanoc::Int::Site] site The site for which a pruner is created
     #
-    # @option params [Boolean] :dry_run (false) true if the files to be deleted
+    # @param [Boolean] dry_run true if the files to be deleted
     #   should only be printed instead of actually deleted, false if the files
     #   should actually be deleted.
-    def initialize(site, params = {})
+    #
+    # @param [Enumerable<String>] exclude
+    def initialize(site, dry_run: false, exclude: [])
       @site    = site
-      @dry_run = params.fetch(:dry_run) { false }
-      @exclude = params.fetch(:exclude) { [] }
+      @dry_run = dry_run
+      @exclude = exclude
     end
 
     # Prunes all output files not managed by nanoc.

--- a/lib/nanoc/helpers/tagging.rb
+++ b/lib/nanoc/helpers/tagging.rb
@@ -15,21 +15,16 @@ module Nanoc::Helpers
     # tags will be linked using the {#link_for_tag} function; the
     # HTML-escaping rules for {#link_for_tag} apply here as well.
     #
-    # @option params [String] base_url The URL to which the tag will be appended
+    # @param [String] base_url The URL to which the tag will be appended
     #   to construct the link URL. This URL must have a trailing slash.
     #
-    # @option params [String] none_text ("(none)") The text to display when
+    # @param [String] none_text The text to display when
     #   the item has no tags
     #
-    # @option params [String] separator (", ") The separator to put between
-    #   tags
+    # @param [String] separator The separator to put between tags
     #
     # @return [String] A hyperlinked list of tags for the given item
-    def tags_for(item, params = {})
-      base_url  = params.fetch(:base_url)
-      none_text = params[:none_text] || '(none)'
-      separator = params[:separator] || ', '
-
+    def tags_for(item, base_url:, none_text: '(none)', separator: ', ')
       if item[:tags].nil? || item[:tags].empty?
         none_text
       else

--- a/lib/nanoc/helpers/text.rb
+++ b/lib/nanoc/helpers/text.rb
@@ -7,22 +7,20 @@ module Nanoc::Helpers
     #
     # @param [String] string The string for which to build an excerpt
     #
-    # @option params [Number] length (25) The maximum number of characters
+    # @param [Number] length The maximum number of characters
     #   this excerpt can contain, including the omission.
     #
-    # @option params [String] omission ("...") The string to append to the
+    # @param [String] omission The string to append to the
     #   excerpt when the excerpt is shorter than the original string
     #
     # @return [String] The excerpt of the given string
-    def excerptize(string, params = {})
-      # Initialize params
-      params[:length] ||= 25
-      params[:omission] ||= '...'
-
-      # Get excerpt
-      length = params[:length] - params[:omission].length
-      length = 0 if length < 0
-      (string.length > params[:length] ? string[0...length] + params[:omission] : string)
+    def excerptize(string, length: 25, omission: '...')
+      if string.length > length
+        excerpt_length = [0, length - omission.length].max
+        string[0...excerpt_length] + omission
+      else
+        string
+      end
     end
 
     # Strips all HTML tags out of the given string.

--- a/spec/nanoc/base/entities/identifier_spec.rb
+++ b/spec/nanoc/base/entities/identifier_spec.rb
@@ -81,6 +81,19 @@ describe Nanoc::Identifier do
           .to raise_error(Nanoc::Identifier::InvalidTypeError)
       end
     end
+
+    context 'default type' do
+      it 'is full' do
+        expect(described_class.new('/foo')).to be_full
+      end
+    end
+
+    context 'other args specified' do
+      it 'errors' do
+        expect { described_class.new('?', animal: :donkey) }
+          .to raise_error(ArgumentError)
+      end
+    end
   end
 
   describe '#to_s' do

--- a/spec/nanoc/base/services/recording_executor_spec.rb
+++ b/spec/nanoc/base/services/recording_executor_spec.rb
@@ -22,39 +22,44 @@ describe Nanoc::Int::RecordingExecutor do
     end
 
     it 'records layout call with arguments' do
-      executor.layout(rep, '/default.*', x: 123)
-      expect(executor.rule_memory).to include([:layout, '/default.*', { x: 123 }])
+      executor.layout(rep, '/default.*', final: false)
+      expect(executor.rule_memory).to include([:layout, '/default.*', { final: false }])
     end
   end
 
   describe '#snapshot' do
     context 'snapshot already exists' do
       before do
-        executor.snapshot(rep, :foo, stuff: :giraffe)
+        executor.snapshot(rep, :foo)
       end
 
       it 'raises when creating same snapshot' do
-        expect { executor.snapshot(rep, :foo, stuff: :donkey) }
+        expect { executor.snapshot(rep, :foo) }
           .to raise_error(Nanoc::Int::Errors::CannotCreateMultipleSnapshotsWithSameName)
       end
     end
 
     it 'records snapshot call without arguments' do
       executor.snapshot(rep, :foo)
-      expect(executor.rule_memory).to include([:snapshot, :foo, {}])
+      expect(executor.rule_memory).to include([:snapshot, :foo, { final: true }])
     end
 
     it 'records snapshot call with arguments' do
-      executor.snapshot(rep, :foo, x: 123)
-      expect(executor.rule_memory).to include([:snapshot, :foo, { x: 123 }])
+      executor.snapshot(rep, :foo, final: false)
+      expect(executor.rule_memory).to include([:snapshot, :foo, { final: false }])
+    end
+
+    it 'raises when given unknown arguments' do
+      expect { executor.snapshot(rep, :foo, animal: 'giraffe') }
+        .to raise_error(ArgumentError)
     end
 
     it 'can create multiple snapshots with different names' do
       executor.snapshot(rep, :foo)
       executor.snapshot(rep, :bar)
 
-      expect(executor.rule_memory).to include([:snapshot, :foo, {}])
-      expect(executor.rule_memory).to include([:snapshot, :bar, {}])
+      expect(executor.rule_memory).to include([:snapshot, :foo, { final: true }])
+      expect(executor.rule_memory).to include([:snapshot, :bar, { final: true }])
     end
   end
 

--- a/test/cli/commands/test_compile.rb
+++ b/test/cli/commands/test_compile.rb
@@ -149,9 +149,8 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
       options = {}
       arguments = []
       cmd = nil
-      listener_classes = [test_listener_class]
-      cmd_runner = Nanoc::CLI::Commands::Compile.new(
-        options, arguments, cmd, listener_classes: listener_classes)
+      cmd_runner = Nanoc::CLI::Commands::Compile.new(options, arguments, cmd)
+      cmd_runner.listener_classes = [test_listener_class]
 
       cmd_runner.run
 


### PR DESCRIPTION
Ruby 2.2 supports keyword arguments, which has two advantages:

* It makes existing code more compact. No more `params.fetch` necessary.
* It increases reliability because unrecognised arguments will cause an `ArgumentError`.

Some occurrences of `params` cannot be replaced with keyword arguments—filters, for instance.

This change also removes a deprecated extra unused `params` argument in the `CodeSnippet` constructor.

To do:

* [x] Use keyword arguments everywhere
* [x] Update documentation from `@option` to `@param`