### PR TITLE
Load commands as UTF-8

### DIFF
--- a/lib/nanoc/cli.rb
+++ b/lib/nanoc/cli.rb
@@ -152,7 +152,7 @@ module Nanoc::CLI
   # @return [Cri::Command] The loaded command
   def self.load_command_at(filename, command_name = nil)
     # Load
-    code = File.read(filename)
+    code = File.read(filename, encoding: 'UTF-8')
     cmd = Cri::Command.define(code, filename)
 
     # Set name

--- a/test/cli/test_cli.rb
+++ b/test/cli/test_cli.rb
@@ -125,6 +125,13 @@ EOS
     end
   end
 
+  def test_load_command_at_with_non_utf8_encoding
+    Encoding.default_external = Encoding::US_ASCII
+    Nanoc::CLI.load_command_at(root_dir + '/lib/nanoc/cli/commands/create-site.rb')
+  ensure
+    Encoding.default_external = Encoding::UTF_8
+  end
+
   def test_after_setup
     $after_setup_success = false
     Nanoc::CLI.after_setup do

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -262,6 +262,10 @@ EOS
   def skip_unless_symlinks_supported
     skip 'Symlinks are not supported by Ruby on Windows' unless symlinks_supported?
   end
+
+  def root_dir
+    File.absolute_path(File.dirname(__FILE__) + '/..')
+  end
 end
 
 class Nanoc::TestCase < Minitest::Test


### PR DESCRIPTION
Fixes #741.

Nanoc loads commands using the environment’s encoding. We know for a fact that these are UTF-8, so relying on the environment is unnecessary, and even wrong, as shown by the crash.