### PR TITLE
Allow more recent sass version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'rouge'
 gem 'rspec'
 gem 'rubocop'
 gem 'rubypants'
-gem 'sass', '~> 3.2.2'
+gem 'sass'
 gem 'simplecov', require: false
 gem 'slim'
 gem 'typogruby'

--- a/test/filters/test_sass.rb
+++ b/test/filters/test_sass.rb
@@ -1,4 +1,14 @@
 class Nanoc::Filters::SassTest < Nanoc::TestCase
+  def setup
+    super
+
+    if_have 'sass' do
+      unless ::Sass.load_paths.include?('.')
+        ::Sass.load_paths << '.'
+      end
+    end
+  end
+
   def test_filter
     if_have 'sass' do
       # Get filter


### PR DESCRIPTION
Sass got locked into the 3.2.x branch, presumably due to a bug in a more recent version that caused issues with Nanoc a while back. Sadly, upgrading breaks tests:

```
  3) Error:
Nanoc::Filters::SassTest#test_filter_can_import_external_files:
Sass::SyntaxError: File to import not found or unreadable: moo.
    (sass):1
    /usr/local/lib/ruby/gems/2.2.0/gems/sass-3.4.19/lib/sass/tree/import_node.rb:67:in `rescue in import'
[snip]
    /Users/ddfreyne/Documents/Development/nanoc/repos/nanoc/lib/nanoc/filters/sass.rb:18:in `run'
    /Users/ddfreyne/Documents/Development/nanoc/repos/nanoc/lib/nanoc/base/compilation/filter.rb:130:in `setup_and_run'
    /Users/ddfreyne/Documents/Development/nanoc/repos/nanoc/test/filters/test_sass.rb:54:in `block in test_filter_can_import_external_files'
    /Users/ddfreyne/Documents/Development/nanoc/repos/nanoc/test/helper.rb:47:in `if_have'
    /Users/ddfreyne/Documents/Development/nanoc/repos/nanoc/test/filters/test_sass.rb:46:in `test_filter_can_import_external_files'
```