### PR TITLE
Use rule memory for compiling reps

### DIFF
--- a/lib/nanoc/base/entities/rule_memory.rb
+++ b/lib/nanoc/base/entities/rule_memory.rb
@@ -32,6 +32,10 @@ module Nanoc::Int
       @actions.select { |a| a.is_a?(Nanoc::Int::RuleMemoryActions::Snapshot) }
     end
 
+    def any_layouts?
+      @actions.any? { |a| a.is_a?(Nanoc::Int::RuleMemoryActions::Layout) }
+    end
+
     def serialize
       map(&:serialize)
     end

--- a/spec/nanoc/base/services/rule_memory_calculator_spec.rb
+++ b/spec/nanoc/base/services/rule_memory_calculator_spec.rb
@@ -31,7 +31,7 @@ describe(Nanoc::Int::RuleMemoryCalculator) do
       example do
         subject
 
-        expect(subject.size).to eql(6)
+        expect(subject.size).to eql(7)
 
         expect(subject[0]).to be_a(Nanoc::Int::RuleMemoryActions::Snapshot)
         expect(subject[0].snapshot_name).to eql(:raw)
@@ -56,9 +56,14 @@ describe(Nanoc::Int::RuleMemoryCalculator) do
         expect(subject[4].params).to eql({})
 
         expect(subject[5]).to be_a(Nanoc::Int::RuleMemoryActions::Snapshot)
-        expect(subject[5].snapshot_name).to eql(:last)
+        expect(subject[5].snapshot_name).to eql(:post)
         expect(subject[5]).to be_final
         expect(subject[5].path).to be_nil
+
+        expect(subject[6]).to be_a(Nanoc::Int::RuleMemoryActions::Snapshot)
+        expect(subject[6].snapshot_name).to eql(:last)
+        expect(subject[6]).to be_final
+        expect(subject[6].path).to be_nil
       end
     end
 
@@ -115,7 +120,7 @@ describe(Nanoc::Int::RuleMemoryCalculator) do
     end
 
     example do
-      expect(subject.size).to eql(3)
+      expect(subject.size).to eql(4)
 
       expect(subject[0]).to be_a(Nanoc::Int::SnapshotDef)
       expect(subject[0].name).to eql(:raw)
@@ -126,8 +131,12 @@ describe(Nanoc::Int::RuleMemoryCalculator) do
       expect(subject[1]).not_to be_final
 
       expect(subject[2]).to be_a(Nanoc::Int::SnapshotDef)
-      expect(subject[2].name).to eql(:last)
+      expect(subject[2].name).to eql(:post)
       expect(subject[2]).to be_final
+
+      expect(subject[3]).to be_a(Nanoc::Int::SnapshotDef)
+      expect(subject[3].name).to eql(:last)
+      expect(subject[3]).to be_final
     end
   end
 end

--- a/test/base/test_compiler.rb
+++ b/test/base/test_compiler.rb
@@ -164,7 +164,7 @@ class Nanoc::Int::CompilerTest < Nanoc::TestCase
 
     # Create compiler
     compiler = new_compiler(site)
-    compiler.rules_collection.expects(:compilation_rule_for).times(2).with(rep).returns(rule)
+    compiler.rules_collection.stubs(:compilation_rule_for).with(rep).returns(rule)
     compiler.rules_collection.layout_filter_mapping[Nanoc::Int::Pattern.from(%r{^/blah/$})] = [:erb, {}]
     site.stubs(:compiler).returns(compiler)
 


### PR DESCRIPTION
This makes the compiler use the rule actions, rather than executing the rules a second time.

This gets rid of an icky bit of duplication in `#new_rule_memory_for_rep`, and using rule actions means that we are a step closer to decoupling the rules file from Nanoc core.

It also fixes an issue which would cause a path defined for the `:post` snapshot to have no effect.