### PR TITLE
Give Checks file a base path

### DIFF
--- a/lib/nanoc/extra/checking/dsl.rb
+++ b/lib/nanoc/extra/checking/dsl.rb
@@ -5,7 +5,7 @@ module Nanoc::Extra::Checking
 
     def self.from_file(filename)
       dsl = new
-      dsl.instance_eval File.read(filename)
+      dsl.instance_eval(File.read(filename), filename)
       dsl
     end
 

--- a/test/extra/checking/test_dsl.rb
+++ b/test/extra/checking/test_dsl.rb
@@ -11,4 +11,13 @@ class Nanoc::Extra::Checking::DSLTest < Nanoc::TestCase
       assert_equal [:bar], dsl.deploy_checks
     end
   end
+
+  def test_has_base_path
+    with_site do |_site|
+      File.write('stuff.rb', '$greeting = "hello"')
+      File.write('Checks', 'require "./stuff"')
+      Nanoc::Extra::Checking::DSL.from_file('Checks')
+      assert_equal 'hello', $greeting
+    end
+  end
 end


### PR DESCRIPTION
Relative requires do not work without a base path.