### PR TITLE
Fix finding parent of child of root

### DIFF
--- a/lib/nanoc/base/views/item_without_reps_view.rb
+++ b/lib/nanoc/base/views/item_without_reps_view.rb
@@ -29,9 +29,7 @@ module Nanoc
       end
 
       parent_identifier = '/' + unwrap.identifier.components[0..-2].join('/') + '/'
-
-      # FIXME: Fix this elsewhere
-      parent_identifier.sub!(/\/\/$/, '/')
+      parent_identifier = '/' if parent_identifier == '//'
 
       parent = @context.items[parent_identifier]
 

--- a/spec/nanoc/base/views/item_view_spec.rb
+++ b/spec/nanoc/base/views/item_view_spec.rb
@@ -59,6 +59,16 @@ describe Nanoc::ItemWithRepsView do
         end
 
         it { is_expected.to be_frozen }
+
+        context 'with root parent' do
+          let(:parent_item) { Nanoc::Int::Item.new('parent', {}, '/') }
+          let(:identifier) { Nanoc::Identifier.new('/me/', type: :legacy) }
+
+          it 'returns a view for the parent' do
+            expect(subject.class).to eql(Nanoc::ItemWithRepsView)
+            expect(subject.unwrap).to eql(parent_item)
+          end
+        end
       end
     end
 

--- a/spec/nanoc/regressions/gh_769_spec.rb
+++ b/spec/nanoc/regressions/gh_769_spec.rb
@@ -1,0 +1,30 @@
+describe 'GH-769', site: true do
+  before do
+    File.write('content/index.md', 'Index!')
+    File.write('content/donkey.md', 'Donkey! [<%= @item.parent.identifier %>]')
+
+    File.open('nanoc.yaml', 'w') do |io|
+      io << 'string_pattern_type: legacy' << "\n"
+      io << 'data_sources:' << "\n"
+      io << '  -' << "\n"
+      io << '    type: filesystem' << "\n"
+      io << '    identifier_type: legacy' << "\n"
+    end
+
+    File.write('Rules', <<EOS)
+  compile '*' do
+    filter :erb
+    write item.identifier + 'index.html'
+  end
+
+  layout '/foo.*', :erb
+EOS
+  end
+
+  it 'finds the parent if the parent is root' do
+    site = Nanoc::Int::SiteLoader.new.new_from_cwd
+    site.compile
+
+    expect(File.read('output/donkey/index.html')).to eql('Donkey! [/]')
+  end
+end


### PR DESCRIPTION
This was already fixed as part of another PR, but this PR adds tests.

Fixes #769.