### PR TITLE
Disallow storing document (views) in attributes

### DIFF
--- a/lib/nanoc/base/views/mixins/mutable_document_view_mixin.rb
+++ b/lib/nanoc/base/views/mixins/mutable_document_view_mixin.rb
@@ -1,11 +1,34 @@
 module Nanoc
   module MutableDocumentViewMixin
+    # @api private
+    class DisallowedAttributeValueError < Nanoc::Error
+      attr_reader :value
+
+      def initialize(value)
+        @value = value
+      end
+
+      def message
+        "The #{value.class} cannot be stored inside an attribute. Store its identifier instead."
+      end
+    end
+
     # Sets the value for the given attribute.
     #
     # @param [Symbol] key
     #
     # @see Hash#[]=
     def []=(key, value)
+      disallowed_value_classes = Set.new([
+        Nanoc::Int::Item,
+        Nanoc::Int::Layout,
+        Nanoc::ItemView,
+        Nanoc::LayoutView,
+      ])
+      if disallowed_value_classes.include?(value.class)
+        raise DisallowedAttributeValueError.new(value)
+      end
+
       unwrap.attributes[key] = value
     end
 

--- a/spec/nanoc/base/views/mutable_document_view_spec.rb
+++ b/spec/nanoc/base/views/mutable_document_view_spec.rb
@@ -7,6 +7,26 @@ shared_examples 'a mutable document view' do
       view[:title] = 'Donkey'
       expect(view[:title]).to eq('Donkey')
     end
+
+    it 'disallows items' do
+      item = Nanoc::Int::Item.new('content', {}, '/foo.md')
+      expect { view[:item] = item }.to raise_error(Nanoc::MutableDocumentViewMixin::DisallowedAttributeValueError)
+    end
+
+    it 'disallows layouts' do
+      layout = Nanoc::Int::Layout.new('content', {}, '/foo.md')
+      expect { view[:layout] = layout }.to raise_error(Nanoc::MutableDocumentViewMixin::DisallowedAttributeValueError)
+    end
+
+    it 'disallows item views' do
+      item = Nanoc::ItemView.new(Nanoc::Int::Item.new('content', {}, '/foo.md'))
+      expect { view[:item] = item }.to raise_error(Nanoc::MutableDocumentViewMixin::DisallowedAttributeValueError)
+    end
+
+    it 'disallows layout views' do
+      layout = Nanoc::LayoutView.new(Nanoc::Int::Layout.new('content', {}, '/foo.md'))
+      expect { view[:layout] = layout }.to raise_error(Nanoc::MutableDocumentViewMixin::DisallowedAttributeValueError)
+    end
   end
 
   describe '#update_attributes' do


### PR DESCRIPTION
Fix for #682.

This is possibly not the best approach—maybe rather than disallowing it, handle cases like these gracefully.