### PR TITLE
Add DocumentView#attributes

### DIFF
--- a/lib/nanoc/base/views/mixins/document_view_mixin.rb
+++ b/lib/nanoc/base/views/mixins/document_view_mixin.rb
@@ -37,6 +37,14 @@ module Nanoc
       unwrap.attributes[key]
     end
 
+    # @return [Hash]
+    def attributes
+      Nanoc::Int::NotificationCenter.post(:visit_started, unwrap)
+      Nanoc::Int::NotificationCenter.post(:visit_ended,   unwrap)
+
+      unwrap.attributes
+    end
+
     # @see Hash#fetch
     def fetch(key, fallback = NONE, &_block)
       Nanoc::Int::NotificationCenter.post(:visit_started, unwrap)

--- a/spec/nanoc/base/views/document_view_spec.rb
+++ b/spec/nanoc/base/views/document_view_spec.rb
@@ -71,6 +71,22 @@ shared_examples 'a document view' do
     end
   end
 
+  describe '#attributes' do
+    let(:item) { entity_class.new('stuff', { animal: 'donkey' }, '/foo/') }
+    let(:view) { described_class.new(item) }
+
+    before do
+      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:visit_started, item).ordered
+      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:visit_ended, item).ordered
+    end
+
+    subject { view.attributes }
+
+    it 'returns attributes' do
+      expect(subject).to eql(animal: 'donkey')
+    end
+  end
+
   describe '#fetch' do
     let(:item) { entity_class.new('stuff', { animal: 'donkey' }, '/foo/') }
     let(:view) { described_class.new(item) }


### PR DESCRIPTION
This is useful when converting an item or a layout into a JSON representation.

(This was initially removed from Nanoc 4 because it was an internal method with public visibility in nanoc 3. Using it meant bypassing the dependency tracking mechanism. With this new implementation, that is no longer an issue.)

Fixes #699.