### PR TITLE
Add `#each` to `ConfigView`

### DIFF
--- a/lib/nanoc/base/views/config_view.rb
+++ b/lib/nanoc/base/views/config_view.rb
@@ -36,5 +36,10 @@ module Nanoc
     def [](key)
       @config[key]
     end
+
+    # @see Hash#each
+    def each(&block)
+      @config.each(&block)
+    end
   end
 end


### PR DESCRIPTION
Closes #705 

I actually wrote a little dinky test for this in *test_compiler_dsl.rb*: 

``` ruby
  def test_config_iteration
    hash = { :key_one => 1, :key_two => 2}
    @config = Nanoc::ConfigView.new(hash, nil)
    @config.each do |k, v|
      puts k, v
    end
  end
```

It works, but because no other `ConfigView` syntaxes are tested (and the fact that STDOUT is muted) I decided not to include it. I could if there's a better way to work this.