### PR TITLE
Use direct stylesheet link

### DIFF
--- a/lib/nanoc/cli/commands/create-site.rb
+++ b/lib/nanoc/cli/commands/create-site.rb
@@ -254,7 +254,7 @@ EOS
   <head>
     <meta charset="utf-8">
     <title>A Brand New Nanoc Site - <%= @item[:title] %></title>
-    <link rel="stylesheet" href="<%= @items['/stylesheet.*'].path %>">
+    <link rel="stylesheet" href="/stylesheet.css">
 
     <!-- you don't need to keep this, but it's cool for stats! -->
     <meta name="generator" content="Nanoc <%= Nanoc::VERSION %>">


### PR DESCRIPTION
Rather thank linking to the stylesheet by finding it using `@items` and then getting the path, we can simply use a direct link to the stylesheet. This approach is more straightforward and less confusing.

Fixes #685.