### PR TITLE
Remove #unwrap rescue

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,9 +27,6 @@ ClassAndModuleChildren:
 Style/AlignHash:
   Enabled: false
 
-Style/RescueModifier:
-  Enabled: false
-
 Style/EmptyElse:
   Enabled: false
 

--- a/lib/nanoc/base/compilation/filter.rb
+++ b/lib/nanoc/base/compilation/filter.rb
@@ -185,7 +185,7 @@ module Nanoc
     #
     # @return [void]
     def depend_on(items)
-      items = items.map { |i| i.unwrap rescue i }
+      items = items.map { |i| i.is_a?(Nanoc::ItemView) ? i.unwrap : i }
 
       # Notify
       items.each do |item|

--- a/lib/nanoc/base/services/item_rep_selector.rb
+++ b/lib/nanoc/base/services/item_rep_selector.rb
@@ -29,7 +29,7 @@ module Nanoc::Int
     end
 
     def handle_dependency_error(e, rep, graph)
-      other_rep = e.rep.unwrap rescue e.rep
+      other_rep = e.rep
       graph.add_edge(other_rep, rep)
       unless graph.vertices.include?(other_rep)
         graph.add_vertex(other_rep)

--- a/lib/nanoc/helpers/capturing.rb
+++ b/lib/nanoc/helpers/capturing.rb
@@ -95,8 +95,7 @@ module Nanoc::Helpers
           raise ArgumentError, 'expected 2 arguments (the item ' \
             "and the name of the capture) but got #{args.size} instead"
         end
-        item = args[0]
-        item = item.unwrap if item.respond_to?(:unwrap)
+        item = args[0].is_a?(Nanoc::ItemView) ? args[0].unwrap : args[0]
         name = args[1]
 
         # Create dependency


### PR DESCRIPTION
Rescuing everything and retrying is bad and confusing, and the reason why `RescueModifier` exists. Fixed!