### PR TITLE
Fix crash on Array#all in fog deployer

### DIFF
--- a/lib/nanoc/extra/deployers/fog.rb
+++ b/lib/nanoc/extra/deployers/fog.rb
@@ -69,7 +69,7 @@ module Nanoc::Extra::Deployers
         truncated = set.is_truncated
         files += set
       end
-      keys_to_destroy = files.all.map(&:key)
+      keys_to_destroy = files.map(&:key)
       keys_to_invalidate = []
       etags = read_etags(files)
 


### PR DESCRIPTION
I attempted to write a test for this, but without luck.

Fixes #718.