### PR TITLE
Use #write in default site

### DIFF
--- a/lib/nanoc/cli/commands/create-site.rb
+++ b/lib/nanoc/cli/commands/create-site.rb
@@ -124,9 +124,6 @@ end
 #  layout '/default.*'
 #end
 
-compile '/**/*' do
-end
-
 route '/**/*.{html,md}' do
   if item.identifier =~ '/index.*'
     '/index.html'
@@ -135,8 +132,8 @@ route '/**/*.{html,md}' do
   end
 end
 
-route '/**/*' do
-  item.identifier.to_s
+compile '/**/*' do
+  write item.identifier.to_s
 end
 
 layout '/**/*', :erb


### PR DESCRIPTION
Fixes #757.

There are no other useful places in the default site to use `#write` for.