### PR TITLE
Use :pre, not :last, as the default snapshot

### DIFF
--- a/lib/nanoc/base/views/item_view.rb
+++ b/lib/nanoc/base/views/item_view.rb
@@ -14,7 +14,7 @@ module Nanoc
     #   any).
     #
     # @return [String] The content of the given rep at the given snapshot.
-    def compiled_content(rep: :default, snapshot: :last)
+    def compiled_content(rep: :default, snapshot: :pre)
       reps.fetch(rep).compiled_content(snapshot: snapshot)
     end
 

--- a/spec/nanoc/base/views/item_view_spec.rb
+++ b/spec/nanoc/base/views/item_view_spec.rb
@@ -100,10 +100,14 @@ describe Nanoc::ItemView do
         ir.compiled = true
         ir.snapshot_defs = [
           Nanoc::Int::SnapshotDef.new(:last, false),
+          Nanoc::Int::SnapshotDef.new(:pre, true),
+          Nanoc::Int::SnapshotDef.new(:post, false),
           Nanoc::Int::SnapshotDef.new(:specific, true),
         ]
         ir.snapshot_contents = {
-          last: Nanoc::Int::TextualContent.new('Default Hallo'),
+          last: Nanoc::Int::TextualContent.new('Last Hallo'),
+          pre: Nanoc::Int::TextualContent.new('Pre Hallo'),
+          post: Nanoc::Int::TextualContent.new('Post Hallo'),
           specific: Nanoc::Int::TextualContent.new('Specific Hallo'),
         }
       end
@@ -119,7 +123,7 @@ describe Nanoc::ItemView do
           .with(:visit_ended, item).ordered
       end
 
-      it { is_expected.to eq('Default Hallo') }
+      it { is_expected.to eq('Pre Hallo') }
 
       context 'requesting explicit snapshot' do
         let(:params) { { snapshot: :specific } }
@@ -138,7 +142,7 @@ describe Nanoc::ItemView do
           .with(:visit_ended, item).ordered
       end
 
-      it { is_expected.to eq('Default Hallo') }
+      it { is_expected.to eq('Pre Hallo') }
 
       context 'requesting explicit snapshot' do
         let(:params) { { snapshot: :specific } }


### PR DESCRIPTION
In Nanoc 4.0.x, `:pre` is the default snapshot. This was mistakenly changed to `:last` in `master.