### PR TITLE
Only attempt to clean if the item is a string

### DIFF
--- a/lib/nanoc/cli/stream_cleaners/ansi_colors.rb
+++ b/lib/nanoc/cli/stream_cleaners/ansi_colors.rb
@@ -5,7 +5,7 @@ module Nanoc::CLI::StreamCleaners
   class ANSIColors < Abstract
     # @see Nanoc::CLI::StreamCleaners::Abstract#clean
     def clean(s)
-      s.gsub(/\e\[.+?m/, '')
+      s.is_a?(String) ? s.gsub(/\e\[.+?m/, '') : s
     end
   end
 end


### PR DESCRIPTION
I've noticed that if I try to do some quick debugging—like, `puts @config`, this little helper will complain about a missing `gsub`, because `s` is a Hash or a String or something.

I think it's necessary every now and then to not assume everything being printed is a string, so this PR protects against that.