### PR TITLE
Query data source for glob patterns

### DIFF
--- a/bin/nanoc
+++ b/bin/nanoc
@@ -6,4 +6,10 @@ if File.file?('Gemfile') && !defined?(Bundler)
   warn 'A Gemfile was detected, but Bundler is not loaded. This is probably not what you want. To run Nanoc with Bundler, use `bundle exec nanoc`.'
 end
 
-Nanoc::CLI.run(ARGV)
+require 'ruby-prof'
+
+result = RubyProf.profile do
+  Nanoc::CLI.run(ARGV)
+end
+printer = RubyProf::GraphHtmlPrinter.new(result)
+File.open('graph.html', 'w') { |io| printer.print(io, {}) }

--- a/lib/nanoc/base/entities/identifiable_collection.rb
+++ b/lib/nanoc/base/entities/identifiable_collection.rb
@@ -54,7 +54,8 @@ module Nanoc::Int
         if use_globs?
           # FIXME: fails when adding documents with preprocessor
           # (maybe turn preprocessor into data source?)
-          @document_sources.flat_map { |ds| ds.objects_matching_pattern(pattern) }
+          paths = @document_sources.flat_map { |ds| ds.paths_matching_pattern(pattern) }
+          paths.map { |path| self[path] }
         else
           []
         end

--- a/lib/nanoc/base/entities/identifiable_collection.rb
+++ b/lib/nanoc/base/entities/identifiable_collection.rb
@@ -84,23 +84,22 @@ module Nanoc::Int
 
     def object_matching_glob(glob)
       if use_globs?
-        pat = Nanoc::Int::Pattern.from(glob)
-        if @objects.first.is_a?(Nanoc::Int::Layout)
-          @data_sources.each do |ds|
-            if ds.respond_to?(:glob_layout)
-              paths = ds.glob_layout(glob)
-              unless paths.empty?
-                return object_with_identifier(paths[0])
-              end
-            end
+        method =
+          case @objects.first
+          when Nanoc::Int::Layout
+            :glob_layout
+          when Nanoc::Int::Item
+            :glob_item
+          else
+            raise "Unknown type: #{@objects.first.class}"
           end
-        elsif @objects.first.is_a?(Nanoc::Int::Item)
-          @data_sources.each do |ds|
-            if ds.respond_to?(:glob_item)
-              paths = ds.glob_item(glob)
-              unless paths.empty?
-                return object_with_identifier(paths[0])
-              end
+
+        pat = Nanoc::Int::Pattern.from(glob)
+        @data_sources.each do |ds|
+          if ds.respond_to?(method)
+            paths = ds.send(method, glob)
+            unless paths.empty?
+              return object_with_identifier(paths[0])
             end
           end
         end

--- a/lib/nanoc/base/entities/identifiable_collection.rb
+++ b/lib/nanoc/base/entities/identifiable_collection.rb
@@ -75,8 +75,8 @@ module Nanoc::Int
 
     def object_matching_glob(glob)
       if use_globs?
-        pattern = Nanoc::Int::Pattern.from(glob)
-        objects_matching_pattern(pattern).first
+        pat = Nanoc::Int::Pattern.from(glob)
+        objects_matching_pattern(pat).first
       else
         nil
       end

--- a/lib/nanoc/base/entities/identifiable_collection.rb
+++ b/lib/nanoc/base/entities/identifiable_collection.rb
@@ -10,9 +10,9 @@ module Nanoc::Int
     def_delegator :@objects, :<<
     def_delegator :@objects, :concat
 
-    def initialize(config, data_sources = nil)
+    def initialize(config, document_sources = nil)
       @config = config
-      @data_sources = data_sources
+      @document_sources = document_sources
 
       @objects = []
     end
@@ -50,25 +50,9 @@ module Nanoc::Int
 
     def objects_matching_pattern(pattern)
       if pattern.is_a?(Nanoc::Int::StringPattern)
-        if use_globs?
-          method =
-            case @objects.first
-            when Nanoc::Int::Layout
-              :glob_layout
-            when Nanoc::Int::Item
-              :glob_item
-            else
-              raise "Unknown type: #{@objects.first.class}"
-            end
-
-          @data_sources.lazy.flat_map do |ds|
-            if ds.respond_to?(method)
-              paths = ds.send(method, pattern.to_s)
-              paths.lazy.map { |path| object_with_identifier(path) }
-            end
-          end
+        if use_globs? && @document_sources
+          @document_sources.flat_map { |ds| ds.objects_matching_pattern(pattern) }
         else
-          # FIXME: support legacy pattern
           []
         end
       else

--- a/lib/nanoc/base/entities/identifiable_collection.rb
+++ b/lib/nanoc/base/entities/identifiable_collection.rb
@@ -50,8 +50,8 @@ module Nanoc::Int
 
     def objects_matching_pattern(pattern)
       # TODO: verify type of pattern
-      if pattern.is_a?(Nanoc::Int::StringPattern)
-        if use_globs? && @document_sources
+      if pattern.is_a?(Nanoc::Int::StringPattern) && @document_sources
+        if use_globs?
           # FIXME: fails when adding documents with preprocessor
           # (maybe turn preprocessor into data source?)
           @document_sources.flat_map { |ds| ds.objects_matching_pattern(pattern) }

--- a/lib/nanoc/base/entities/identifiable_collection.rb
+++ b/lib/nanoc/base/entities/identifiable_collection.rb
@@ -10,8 +10,9 @@ module Nanoc::Int
     def_delegator :@objects, :<<
     def_delegator :@objects, :concat
 
-    def initialize(config)
+    def initialize(config, data_sources = nil)
       @config = config
+      @data_sources = data_sources
 
       @objects = []
     end
@@ -60,6 +61,16 @@ module Nanoc::Int
     def object_matching_glob(glob)
       if use_globs?
         pat = Nanoc::Int::Pattern.from(glob)
+        if @objects.first.is_a?(Nanoc::Int::Item)
+          @data_sources.each do |ds|
+            if ds.respond_to?(:glob_item)
+              paths = ds.glob_item(glob)
+              unless paths.empty?
+                return object_with_identifier(paths[0])
+              end
+            end
+          end
+        end
         @objects.find { |i| pat.match?(i.identifier) }
       else
         nil

--- a/lib/nanoc/base/entities/identifiable_collection.rb
+++ b/lib/nanoc/base/entities/identifiable_collection.rb
@@ -49,8 +49,11 @@ module Nanoc::Int
     end
 
     def objects_matching_pattern(pattern)
+      # TODO: verify type of pattern
       if pattern.is_a?(Nanoc::Int::StringPattern)
         if use_globs? && @document_sources
+          # FIXME: fails when adding documents with preprocessor
+          # (maybe turn preprocessor into data source?)
           @document_sources.flat_map { |ds| ds.objects_matching_pattern(pattern) }
         else
           []
@@ -71,8 +74,12 @@ module Nanoc::Int
     end
 
     def object_matching_glob(glob)
-      pattern = Nanoc::Int::Pattern.from(glob)
-      objects_matching_pattern(pattern).first
+      if use_globs?
+        pattern = Nanoc::Int::Pattern.from(glob)
+        objects_matching_pattern(pattern).first
+      else
+        nil
+      end
     end
 
     def build_mapping

--- a/lib/nanoc/base/repos/site_loader.rb
+++ b/lib/nanoc/base/repos/site_loader.rb
@@ -15,6 +15,8 @@ module Nanoc::Int
     private
 
     class DocumentSource
+      attr_reader :data_source
+
       def initialize(data_source)
         @data_source = data_source
       end

--- a/lib/nanoc/base/repos/site_loader.rb
+++ b/lib/nanoc/base/repos/site_loader.rb
@@ -18,10 +18,10 @@ module Nanoc::Int
       code_snippets = code_snippets_from_config(config)
       code_snippets.each(&:load)
 
-      items = Nanoc::Int::IdentifiableCollection.new(config)
-      layouts = Nanoc::Int::IdentifiableCollection.new(config)
-
       with_data_sources(config) do |data_sources|
+        items = Nanoc::Int::IdentifiableCollection.new(config, data_sources)
+        layouts = Nanoc::Int::IdentifiableCollection.new(config, data_sources)
+
         data_sources.each do |ds|
           items_in_ds = ds.items
           layouts_in_ds = ds.layouts
@@ -32,14 +32,14 @@ module Nanoc::Int
           items.concat(items_in_ds)
           layouts.concat(layouts_in_ds)
         end
-      end
 
-      Nanoc::Int::Site.new(
-        config: config,
-        code_snippets: code_snippets,
-        items: items,
-        layouts: layouts,
-      )
+        Nanoc::Int::Site.new(
+          config: config,
+          code_snippets: code_snippets,
+          items: items,
+          layouts: layouts,
+        )
+      end
     end
 
     # @return [Boolean]

--- a/lib/nanoc/base/repos/site_loader.rb
+++ b/lib/nanoc/base/repos/site_loader.rb
@@ -29,12 +29,13 @@ module Nanoc::Int
         raise NotImplementedError
       end
 
-      def object_matching_pattern(pattern)
-        objects.find { |o| o.identifier =~ pattern }
-      end
-
       def objects_matching_pattern(pattern)
         objects.select { |o| o.identifier =~ pattern }
+      end
+
+      def paths_matching_pattern(pattern)
+        # FIXME: assumes path identifiers
+        objects.lazy.map { |o| o.identifier }.select { |o| o.identifier =~ pattern }
       end
     end
 
@@ -43,7 +44,14 @@ module Nanoc::Int
         data_source.items
       end
 
-      # TODO: override #objects_matching_pattern
+      def paths_matching_pattern(pattern)
+        if data_source.respond_to?(:glob_item) && pattern.is_a?(Nanoc::Int::StringPattern)
+          # FIXME: match paths, not objects
+          data_source.glob_item(pattern.to_s)
+        else
+          super
+        end
+      end
     end
 
     class LayoutSource < DocumentSource
@@ -51,7 +59,14 @@ module Nanoc::Int
         data_source.layouts
       end
 
-      # TODO: override #objects_matching_pattern
+      def paths_matching_pattern(pattern)
+        if data_source.respond_to?(:glob_layout) && pattern.is_a?(Nanoc::Int::StringPattern)
+          # FIXME: match paths, not objects
+          data_source.glob_layout(pattern.to_s)
+        else
+          super
+        end
+      end
     end
 
     def site_from_config(config)

--- a/lib/nanoc/base/views/identifiable_collection_view.rb
+++ b/lib/nanoc/base/views/identifiable_collection_view.rb
@@ -43,8 +43,8 @@ module Nanoc
     #
     # @return [Enumerable]
     def find_all(arg)
-      pat = Nanoc::Int::Pattern.from(arg)
-      select { |i| pat.match?(i.identifier) }
+      pattern = Nanoc::Int::Pattern.from(arg)
+      @objects.objects_matching_pattern(pattern).map { |o| view_class.new(o, @context) }
     end
 
     # @overload [](string)

--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -24,6 +24,10 @@ module Nanoc::DataSources
       load_objects(content_dir_name, 'item', Nanoc::Int::Item)
     end
 
+    def glob_item(pattern)
+      Dir['content' + pattern.to_s].map { |s| s.sub(/^content/, '') }
+    end
+
     # See {Nanoc::DataSource#layouts}.
     def layouts
       load_objects(layouts_dir_name, 'layout', Nanoc::Int::Layout)

--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -28,6 +28,10 @@ module Nanoc::DataSources
       Dir['content' + pattern.to_s].map { |s| s.sub(/^content/, '') }
     end
 
+    def glob_layout(pattern)
+      Dir['layouts' + pattern.to_s].map { |s| s.sub(/^layouts/, '') }
+    end
+
     # See {Nanoc::DataSource#layouts}.
     def layouts
       load_objects(layouts_dir_name, 'layout', Nanoc::Int::Layout)

--- a/spec/nanoc/base/entities/identifiable_collection_spec.rb
+++ b/spec/nanoc/base/entities/identifiable_collection_spec.rb
@@ -1,0 +1,7 @@
+describe Nanoc::Int::IdentifiableCollection do
+  let(:identifiable_collection) do
+    described_class.new(config)
+  end
+
+  let(:config) { {} }
+end

--- a/spec/nanoc/base/views/identifiable_collection_view_spec.rb
+++ b/spec/nanoc/base/views/identifiable_collection_view_spec.rb
@@ -143,7 +143,7 @@ shared_examples 'an identifiable collection' do
       let(:arg) { '/*.css' }
 
       it 'contains views' do
-        expect(subject.size).to eql(2)
+        expect(subject.to_a.size).to eql(2)
         about_css = subject.find { |iv| iv.identifier == '/about.css' }
         style_css = subject.find { |iv| iv.identifier == '/style.css' }
         expect(about_css.class).to equal(view_class)

--- a/spec/nanoc/base/views/identifiable_collection_view_spec.rb
+++ b/spec/nanoc/base/views/identifiable_collection_view_spec.rb
@@ -155,7 +155,7 @@ shared_examples 'an identifiable collection' do
       let(:arg) { %r{\.css\z} }
 
       it 'contains views' do
-        expect(subject.size).to eql(2)
+        expect(subject.to_a.size).to eql(2)
         about_css = subject.find { |iv| iv.identifier == '/about.css' }
         style_css = subject.find { |iv| iv.identifier == '/style.css' }
         expect(about_css.class).to equal(view_class)


### PR DESCRIPTION
**EXPERIMENTAL** and horribly work-in-progress.

When a glob is given to `IdentifiableCollection#[]`, query the data source and glob efficiently.

No visible speed improvement so far.