### PR TITLE
Fix #attribute_to_time timezone issues

### DIFF
--- a/lib/nanoc/helpers/blogging.rb
+++ b/lib/nanoc/helpers/blogging.rb
@@ -385,11 +385,17 @@ module Nanoc::Helpers
     #   information but is not necessarily a Time instance yet
     #
     # @return [Time] The Time instance corresponding to the given input
-    def attribute_to_time(time)
-      time = time.to_time if time.is_a?(DateTime)
-      time = Time.local(time.year, time.month, time.day) if time.is_a?(Date)
-      time = Time.parse(time) if time.is_a?(String)
-      time
+    def attribute_to_time(arg)
+      case arg
+      when DateTime
+        arg.to_time
+      when Date
+        Time.local(arg.year, arg.month, arg.day)
+      when String
+        Time.parse(arg)
+      else
+        arg
+      end
     end
   end
 end

--- a/lib/nanoc/helpers/blogging.rb
+++ b/lib/nanoc/helpers/blogging.rb
@@ -378,7 +378,8 @@ module Nanoc::Helpers
     end
 
     # Converts the given attribute (which can be a string, a Time, a Date or a
-    # DateTime) into a Time.
+    # DateTime) into a Time. When given a Date instance or a string, the
+    # argument is assumed to be in the local timezone.
     #
     # @param [String, Time, Date, DateTime] time Something that contains time
     #   information but is not necessarily a Time instance yet

--- a/spec/nanoc/helpers/blogging_spec.rb
+++ b/spec/nanoc/helpers/blogging_spec.rb
@@ -245,7 +245,7 @@ describe Nanoc::Helpers::Blogging do
 
     context 'with Date instance' do
       let(:arg) { Date.new(2015, 11, 7) }
-      it { is_expected.to eql(Time.at(1446850800)) }
+      it { is_expected.to eql(Time.at(1446854400 - Time.now.utc_offset)) }
     end
 
     context 'with DateTime instance' do
@@ -255,7 +255,7 @@ describe Nanoc::Helpers::Blogging do
 
     context 'with string' do
       let(:arg) { '2015-11-7 13:31:16' }
-      it { is_expected.to eql(Time.at(1446899476)) }
+      it { is_expected.to eql(Time.at(1446903076 - Time.now.utc_offset)) }
     end
   end
 

--- a/spec/nanoc/helpers/blogging_spec.rb
+++ b/spec/nanoc/helpers/blogging_spec.rb
@@ -238,24 +238,28 @@ describe Nanoc::Helpers::Blogging do
   describe '#attribute_to_time' do
     subject { mod.attribute_to_time(arg) }
 
+    let(:around_noon_local) { Time.at(1446903076 - Time.now.utc_offset) }
+    let(:around_noon_utc) { Time.at(1446903076) }
+    let(:beginning_of_day_local) { Time.at(1446854400 - Time.now.utc_offset) }
+
     context 'with Time instance' do
-      let(:arg) { Time.at(1446899476) }
-      it { is_expected.to eql(Time.at(1446899476)) }
+      let(:arg) { around_noon_utc }
+      it { is_expected.to eql(around_noon_utc) }
     end
 
     context 'with Date instance' do
       let(:arg) { Date.new(2015, 11, 7) }
-      it { is_expected.to eql(Time.at(1446854400 - Time.now.utc_offset)) }
+      it { is_expected.to eql(beginning_of_day_local) }
     end
 
     context 'with DateTime instance' do
-      let(:arg) { DateTime.new(2015, 11, 7, 12, 31, 16) }
-      it { is_expected.to eql(Time.at(1446899476)) }
+      let(:arg) { DateTime.new(2015, 11, 7, 13, 31, 16) }
+      it { is_expected.to eql(around_noon_utc) }
     end
 
     context 'with string' do
       let(:arg) { '2015-11-7 13:31:16' }
-      it { is_expected.to eql(Time.at(1446903076 - Time.now.utc_offset)) }
+      it { is_expected.to eql(around_noon_local) }
     end
   end
 


### PR DESCRIPTION
When give a `Date` or `String` instance, `#attribute_to_time` does not have timezone information, and so I believe the correct approach is to treat the argument as *local* time. The tests failed in UTC since they did not take the time offset into account.

This PR makes the argument be treated as local time. (Enhancement rather than a bug, because it’s mostly the specs being wrong, and the documentation being vague.)

A small bonus change involves refactoring `#attribute_to_time` so it no longer has assignments or explicit type checks with `if`.

Also see #717.