### PR TITLE
Error on non-hash frontmatter

### DIFF
--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -219,6 +219,7 @@ module Nanoc::DataSources
         rescue Exception => e
           raise "Could not parse YAML for #{meta_filename}: #{e.message}"
         end
+        verify_meta(meta, meta_filename)
         return [meta, content]
       end
 
@@ -244,10 +245,23 @@ module Nanoc::DataSources
       rescue Exception => e
         raise "Could not parse YAML for #{content_filename}: #{e.message}"
       end
+      verify_meta(meta, content_filename)
       content = pieces[4]
 
       # Done
       [meta, content]
+    end
+
+    class InvalidMetadataError < Nanoc::Error
+      def initialize(filename, klass)
+        super("The file #{filename} has invalid metadata (expected key-value pairs, found #{klass} instead)")
+      end
+    end
+
+    def verify_meta(meta, filename)
+      return if meta.is_a?(Hash)
+
+      raise InvalidMetadataError.new(filename, meta.class)
     end
 
     # Reads the content of the file with the given name and returns a string

--- a/test/data_sources/test_filesystem.rb
+++ b/test/data_sources/test_filesystem.rb
@@ -451,4 +451,31 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
     assert_equal({ 'foo' => 'bar' }, result[0])
     assert_equal('blah blah',       result[1])
   end
+
+  def test_parse_internal_bad_metadata
+    content = \
+      "---\n" \
+      "Hello world!\n" \
+      "---\n" \
+      "blah blah\n"
+
+    File.open('test.html', 'w') { |io| io.write(content) }
+
+    data_source = Nanoc::DataSources::FilesystemUnified.new(nil, nil, nil, nil)
+
+    assert_raises(Nanoc::DataSources::Filesystem::InvalidMetadataError) do
+      data_source.instance_eval { parse('test.html', nil, 'foobar') }
+    end
+  end
+
+  def test_parse_external_bad_metadata
+    File.open('test.html', 'w') { |io| io.write('blah blah') }
+    File.open('test.yaml', 'w') { |io| io.write('Hello world!') }
+
+    data_source = Nanoc::DataSources::FilesystemUnified.new(nil, nil, nil, nil)
+
+    assert_raises(Nanoc::DataSources::Filesystem::InvalidMetadataError) do
+      data_source.instance_eval { parse('test.html', 'test.yaml', 'foobar') }
+    end
+  end
 end


### PR DESCRIPTION
When the frontmatter is not a hash (e.g. nil, or a string), raise an exception that is easier to understand than whatever happens now (`TypeError: no implicit conversion of String into Hash`).

Fixes #670.