### PR TITLE
Add DateTime handling to attribute_to_time

### DIFF
--- a/lib/nanoc/helpers/blogging.rb
+++ b/lib/nanoc/helpers/blogging.rb
@@ -377,14 +377,15 @@ module Nanoc::Helpers
       'tag:' + hostname + ',' + formatted_date + ':' + base_dir + (item.path || item.identifier.to_s)
     end
 
-    # Converts the given attribute (which can be a string, a Time or a Date)
-    # into a Time.
+    # Converts the given attribute (which can be a string, a Time, a Date or a
+    # DateTime) into a Time.
     #
-    # @param [String, Time, Date] time Something that contains time
+    # @param [String, Time, Date, DateTime] time Something that contains time
     #   information but is not necessarily a Time instance yet
     #
     # @return [Time] The Time instance corresponding to the given input
     def attribute_to_time(time)
+      time = time.to_time if time.is_a?(DateTime)
       time = Time.local(time.year, time.month, time.day) if time.is_a?(Date)
       time = Time.parse(time) if time.is_a?(String)
       time


### PR DESCRIPTION
This enhances `attribute_to_time` which previously removed all time
information from a DateTime. This happened because DateTime identifies
itself as a Date.

    2.2.3 :001 > require 'date'
     => true
    2.2.3 :002 > DateTime.now.is_a?(Date)
     => true

Up to now, if `time.is_a?(Date)` is true, `attribute_to_time` will
create a new Time, with just year, month and day set. To fix that
behaviour, this commit adds a new condition at the beginning of
`attribute_to_time`, which uses `time.to_time` as long as `time` is a
DateTime.