### PR TITLE
Feature/external links exclude files

### DIFF
--- a/lib/nanoc/cli/commands/create-site.rb
+++ b/lib/nanoc/cli/commands/create-site.rb
@@ -100,6 +100,12 @@ checks:
     # E.g.:
     #   exclude: ['^http://example.com$']
     exclude: []
+
+    # A list of file patterns, specified as regular expressions, to exclude from the check.
+    # If a file matches this pattern, the links from this file will not be checked.
+    # E.g.:
+    #   exclude_files: ['blog/page']
+    exclude_files: []
 EOS
 
     DEFAULT_RULES = <<EOS unless defined? DEFAULT_RULES

--- a/lib/nanoc/cli/commands/create-site.rb
+++ b/lib/nanoc/cli/commands/create-site.rb
@@ -92,14 +92,14 @@ checks:
     #   exclude: ['^/server_status']
     exclude: []
 
-    # Configuration for the “external_links” checker, which checks whether all
-    # external links are valid.
-    external_links:
-      # A list of patterns, specified as regular expressions, to exclude from the check.
-      # If an external link matches this pattern, the validity check will be skipped.
-      # E.g.:
-      #   exclude: ['^http://example.com$']
-      exclude: []
+  # Configuration for the “external_links” checker, which checks whether all
+  # external links are valid.
+  external_links:
+    # A list of patterns, specified as regular expressions, to exclude from the check.
+    # If an external link matches this pattern, the validity check will be skipped.
+    # E.g.:
+    #   exclude: ['^http://example.com$']
+    exclude: []
 EOS
 
     DEFAULT_RULES = <<EOS unless defined? DEFAULT_RULES

--- a/lib/nanoc/extra/checking/checks/external_links.rb
+++ b/lib/nanoc/extra/checking/checks/external_links.rb
@@ -14,7 +14,7 @@ module ::Nanoc::Extra::Checking::Checks
     def run
       # Find all broken external hrefs
       # TODO: de-duplicate this (duplicated in internal links check)
-      filenames = output_filenames.select { |f| File.extname(f) == '.html' }
+      filenames = output_filenames.select { |f| File.extname(f) == '.html' && !excluded_file?(f) }
       hrefs_with_filenames = ::Nanoc::Extra::LinkCollector.new(filenames, :external).filenames_per_href
       results = select_invalid(hrefs_with_filenames.keys)
 
@@ -168,6 +168,11 @@ module ::Nanoc::Extra::Checking::Checks
     def excluded?(href)
       excludes =  @config.fetch(:checks, {}).fetch(:external_links, {}).fetch(:exclude, [])
       excludes.any? { |pattern| Regexp.new(pattern).match(href) }
+    end
+
+    def excluded_file?(file)
+      excludes =  @config.fetch(:checks, {}).fetch(:external_links, {}).fetch(:exclude_files, [])
+      excludes.any? { |pattern| Regexp.new(pattern).match(file) }
     end
   end
 end

--- a/test/extra/checking/checks/test_external_links.rb
+++ b/test/extra/checking/checks/test_external_links.rb
@@ -85,4 +85,16 @@ class Nanoc::Extra::Checking::Checks::ExternalLinksTest < Nanoc::TestCase
       refute check.send(:excluded?, 'http://notexcluded.com')
     end
   end
+
+  def test_excluded_file
+    with_site do |site|
+      # Create check
+      check = Nanoc::Extra::Checking::Checks::ExternalLinks.create(site)
+      site.config.update({ checks: { external_links: { exclude_files: ['blog/page'] } } })
+
+      # Test
+      assert check.send(:excluded_file?, 'output/blog/page1/index.html')
+      refute check.send(:excluded_file?, 'output/blog/pag1/index.html')
+    end
+  end
 end


### PR DESCRIPTION
I have a lot of pages on my site that contain derived content from other pages (e.g. paginated pages, tag pages, ...). Since the external link check is expensive, I'd like to skip these pages.

I added an 'exclude_files' config to exclude certain files from the external link check. I'm not wildly enthusiastic about writing expressions that depend on filenames, because they contain 'output/' etc., so they're not ideal to write. I'm guessing that ideally, you'd want to filter on item IDs maybe, or something similar, but that means more changes to the external_links. I'm open to suggestions for improvement here.