### PR TITLE
Some slight changes to .travis.yml for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,5 @@ cache: bundler
 
 sudo: false
 
+git:
+  depth: 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,6 @@ notifications:
     skip_join: true
 
 cache: bundler
+
+sudo: false
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,5 @@ notifications:
       - "%{repository}/%{branch} %{commit} %{author}: %{message}"
     use_notice: true
     skip_join: true
+
+cache: bundler


### PR DESCRIPTION
* [Setting the cache to `bundler`](http://docs.travis-ci.com/user/caching/) allows the Travis container to just reuse installed gems
* [`sudo: false`](http://docs.travis-ci.com/user/workers/container-based-infrastructure/) moves the builds to the container infrastructure, which means faster builds.
* We can just limit the git clone depth to an arbitrary number (10) to make the clone a bit faster.