### PR TITLE
Remove item reps from items

### DIFF
--- a/lib/nanoc/base.rb
+++ b/lib/nanoc/base.rb
@@ -17,6 +17,7 @@ module Nanoc::Int
   autoload 'Compiler',             'nanoc/base/compilation/compiler'
   autoload 'CompilerDSL',          'nanoc/base/compilation/compiler_dsl'
   autoload 'DependencyTracker',    'nanoc/base/compilation/dependency_tracker'
+  autoload 'ItemRepRepo',          'nanoc/base/compilation/item_rep_repo'
   autoload 'OutdatednessChecker',  'nanoc/base/compilation/outdatedness_checker'
   autoload 'OutdatednessReasons',  'nanoc/base/compilation/outdatedness_reasons'
   autoload 'Rule',                 'nanoc/base/compilation/rule'

--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -172,16 +172,22 @@ module Nanoc::Int
         content_or_filename_assigns = { content: rep.snapshot_contents[:last].string }
       end
 
+      context = context_for(rep)
+
       # TODO: Do not expose @site (necessary for captures store though…)
       content_or_filename_assigns.merge({
-        item: Nanoc::ItemView.new(rep.item),
-        rep: Nanoc::ItemRepView.new(rep),
-        item_rep: Nanoc::ItemRepView.new(rep),
-        items: Nanoc::ItemCollectionView.new(site.items),
-        layouts: Nanoc::LayoutCollectionView.new(site.layouts),
-        config: Nanoc::ConfigView.new(site.config),
-        site: Nanoc::SiteView.new(site),
+        item: Nanoc::ItemView.new(rep.item, context),
+        rep: Nanoc::ItemRepView.new(rep, context),
+        item_rep: Nanoc::ItemRepView.new(rep, context),
+        items: Nanoc::ItemCollectionView.new(site.items, context),
+        layouts: Nanoc::LayoutCollectionView.new(site.layouts, context),
+        config: Nanoc::ConfigView.new(site.config, context),
+        site: Nanoc::SiteView.new(site, context),
       })
+    end
+
+    def context_for(_rep)
+      Nanoc::ViewContext.new
     end
 
     private

--- a/lib/nanoc/base/compilation/filter.rb
+++ b/lib/nanoc/base/compilation/filter.rb
@@ -181,10 +181,9 @@ module Nanoc
     # the given collection of items. In other words, require the given items
     # to be compiled first before this items is processed.
     #
-    # @param [Array<Nanoc::Int::Item>] items The items that are depended on.
-    #
     # @return [void]
     def depend_on(items)
+      orig_items = items
       items = items.map { |i| i.is_a?(Nanoc::ItemView) ? i.unwrap : i }
 
       # Notify
@@ -195,7 +194,7 @@ module Nanoc
 
       # Raise unmet dependency error if necessary
       items.each do |item|
-        rep = item.reps.find { |r| !r.compiled? }
+        rep = orig_items.sample._context.reps[item].find { |r| !r.compiled? }
         raise Nanoc::Int::Errors::UnmetDependency.new(rep) if rep
       end
     end

--- a/lib/nanoc/base/compilation/item_rep_repo.rb
+++ b/lib/nanoc/base/compilation/item_rep_repo.rb
@@ -1,0 +1,33 @@
+module Nanoc::Int
+  # Stores item reps (in memory).
+  #
+  # @api private
+  class ItemRepRepo
+    include Enumerable
+
+    def initialize
+      @reps = []
+      @reps_by_item = {}
+    end
+
+    def <<(rep)
+      @reps << rep
+
+      @reps_by_item[rep.item] ||= []
+      @reps_by_item[rep.item] << rep
+    end
+
+    def to_a
+      @reps
+    end
+
+    def each(&block)
+      @reps.each(&block)
+      self
+    end
+
+    def [](item)
+      @reps_by_item.fetch(item, [])
+    end
+  end
+end

--- a/lib/nanoc/base/compilation/outdatedness_checker.rb
+++ b/lib/nanoc/base/compilation/outdatedness_checker.rb
@@ -20,13 +20,15 @@ module Nanoc::Int
     # @param [Nanoc::Int::RulesCollection] rules_collection
     # @param [Nanoc::Int::RuleMemoryStore] rule_memory_store
     # @param [Nanoc::Int::RuleMemoryCalculator] rule_memory_calculator
-    def initialize(site:, checksum_store:, dependency_store:, rules_collection:, rule_memory_store:, rule_memory_calculator:)
+    # @param [Nanoc::Int::ItemRepRepo] reps
+    def initialize(site:, checksum_store:, dependency_store:, rules_collection:, rule_memory_store:, rule_memory_calculator:, reps:)
       @site = site
       @checksum_store = checksum_store
       @dependency_store = dependency_store
       @rules_collection = rules_collection
       @rule_memory_store = rule_memory_store
       @rule_memory_calculator = rule_memory_calculator
+      @reps = reps
 
       @basic_outdatedness_reasons = {}
       @outdatedness_reasons = {}
@@ -109,7 +111,7 @@ module Nanoc::Int
         # Not outdated
         return nil
       when Nanoc::Int::Item
-        obj.reps.find { |rep| basic_outdatedness_reason_for(rep) }
+        @reps[obj].find { |rep| basic_outdatedness_reason_for(rep) }
       when Nanoc::Int::Layout
         # Outdated if rules outdated
         return Reasons::RulesModified if

--- a/lib/nanoc/base/compilation/rule.rb
+++ b/lib/nanoc/base/compilation/rule.rb
@@ -53,14 +53,14 @@ module Nanoc::Int
     # Applies this rule to the given item rep.
     #
     # @param [Nanoc::Int::ItemRep] rep
-    #
     # @param [Nanoc::Int::Site] site
-    #
     # @param [Nanoc::Int::Executor, Nanoc::Int::RecordingExecutor] executor
+    # @param [Nanoc::ViewContext] view_context
     #
     # @return [void]
-    def apply_to(rep, site:, executor:)
-      context = Nanoc::Int::RuleContext.new(rep: rep, executor: executor, site: site)
+    def apply_to(rep, site:, executor:, view_context:)
+      context = Nanoc::Int::RuleContext.new(
+        rep: rep, executor: executor, site: site, view_context: view_context)
       context.instance_exec(matches(rep.item.identifier), &@block)
     end
 

--- a/lib/nanoc/base/compilation/rule_context.rb
+++ b/lib/nanoc/base/compilation/rule_context.rb
@@ -12,13 +12,13 @@ module Nanoc::Int
       @_executor = executor
 
       super({
-        item: Nanoc::ItemView.new(rep.item),
-        rep: Nanoc::ItemRepView.new(rep),
-        item_rep: Nanoc::ItemRepView.new(rep),
-        items: Nanoc::ItemCollectionView.new(site.items),
-        layouts: Nanoc::LayoutCollectionView.new(site.layouts),
-        config: Nanoc::ConfigView.new(site.config),
-        site: Nanoc::SiteView.new(site),
+        item: Nanoc::ItemView.new(rep.item, nil),
+        rep: Nanoc::ItemRepView.new(rep, nil),
+        item_rep: Nanoc::ItemRepView.new(rep, nil),
+        items: Nanoc::ItemCollectionView.new(site.items, nil),
+        layouts: Nanoc::LayoutCollectionView.new(site.layouts, nil),
+        config: Nanoc::ConfigView.new(site.config, nil),
+        site: Nanoc::SiteView.new(site, nil),
       })
     end
 

--- a/lib/nanoc/base/compilation/rule_context.rb
+++ b/lib/nanoc/base/compilation/rule_context.rb
@@ -8,17 +8,18 @@ module Nanoc::Int
     # @param [Nanoc::Int::ItemRep] rep
     # @param [Nanoc::Int::Site] site
     # @param [Nanoc::Int::Executor, Nanoc::Int::RecordingExecutor] executor
-    def initialize(rep:, site:, executor:)
+    # @param [Nanoc::ViewContext] view_context
+    def initialize(rep:, site:, executor:, view_context:)
       @_executor = executor
 
       super({
-        item: Nanoc::ItemView.new(rep.item, nil),
-        rep: Nanoc::ItemRepView.new(rep, nil),
-        item_rep: Nanoc::ItemRepView.new(rep, nil),
-        items: Nanoc::ItemCollectionView.new(site.items, nil),
-        layouts: Nanoc::LayoutCollectionView.new(site.layouts, nil),
-        config: Nanoc::ConfigView.new(site.config, nil),
-        site: Nanoc::SiteView.new(site, nil),
+        item: Nanoc::ItemView.new(rep.item, view_context),
+        rep: Nanoc::ItemRepView.new(rep, view_context),
+        item_rep: Nanoc::ItemRepView.new(rep, view_context),
+        items: Nanoc::ItemCollectionView.new(site.items, view_context),
+        layouts: Nanoc::LayoutCollectionView.new(site.layouts, view_context),
+        config: Nanoc::ConfigView.new(site.config, view_context),
+        site: Nanoc::SiteView.new(site, view_context),
       })
     end
 

--- a/lib/nanoc/base/entities/item.rb
+++ b/lib/nanoc/base/entities/item.rb
@@ -1,9 +1,6 @@
 module Nanoc::Int
   # @api private
   class Item < ::Nanoc::Int::Document
-    # @return [Array<Nanoc::Int::ItemRep>] This item’s list of item reps
-    attr_reader :reps
-
     # @return [Nanoc::Int::Item, nil] The parent item of this item. This can be
     #   nil even for non-root items.
     attr_accessor :parent
@@ -17,7 +14,6 @@ module Nanoc::Int
 
       @parent = nil
       @children = []
-      @reps = []
       @forced_outdated_status = ForcedOutdatedStatus.new
     end
 

--- a/lib/nanoc/base/services/compiler_loader.rb
+++ b/lib/nanoc/base/services/compiler_loader.rb
@@ -16,6 +16,8 @@ module Nanoc::Int
       checksum_store =
         Nanoc::Int::ChecksumStore.new(site: site)
 
+      item_rep_repo = Nanoc::Int::ItemRepRepo.new
+
       outdatedness_checker =
         Nanoc::Int::OutdatednessChecker.new(
           site: site,
@@ -24,6 +26,7 @@ module Nanoc::Int
           rules_collection: rules_collection,
           rule_memory_store: rule_memory_store,
           rule_memory_calculator: rule_memory_calculator,
+          reps: item_rep_repo,
         )
 
       params = {
@@ -33,6 +36,7 @@ module Nanoc::Int
         rule_memory_calculator: rule_memory_calculator,
         dependency_store: dependency_store,
         outdatedness_checker: outdatedness_checker,
+        reps: item_rep_repo,
       }
 
       compiler = Nanoc::Int::Compiler.new(site, rules_collection, params)

--- a/lib/nanoc/base/services/item_rep_builder.rb
+++ b/lib/nanoc/base/services/item_rep_builder.rb
@@ -3,20 +3,16 @@ module Nanoc::Int
   class ItemRepBuilder
     attr_reader :reps
 
-    def initialize(site, rules_collection)
+    def initialize(site, rules_collection, reps)
       @site = site
       @rules_collection = rules_collection
-
-      @reps = []
+      @reps = reps
     end
 
     def run
       @site.items.each do |item|
         rep_names_for(item).each do |rep_name|
-          rep = Nanoc::Int::ItemRep.new(item, rep_name)
-
-          item.reps << rep
-          @reps << rep
+          @reps << Nanoc::Int::ItemRep.new(item, rep_name)
         end
       end
 

--- a/lib/nanoc/base/services/item_rep_router.rb
+++ b/lib/nanoc/base/services/item_rep_router.rb
@@ -29,7 +29,7 @@ module Nanoc::Int
     end
 
     def basic_path_for(rep, rule)
-      basic_path = rule.apply_to(rep, executor: nil, site: @site)
+      basic_path = rule.apply_to(rep, executor: nil, site: @site, view_context: nil)
 
       if basic_path && basic_path !~ %r{^/}
         raise "The path returned for the #{rep.inspect} item representation, “#{basic_path}”, does not start with a slash. Please ensure that all routing rules return a path that starts with a slash."

--- a/lib/nanoc/base/services/preprocessor.rb
+++ b/lib/nanoc/base/services/preprocessor.rb
@@ -19,9 +19,9 @@ module Nanoc::Int
     # @api private
     def new_preprocessor_context
       Nanoc::Int::Context.new({
-        config: Nanoc::MutableConfigView.new(@site.config),
-        items: Nanoc::MutableItemCollectionView.new(@site.items),
-        layouts: Nanoc::MutableLayoutCollectionView.new(@site.layouts),
+        config: Nanoc::MutableConfigView.new(@site.config, nil),
+        items: Nanoc::MutableItemCollectionView.new(@site.items, nil),
+        layouts: Nanoc::MutableLayoutCollectionView.new(@site.layouts, nil),
       })
     end
   end

--- a/lib/nanoc/base/services/rule_memory_calculator.rb
+++ b/lib/nanoc/base/services/rule_memory_calculator.rb
@@ -56,7 +56,7 @@ module Nanoc::Int
       executor = Nanoc::Int::RecordingExecutor.new
       @rules_collection
         .compilation_rule_for(rep)
-        .apply_to(rep, executor: executor, site: @site)
+        .apply_to(rep, executor: executor, site: @site, view_context: nil)
       executor.record_write(rep, rep.path)
       make_rule_memory_serializable(executor.rule_memory)
     end

--- a/lib/nanoc/base/views.rb
+++ b/lib/nanoc/base/views.rb
@@ -1,6 +1,9 @@
 require_relative 'views/mixins/document_view_mixin'
 require_relative 'views/mixins/mutable_document_view_mixin'
 
+require_relative 'views/view'
+require_relative 'views/view_context'
+
 require_relative 'views/config_view'
 require_relative 'views/identifiable_collection_view'
 require_relative 'views/item_view'

--- a/lib/nanoc/base/views/config_view.rb
+++ b/lib/nanoc/base/views/config_view.rb
@@ -1,10 +1,11 @@
 module Nanoc
-  class ConfigView
+  class ConfigView < ::Nanoc::View
     # @api private
     NONE = Object.new
 
     # @api private
-    def initialize(config)
+    def initialize(config, context)
+      super(context)
       @config = config
     end
 

--- a/lib/nanoc/base/views/identifiable_collection_view.rb
+++ b/lib/nanoc/base/views/identifiable_collection_view.rb
@@ -1,9 +1,10 @@
 module Nanoc
-  class IdentifiableCollectionView
+  class IdentifiableCollectionView < ::Nanoc::View
     include Enumerable
 
     # @api private
-    def initialize(objects)
+    def initialize(objects, context)
+      super(context)
       @objects = objects
     end
 
@@ -27,7 +28,7 @@ module Nanoc
     #
     # @return [self]
     def each
-      @objects.each { |i| yield view_class.new(i) }
+      @objects.each { |i| yield view_class.new(i, @context) }
       self
     end
 
@@ -70,7 +71,7 @@ module Nanoc
     #   @return [#identifier] if an object was found
     def [](arg)
       res = @objects[arg]
-      res && view_class.new(res)
+      res && view_class.new(res, @context)
     end
   end
 end

--- a/lib/nanoc/base/views/item_rep_collection_view.rb
+++ b/lib/nanoc/base/views/item_rep_collection_view.rb
@@ -20,7 +20,7 @@ module Nanoc
     end
 
     def to_ary
-      @item_reps.map { |ir| Nanoc::ItemRepView.new(ir, nil) }
+      @item_reps.map { |ir| Nanoc::ItemRepView.new(ir, @context) }
     end
 
     # Calls the given block once for each item rep, passing that item rep as a parameter.
@@ -31,7 +31,7 @@ module Nanoc
     #
     # @return [self]
     def each
-      @item_reps.each { |ir| yield Nanoc::ItemRepView.new(ir, nil) }
+      @item_reps.each { |ir| yield Nanoc::ItemRepView.new(ir, @context) }
       self
     end
 
@@ -49,7 +49,7 @@ module Nanoc
     # @return [Nanoc::ItemRepView] if an item rep with the given name was found
     def [](rep_name)
       res = @item_reps.find { |ir| ir.name == rep_name }
-      res && Nanoc::ItemRepView.new(res, nil)
+      res && Nanoc::ItemRepView.new(res, @context)
     end
 
     # Return the item rep with the given name, or raises an exception if there
@@ -63,7 +63,7 @@ module Nanoc
     def fetch(rep_name)
       res = @item_reps.find { |ir| ir.name == rep_name }
       if res
-        Nanoc::ItemRepView.new(res, nil)
+        Nanoc::ItemRepView.new(res, @context)
       else
         raise NoSuchItemRepError.new(rep_name)
       end

--- a/lib/nanoc/base/views/item_rep_collection_view.rb
+++ b/lib/nanoc/base/views/item_rep_collection_view.rb
@@ -1,5 +1,5 @@
 module Nanoc
-  class ItemRepCollectionView
+  class ItemRepCollectionView < ::Nanoc::View
     include Enumerable
 
     class NoSuchItemRepError < ::Nanoc::Error
@@ -9,7 +9,8 @@ module Nanoc
     end
 
     # @api private
-    def initialize(item_reps)
+    def initialize(item_reps, context)
+      super(context)
       @item_reps = item_reps
     end
 
@@ -19,7 +20,7 @@ module Nanoc
     end
 
     def to_ary
-      @item_reps.map { |ir| Nanoc::ItemRepView.new(ir) }
+      @item_reps.map { |ir| Nanoc::ItemRepView.new(ir, nil) }
     end
 
     # Calls the given block once for each item rep, passing that item rep as a parameter.
@@ -30,7 +31,7 @@ module Nanoc
     #
     # @return [self]
     def each
-      @item_reps.each { |ir| yield Nanoc::ItemRepView.new(ir) }
+      @item_reps.each { |ir| yield Nanoc::ItemRepView.new(ir, nil) }
       self
     end
 
@@ -48,7 +49,7 @@ module Nanoc
     # @return [Nanoc::ItemRepView] if an item rep with the given name was found
     def [](rep_name)
       res = @item_reps.find { |ir| ir.name == rep_name }
-      res && Nanoc::ItemRepView.new(res)
+      res && Nanoc::ItemRepView.new(res, nil)
     end
 
     # Return the item rep with the given name, or raises an exception if there
@@ -62,7 +63,7 @@ module Nanoc
     def fetch(rep_name)
       res = @item_reps.find { |ir| ir.name == rep_name }
       if res
-        Nanoc::ItemRepView.new(res)
+        Nanoc::ItemRepView.new(res, nil)
       else
         raise NoSuchItemRepError.new(rep_name)
       end

--- a/lib/nanoc/base/views/item_rep_view.rb
+++ b/lib/nanoc/base/views/item_rep_view.rb
@@ -1,7 +1,8 @@
 module Nanoc
-  class ItemRepView
+  class ItemRepView < ::Nanoc::View
     # @api private
-    def initialize(item_rep)
+    def initialize(item_rep, context)
+      super(context)
       @item_rep = item_rep
     end
 
@@ -61,7 +62,7 @@ module Nanoc
     #
     # @return [Nanoc::ItemView]
     def item
-      Nanoc::ItemView.new(@item_rep.item)
+      Nanoc::ItemView.new(@item_rep.item, @context)
     end
 
     # @api private

--- a/lib/nanoc/base/views/item_view.rb
+++ b/lib/nanoc/base/views/item_view.rb
@@ -1,5 +1,5 @@
 module Nanoc
-  class ItemView
+  class ItemView < ::Nanoc::View
     include Nanoc::DocumentViewMixin
 
     # Returns the compiled content.
@@ -40,7 +40,7 @@ module Nanoc
     #
     # @return [Enumerable<Nanoc::ItemView>]
     def children
-      unwrap.children.map { |i| Nanoc::ItemView.new(i) }
+      unwrap.children.map { |i| Nanoc::ItemView.new(i, @context) }
     end
 
     # Returns the parent of this item, if one exists. For items with identifiers
@@ -50,7 +50,7 @@ module Nanoc
     #
     # @return [nil] if the item has no parent
     def parent
-      unwrap.parent && Nanoc::ItemView.new(unwrap.parent)
+      unwrap.parent && Nanoc::ItemView.new(unwrap.parent, @context)
     end
 
     # @return [Boolean] True if the item is binary, false otherwise
@@ -62,7 +62,7 @@ module Nanoc
     #
     # @return [Nanoc::ItemRepCollectionView]
     def reps
-      Nanoc::ItemRepCollectionView.new(unwrap.reps)
+      Nanoc::ItemRepCollectionView.new(unwrap.reps, @context)
     end
 
     # @api private

--- a/lib/nanoc/base/views/item_view.rb
+++ b/lib/nanoc/base/views/item_view.rb
@@ -62,7 +62,7 @@ module Nanoc
     #
     # @return [Nanoc::ItemRepCollectionView]
     def reps
-      Nanoc::ItemRepCollectionView.new(unwrap.reps, @context)
+      Nanoc::ItemRepCollectionView.new(@context.reps[unwrap], @context)
     end
 
     # @api private

--- a/lib/nanoc/base/views/layout_view.rb
+++ b/lib/nanoc/base/views/layout_view.rb
@@ -1,5 +1,5 @@
 module Nanoc
-  class LayoutView
+  class LayoutView < ::Nanoc::View
     include Nanoc::DocumentViewMixin
   end
 end

--- a/lib/nanoc/base/views/mixins/document_view_mixin.rb
+++ b/lib/nanoc/base/views/mixins/document_view_mixin.rb
@@ -4,7 +4,8 @@ module Nanoc
     NONE = Object.new
 
     # @api private
-    def initialize(document)
+    def initialize(document, context)
+      super(context)
       @document = document
     end
 

--- a/lib/nanoc/base/views/mutable_identifiable_collection_view.rb
+++ b/lib/nanoc/base/views/mutable_identifiable_collection_view.rb
@@ -8,7 +8,7 @@ module Nanoc
     #
     # @return [self]
     def delete_if(&_block)
-      @objects.delete_if { |o| yield(view_class.new(o)) }
+      @objects.delete_if { |o| yield(view_class.new(o, @context)) }
       self
     end
   end

--- a/lib/nanoc/base/views/site_view.rb
+++ b/lib/nanoc/base/views/site_view.rb
@@ -1,7 +1,8 @@
 module Nanoc
-  class SiteView
+  class SiteView < ::Nanoc::View
     # @api private
-    def initialize(site)
+    def initialize(site, context)
+      super(context)
       @site = site
     end
 

--- a/lib/nanoc/base/views/view.rb
+++ b/lib/nanoc/base/views/view.rb
@@ -1,0 +1,8 @@
+module Nanoc
+  class View
+    # @api private
+    def initialize(context)
+      @context = context
+    end
+  end
+end

--- a/lib/nanoc/base/views/view.rb
+++ b/lib/nanoc/base/views/view.rb
@@ -4,5 +4,9 @@ module Nanoc
     def initialize(context)
       @context = context
     end
+
+    def _context
+      @context
+    end
   end
 end

--- a/lib/nanoc/base/views/view_context.rb
+++ b/lib/nanoc/base/views/view_context.rb
@@ -1,0 +1,5 @@
+module Nanoc
+  # @api private
+  class ViewContext
+  end
+end

--- a/lib/nanoc/base/views/view_context.rb
+++ b/lib/nanoc/base/views/view_context.rb
@@ -1,5 +1,10 @@
 module Nanoc
   # @api private
   class ViewContext
+    attr_reader :reps
+
+    def initialize(reps:)
+      @reps = reps
+    end
   end
 end

--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -17,8 +17,6 @@ EOS
 
 module Nanoc::CLI::Commands
   class Compile < ::Nanoc::CLI::CommandRunner
-    extend Nanoc::Int::Memoization
-
     # Listens to compilation events and reacts to them. This abstract class
     # does not have a real implementation; subclasses should override {#start}
     # and set up notifications to listen to.
@@ -426,9 +424,8 @@ module Nanoc::CLI::Commands
     end
 
     def reps
-      site.items.map(&:reps).flatten
+      site.compiler.reps
     end
-    memoize :reps
 
     def prune_config
       site.config[:prune] || {}

--- a/lib/nanoc/cli/commands/shell.rb
+++ b/lib/nanoc/cli/commands/shell.rb
@@ -23,9 +23,9 @@ module Nanoc::CLI::Commands
 
     def self.env_for(site)
       {
-        items: Nanoc::ItemCollectionView.new(site.items),
-        layouts: Nanoc::LayoutCollectionView.new(site.layouts),
-        config: Nanoc::ConfigView.new(site.config),
+        items: Nanoc::ItemCollectionView.new(site.items, nil),
+        layouts: Nanoc::LayoutCollectionView.new(site.layouts, nil),
+        config: Nanoc::ConfigView.new(site.config, nil),
       }
     end
   end

--- a/lib/nanoc/cli/commands/show-rules.rb
+++ b/lib/nanoc/cli/commands/show-rules.rb
@@ -12,6 +12,7 @@ module Nanoc::CLI::Commands
 
       @c = Nanoc::CLI::ANSIStringColorizer
       @rules = site.compiler.rules_collection
+      @reps = site.compiler.reps
 
       site.items.sort_by(&:identifier).each   { |e| explain_item(e) }
       site.layouts.sort_by(&:identifier).each { |e| explain_layout(e) }
@@ -20,7 +21,7 @@ module Nanoc::CLI::Commands
     def explain_item(item)
       puts "#{@c.c('Item ' + item.identifier, :bold, :yellow)}:"
 
-      item.reps.each do |rep|
+      @reps[item].each do |rep|
         rule = @rules.compilation_rule_for(rep)
         puts "  Rep #{rep.name}: #{rule ? rule.pattern : '(none)'}"
       end

--- a/lib/nanoc/extra/checking/check.rb
+++ b/lib/nanoc/extra/checking/check.rb
@@ -19,11 +19,14 @@ module Nanoc::Extra::Checking
       end
       output_filenames = Dir[output_dir + '/**/*'].select { |f| File.file?(f) }
 
+      # FIXME: ugly
+      view_context = site.compiler.create_view_context
+
       context = {
-        items: Nanoc::ItemCollectionView.new(site.items, nil),
-        layouts: Nanoc::LayoutCollectionView.new(site.layouts, nil),
-        config: Nanoc::ConfigView.new(site.config, nil),
-        site: Nanoc::SiteView.new(site, nil), # TODO: remove me
+        items: Nanoc::ItemCollectionView.new(site.items, view_context),
+        layouts: Nanoc::LayoutCollectionView.new(site.layouts, view_context),
+        config: Nanoc::ConfigView.new(site.config, view_context),
+        site: Nanoc::SiteView.new(site, view_context), # TODO: remove me
         output_filenames: output_filenames,
       }
 

--- a/lib/nanoc/extra/checking/check.rb
+++ b/lib/nanoc/extra/checking/check.rb
@@ -20,10 +20,10 @@ module Nanoc::Extra::Checking
       output_filenames = Dir[output_dir + '/**/*'].select { |f| File.file?(f) }
 
       context = {
-        items: Nanoc::ItemCollectionView.new(site.items),
-        layouts: Nanoc::LayoutCollectionView.new(site.layouts),
-        config: Nanoc::ConfigView.new(site.config),
-        site: Nanoc::SiteView.new(site), # TODO: remove me
+        items: Nanoc::ItemCollectionView.new(site.items, nil),
+        layouts: Nanoc::LayoutCollectionView.new(site.layouts, nil),
+        config: Nanoc::ConfigView.new(site.config, nil),
+        site: Nanoc::SiteView.new(site, nil), # TODO: remove me
         output_filenames: output_filenames,
       }
 

--- a/lib/nanoc/extra/pruner.rb
+++ b/lib/nanoc/extra/pruner.rb
@@ -28,9 +28,7 @@ module Nanoc::Extra
 
       # Get compiled files
       # FIXME: requires #build_reps to have been called
-      all_raw_paths = site.items.map do |item|
-        item.reps.map(&:raw_path)
-      end
+      all_raw_paths = site.compiler.reps.map(&:raw_path)
       compiled_files = all_raw_paths.flatten.compact.select { |f| File.file?(f) }
 
       # Get present files and dirs

--- a/lib/nanoc/filters/sass/sass_filesystem_importer.rb
+++ b/lib/nanoc/filters/sass/sass_filesystem_importer.rb
@@ -11,7 +11,6 @@ class ::Sass::Importers::Filesystem
     filter = options[:nanoc_current_filter]
     if filter
       item = filter.imported_filename_to_item(full_filename)
-      item = item.unwrap if item.respond_to?(:unwrap)
       filter.depend_on([item]) unless item.nil?
     end
 

--- a/lib/nanoc/helpers/capturing.rb
+++ b/lib/nanoc/helpers/capturing.rb
@@ -110,7 +110,7 @@ module Nanoc::Helpers
           unless @site.unwrap.captures_store_compiled_items.include? item
             @site.unwrap.captures_store_compiled_items << item
             item.forced_outdated = true
-            item.reps.each do |r|
+            @site.unwrap.compiler.reps[item].each do |r|
               r.snapshot_contents = { last: item.content }
               raise Nanoc::Int::Errors::UnmetDependency.new(r)
             end

--- a/spec/nanoc/base/checksummer_spec.rb
+++ b/spec/nanoc/base/checksummer_spec.rb
@@ -207,28 +207,28 @@ describe Nanoc::Int::Checksummer do
   end
 
   context 'Nanoc::ItemView' do
-    let(:obj) { Nanoc::ItemView.new(item) }
+    let(:obj) { Nanoc::ItemView.new(item, nil) }
     let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo.md') }
 
     it { is_expected.to eql('Nanoc::ItemView<Nanoc::Int::Item<content=Nanoc::Int::TextualContent<String<asdf>>,attributes=Hash<>,identifier=Nanoc::Identifier<String</foo.md>>>>') }
   end
 
   context 'Nanoc::LayoutView' do
-    let(:obj) { Nanoc::LayoutView.new(layout) }
+    let(:obj) { Nanoc::LayoutView.new(layout, nil) }
     let(:layout) { Nanoc::Int::Layout.new('asdf', {}, '/foo.md') }
 
     it { is_expected.to eql('Nanoc::LayoutView<Nanoc::Int::Layout<content=Nanoc::Int::TextualContent<String<asdf>>,attributes=Hash<>,identifier=Nanoc::Identifier<String</foo.md>>>>') }
   end
 
   context 'Nanoc::ConfigView' do
-    let(:obj) { Nanoc::ConfigView.new(config) }
+    let(:obj) { Nanoc::ConfigView.new(config, nil) }
     let(:config) { Nanoc::Int::Configuration.new({ 'foo' => 'bar' }) }
 
     it { is_expected.to eql('Nanoc::ConfigView<Nanoc::Int::Configuration<Symbol<foo>=String<bar>,>>') }
   end
 
   context 'Nanoc::ItemCollectionView' do
-    let(:obj) { Nanoc::ItemCollectionView.new(wrapped) }
+    let(:obj) { Nanoc::ItemCollectionView.new(wrapped, nil) }
 
     let(:config) { Nanoc::Int::Configuration.new({ 'foo' => 'bar' }) }
 

--- a/spec/nanoc/base/services/executor_spec.rb
+++ b/spec/nanoc/base/services/executor_spec.rb
@@ -292,7 +292,7 @@ describe Nanoc::Int::Executor do
         let(:layout_content) { 'head <%= @item_rep.compiled_content(snapshot: :pre) %> foot' }
 
         let(:assigns) do
-          { item_rep: Nanoc::ItemRepView.new(rep) }
+          { item_rep: Nanoc::ItemRepView.new(rep, nil) }
         end
 
         it 'can contain compiled_content reference' do

--- a/spec/nanoc/base/views/config_spec.rb
+++ b/spec/nanoc/base/views/config_spec.rb
@@ -3,7 +3,7 @@ describe Nanoc::ConfigView do
     { amount: 9000, animal: 'donkey' }
   end
 
-  let(:view) { described_class.new(config) }
+  let(:view) { described_class.new(config, nil) }
 
   describe '#[]' do
     subject { view[key] }

--- a/spec/nanoc/base/views/document_view_spec.rb
+++ b/spec/nanoc/base/views/document_view_spec.rb
@@ -1,7 +1,7 @@
 shared_examples 'a document view' do
   describe '#== and #eql?' do
     let(:document) { entity_class.new('content', {}, '/asdf/') }
-    let(:view) { described_class.new(document) }
+    let(:view) { described_class.new(document, nil) }
 
     context 'comparing with document with same identifier' do
       let(:other) { entity_class.new('content', {}, '/asdf/') }
@@ -22,7 +22,7 @@ shared_examples 'a document view' do
     end
 
     context 'comparing with document view with same identifier' do
-      let(:other) { Nanoc::LayoutView.new(entity_class.new('content', {}, '/asdf/')) }
+      let(:other) { Nanoc::LayoutView.new(entity_class.new('content', {}, '/asdf/'), nil) }
 
       it 'is equal' do
         expect(view).to eq(other)
@@ -31,7 +31,7 @@ shared_examples 'a document view' do
     end
 
     context 'comparing with document view with different identifier' do
-      let(:other) { Nanoc::LayoutView.new(entity_class.new('content', {}, '/fdsa/')) }
+      let(:other) { Nanoc::LayoutView.new(entity_class.new('content', {}, '/fdsa/'), nil) }
 
       it 'is not equal' do
         expect(view).not_to eq(other)
@@ -42,7 +42,7 @@ shared_examples 'a document view' do
 
   describe '#[]' do
     let(:document) { entity_class.new('stuff', { animal: 'donkey' }, '/foo/') }
-    let(:view) { described_class.new(document) }
+    let(:view) { described_class.new(document, nil) }
 
     subject { view[key] }
 
@@ -64,7 +64,7 @@ shared_examples 'a document view' do
 
   describe '#fetch' do
     let(:item) { entity_class.new('stuff', { animal: 'donkey' }, '/foo/') }
-    let(:view) { described_class.new(item) }
+    let(:view) { described_class.new(item, nil) }
 
     before do
       expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:visit_started, item).ordered
@@ -104,7 +104,7 @@ shared_examples 'a document view' do
 
   describe '#key?' do
     let(:document) { entity_class.new('stuff', { animal: 'donkey' }, '/foo/') }
-    let(:view) { described_class.new(document) }
+    let(:view) { described_class.new(document, nil) }
 
     before do
       expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:visit_started, document).ordered
@@ -126,7 +126,7 @@ shared_examples 'a document view' do
 
   describe '#hash' do
     let(:document) { double(:document, identifier: '/foo/') }
-    let(:view) { described_class.new(document) }
+    let(:view) { described_class.new(document, nil) }
 
     subject { view.hash }
 

--- a/spec/nanoc/base/views/identifiable_collection_spec.rb
+++ b/spec/nanoc/base/views/identifiable_collection_spec.rb
@@ -1,6 +1,8 @@
 # Needs :view_class
 shared_examples 'an identifiable collection' do
-  let(:view) { described_class.new(wrapped, nil) }
+  let(:view) { described_class.new(wrapped, view_context) }
+
+  let(:view_context) { double(:view_context) }
 
   let(:config) do
     { string_pattern_type: 'glob' }
@@ -31,6 +33,10 @@ shared_examples 'an identifiable collection' do
 
     it 'returns self' do
       expect(view.each { |_i| }).to equal(view)
+    end
+
+    it 'yields elements with the right context' do
+      view.each { |v| expect(v._context).to equal(view_context) }
     end
   end
 
@@ -77,6 +83,10 @@ shared_examples 'an identifiable collection' do
       it 'returns wrapped object' do
         expect(subject.class).to equal(view_class)
         expect(subject.unwrap).to equal(home_object)
+      end
+
+      it 'returns objects with right context' do
+        expect(subject._context).to equal(view_context)
       end
     end
 

--- a/spec/nanoc/base/views/identifiable_collection_spec.rb
+++ b/spec/nanoc/base/views/identifiable_collection_spec.rb
@@ -1,6 +1,6 @@
 # Needs :view_class
 shared_examples 'an identifiable collection' do
-  let(:view) { described_class.new(wrapped) }
+  let(:view) { described_class.new(wrapped, nil) }
 
   let(:config) do
     { string_pattern_type: 'glob' }

--- a/spec/nanoc/base/views/item_rep_collection_spec.rb
+++ b/spec/nanoc/base/views/item_rep_collection_spec.rb
@@ -1,5 +1,5 @@
 describe Nanoc::ItemRepCollectionView do
-  let(:view) { described_class.new(wrapped) }
+  let(:view) { described_class.new(wrapped, nil) }
 
   let(:wrapped) do
     [

--- a/spec/nanoc/base/views/item_rep_collection_spec.rb
+++ b/spec/nanoc/base/views/item_rep_collection_spec.rb
@@ -1,5 +1,7 @@
 describe Nanoc::ItemRepCollectionView do
-  let(:view) { described_class.new(wrapped, nil) }
+  let(:view) { described_class.new(wrapped, view_context) }
+
+  let(:view_context) { double(:view_context) }
 
   let(:wrapped) do
     [
@@ -24,6 +26,10 @@ describe Nanoc::ItemRepCollectionView do
     it 'returns self' do
       expect(view.each { |_i| }).to equal(view)
     end
+
+    it 'yields elements with the right context' do
+      view.each { |v| expect(v._context).to equal(view_context) }
+    end
   end
 
   describe '#size' do
@@ -40,6 +46,10 @@ describe Nanoc::ItemRepCollectionView do
       expect(subject.size).to eq(3)
       expect(subject[0].class).to eql(Nanoc::ItemRepView)
       expect(subject[0].name).to eql(:foo)
+    end
+
+    it 'returns an array with correct contexts' do
+      expect(subject[0]._context).to equal(view_context)
     end
   end
 
@@ -58,6 +68,10 @@ describe Nanoc::ItemRepCollectionView do
       it 'returns a view' do
         expect(subject.class).to eq(Nanoc::ItemRepView)
         expect(subject.name).to eq(:foo)
+      end
+
+      it 'returns a view with the correct context' do
+        expect(subject._context).to equal(view_context)
       end
     end
   end
@@ -79,6 +93,10 @@ describe Nanoc::ItemRepCollectionView do
       it 'returns a view' do
         expect(subject.class).to eq(Nanoc::ItemRepView)
         expect(subject.name).to eq(:foo)
+      end
+
+      it 'returns a view with the correct context' do
+        expect(subject._context).to equal(view_context)
       end
     end
   end

--- a/spec/nanoc/base/views/item_rep_spec.rb
+++ b/spec/nanoc/base/views/item_rep_spec.rb
@@ -2,7 +2,7 @@ describe Nanoc::ItemRepView do
   describe '#== and #eql?' do
     let(:item_rep) { double(:item_rep, item: item, name: :jacques) }
     let(:item) { double(:item, identifier: '/foo/') }
-    let(:view) { described_class.new(item_rep) }
+    let(:view) { described_class.new(item_rep, nil) }
 
     context 'comparing with item rep with same identifier' do
       let(:other_item) { double(:other_item, identifier: '/foo/') }
@@ -36,7 +36,7 @@ describe Nanoc::ItemRepView do
 
     context 'comparing with item rep with same identifier' do
       let(:other_item) { double(:other_item, identifier: '/foo/') }
-      let(:other) { described_class.new(double(:other_item_rep, item: other_item, name: :jacques)) }
+      let(:other) { described_class.new(double(:other_item_rep, item: other_item, name: :jacques), nil) }
 
       it 'is equal' do
         expect(view).to eq(other)
@@ -46,7 +46,7 @@ describe Nanoc::ItemRepView do
 
     context 'comparing with item rep with different identifier' do
       let(:other_item) { double(:other_item, identifier: '/bar/') }
-      let(:other) { described_class.new(double(:other_item_rep, item: other_item, name: :jacques)) }
+      let(:other) { described_class.new(double(:other_item_rep, item: other_item, name: :jacques), nil) }
 
       it 'is not equal' do
         expect(view).not_to eq(other)
@@ -56,7 +56,7 @@ describe Nanoc::ItemRepView do
 
     context 'comparing with item rep with different name' do
       let(:other_item) { double(:other_item, identifier: '/foo/') }
-      let(:other) { described_class.new(double(:other_item_rep, item: other_item, name: :marvin)) }
+      let(:other) { described_class.new(double(:other_item_rep, item: other_item, name: :marvin), nil) }
 
       it 'is not equal' do
         expect(view).not_to eq(other)
@@ -68,7 +68,7 @@ describe Nanoc::ItemRepView do
   describe '#hash' do
     let(:item_rep) { double(:item_rep, item: item, name: :jacques) }
     let(:item) { double(:item, identifier: '/foo/') }
-    let(:view) { described_class.new(item_rep) }
+    let(:view) { described_class.new(item_rep, nil) }
 
     subject { view.hash }
 
@@ -78,7 +78,7 @@ describe Nanoc::ItemRepView do
   describe '#compiled_content' do
     subject { view.compiled_content }
 
-    let(:view) { described_class.new(rep) }
+    let(:view) { described_class.new(rep, nil) }
 
     let(:rep) do
       Nanoc::Int::ItemRep.new(item, :default).tap do |ir|
@@ -106,7 +106,7 @@ describe Nanoc::ItemRepView do
   describe '#path' do
     subject { view.path }
 
-    let(:view) { described_class.new(rep) }
+    let(:view) { described_class.new(rep, nil) }
 
     let(:rep) do
       Nanoc::Int::ItemRep.new(item, :default).tap do |ir|
@@ -133,7 +133,7 @@ describe Nanoc::ItemRepView do
   describe '#raw_path' do
     subject { view.raw_path }
 
-    let(:view) { described_class.new(rep) }
+    let(:view) { described_class.new(rep, nil) }
 
     let(:rep) do
       Nanoc::Int::ItemRep.new(item, :default).tap do |ir|

--- a/spec/nanoc/base/views/item_rep_spec.rb
+++ b/spec/nanoc/base/views/item_rep_spec.rb
@@ -1,8 +1,10 @@
 describe Nanoc::ItemRepView do
+  let(:view_context) { double(:view_context) }
+
   describe '#== and #eql?' do
-    let(:item_rep) { double(:item_rep, item: item, name: :jacques) }
-    let(:item) { double(:item, identifier: '/foo/') }
-    let(:view) { described_class.new(item_rep, nil) }
+    let(:item_rep) { Nanoc::Int::ItemRep.new(item, :jacques) }
+    let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo/') }
+    let(:view) { described_class.new(item_rep, view_context) }
 
     context 'comparing with item rep with same identifier' do
       let(:other_item) { double(:other_item, identifier: '/foo/') }
@@ -66,13 +68,13 @@ describe Nanoc::ItemRepView do
   end
 
   describe '#hash' do
-    let(:item_rep) { double(:item_rep, item: item, name: :jacques) }
-    let(:item) { double(:item, identifier: '/foo/') }
-    let(:view) { described_class.new(item_rep, nil) }
+    let(:item_rep) { Nanoc::Int::ItemRep.new(item, :jacques) }
+    let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo/') }
+    let(:view) { described_class.new(item_rep, view_context) }
 
     subject { view.hash }
 
-    it { should == described_class.hash ^ '/foo/'.hash ^ :jacques.hash }
+    it { should == described_class.hash ^ Nanoc::Identifier.new('/foo/').hash ^ :jacques.hash }
   end
 
   describe '#compiled_content' do
@@ -155,5 +157,21 @@ describe Nanoc::ItemRepView do
     end
 
     it { should eq('output/about/index.html') }
+  end
+
+  describe '#item' do
+    let(:item_rep) { Nanoc::Int::ItemRep.new(item, :jacques) }
+    let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo/') }
+    let(:view) { described_class.new(item_rep, view_context) }
+
+    subject { view.item }
+
+    it 'returns an item view' do
+      expect(subject).to be_a(Nanoc::ItemView)
+    end
+
+    it 'returns an item view with the right context' do
+      expect(subject._context).to equal(view_context)
+    end
   end
 end

--- a/spec/nanoc/base/views/item_spec.rb
+++ b/spec/nanoc/base/views/item_spec.rb
@@ -4,7 +4,7 @@ describe Nanoc::ItemView do
 
   describe '#raw_content' do
     let(:item) { Nanoc::Int::Item.new('content', {}, '/asdf/') }
-    let(:view) { described_class.new(item) }
+    let(:view) { described_class.new(item, nil) }
 
     subject { view.raw_content }
 
@@ -16,7 +16,7 @@ describe Nanoc::ItemView do
       Nanoc::Int::Item.new('me', {}, '/me/').tap { |i| i.parent = parent_item }
     end
 
-    let(:view) { described_class.new(item) }
+    let(:view) { described_class.new(item, nil) }
 
     subject { view.parent }
 
@@ -51,7 +51,7 @@ describe Nanoc::ItemView do
     let(:rep_a) { double(:rep_a) }
     let(:rep_b) { double(:rep_b) }
 
-    let(:view) { described_class.new(item) }
+    let(:view) { described_class.new(item, nil) }
 
     subject { view.reps }
 
@@ -64,7 +64,7 @@ describe Nanoc::ItemView do
   describe '#compiled_content' do
     subject { view.compiled_content(params) }
 
-    let(:view) { described_class.new(item) }
+    let(:view) { described_class.new(item, nil) }
 
     let(:item) do
       Nanoc::Int::Item.new('content', {}, '/asdf/')
@@ -138,7 +138,7 @@ describe Nanoc::ItemView do
   describe '#path' do
     subject { view.path(params) }
 
-    let(:view) { described_class.new(item) }
+    let(:view) { described_class.new(item, nil) }
 
     let(:item) do
       Nanoc::Int::Item.new('content', {}, '/asdf.md')

--- a/spec/nanoc/base/views/mutable_config_spec.rb
+++ b/spec/nanoc/base/views/mutable_config_spec.rb
@@ -1,7 +1,7 @@
 describe Nanoc::MutableConfigView do
   describe '#[]=' do
     let(:config) { {} }
-    let(:view) { described_class.new(config) }
+    let(:view) { described_class.new(config, nil) }
 
     it 'sets attributes' do
       view[:awesomeness] = 'rather high'

--- a/spec/nanoc/base/views/mutable_document_view_spec.rb
+++ b/spec/nanoc/base/views/mutable_document_view_spec.rb
@@ -1,7 +1,7 @@
 shared_examples 'a mutable document view' do
   describe '#[]=' do
     let(:item) { entity_class.new('content', {}, '/asdf/') }
-    let(:view) { described_class.new(item) }
+    let(:view) { described_class.new(item, nil) }
 
     it 'sets attributes' do
       view[:title] = 'Donkey'
@@ -11,7 +11,7 @@ shared_examples 'a mutable document view' do
 
   describe '#update_attributes' do
     let(:item) { entity_class.new('content', {}, '/asdf/') }
-    let(:view) { described_class.new(item) }
+    let(:view) { described_class.new(item, nil) }
 
     let(:update) { { friend: 'Giraffe' } }
 

--- a/spec/nanoc/base/views/mutable_identifiable_collection_spec.rb
+++ b/spec/nanoc/base/views/mutable_identifiable_collection_spec.rb
@@ -1,5 +1,5 @@
 shared_examples 'a mutable identifiable collection' do
-  let(:view) { described_class.new(wrapped) }
+  let(:view) { described_class.new(wrapped, nil) }
 
   let(:config) do
     {}

--- a/spec/nanoc/base/views/mutable_identifiable_collection_spec.rb
+++ b/spec/nanoc/base/views/mutable_identifiable_collection_spec.rb
@@ -1,5 +1,7 @@
 shared_examples 'a mutable identifiable collection' do
-  let(:view) { described_class.new(wrapped, nil) }
+  let(:view) { described_class.new(wrapped, view_context) }
+
+  let(:view_context) { double(:view_context) }
 
   let(:config) do
     {}
@@ -25,6 +27,10 @@ shared_examples 'a mutable identifiable collection' do
     it 'returns self' do
       ret = view.delete_if { |_i| false }
       expect(ret).to equal(view)
+    end
+
+    it 'yields items with the proper context' do
+      view.delete_if { |i| expect(i._context).to equal(view_context) }
     end
   end
 end

--- a/spec/nanoc/base/views/mutable_item_collection_spec.rb
+++ b/spec/nanoc/base/views/mutable_item_collection_spec.rb
@@ -18,7 +18,7 @@ describe Nanoc::MutableItemCollectionView do
       end
     end
 
-    let(:view) { described_class.new(wrapped) }
+    let(:view) { described_class.new(wrapped, nil) }
 
     it 'creates an object' do
       view.create('new content', { title: 'New Page' }, '/new/')

--- a/spec/nanoc/base/views/mutable_layout_collection_spec.rb
+++ b/spec/nanoc/base/views/mutable_layout_collection_spec.rb
@@ -18,7 +18,7 @@ describe Nanoc::MutableLayoutCollectionView do
       end
     end
 
-    let(:view) { described_class.new(wrapped) }
+    let(:view) { described_class.new(wrapped, nil) }
 
     it 'creates an object' do
       view.create('new content', { title: 'New Page' }, '/new/')

--- a/spec/nanoc/cli/commands/show_rules_spec.rb
+++ b/spec/nanoc/cli/commands/show_rules_spec.rb
@@ -24,17 +24,19 @@ describe Nanoc::CLI::Commands::ShowRules do
 
     let(:items) do
       Nanoc::Int::IdentifiableCollection.new(config).tap do |ic|
-        ic << Nanoc::Int::Item.new('About Me', {}, '/about.md').tap do |i|
-          i.reps << Nanoc::Int::ItemRep.new(i, :default)
-          i.reps << Nanoc::Int::ItemRep.new(i, :text)
-        end
-        ic << Nanoc::Int::Item.new('About My Dog', {}, '/dog.md').tap do |i|
-          i.reps << Nanoc::Int::ItemRep.new(i, :default)
-          i.reps << Nanoc::Int::ItemRep.new(i, :text)
-        end
-        ic << Nanoc::Int::Item.new('Raw Data', {}, '/other.dat').tap do |i|
-          i.reps << Nanoc::Int::ItemRep.new(i, :default)
-        end
+        ic << Nanoc::Int::Item.new('About Me', {}, '/about.md')
+        ic << Nanoc::Int::Item.new('About My Dog', {}, '/dog.md')
+        ic << Nanoc::Int::Item.new('Raw Data', {}, '/other.dat')
+      end
+    end
+
+    let(:reps) do
+      Nanoc::Int::ItemRepRepo.new.tap do |reps|
+        reps << Nanoc::Int::ItemRep.new(items['/about.md'], :default)
+        reps << Nanoc::Int::ItemRep.new(items['/about.md'], :text)
+        reps << Nanoc::Int::ItemRep.new(items['/dog.md'], :default)
+        reps << Nanoc::Int::ItemRep.new(items['/dog.md'], :text)
+        reps << Nanoc::Int::ItemRep.new(items['/other.dat'], :default)
       end
     end
 
@@ -48,7 +50,7 @@ describe Nanoc::CLI::Commands::ShowRules do
 
     let(:config) { double(:config) }
 
-    let(:compiler) { double(:compiler, rules_collection: rules_collection) }
+    let(:compiler) { double(:compiler, rules_collection: rules_collection, reps: reps) }
 
     let(:rules_collection) do
       Nanoc::Int::RulesCollection.new.tap do |rc|

--- a/spec/nanoc/helpers/blogging_spec.rb
+++ b/spec/nanoc/helpers/blogging_spec.rb
@@ -9,6 +9,12 @@ describe Nanoc::Helpers::Blogging do
     { items: [] }
   end
 
+  let(:view_context) { Nanoc::ViewContext.new(reps: reps) }
+
+  let(:reps) do
+    Nanoc::Int::ItemRepRepo.new
+  end
+
   describe '#articles' do
     subject { mod.articles }
 
@@ -42,7 +48,7 @@ describe Nanoc::Helpers::Blogging do
       items << item_b
       items << item_c
 
-      { items: Nanoc::ItemCollectionView.new(items, nil) }
+      { items: Nanoc::ItemCollectionView.new(items, view_context) }
     end
 
     it 'returns the two articles' do
@@ -86,7 +92,7 @@ describe Nanoc::Helpers::Blogging do
       items << item_b
       items << item_c
 
-      { items: Nanoc::ItemCollectionView.new(items, nil) }
+      { items: Nanoc::ItemCollectionView.new(items, view_context) }
     end
 
     it 'returns the two articles' do
@@ -100,15 +106,17 @@ describe Nanoc::Helpers::Blogging do
     subject { mod.url_for(item_view) }
 
     let(:item) do
-      Nanoc::Int::Item.new('Stuff', item_attributes, '/stuff/').tap do |item|
-        item.reps << Nanoc::Int::ItemRep.new(item, :default).tap do |rep|
-          rep.paths[:last] = '/rep/path/stuff.html'
-        end
-      end
+      Nanoc::Int::Item.new('Stuff', item_attributes, '/stuff/')
     end
 
     let(:item_view) do
-      Nanoc::ItemView.new(item, nil)
+      Nanoc::ItemView.new(item, view_context)
+    end
+
+    let(:rep) do
+      Nanoc::Int::ItemRep.new(item, :default).tap do |rep|
+        rep.paths[:last] = '/rep/path/stuff.html'
+      end
     end
 
     let(:item_attributes) do
@@ -119,6 +127,10 @@ describe Nanoc::Helpers::Blogging do
       {
         config: { base_url: base_url },
       }
+    end
+
+    before do
+      reps << rep
     end
 
     context 'without base_url' do
@@ -166,15 +178,17 @@ describe Nanoc::Helpers::Blogging do
     subject { mod.feed_url }
 
     let(:item) do
-      Nanoc::Int::Item.new('Feed', item_attributes, '/feed/').tap do |item|
-        item.reps << Nanoc::Int::ItemRep.new(item, :default).tap do |rep|
-          rep.paths[:last] = '/feed.xml'
-        end
+      Nanoc::Int::Item.new('Feed', item_attributes, '/feed/')
+    end
+
+    let(:rep) do
+      Nanoc::Int::ItemRep.new(item, :default).tap do |rep|
+        rep.paths[:last] = '/feed.xml'
       end
     end
 
     let(:item_view) do
-      Nanoc::ItemView.new(item, nil)
+      Nanoc::ItemView.new(item, view_context)
     end
 
     let(:item_attributes) do
@@ -186,6 +200,10 @@ describe Nanoc::Helpers::Blogging do
         config: { base_url: base_url },
         item: item_view,
       }
+    end
+
+    before do
+      reps << rep
     end
 
     context 'without base_url' do
@@ -221,17 +239,19 @@ describe Nanoc::Helpers::Blogging do
     subject { mod.atom_tag_for(item_view) }
 
     let(:item) do
-      Nanoc::Int::Item.new('Stuff', item_attributes, '/stuff/').tap do |item|
-        item.reps << Nanoc::Int::ItemRep.new(item, :default).tap do |rep|
-          rep.paths[:last] = item_rep_path
-        end
+      Nanoc::Int::Item.new('Stuff', item_attributes, '/stuff/')
+    end
+
+    let(:rep) do
+      Nanoc::Int::ItemRep.new(item, :default).tap do |rep|
+        rep.paths[:last] = item_rep_path
       end
     end
 
     let(:item_rep_path) { '/stuff.xml' }
 
     let(:item_view) do
-      Nanoc::ItemView.new(item, nil)
+      Nanoc::ItemView.new(item, view_context)
     end
 
     let(:item_attributes) do
@@ -246,6 +266,10 @@ describe Nanoc::Helpers::Blogging do
     end
 
     let(:base_url) { 'http://url.base' }
+
+    before do
+      reps << rep
+    end
 
     context 'item with path' do
       let(:item_rep_path) { '/stuff.xml' }

--- a/spec/nanoc/helpers/blogging_spec.rb
+++ b/spec/nanoc/helpers/blogging_spec.rb
@@ -42,7 +42,7 @@ describe Nanoc::Helpers::Blogging do
       items << item_b
       items << item_c
 
-      { items: Nanoc::ItemCollectionView.new(items) }
+      { items: Nanoc::ItemCollectionView.new(items, nil) }
     end
 
     it 'returns the two articles' do
@@ -86,7 +86,7 @@ describe Nanoc::Helpers::Blogging do
       items << item_b
       items << item_c
 
-      { items: Nanoc::ItemCollectionView.new(items) }
+      { items: Nanoc::ItemCollectionView.new(items, nil) }
     end
 
     it 'returns the two articles' do
@@ -108,7 +108,7 @@ describe Nanoc::Helpers::Blogging do
     end
 
     let(:item_view) do
-      Nanoc::ItemView.new(item)
+      Nanoc::ItemView.new(item, nil)
     end
 
     let(:item_attributes) do
@@ -174,7 +174,7 @@ describe Nanoc::Helpers::Blogging do
     end
 
     let(:item_view) do
-      Nanoc::ItemView.new(item)
+      Nanoc::ItemView.new(item, nil)
     end
 
     let(:item_attributes) do
@@ -231,7 +231,7 @@ describe Nanoc::Helpers::Blogging do
     let(:item_rep_path) { '/stuff.xml' }
 
     let(:item_view) do
-      Nanoc::ItemView.new(item)
+      Nanoc::ItemView.new(item, nil)
     end
 
     let(:item_attributes) do

--- a/test/base/test_compiler.rb
+++ b/test/base/test_compiler.rb
@@ -9,6 +9,8 @@ class Nanoc::Int::CompilerTest < Nanoc::TestCase
 
     rules_collection = Nanoc::Int::RulesCollection.new
 
+    reps = Nanoc::Int::ItemRepRepo.new
+
     params = {
       compiled_content_cache: Nanoc::Int::CompiledContentCache.new,
       checksum_store: Nanoc::Int::ChecksumStore.new(site: site),
@@ -19,6 +21,7 @@ class Nanoc::Int::CompilerTest < Nanoc::TestCase
       ),
       dependency_store: Nanoc::Int::DependencyStore.new(
         site.items.to_a + site.layouts.to_a),
+      reps: reps,
     }
 
     params[:outdatedness_checker] =
@@ -29,6 +32,7 @@ class Nanoc::Int::CompilerTest < Nanoc::TestCase
         rules_collection: params[:rules_collection],
         rule_memory_store: params[:rule_memory_store],
         rule_memory_calculator: params[:rule_memory_calculator],
+        reps: reps,
       )
 
     Nanoc::Int::Compiler.new(site, rules_collection, params)
@@ -289,7 +293,7 @@ class Nanoc::Int::CompilerTest < Nanoc::TestCase
 
       # At this point, even the already compiled items in the previous pass
       # should have their compiled content assigned, so this should work:
-      site.items['/index.*'].reps[0].compiled_content
+      site.compiler.reps[site.items['/index.*']][0].compiled_content
     end
   end
 

--- a/test/base/test_compiler_dsl.rb
+++ b/test/base/test_compiler_dsl.rb
@@ -83,7 +83,7 @@ class Nanoc::Int::CompilerDSLTest < Nanoc::TestCase
       compiler.build_reps
 
       # Check
-      rep = site.items['/index.*'].reps[0]
+      rep = compiler.reps[site.items['/index.*']][0]
       routing_rules = site.compiler.rules_collection.routing_rules_for(rep)
       routing_rule = routing_rules[:last]
       refute_nil routing_rule

--- a/test/base/test_outdatedness_checker.rb
+++ b/test/base/test_outdatedness_checker.rb
@@ -15,7 +15,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.build_reps
       site.compiler.load_stores
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items['/'].reps[0]
+      rep = site.compiler.reps[site.items.find { |i| i.identifier == '/' }][0]
       assert_nil outdatedness_checker.outdatedness_reason_for(rep)
     end
   end
@@ -41,7 +41,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.build_reps
       site.compiler.load_stores
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items.find { |i| i.identifier == '/' }.reps[0]
+      rep = site.compiler.reps[site.items.find { |i| i.identifier == '/' }][0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::NotEnoughData,
         outdatedness_checker.outdatedness_reason_for(rep)
     end
@@ -68,7 +68,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.build_reps
       site.compiler.load_stores
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items.find { |i| i.identifier == '/' }.reps[0]
+      rep = site.compiler.reps[site.items.find { |i| i.identifier == '/' }][0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::NotWritten,
         outdatedness_checker.outdatedness_reason_for(rep)
     end
@@ -96,7 +96,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.build_reps
       site.compiler.load_stores
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items.find { |i| i.identifier == '/new/' }.reps[0]
+      rep = site.compiler.reps[site.items.find { |i| i.identifier == '/new/' }][0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::SourceModified,
         outdatedness_checker.outdatedness_reason_for(rep)
     end
@@ -125,7 +125,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.load_stores
 
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items.find { |i| i.identifier == '/' }.reps[0]
+      rep = site.compiler.reps[site.items.find { |i| i.identifier == '/' }][0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::DependenciesOutdated,
         outdatedness_checker.outdatedness_reason_for(rep)
     end
@@ -160,7 +160,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.load_stores
 
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items.find { |i| i.identifier == '/a/' }.reps[0]
+      rep = site.compiler.reps[site.items.find { |i| i.identifier == '/a/' }][0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::DependenciesOutdated,
         outdatedness_checker.outdatedness_reason_for(rep)
     end
@@ -198,7 +198,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.load_stores
 
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items.find { |i| i.identifier == '/a/' }.reps[0]
+      rep = site.compiler.reps[site.items.find { |i| i.identifier == '/a/' }][0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::DependenciesOutdated,
         outdatedness_checker.outdatedness_reason_for(rep)
     end
@@ -233,7 +233,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.load_stores
 
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items.find { |i| i.identifier == '/a/' }.reps[0]
+      rep = site.compiler.reps[site.items.find { |i| i.identifier == '/a/' }][0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::DependenciesOutdated,
         outdatedness_checker.outdatedness_reason_for(rep)
     end
@@ -270,7 +270,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.load_stores
 
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items.find { |i| i.identifier == '/a/' }.reps[0]
+      rep = site.compiler.reps[site.items.find { |i| i.identifier == '/a/' }][0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::DependenciesOutdated,
         outdatedness_checker.outdatedness_reason_for(rep)
     end
@@ -298,7 +298,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.build_reps
       site.compiler.load_stores
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items.find { |i| i.identifier == '/' }.reps[0]
+      rep = site.compiler.reps[site.items.find { |i| i.identifier == '/' }][0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::CodeSnippetsModified,
         outdatedness_checker.outdatedness_reason_for(rep)
     end
@@ -331,7 +331,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.build_reps
       site.compiler.load_stores
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items.find { |i| i.identifier == '/' }.reps[0]
+      rep = site.compiler.reps[site.items.find { |i| i.identifier == '/' }][0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::ConfigurationModified,
         outdatedness_checker.outdatedness_reason_for(rep)
     end
@@ -357,7 +357,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.build_reps
       site.compiler.load_stores
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items.find { |i| i.identifier == '/' }.reps[0]
+      rep = site.compiler.reps[site.items.find { |i| i.identifier == '/' }][0]
       assert_nil outdatedness_checker.outdatedness_reason_for(rep)
     end
   end
@@ -401,7 +401,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.build_reps
       site.compiler.load_stores
       outdatedness_checker = site.compiler.send :outdatedness_checker
-      rep = site.items.find { |i| i.identifier == '/' }.reps[0]
+      rep = site.compiler.reps[site.items.find { |i| i.identifier == '/' }][0]
       assert_equal ::Nanoc::Int::OutdatednessReasons::RulesModified,
         outdatedness_checker.outdatedness_reason_for(rep)
     end

--- a/test/base/test_rule_context.rb
+++ b/test/base/test_rule_context.rb
@@ -15,7 +15,8 @@ class Nanoc::Int::RuleContextTest < Nanoc::TestCase
 
     # Create context
     executor = nil
-    rule_context = Nanoc::Int::RuleContext.new(rep: rep, executor: executor, site: site)
+    view_context = nil
+    rule_context = Nanoc::Int::RuleContext.new(rep: rep, executor: executor, site: site, view_context: nil)
 
     # Check classes
     assert_equal Nanoc::ItemRepView,          rule_context.rep.class
@@ -52,7 +53,8 @@ class Nanoc::Int::RuleContextTest < Nanoc::TestCase
 
     # Create context
     executor = nil
-    rule_context = Nanoc::Int::RuleContext.new(rep: rep, executor: executor, site: site)
+    view_context = nil
+    rule_context = Nanoc::Int::RuleContext.new(rep: rep, executor: executor, site: site, view_context: nil)
 
     # Check
     assert_raises(NoMethodError) do

--- a/test/filters/test_less.rb
+++ b/test/filters/test_less.rb
@@ -2,7 +2,7 @@ class Nanoc::Filters::LessTest < Nanoc::TestCase
   def test_filter
     if_have 'less' do
       # Create item
-      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'))
+      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'), nil)
 
       # Create filter
       filter = ::Nanoc::Filters::Less.new(item: @item, items: [@item])
@@ -20,7 +20,7 @@ class Nanoc::Filters::LessTest < Nanoc::TestCase
       File.open('content/foo/bar/imported_file.less', 'w') { |io| io.write('p { color: red; }') }
 
       # Create item
-      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'))
+      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'), nil)
 
       # Create filter
       filter = ::Nanoc::Filters::Less.new(item: @item, items: [@item])
@@ -39,7 +39,7 @@ class Nanoc::Filters::LessTest < Nanoc::TestCase
 
       # Create item
       File.open('content/foo/bar.txt', 'w') { |io| io.write('meh') }
-      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'))
+      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'), nil)
 
       # Create filter
       filter = ::Nanoc::Filters::Less.new(item: @item, items: [@item])
@@ -108,7 +108,7 @@ class Nanoc::Filters::LessTest < Nanoc::TestCase
   def test_compression
     if_have 'less' do
       # Create item
-      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'))
+      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'), nil)
 
       # Create filter
       filter = ::Nanoc::Filters::Less.new(item: @item, items: [@item])

--- a/test/filters/test_sass.rb
+++ b/test/filters/test_sass.rb
@@ -292,6 +292,7 @@ class Nanoc::Filters::SassTest < Nanoc::TestCase
           { content_filename: 'content/xyzzy.sass' },
           '/blah/',
         ),
+        nil,
       ),
     ]
     params = { item: items[0], items: items }.merge(params)

--- a/test/filters/test_xsl.rb
+++ b/test/filters/test_xsl.rb
@@ -87,11 +87,11 @@ EOS
       item = Nanoc::Int::Item.new(SAMPLE_XML_IN,
                              {},
                              '/content/')
-      item = Nanoc::ItemView.new(item)
+      item = Nanoc::ItemView.new(item, nil)
       layout = Nanoc::Int::Layout.new(SAMPLE_XSL,
                                  {},
                                  '/layout/')
-      layout = Nanoc::LayoutView.new(layout)
+      layout = Nanoc::LayoutView.new(layout, nil)
 
       # Create an instance of the filter
       assigns = {
@@ -113,11 +113,11 @@ EOS
       item = Nanoc::Int::Item.new(SAMPLE_XML_IN_WITH_PARAMS,
                              {},
                              '/content/')
-      item = Nanoc::ItemView.new(item)
+      item = Nanoc::ItemView.new(item, nil)
       layout = Nanoc::Int::Layout.new(SAMPLE_XSL_WITH_PARAMS,
                                  {},
                                  '/layout/')
-      layout = Nanoc::LayoutView.new(layout)
+      layout = Nanoc::LayoutView.new(layout, nil)
 
       # Create an instance of the filter
       assigns = {
@@ -140,11 +140,11 @@ EOS
       item = Nanoc::Int::Item.new(SAMPLE_XML_IN_WITH_OMIT_XML_DECL,
                              {},
                              '/content/')
-      item = Nanoc::ItemView.new(item)
+      item = Nanoc::ItemView.new(item, nil)
       layout = Nanoc::Int::Layout.new(SAMPLE_XSL_WITH_OMIT_XML_DECL,
                                  {},
                                  '/layout/')
-      layout = Nanoc::LayoutView.new(layout)
+      layout = Nanoc::LayoutView.new(layout, nil)
 
       # Create an instance of the filter
       assigns = {

--- a/test/helpers/test_blogging.rb
+++ b/test/helpers/test_blogging.rb
@@ -47,7 +47,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items[2].expects(:compiled_content).with(snapshot: :pre).returns('item 2 content')
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
 
       # Create feed item
       @item = mock
@@ -78,7 +78,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items[2].expects(:compiled_content).returns('item 2 content')
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
 
       # Create feed item
       @item = mock
@@ -99,7 +99,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items = [mock_item, mock_item]
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
 
       # Create feed item
       @item = mock
@@ -124,7 +124,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items = [mock_item, mock_article]
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: nil })
+      @config = Nanoc::ConfigView.new({ base_url: nil }, nil)
 
       # Create feed item
       @item = mock
@@ -149,7 +149,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items = [mock_item, mock_article]
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
 
       # Create feed item
       @item = mock
@@ -174,7 +174,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items = [mock_item, mock_article]
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
 
       # Create feed item
       @item = mock
@@ -204,7 +204,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items[0].expects(:compiled_content).returns('item 1 content')
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com/' })
+      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com/' }, nil)
 
       # Create feed item
       @item = mock
@@ -246,7 +246,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items = [mock_item, mock_article]
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
 
       # Create feed item
       @item = mock
@@ -273,7 +273,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items[2].stubs(:[]).with(:created_at).returns(nil)
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
 
       # Create feed item
       @item = mock
@@ -299,7 +299,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items[1].expects(:compiled_content).with(snapshot: :pre).returns('asdf')
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
 
       # Create feed item
       @item = mock
@@ -329,7 +329,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
         author_uri: 'http://example.com/~bob/',
         title: 'My Blog Or Something',
         base_url: 'http://example.com',
-      })
+      }, nil)
 
       # Create feed item
       @item = mock
@@ -353,7 +353,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items[1].expects(:compiled_content).with(snapshot: :pre).returns('asdf')
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
 
       # Create feed item
       @item = mock
@@ -377,7 +377,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       end
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
 
       # Create feed item
       @item = mock
@@ -410,7 +410,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items[1].stubs(:[]).with(:created_at).returns('22-03-2009')
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
 
       # Create feed item
       @item = mock
@@ -439,7 +439,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items[1].stubs(:[]).with(:created_at).returns('01-01-2014')
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
 
       # Create feed item
       @item = mock
@@ -463,7 +463,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items = [mock_article]
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
 
       # Create feed item
       @item = mock
@@ -484,7 +484,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items = [mock_article]
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
 
       # Create feed item
       @item = mock
@@ -505,7 +505,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items = [mock_article]
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
 
       # Create feed item
       @item = mock
@@ -526,7 +526,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items = [mock_article]
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
 
       # Create feed item
       @item = mock
@@ -548,7 +548,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items[0].stubs(:path).returns(nil)
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
 
       # Create feed item
       @item = mock

--- a/test/helpers/test_capturing.rb
+++ b/test/helpers/test_capturing.rb
@@ -17,8 +17,8 @@ class Nanoc::Helpers::CapturingTest < Nanoc::TestCase
     # Build site
     site = Nanoc::Int::SiteLoader.new.new_empty
     item = Nanoc::Int::Item.new('moo', {}, '/blah/')
-    @site = Nanoc::SiteView.new(Nanoc::Int::SiteLoader.new.new_empty)
-    @item = Nanoc::ItemView.new(item)
+    @site = Nanoc::SiteView.new(Nanoc::Int::SiteLoader.new.new_empty, nil)
+    @item = Nanoc::ItemView.new(item, nil)
 
     # Evaluate content
     result = ::ERB.new(content).result(binding)
@@ -32,8 +32,8 @@ class Nanoc::Helpers::CapturingTest < Nanoc::TestCase
     require 'erb'
 
     # Build site
-    @site = Nanoc::SiteView.new(Nanoc::Int::SiteLoader.new.new_empty)
-    @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('moo', {}, '/blah/'))
+    @site = Nanoc::SiteView.new(Nanoc::Int::SiteLoader.new.new_empty, nil)
+    @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('moo', {}, '/blah/'), nil)
 
     # Capture
     _erbout = 'foo'
@@ -66,8 +66,8 @@ head
 foot
 EOS
 
-    @site = Nanoc::SiteView.new(Nanoc::Int::SiteLoader.new.new_empty)
-    @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', {}, '/'))
+    @site = Nanoc::SiteView.new(Nanoc::Int::SiteLoader.new.new_empty, nil)
+    @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', {}, '/'), nil)
 
     result = ::ERB.new(content).result(binding)
 
@@ -84,16 +84,16 @@ EOS
       io.write "route '*' do ; item.identifier + 'index.html' ; end\n"
     end
 
-    @site = Nanoc::SiteView.new(Nanoc::Int::SiteLoader.new.new_empty)
-    @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', {}, '/'))
+    @site = Nanoc::SiteView.new(Nanoc::Int::SiteLoader.new.new_empty, nil)
+    @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', {}, '/'), nil)
     content = '<% content_for :a do %>Content One<% end %>'
     ::ERB.new(content).result(binding)
 
     assert_equal 'Content One', content_for(@item, :a)
     assert_equal nil,           content_for(@item, :b)
 
-    @site = Nanoc::SiteView.new(Nanoc::Int::SiteLoader.new.new_empty)
-    @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', {}, '/'))
+    @site = Nanoc::SiteView.new(Nanoc::Int::SiteLoader.new.new_empty, nil)
+    @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', {}, '/'), nil)
     content = '<% content_for :b do %>Content Two<% end %>'
     ::ERB.new(content).result(binding)
 

--- a/test/helpers/test_filtering.rb
+++ b/test/helpers/test_filtering.rb
@@ -11,7 +11,7 @@ class Nanoc::Helpers::FilteringTest < Nanoc::TestCase
 
       # Mock item and rep
       @item_rep = mock
-      @item_rep = Nanoc::ItemRepView.new(@item_rep)
+      @item_rep = Nanoc::ItemRepView.new(@item_rep, nil)
 
       # Evaluate content
       result = ::ERB.new(content).result(binding)
@@ -32,8 +32,8 @@ class Nanoc::Helpers::FilteringTest < Nanoc::TestCase
       item = Nanoc::Int::Item.new('stuff', { title: 'Bar...' }, '/foo.md')
       item_rep = Nanoc::Int::ItemRep.new(item, :default)
 
-      @item = Nanoc::ItemView.new(item)
-      @item_rep = Nanoc::ItemRepView.new(item_rep)
+      @item = Nanoc::ItemView.new(item, nil)
+      @item_rep = Nanoc::ItemRepView.new(item_rep, nil)
 
       result = ::ERB.new(content).result(binding)
 
@@ -64,7 +64,7 @@ class Nanoc::Helpers::FilteringTest < Nanoc::TestCase
 
       # Mock item and rep
       @item_rep = mock
-      @item_rep = Nanoc::ItemRepView.new(@item_rep)
+      @item_rep = Nanoc::ItemRepView.new(@item_rep, nil)
 
       # Evaluate content
       result = ::ERB.new(content).result(binding)
@@ -82,7 +82,7 @@ class Nanoc::Helpers::FilteringTest < Nanoc::TestCase
 
       # Mock item and rep
       @item_rep = mock
-      @item_rep = Nanoc::ItemRepView.new(@item_rep)
+      @item_rep = Nanoc::ItemRepView.new(@item_rep, nil)
 
       # Evaluate content
       result = ::Haml::Engine.new(content).render(binding)
@@ -102,7 +102,7 @@ class Nanoc::Helpers::FilteringTest < Nanoc::TestCase
 
     # Mock item and rep
     @item_rep = mock
-    @item_rep = Nanoc::ItemRepView.new(@item_rep)
+    @item_rep = Nanoc::ItemRepView.new(@item_rep, nil)
 
     ::ERB.new(content).result(binding)
 

--- a/test/helpers/test_rendering.rb
+++ b/test/helpers/test_rendering.rb
@@ -12,8 +12,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
       end
 
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
-      @site = Nanoc::SiteView.new(site)
-      @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
+      @site = Nanoc::SiteView.new(site, nil)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, nil)
 
       assert_equal('This is the /foo/ layout.', render('/foo/'))
     end
@@ -30,8 +30,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
       end
 
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
-      @site = Nanoc::SiteView.new(site)
-      @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
+      @site = Nanoc::SiteView.new(site, nil)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, nil)
 
       assert_equal('This is the /foo/ layout.', render('/foo'))
     end
@@ -48,8 +48,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
       end
 
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
-      @site = Nanoc::SiteView.new(site)
-      @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
+      @site = Nanoc::SiteView.new(site, nil)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, nil)
 
       assert_equal('I am the Nanoc::LayoutView class.', render('/foo/'))
     end
@@ -66,8 +66,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
       end
 
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
-      @site = Nanoc::SiteView.new(site)
-      @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
+      @site = Nanoc::SiteView.new(site, nil)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, nil)
 
       assert_equal('I am the Nanoc::Int::Layout class.', render('/foo/'))
     end
@@ -76,8 +76,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
   def test_render_with_unknown_layout
     with_site do |site|
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
-      @site = Nanoc::SiteView.new(site)
-      @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
+      @site = Nanoc::SiteView.new(site, nil)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, nil)
 
       assert_raises(Nanoc::Int::Errors::UnknownLayout) do
         render '/dsfghjkl/'
@@ -94,8 +94,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
       File.open('layouts/foo.erb', 'w').close
 
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
-      @site = Nanoc::SiteView.new(site)
-      @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
+      @site = Nanoc::SiteView.new(site, nil)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, nil)
 
       assert_raises(Nanoc::Int::Errors::CannotDetermineFilter) do
         render '/foo/'
@@ -112,8 +112,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
       File.open('layouts/foo.erb', 'w').close
 
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
-      @site = Nanoc::SiteView.new(site)
-      @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
+      @site = Nanoc::SiteView.new(site, nil)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, nil)
 
       assert_raises(Nanoc::Int::Errors::UnknownFilter) do
         render '/foo/'
@@ -132,8 +132,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
       end
 
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
-      @site = Nanoc::SiteView.new(site)
-      @layouts = Nanoc::LayoutCollectionView.new(site.layouts)
+      @site = Nanoc::SiteView.new(site, nil)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, nil)
 
       _erbout = '[erbout-before]'
       result = render '/foo/' do

--- a/test/helpers/test_tagging.rb
+++ b/test/helpers/test_tagging.rb
@@ -3,7 +3,7 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
 
   def test_tags_for_without_tags
     # Create item
-    item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', {}, '/path/'))
+    item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', {}, '/path/'), nil)
 
     # Check
     assert_equal(
@@ -14,7 +14,7 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
 
   def test_tags_for_with_custom_base_url
     # Create item
-    item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', { tags: %w(foo bar) }, '/path/'))
+    item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', { tags: %w(foo bar) }, '/path/'), nil)
 
     # Check
     assert_equal(
@@ -26,7 +26,7 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
 
   def test_tags_for_with_custom_none_text
     # Create item
-    item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', { tags: [] }, '/path/'))
+    item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', { tags: [] }, '/path/'), nil)
 
     # Check
     assert_equal(
@@ -37,7 +37,7 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
 
   def test_tags_for_with_custom_separator
     # Create item
-    item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', { tags: %w(foo bar) }, '/path/'))
+    item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', { tags: %w(foo bar) }, '/path/'), nil)
 
     # Check
     assert_equal(
@@ -49,11 +49,14 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
 
   def test_items_with_tag
     # Create items
-    @items = Nanoc::ItemCollectionView.new([
-      Nanoc::Int::Item.new('item 1', { tags: [:foo]       }, '/item1/'),
-      Nanoc::Int::Item.new('item 2', { tags: [:bar]       }, '/item2/'),
-      Nanoc::Int::Item.new('item 3', { tags: [:foo, :bar] }, '/item3/'),
-    ])
+    @items = Nanoc::ItemCollectionView.new(
+      [
+        Nanoc::Int::Item.new('item 1', { tags: [:foo]       }, '/item1/'),
+        Nanoc::Int::Item.new('item 2', { tags: [:bar]       }, '/item2/'),
+        Nanoc::Int::Item.new('item 3', { tags: [:foo, :bar] }, '/item3/'),
+      ],
+      nil,
+    )
 
     # Find items
     items_with_foo_tag = items_with_tag(:foo)

--- a/test/helpers/test_xml_sitemap.rb
+++ b/test/helpers/test_xml_sitemap.rb
@@ -1,12 +1,16 @@
 class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
   include Nanoc::Helpers::XMLSitemap
 
-  def teardown
+  def setup
     super
+
+    @reps = Nanoc::Int::ItemRepRepo.new
+    @view_context = Nanoc::ViewContext.new(reps: @reps)
+
     @items = nil
-    @item  = nil
-    @site  = nil
-    super
+    @item = nil
+    @site = nil
+    @config = nil
   end
 
   def test_xml_sitemap
@@ -15,29 +19,29 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
       @items = Nanoc::Int::IdentifiableCollection.new({})
 
       # Create item 1
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'), nil)
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'), @view_context)
       @items << item
       create_item_rep(item.unwrap, :one_a, '/item-one/a/')
       create_item_rep(item.unwrap, :one_b, '/item-one/b/')
 
       # Create item 2
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 2', { is_hidden: true }, '/item-two/'), nil)
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 2', { is_hidden: true }, '/item-two/'), @view_context)
       @items << item
 
       # Create item 3
       attrs = { mtime: Time.parse('2004-07-12'), changefreq: 'daily', priority: 0.5 }
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 3', attrs, '/item-three/'), nil)
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 3', attrs, '/item-three/'), @view_context)
       @items << item
       create_item_rep(item.unwrap, :three_a, '/item-three/a/')
       create_item_rep(item.unwrap, :three_b, '/item-three/b/')
 
       # Create item 4
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 4', {}, '/item-four/'), nil)
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 4', {}, '/item-four/'), @view_context)
       @items << item
       create_item_rep(item.unwrap, :four_a, nil)
 
       # Create sitemap item
-      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), nil)
+      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), @view_context)
 
       # Create site
       @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
@@ -75,7 +79,7 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
       # Create items
       @items = Nanoc::Int::IdentifiableCollection.new({})
       @items << nil
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'), nil)
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'), @view_context)
       @items << item
       create_item_rep(item.unwrap, :one_a, '/item-one/a/')
       create_item_rep(item.unwrap, :one_b, '/item-one/b/')
@@ -111,13 +115,13 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
     if_have 'builder', 'nokogiri' do
       # Create items
       @items = Nanoc::Int::IdentifiableCollection.new({})
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'), nil)
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'), @view_context)
       @items << item
       create_item_rep(item.unwrap, :one_a, '/item-one/a/')
       create_item_rep(item.unwrap, :one_b, '/item-one/b/')
 
       # Create sitemap item
-      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), nil)
+      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), @view_context)
 
       # Create site
       @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
@@ -142,21 +146,21 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
     if_have 'builder', 'nokogiri' do
       # Create items
       @items = Nanoc::Int::IdentifiableCollection.new({})
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/george/'), nil)
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/george/'), @view_context)
       @items << item
       create_item_rep(item.unwrap, :a_alice,   '/george/alice/')
       create_item_rep(item.unwrap, :b_zoey,    '/george/zoey/')
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/walton/'), nil)
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/walton/'), @view_context)
       @items << item
       create_item_rep(item.unwrap, :a_eve,     '/walton/eve/')
       create_item_rep(item.unwrap, :b_bob,     '/walton/bob/')
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/lucas/'), nil)
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/lucas/'), @view_context)
       @items << item
       create_item_rep(item.unwrap, :a_trudy,   '/lucas/trudy/')
       create_item_rep(item.unwrap, :b_mallory, '/lucas/mallory/')
 
       # Create sitemap item
-      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), nil)
+      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), @view_context)
 
       # Create site
       @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
@@ -185,7 +189,7 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
     rep = Nanoc::Int::ItemRep.new(item, name)
     rep.paths     = { last: path }
     rep.raw_paths = { last: path }
-    item.reps << rep
+    @reps << rep
     rep
   end
 end

--- a/test/helpers/test_xml_sitemap.rb
+++ b/test/helpers/test_xml_sitemap.rb
@@ -15,32 +15,32 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
       @items = Nanoc::Int::IdentifiableCollection.new({})
 
       # Create item 1
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'))
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'), nil)
       @items << item
       create_item_rep(item.unwrap, :one_a, '/item-one/a/')
       create_item_rep(item.unwrap, :one_b, '/item-one/b/')
 
       # Create item 2
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 2', { is_hidden: true }, '/item-two/'))
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 2', { is_hidden: true }, '/item-two/'), nil)
       @items << item
 
       # Create item 3
       attrs = { mtime: Time.parse('2004-07-12'), changefreq: 'daily', priority: 0.5 }
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 3', attrs, '/item-three/'))
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 3', attrs, '/item-three/'), nil)
       @items << item
       create_item_rep(item.unwrap, :three_a, '/item-three/a/')
       create_item_rep(item.unwrap, :three_b, '/item-three/b/')
 
       # Create item 4
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 4', {}, '/item-four/'))
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 4', {}, '/item-four/'), nil)
       @items << item
       create_item_rep(item.unwrap, :four_a, nil)
 
       # Create sitemap item
-      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'))
+      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), nil)
 
       # Create site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
 
       # Build sitemap
       res = xml_sitemap
@@ -75,7 +75,7 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
       # Create items
       @items = Nanoc::Int::IdentifiableCollection.new({})
       @items << nil
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'))
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'), nil)
       @items << item
       create_item_rep(item.unwrap, :one_a, '/item-one/a/')
       create_item_rep(item.unwrap, :one_b, '/item-one/b/')
@@ -85,7 +85,7 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
       @item = Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/')
 
       # Create site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
 
       # Build sitemap
       res = xml_sitemap(items: [item])
@@ -111,16 +111,16 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
     if_have 'builder', 'nokogiri' do
       # Create items
       @items = Nanoc::Int::IdentifiableCollection.new({})
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'))
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'), nil)
       @items << item
       create_item_rep(item.unwrap, :one_a, '/item-one/a/')
       create_item_rep(item.unwrap, :one_b, '/item-one/b/')
 
       # Create sitemap item
-      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'))
+      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), nil)
 
       # Create site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
 
       # Build sitemap
       res = xml_sitemap(rep_select: ->(rep) { rep.name == :one_a })
@@ -142,24 +142,24 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
     if_have 'builder', 'nokogiri' do
       # Create items
       @items = Nanoc::Int::IdentifiableCollection.new({})
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/george/'))
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/george/'), nil)
       @items << item
       create_item_rep(item.unwrap, :a_alice,   '/george/alice/')
       create_item_rep(item.unwrap, :b_zoey,    '/george/zoey/')
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/walton/'))
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/walton/'), nil)
       @items << item
       create_item_rep(item.unwrap, :a_eve,     '/walton/eve/')
       create_item_rep(item.unwrap, :b_bob,     '/walton/bob/')
-      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/lucas/'))
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/lucas/'), nil)
       @items << item
       create_item_rep(item.unwrap, :a_trudy,   '/lucas/trudy/')
       create_item_rep(item.unwrap, :b_mallory, '/lucas/mallory/')
 
       # Create sitemap item
-      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'))
+      @item = Nanoc::ItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), nil)
 
       # Create site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
 
       # Build sitemap
       res = xml_sitemap(items: @items)


### PR DESCRIPTION
This decouples item reps (which are a generated artefact) from items (which are part of the source).

The introduction of a view context makes it easier to also decouple item reps from their compiled content, which will make it easier to bring memory usage down (by keeping compiled content elsewhere).

Alternative to #655.