### PR TITLE
Removed english text from link_to helper.

### DIFF
--- a/lib/nanoc/helpers/link_to.rb
+++ b/lib/nanoc/helpers/link_to.rb
@@ -89,7 +89,7 @@ module Nanoc::Helpers
 
       if @item_rep && @item_rep.path == path
         # Create message
-        "<span class=\"active\" title=\"You're here.\">#{text}</span>"
+        "<span class=\"active\">#{text}</span>"
       else
         link_to(text, target, attributes)
       end

--- a/lib/nanoc/helpers/link_to.rb
+++ b/lib/nanoc/helpers/link_to.rb
@@ -82,7 +82,7 @@ module Nanoc::Helpers
     # @example Linking to the same page
     #
     #   link_to_unless_current('This Item', @item)
-    #   # => '<span class="active" title="You\'re here.">This Item</span>'
+    #   # => '<span class="active">This Item</span>'
     def link_to_unless_current(text, target, attributes = {})
       # Find path
       path = target.is_a?(String) ? target : target.path

--- a/test/helpers/test_link_to.rb
+++ b/test/helpers/test_link_to.rb
@@ -67,7 +67,7 @@ class Nanoc::Helpers::LinkToTest < Nanoc::TestCase
 
     # Check
     assert_equal(
-      '<span class="active" title="You\'re here.">Bar</span>',
+      '<span class="active">Bar</span>',
       link_to_unless_current('Bar', @item_rep),
     )
   ensure


### PR DESCRIPTION
The `link_to_unless_current` function from `link_to` helper was outputing english text. This should be avoided.