### PR TITLE
link_to_unless_current

### DIFF
--- a/lib/nanoc/helpers/link_to.rb
+++ b/lib/nanoc/helpers/link_to.rb
@@ -88,8 +88,23 @@ module Nanoc::Helpers
       path = target.is_a?(String) ? target : target.path
 
       if @item_rep && @item_rep.path == path
+        active_class = attributes[:active_class] || 'active'
+        attributes.delete :active_class
+
+        # merge active_class with attributes' class
+        if attributes.has_key? :class then
+          attributes[:class] += " #{active_class}"
+        else
+          attributes[:class] = active_class
+        end
+
+        # Join attributes, prefixed by a space
+        attributes = attributes.reduce('') do |memo, (key, value)|
+          memo + ' ' + key.to_s + '="' + h(value) + '"'
+        end
+
         # Create message
-        "<span class=\"active\">#{text}</span>"
+        "<span#{attributes}>#{text}</span>"
       else
         link_to(text, target, attributes)
       end

--- a/test/helpers/test_link_to.rb
+++ b/test/helpers/test_link_to.rb
@@ -74,6 +74,48 @@ class Nanoc::Helpers::LinkToTest < Nanoc::TestCase
     @item = nil
   end
 
+  def test_link_to_unless_current_current_with_attributes
+    # Create item
+    @item_rep = mock
+    @item_rep.stubs(:path).returns('/foo/')
+
+    # Check
+    assert_equal(
+      '<span class="quux active" title="Foo &amp; Bar">Bar</span>',
+      link_to_unless_current('Bar', @item_rep, class: 'quux', title: 'Foo & Bar'),
+    )
+  ensure
+    @item = nil
+  end
+
+  def test_link_to_unless_current_current_with_active_class
+    # Create item
+    @item_rep = mock
+    @item_rep.stubs(:path).returns('/foo/')
+
+    # Check
+    assert_equal(
+      '<span class="foo-bar-active">Bar</span>',
+      link_to_unless_current('Bar', @item_rep, active_class: 'foo-bar-active'),
+    )
+  ensure
+    @item = nil
+  end
+
+  def test_link_to_unless_current_current_with_active_class_and_class
+    # Create item
+    @item_rep = mock
+    @item_rep.stubs(:path).returns('/foo/')
+
+    # Check
+    assert_equal(
+      '<span class="quux foo-bar-active">Bar</span>',
+      link_to_unless_current('Bar', @item_rep, class: 'quux', active_class: 'foo-bar-active'),
+    )
+  ensure
+    @item = nil
+  end
+
   def test_link_to_unless_current_not_current
     # Create item
     @item_rep = mock


### PR DESCRIPTION
Fixs #737.

`attributes` hash now accepts an `:active_class` key which defaults to `'active'` and, if it links to the current page, it's merged with `attributes`' `:class` key and removed from the hash.