### PR TITLE
Fix broken shell command

### DIFF
--- a/lib/nanoc/cli/commands/shell.rb
+++ b/lib/nanoc/cli/commands/shell.rb
@@ -21,7 +21,7 @@ module Nanoc::CLI::Commands
       self.class.env_for_site(site)
     end
 
-    def self.env_for(site)
+    def self.env_for_site(site)
       {
         items: Nanoc::ItemCollectionView.new(site.items),
         layouts: Nanoc::LayoutCollectionView.new(site.layouts),

--- a/spec/nanoc/cli/commands/shell_spec.rb
+++ b/spec/nanoc/cli/commands/shell_spec.rb
@@ -1,6 +1,21 @@
-describe Nanoc::CLI::Commands::Shell do
-  describe '#env_for' do
-    subject { described_class.env_for(site) }
+describe Nanoc::CLI::Commands::Shell, site: true do
+  describe '#run' do
+    before do
+      # Prevent double-loading
+      expect(Nanoc::CLI).to receive(:setup)
+    end
+
+    it 'can be invoked' do
+      context = Object.new
+      expect(Nanoc::Int::Context).to receive(:new).with(anything) { context }
+      expect(context).to receive(:pry)
+
+      Nanoc::CLI.run(['shell'])
+    end
+  end
+
+  describe '#env_for_site' do
+    subject { described_class.env_for_site(site) }
 
     let(:site) do
       double(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,17 @@ RSpec.configure do |c|
       end
     end
   end
+
+  c.before(:each, site: true) do
+    FileUtils.mkdir_p('content')
+    FileUtils.mkdir_p('layouts')
+    FileUtils.mkdir_p('lib')
+    FileUtils.mkdir_p('output')
+
+    File.write('nanoc.yaml', '{}')
+
+    File.write('Rules', 'passthrough "/**/*"')
+  end
 end
 
 RSpec::Matchers.define :raise_frozen_error do |_expected|


### PR DESCRIPTION
The `shell` command is broken because `#env_for_site` does not exist.

Based on #671 (by @jimjimovich) with a spec fix and an additional spec.