### PR TITLE
Support Ruby 2.1

### DIFF
--- a/nanoc.gemspec
+++ b/nanoc.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.rdoc_options     = ['--main', 'README.md']
   s.extra_rdoc_files = ['ChangeLog', 'LICENSE', 'README.md', 'NEWS.md']
 
-  s.required_ruby_version = '>= 2.2.0'
+  s.required_ruby_version = '>= 2.1.0'
 
   s.add_runtime_dependency('cri', '~> 2.3')
 


### PR DESCRIPTION
4.0.1 was supposed to have its minimum required Ruby version lowered from 2.2 to 2.1, but the only thing that was changed was to run the tests on Ruby 2.1 on Travis CI, which worked fine.

This PR changes the actual minimum required Ruby version, checked when doing a `bundle install` or a `gem install`, to 2.1.

CC @Fjan 