### PR TITLE
addresses #664

### DIFF
--- a/lib/nanoc/base/entities/identifier.rb
+++ b/lib/nanoc/base/entities/identifier.rb
@@ -147,6 +147,26 @@ module Nanoc
       s && s[1..-1]
     end
 
+    # @return [String]
+    def without_exts
+      extname = exts.join('.')
+      if extname.size > 0
+        @string[0..-extname.size - 2]
+      else
+        @string
+      end
+    end
+
+    # @return [Array] List of extensions, without a leading dot.
+    def exts
+      unless full?
+        raise UnsupportedLegacyOperationError
+      end
+
+      s = File.basename(@string)
+      s ? s.split('.', -1).drop(1) : []
+    end
+
     def to_s
       @string
     end

--- a/spec/nanoc/base/entities/identifier_spec.rb
+++ b/spec/nanoc/base/entities/identifier_spec.rb
@@ -375,4 +375,70 @@ describe Nanoc::Identifier do
       it { is_expected.to eql('md') }
     end
   end
+
+  describe '#without_exts' do
+    subject { identifier.without_exts }
+
+    context 'legacy type' do
+      let(:identifier) { described_class.new('/foo/', type: :legacy) }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(Nanoc::Identifier::UnsupportedLegacyOperationError)
+      end
+    end
+
+    context 'identifier with no extension' do
+      let(:identifier) { described_class.new('/foo') }
+
+      it 'does nothing' do
+        expect(subject).to eql('/foo')
+      end
+    end
+
+    context 'identifier with one extension' do
+      let(:identifier) { described_class.new('/foo.md') }
+
+      it 'removes the extension' do
+        expect(subject).to eql('/foo')
+      end
+    end
+
+    context 'identifier with multiple extensions' do
+      let(:identifier) { described_class.new('/foo.html.md') }
+
+      it 'removes the extension' do
+        expect(subject).to eql('/foo')
+      end
+    end
+  end
+
+  describe '#exts' do
+    subject { identifier.exts }
+
+    context 'legacy type' do
+      let(:identifier) { described_class.new('/foo/', type: :legacy) }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(Nanoc::Identifier::UnsupportedLegacyOperationError)
+      end
+    end
+
+    context 'identifier with no extension' do
+      let(:identifier) { described_class.new('/foo') }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'identifier with one extension' do
+      let(:identifier) { described_class.new('/foo.md') }
+
+      it { is_expected.to eql(['md']) }
+    end
+
+    context 'identifier with multiple extensions' do
+      let(:identifier) { described_class.new('/foo.html.md') }
+
+      it { is_expected.to eql(['html', 'md']) }
+    end
+  end
 end


### PR DESCRIPTION
This is a first draft to introduce:

- `#exts` method (returning a list of extensions)
- `#without_exts` (removes all extensions)

methods to Nanoc::Identifier