### PR TITLE
Fix final :pre snapshot not being generated

### DIFF
--- a/lib/nanoc/base/entities/rule_memory.rb
+++ b/lib/nanoc/base/entities/rule_memory.rb
@@ -24,7 +24,7 @@ module Nanoc::Int
     end
 
     def add_snapshot(snapshot_name, final, path)
-      will_add_snapshot(snapshot_name)
+      will_add_snapshot(snapshot_name) if final
       @actions << Nanoc::Int::RuleMemoryActions::Snapshot.new(snapshot_name, final, path)
     end
 

--- a/spec/nanoc/base/entities/rule_memory_spec.rb
+++ b/spec/nanoc/base/entities/rule_memory_spec.rb
@@ -70,13 +70,23 @@ describe Nanoc::Int::RuleMemory do
       end
     end
 
-    context 'snapshot already exist' do
+    context 'non-final snapshot already exist' do
       before do
         rule_memory.add_snapshot(:before_layout, false, '/bar.md')
       end
 
-      example do
-        expect { rule_memory.add_snapshot(:before_layout, false, '/foo.md') }
+      it 'does not raise' do
+        rule_memory.add_snapshot(:before_layout, true, '/foo.md')
+      end
+    end
+
+    context 'final snapshot already exist' do
+      before do
+        rule_memory.add_snapshot(:before_layout, true, '/bar.md')
+      end
+
+      it 'raises' do
+        expect { rule_memory.add_snapshot(:before_layout, true, '/foo.md') }
           .to raise_error(Nanoc::Int::Errors::CannotCreateMultipleSnapshotsWithSameName)
       end
     end

--- a/spec/nanoc/rule_dsl/recording_executor_spec.rb
+++ b/spec/nanoc/rule_dsl/recording_executor_spec.rb
@@ -29,19 +29,31 @@ describe Nanoc::RuleDSL::RecordingExecutor do
     it 'records layout call without arguments' do
       executor.layout(rep, '/default.*')
 
-      expect(executor.rule_memory.size).to eql(1)
-      expect(executor.rule_memory[0]).to be_a(Nanoc::Int::RuleMemoryActions::Layout)
-      expect(executor.rule_memory[0].layout_identifier).to eql('/default.*')
-      expect(executor.rule_memory[0].params).to eql({})
+      expect(executor.rule_memory.size).to eql(2)
+
+      expect(executor.rule_memory[0]).to be_a(Nanoc::Int::RuleMemoryActions::Snapshot)
+      expect(executor.rule_memory[0].snapshot_name).to eql(:pre)
+      expect(executor.rule_memory[0]).to be_final
+      expect(executor.rule_memory[0].path).to be_nil
+
+      expect(executor.rule_memory[1]).to be_a(Nanoc::Int::RuleMemoryActions::Layout)
+      expect(executor.rule_memory[1].layout_identifier).to eql('/default.*')
+      expect(executor.rule_memory[1].params).to eql({})
     end
 
     it 'records layout call with arguments' do
       executor.layout(rep, '/default.*', final: false)
 
-      expect(executor.rule_memory.size).to eql(1)
-      expect(executor.rule_memory[0]).to be_a(Nanoc::Int::RuleMemoryActions::Layout)
-      expect(executor.rule_memory[0].layout_identifier).to eql('/default.*')
-      expect(executor.rule_memory[0].params).to eql({ final: false })
+      expect(executor.rule_memory.size).to eql(2)
+
+      expect(executor.rule_memory[0]).to be_a(Nanoc::Int::RuleMemoryActions::Snapshot)
+      expect(executor.rule_memory[0].snapshot_name).to eql(:pre)
+      expect(executor.rule_memory[0]).to be_final
+      expect(executor.rule_memory[0].path).to be_nil
+
+      expect(executor.rule_memory[1]).to be_a(Nanoc::Int::RuleMemoryActions::Layout)
+      expect(executor.rule_memory[1].layout_identifier).to eql('/default.*')
+      expect(executor.rule_memory[1].params).to eql({ final: false })
     end
   end
 
@@ -167,6 +179,7 @@ describe Nanoc::RuleDSL::RecordingExecutor do
 
         it 'records' do
           subject
+
           expect(executor.rule_memory.size).to eql(1)
           expect(executor.rule_memory[0]).to be_a(Nanoc::Int::RuleMemoryActions::Snapshot)
           expect(executor.rule_memory[0].snapshot_name).to eql(:foo)
@@ -177,8 +190,14 @@ describe Nanoc::RuleDSL::RecordingExecutor do
         context 'explicit path given' do
           let(:path) { '/routed-foo.html' }
 
-          it 'errors' do
-            expect { subject }.to raise_error(Nanoc::RuleDSL::RecordingExecutor::NonFinalSnapshotWithPathError)
+          it 'records without path' do
+            subject
+
+            expect(executor.rule_memory.size).to eql(1)
+            expect(executor.rule_memory[0]).to be_a(Nanoc::Int::RuleMemoryActions::Snapshot)
+            expect(executor.rule_memory[0].snapshot_name).to eql(:foo)
+            expect(executor.rule_memory[0].path).to be_nil
+            expect(executor.rule_memory[0]).not_to be_final
           end
         end
 
@@ -202,8 +221,14 @@ describe Nanoc::RuleDSL::RecordingExecutor do
             allow(site).to receive(:config).and_return(double(:config))
           end
 
-          it 'errors' do
-            expect { subject }.to raise_error(Nanoc::RuleDSL::RecordingExecutor::NonFinalSnapshotWithPathError)
+          it 'records without path' do
+            subject
+
+            expect(executor.rule_memory.size).to eql(1)
+            expect(executor.rule_memory[0]).to be_a(Nanoc::Int::RuleMemoryActions::Snapshot)
+            expect(executor.rule_memory[0].snapshot_name).to eql(:foo)
+            expect(executor.rule_memory[0].path).to be_nil
+            expect(executor.rule_memory[0]).not_to be_final
           end
         end
       end

--- a/spec/nanoc/rule_dsl/rule_memory_calculator_spec.rb
+++ b/spec/nanoc/rule_dsl/rule_memory_calculator_spec.rb
@@ -31,7 +31,7 @@ describe(Nanoc::RuleDSL::RuleMemoryCalculator) do
       example do
         subject
 
-        expect(subject.size).to eql(7)
+        expect(subject.size).to eql(8)
 
         expect(subject[0]).to be_a(Nanoc::Int::RuleMemoryActions::Snapshot)
         expect(subject[0].snapshot_name).to eql(:raw)
@@ -47,23 +47,28 @@ describe(Nanoc::RuleDSL::RuleMemoryCalculator) do
         expect(subject[2].filter_name).to eql(:erb)
         expect(subject[2].params).to eql({ speed: :over_9000 })
 
-        expect(subject[3]).to be_a(Nanoc::Int::RuleMemoryActions::Layout)
-        expect(subject[3].layout_identifier).to eql('/default.*')
-        expect(subject[3].params).to be_nil
+        expect(subject[3]).to be_a(Nanoc::Int::RuleMemoryActions::Snapshot)
+        expect(subject[3].snapshot_name).to eql(:pre)
+        expect(subject[3]).to be_final
+        expect(subject[3].path).to be_nil
 
-        expect(subject[4]).to be_a(Nanoc::Int::RuleMemoryActions::Filter)
-        expect(subject[4].filter_name).to eql(:typohero)
-        expect(subject[4].params).to eql({})
+        expect(subject[4]).to be_a(Nanoc::Int::RuleMemoryActions::Layout)
+        expect(subject[4].layout_identifier).to eql('/default.*')
+        expect(subject[4].params).to be_nil
 
-        expect(subject[5]).to be_a(Nanoc::Int::RuleMemoryActions::Snapshot)
-        expect(subject[5].snapshot_name).to eql(:post)
-        expect(subject[5]).to be_final
-        expect(subject[5].path).to be_nil
+        expect(subject[5]).to be_a(Nanoc::Int::RuleMemoryActions::Filter)
+        expect(subject[5].filter_name).to eql(:typohero)
+        expect(subject[5].params).to eql({})
 
         expect(subject[6]).to be_a(Nanoc::Int::RuleMemoryActions::Snapshot)
-        expect(subject[6].snapshot_name).to eql(:last)
+        expect(subject[6].snapshot_name).to eql(:post)
         expect(subject[6]).to be_final
         expect(subject[6].path).to be_nil
+
+        expect(subject[7]).to be_a(Nanoc::Int::RuleMemoryActions::Snapshot)
+        expect(subject[7].snapshot_name).to eql(:last)
+        expect(subject[7]).to be_final
+        expect(subject[7].path).to be_nil
       end
     end
 
@@ -120,7 +125,7 @@ describe(Nanoc::RuleDSL::RuleMemoryCalculator) do
     end
 
     example do
-      expect(subject.size).to eql(4)
+      expect(subject.size).to eql(5)
 
       expect(subject[0]).to be_a(Nanoc::Int::SnapshotDef)
       expect(subject[0].name).to eql(:raw)
@@ -131,12 +136,16 @@ describe(Nanoc::RuleDSL::RuleMemoryCalculator) do
       expect(subject[1]).not_to be_final
 
       expect(subject[2]).to be_a(Nanoc::Int::SnapshotDef)
-      expect(subject[2].name).to eql(:post)
+      expect(subject[2].name).to eql(:pre)
       expect(subject[2]).to be_final
 
       expect(subject[3]).to be_a(Nanoc::Int::SnapshotDef)
-      expect(subject[3].name).to eql(:last)
+      expect(subject[3].name).to eql(:post)
       expect(subject[3]).to be_final
+
+      expect(subject[4]).to be_a(Nanoc::Int::SnapshotDef)
+      expect(subject[4].name).to eql(:last)
+      expect(subject[4]).to be_final
     end
   end
 end

--- a/test/base/test_compiler.rb
+++ b/test/base/test_compiler.rb
@@ -39,8 +39,6 @@ class Nanoc::Int::CompilerTest < Nanoc::TestCase
       File.write('content/moo.txt', '<%= 1 %> <%%= 2 %> <%%%= 3 %>')
       File.write('layouts/default.erb', 'head <%= yield %> foot')
 
-      # FIXME: :pre is broken (it’s always non-final)
-
       File.open('Rules', 'w') do |io|
         io.write "compile '/**/*' do\n"
         io.write "  filter :erb\n"
@@ -53,10 +51,10 @@ class Nanoc::Int::CompilerTest < Nanoc::TestCase
         io.write "  '/moo-raw.txt'\n"
         io.write "end\n"
         io.write "\n"
-        # io.write "route '/**/*', snapshot: :pre do\n"
-        # io.write "  '/moo-pre.txt'\n"
-        # io.write "end\n"
-        # io.write "\n"
+        io.write "route '/**/*', snapshot: :pre do\n"
+        io.write "  '/moo-pre.txt'\n"
+        io.write "end\n"
+        io.write "\n"
         io.write "route '/**/*', snapshot: :post do\n"
         io.write "  '/moo-post.txt'\n"
         io.write "end\n"


### PR DESCRIPTION
The `:pre` snapshot is not generated properly (it remains “non-final”). This PR fixes that.

The `NonFinalSnapshotWithPathError` error might need to be removed. I’ll try to keep it in (it’s useful) but getting it to work properly might be hard.

Fixes #762.