### PR TITLE
Make base_url optional in #tags_for

### DIFF
--- a/lib/nanoc/helpers/tagging.rb
+++ b/lib/nanoc/helpers/tagging.rb
@@ -16,7 +16,9 @@ module Nanoc::Helpers
     # HTML-escaping rules for {#link_for_tag} apply here as well.
     #
     # @option params [String] base_url The URL to which the tag will be appended
-    #   to construct the link URL. This URL must have a trailing slash.
+    #   to construct the link URL. This URL must have a trailing slash. The
+    #   function would return a tags string without tag page link if the param
+    #   is not provided.
     #
     # @option params [String] none_text ("(none)") The text to display when
     #   the item has no tags
@@ -26,14 +28,14 @@ module Nanoc::Helpers
     #
     # @return [String] A hyperlinked list of tags for the given item
     def tags_for(item, params = {})
-      base_url  = params[:base_url] || '/tags/'
+      base_url  = params[:base_url]
       none_text = params[:none_text] || '(none)'
       separator = params[:separator] || ', '
 
       if item[:tags].nil? || item[:tags].empty?
         none_text
       else
-        item[:tags].map { |tag| link_for_tag(tag, base_url) }.join(separator)
+        item[:tags].map { |tag| base_url ? link_for_tag(tag, base_url) : tag }.join(separator)
       end
     end
 

--- a/lib/nanoc/helpers/tagging.rb
+++ b/lib/nanoc/helpers/tagging.rb
@@ -26,7 +26,7 @@ module Nanoc::Helpers
     #
     # @return [String] A hyperlinked list of tags for the given item
     def tags_for(item, params = {})
-      base_url  = params.fetch(:base_url)
+      base_url  = params[:base_url] || '/tags/'
       none_text = params[:none_text] || '(none)'
       separator = params[:separator] || ', '
 

--- a/test/helpers/test_tagging.rb
+++ b/test/helpers/test_tagging.rb
@@ -47,6 +47,14 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
     )
   end
 
+  def test_tags_for_without_base_url
+    # Create item
+    item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', { tags: %w(foo bar) }, '/path/'))
+
+    # Check
+    assert_equal('foo, bar', tags_for(item))
+  end
+
   def test_items_with_tag
     # Create items
     @items = Nanoc::ItemCollectionView.new([


### PR DESCRIPTION
While using version 4.0.2rc2, one error occurred after `Tagging` helper and `tags_for` method were added into my code, which told me a KeyError around key `base_url`.

I checked the source in release-4.0.x and found that `base_url` must be provided or there will be an error here. It's never been listed in the document or the official tutorial.

In my mind it's not so important that users MUST have a link to a tag, at least there should be a default tag link url.

Thank you so much for your review.