### PR TITLE
Add Identifier#components

### DIFF
--- a/lib/nanoc/base/entities/identifier.rb
+++ b/lib/nanoc/base/entities/identifier.rb
@@ -156,6 +156,15 @@ module Nanoc
       s ? s.split('.', -1).drop(1) : []
     end
 
+    def components
+      res = to_s.split('/')
+      if res.empty?
+        []
+      else
+        res[1..-1]
+      end
+    end
+
     def to_s
       @string
     end

--- a/spec/nanoc/base/entities/identifier_spec.rb
+++ b/spec/nanoc/base/entities/identifier_spec.rb
@@ -400,4 +400,23 @@ describe Nanoc::Identifier do
       it { is_expected.to eql(true) }
     end
   end
+
+  describe '#components' do
+    subject { identifier.components }
+
+    context 'no components' do
+      let(:identifier) { described_class.new('/') }
+      it { is_expected.to eql([]) }
+    end
+
+    context 'one component' do
+      let(:identifier) { described_class.new('/foo.md') }
+      it { is_expected.to eql(['foo.md']) }
+    end
+
+    context 'two components' do
+      let(:identifier) { described_class.new('/foo/bar.md') }
+      it { is_expected.to eql(['foo', 'bar.md']) }
+    end
+  end
 end


### PR DESCRIPTION
This provides a slightly nicer-to-use alternative to `identifier.to_s.split`.

The return value is such that `'/' + identifier.components.join('/')` is identical to `identifier.to_s`.

See #674.