### PR TITLE
Fix comparisons

### DIFF
--- a/lib/nanoc/base/entities/document.rb
+++ b/lib/nanoc/base/entities/document.rb
@@ -44,13 +44,10 @@ module Nanoc
         self.class.hash ^ identifier.hash
       end
 
-      def eql?(other)
-        self.class == other.class && identifier == other.identifier
-      end
-
       def ==(other)
-        self.eql?(other)
+        other.respond_to?(:identifier) && identifier == other.identifier
       end
+      alias_method :eql?, :==
     end
   end
 end

--- a/lib/nanoc/base/entities/identifier.rb
+++ b/lib/nanoc/base/entities/identifier.rb
@@ -65,7 +65,12 @@ module Nanoc
     end
 
     def ==(other)
-      to_s == other.to_s
+      case other
+      when Nanoc::Identifier, String
+        to_s == other.to_s
+      else
+        false
+      end
     end
     alias_method :eql?, :==
 

--- a/lib/nanoc/base/views/item_rep_view.rb
+++ b/lib/nanoc/base/views/item_rep_view.rb
@@ -12,7 +12,7 @@ module Nanoc
 
     # @see Object#==
     def ==(other)
-      item.identifier == other.item.identifier && name == other.name
+      other.respond_to?(:item) && other.respond_to?(:name) && item == other.item && name == other.name
     end
     alias_method :eql?, :==
 

--- a/spec/nanoc/base/entities/identifier_spec.rb
+++ b/spec/nanoc/base/entities/identifier_spec.rb
@@ -111,33 +111,53 @@ describe Nanoc::Identifier do
   end
 
   describe '#== and #eql?' do
-    context 'equal identifiers' do
+    context 'comparing with equal identifier' do
       let(:identifier_a) { described_class.new('//foo/bar/', type: :legacy) }
       let(:identifier_b) { described_class.new('/foo/bar//', type: :legacy) }
 
-      it 'is equal to identifier' do
+      it 'is equal' do
         expect(identifier_a).to eq(identifier_b)
         expect(identifier_a).to eql(identifier_b)
       end
+    end
 
-      it 'is equal to string' do
+    context 'comparing with equal string' do
+      let(:identifier_a) { described_class.new('//foo/bar/', type: :legacy) }
+      let(:identifier_b) { '/foo/bar/' }
+
+      it 'is equal' do
         expect(identifier_a).to eq(identifier_b.to_s)
         expect(identifier_a).to eql(identifier_b.to_s)
       end
     end
 
-    context 'different identifiers' do
+    context 'comparing with different identifier' do
       let(:identifier_a) { described_class.new('//foo/bar/', type: :legacy) }
       let(:identifier_b) { described_class.new('/baz/qux//', type: :legacy) }
 
-      it 'differs from identifier' do
+      it 'is not equal' do
         expect(identifier_a).not_to eq(identifier_b)
         expect(identifier_a).not_to eql(identifier_b)
       end
+    end
 
-      it 'differs from string' do
-        expect(identifier_a).not_to eq(identifier_b.to_s)
-        expect(identifier_a).not_to eql(identifier_b.to_s)
+    context 'comparing with different string' do
+      let(:identifier_a) { described_class.new('//foo/bar/', type: :legacy) }
+      let(:identifier_b) { '/baz/qux/' }
+
+      it 'is not equal' do
+        expect(identifier_a).not_to eq(identifier_b)
+        expect(identifier_a).not_to eql(identifier_b)
+      end
+    end
+
+    context 'comparing with something that is not an identifier' do
+      let(:identifier_a) { described_class.new('//foo/bar/', type: :legacy) }
+      let(:identifier_b) { :donkey }
+
+      it 'is not equal' do
+        expect(identifier_a).not_to eq(identifier_b)
+        expect(identifier_a).not_to eql(identifier_b)
       end
     end
   end

--- a/spec/nanoc/base/views/item_rep_view_spec.rb
+++ b/spec/nanoc/base/views/item_rep_view_spec.rb
@@ -63,6 +63,16 @@ describe Nanoc::ItemRepView do
         expect(view).not_to eql(other)
       end
     end
+
+    context 'comparing with something that is not an item rep' do
+      let(:other_item) { double(:other_item, identifier: '/foo/') }
+      let(:other) { :donkey }
+
+      it 'is not equal' do
+        expect(view).not_to eq(other)
+        expect(view).not_to eql(other)
+      end
+    end
   end
 
   describe '#hash' do


### PR DESCRIPTION
* Made comparing identifiers somewhat more strict (don’t blindly call `#to_s`)
* Make `Document` equality less strict (don’t require the exact same class—a view also works)
* Don’t crash when comparing an ItemRepView with something else (fixes #735).