### PR TITLE
Let #parent/#children raise for non-legacy identifiers

### DIFF
--- a/lib/nanoc/base/entities/identifier.rb
+++ b/lib/nanoc/base/entities/identifier.rb
@@ -87,6 +87,12 @@ module Nanoc
       @type == :full
     end
 
+    # @return [Boolean] True if this is a legacy identifier (i.e. does not
+    #   include the extension), false otherwise
+    def legacy?
+      @type == :legacy
+    end
+
     # @return [String]
     def chop
       to_s.chop

--- a/lib/nanoc/base/errors.rb
+++ b/lib/nanoc/base/errors.rb
@@ -185,5 +185,12 @@ module Nanoc::Int
         super("There are multiple #{type}s with the #{identifier} identifier.")
       end
     end
+
+    # Error that is raised when attempting to call #parent or #children on an item with a legacy identifier.
+    class CannotGetParentOrChildrenOfNonLegacyItem < Generic
+      def initialize(identifier)
+        super("You cannot get the parent or children of an item that has a “full” identifier (#{identifier}). Getting the parent or children of an item is only possible for items that have a legacy identifier.")
+      end
+    end
   end
 end

--- a/lib/nanoc/base/views/item_view.rb
+++ b/lib/nanoc/base/views/item_view.rb
@@ -40,6 +40,10 @@ module Nanoc
     #
     # @return [Enumerable<Nanoc::ItemView>]
     def children
+      unless unwrap.identifier.legacy?
+        raise Nanoc::Int::Errors::CannotGetParentOrChildrenOfNonLegacyItem.new(unwrap.identifier)
+      end
+
       unwrap.children.map { |i| Nanoc::ItemView.new(i) }
     end
 
@@ -50,6 +54,10 @@ module Nanoc
     #
     # @return [nil] if the item has no parent
     def parent
+      unless unwrap.identifier.legacy?
+        raise Nanoc::Int::Errors::CannotGetParentOrChildrenOfNonLegacyItem.new(unwrap.identifier)
+      end
+
       unwrap.parent && Nanoc::ItemView.new(unwrap.parent)
     end
 

--- a/spec/nanoc/base/entities/identifier_spec.rb
+++ b/spec/nanoc/base/entities/identifier_spec.rb
@@ -359,4 +359,32 @@ describe Nanoc::Identifier do
       it { is_expected.to eql(['html', 'md']) }
     end
   end
+
+  describe '#legacy?' do
+    subject { identifier.legacy? }
+
+    context 'legacy type' do
+      let(:identifier) { described_class.new('/foo/', type: :legacy) }
+      it { is_expected.to eql(true) }
+    end
+
+    context 'full type' do
+      let(:identifier) { described_class.new('/foo/', type: :full) }
+      it { is_expected.to eql(false) }
+    end
+  end
+
+  describe '#full?' do
+    subject { identifier.full? }
+
+    context 'legacy type' do
+      let(:identifier) { described_class.new('/foo/', type: :legacy) }
+      it { is_expected.to eql(false) }
+    end
+
+    context 'full type' do
+      let(:identifier) { described_class.new('/foo/', type: :full) }
+      it { is_expected.to eql(true) }
+    end
+  end
 end

--- a/spec/nanoc/base/views/item_view_spec.rb
+++ b/spec/nanoc/base/views/item_view_spec.rb
@@ -13,7 +13,7 @@ describe Nanoc::ItemView do
 
   describe '#parent' do
     let(:item) do
-      Nanoc::Int::Item.new('me', {}, '/me/').tap { |i| i.parent = parent_item }
+      Nanoc::Int::Item.new('me', {}, identifier).tap { |i| i.parent = parent_item }
     end
 
     let(:view) { described_class.new(item) }
@@ -25,9 +25,25 @@ describe Nanoc::ItemView do
         Nanoc::Int::Item.new('parent', {}, '/parent/')
       end
 
-      it 'returns a view for the parent' do
-        expect(subject.class).to eql(Nanoc::ItemView)
-        expect(subject.unwrap).to eql(parent_item)
+      context 'full identifier' do
+        let(:identifier) do
+          Nanoc::Identifier.new('/me.md')
+        end
+
+        it 'raises' do
+          expect { subject }.to raise_error(Nanoc::Int::Errors::CannotGetParentOrChildrenOfNonLegacyItem)
+        end
+      end
+
+      context 'legacy identifier' do
+        let(:identifier) do
+          Nanoc::Identifier.new('/me/', type: :legacy)
+        end
+
+        it 'returns a view for the parent' do
+          expect(subject.class).to eql(Nanoc::ItemView)
+          expect(subject.unwrap).to eql(parent_item)
+        end
       end
     end
 
@@ -36,14 +52,62 @@ describe Nanoc::ItemView do
         nil
       end
 
-      it 'returns nil' do
-        expect(subject).to be_nil
+      context 'full identifier' do
+        let(:identifier) do
+          Nanoc::Identifier.new('/me.md')
+        end
+
+        it 'raises' do
+          expect { subject }.to raise_error(Nanoc::Int::Errors::CannotGetParentOrChildrenOfNonLegacyItem)
+        end
+      end
+
+      context 'legacy identifier' do
+        let(:identifier) do
+          Nanoc::Identifier.new('/me/', type: :legacy)
+        end
+
+        it 'returns nil' do
+          expect(subject).to be_nil
+        end
       end
     end
   end
 
   describe '#children' do
-    # TODO: implement
+    let(:item) do
+      Nanoc::Int::Item.new('me', {}, identifier).tap { |i| i.children = children }
+    end
+
+    let(:children) do
+      [Nanoc::Int::Item.new('child', {}, '/child/')]
+    end
+
+    let(:view) { described_class.new(item) }
+
+    subject { view.children }
+
+    context 'full identifier' do
+      let(:identifier) do
+        Nanoc::Identifier.new('/me.md')
+      end
+
+      it 'raises' do
+        expect { subject }.to raise_error(Nanoc::Int::Errors::CannotGetParentOrChildrenOfNonLegacyItem)
+      end
+    end
+
+    context 'legacy identifier' do
+      let(:identifier) do
+        Nanoc::Identifier.new('/me/', type: :legacy)
+      end
+
+      it 'returns views for the children' do
+        expect(subject.size).to eql(1)
+        expect(subject[0].class).to eql(Nanoc::ItemView)
+        expect(subject[0].unwrap).to eql(children[0])
+      end
+    end
   end
 
   describe '#reps' do


### PR DESCRIPTION
Fixes #709.

It also adds:

* a test for `#children` (which was still pending)
* `Identifier#legacy?` because it’s useful
* tests for `#full?` and `#legacy?`