### PR TITLE
Fix using #compiled_content in layout

### DIFF
--- a/lib/nanoc/base/entities/item_rep.rb
+++ b/lib/nanoc/base/entities/item_rep.rb
@@ -69,7 +69,7 @@ module Nanoc::Int
       is_moving = [:pre, :post, :last].include?(snapshot_name)
 
       # Check existance of snapshot
-      snapshot_def = snapshot_defs.find { |sd| sd.name == snapshot_name }
+      snapshot_def = snapshot_defs.reverse.find { |sd| sd.name == snapshot_name }
       if !is_moving && (snapshot_def.nil? || !snapshot_def.final?)
         raise Nanoc::Int::Errors::NoSuchSnapshot.new(self, snapshot_name)
       end

--- a/spec/nanoc/regressions/gh_761_spec.rb
+++ b/spec/nanoc/regressions/gh_761_spec.rb
@@ -1,0 +1,23 @@
+describe 'GH-761', site: true do
+  before do
+    File.write('content/donkey.md', 'Compiled content donkey!')
+
+    File.write('layouts/foo.erb', '[<%= @item.compiled_content %>]')
+
+    File.write('Rules', <<EOS)
+  compile '/**/*' do
+    layout '/foo.*'
+    write '/donkey.html'
+  end
+
+  layout '/foo.*', :erb
+EOS
+  end
+
+  it 'supports #compiled_content instead of yield' do
+    site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    site.compile
+
+    expect(File.read('output/donkey.html')).to eql('[Compiled content donkey!]')
+  end
+end

--- a/test/base/test_item_rep.rb
+++ b/test/base/test_item_rep.rb
@@ -115,6 +115,27 @@ class Nanoc::Int::ItemRepTest < Nanoc::TestCase
     assert_equal 'pre!', rep.compiled_content(snapshot: :pre)
   end
 
+  def test_compiled_content_with_multiple_pre_snapshots
+    # Create rep
+    item = Nanoc::Int::Item.new(
+      'blah blah', {}, '/'
+    )
+    rep = Nanoc::Int::ItemRep.new(item, nil)
+    rep.expects(:compiled?).returns(false)
+    rep.snapshot_defs = [
+      Nanoc::Int::SnapshotDef.new(:pre, false),
+      Nanoc::Int::SnapshotDef.new(:pre, true),
+    ]
+    rep.snapshot_contents = {
+      pre: Nanoc::Int::TextualContent.new('pre!'),
+      post: Nanoc::Int::TextualContent.new('post!'),
+      last: Nanoc::Int::TextualContent.new('last!'),
+    }
+
+    # Check
+    assert_equal 'pre!', rep.compiled_content(snapshot: :pre)
+  end
+
   def test_access_compiled_content_of_binary_item
     content = Nanoc::Int::BinaryContent.new(File.expand_path('content/somefile.dat'))
     item = Nanoc::Int::Item.new(content, {}, '/somefile/')


### PR DESCRIPTION
Using `@item.compiled_content` in a layout broke in 4.1.0a1. This was caused by `#compiled_content` searching for the *first* snapshot with a given name (in this case, `:pre`) rather than the last one.

I’ve created a separate regression test in `spec/nanoc/regressions`. I haven’t done something like this before, but it seems sensible.

Fixes #761.