### PR TITLE
fixed typo in class definition of shell command module

### DIFF
--- a/lib/nanoc/cli/commands/shell.rb
+++ b/lib/nanoc/cli/commands/shell.rb
@@ -21,7 +21,7 @@ module Nanoc::CLI::Commands
       self.class.env_for_site(site)
     end
 
-    def self.env_for(site)
+    def self.env_for_site(site)
       {
         items: Nanoc::ItemCollectionView.new(site.items),
         layouts: Nanoc::LayoutCollectionView.new(site.layouts),


### PR DESCRIPTION
Running nanoc shell was producing the following error:
NoMethodError: undefined method `env_for_site' for Nanoc::CLI::Commands::Shell:Class

I changed the method env_for to env_for_site and now everything works fine.