### PR TITLE
Pass in dependency tracker

### DIFF
--- a/lib/nanoc/base/compilation/dependency_tracker.rb
+++ b/lib/nanoc/base/compilation/dependency_tracker.rb
@@ -1,48 +1,38 @@
 module Nanoc::Int
   # @api private
   class DependencyTracker
+    class Null
+      def enter(_obj)
+      end
+
+      def exit(_obj)
+      end
+
+      def bounce(_obj)
+      end
+    end
+
     def initialize(dependency_store)
       @dependency_store = dependency_store
+      @stack = []
     end
 
-    # Record dependencies for the duration of the block.
-    #
-    # @return [void]
-    def run
-      unless block_given?
-        raise ArgumentError, 'No block given'
+    def enter(obj)
+      unless @stack.empty?
+        Nanoc::Int::NotificationCenter.post(:dependency_created, @stack.last, obj)
+        @dependency_store.record_dependency(@stack.last, obj)
       end
 
-      stack = []
-      start_tracking(stack)
-      yield
-    ensure
-      stop_tracking(stack)
+      @stack.push(obj)
     end
 
-    # @api private
-    def start_tracking(stack)
-      Nanoc::Int::NotificationCenter.on(:visit_started, self) do |obj|
-        unless stack.empty?
-          Nanoc::Int::NotificationCenter.post(:dependency_created, stack.last, obj)
-          @dependency_store.record_dependency(stack.last, obj)
-        end
-        stack.push(obj)
-      end
-
-      Nanoc::Int::NotificationCenter.on(:visit_ended, self) do |_obj|
-        stack.pop
-      end
+    def exit(_obj)
+      @stack.pop
     end
 
-    # @api private
-    def stop_tracking(stack)
-      unless stack.empty?
-        raise 'Internal inconsistency: dependency tracker stack not empty at end of compilation'
-      end
-
-      Nanoc::Int::NotificationCenter.remove(:visit_started, self)
-      Nanoc::Int::NotificationCenter.remove(:visit_ended,   self)
+    def bounce(obj)
+      enter(obj)
+      exit(obj)
     end
   end
 end

--- a/lib/nanoc/base/compilation/filter.rb
+++ b/lib/nanoc/base/compilation/filter.rb
@@ -187,10 +187,8 @@ module Nanoc
       items = items.map { |i| i.is_a?(Nanoc::ItemWithRepsView) ? i.unwrap : i }
 
       # Notify
-      items.each do |item|
-        Nanoc::Int::NotificationCenter.post(:visit_started, item)
-        Nanoc::Int::NotificationCenter.post(:visit_ended,   item)
-      end
+      dependency_tracker = @assigns[:item]._context.dependency_tracker
+      items.each { |item| dependency_tracker.bounce(item) }
 
       # Raise unmet dependency error if necessary
       items.each do |item|

--- a/lib/nanoc/base/views/item_rep_view.rb
+++ b/lib/nanoc/base/views/item_rep_view.rb
@@ -36,9 +36,7 @@ module Nanoc
     #
     # @return [String] The content at the given snapshot.
     def compiled_content(snapshot: nil)
-      Nanoc::Int::NotificationCenter.post(:visit_started, unwrap.item)
-      Nanoc::Int::NotificationCenter.post(:visit_ended,   unwrap.item)
-
+      @context.dependency_tracker.bounce(unwrap.item)
       @item_rep.compiled_content(snapshot: snapshot)
     end
 
@@ -52,9 +50,7 @@ module Nanoc
     #
     # @return [String] The item rep’s path.
     def path(snapshot: :last)
-      Nanoc::Int::NotificationCenter.post(:visit_started, unwrap.item)
-      Nanoc::Int::NotificationCenter.post(:visit_ended,   unwrap.item)
-
+      @context.dependency_tracker.bounce(unwrap.item)
       @item_rep.path(snapshot: snapshot)
     end
 
@@ -67,9 +63,7 @@ module Nanoc
 
     # @api private
     def raw_path(snapshot: :last)
-      Nanoc::Int::NotificationCenter.post(:visit_started, unwrap.item)
-      Nanoc::Int::NotificationCenter.post(:visit_ended,   unwrap.item)
-
+      @context.dependency_tracker.bounce(unwrap.item)
       @item_rep.raw_path(snapshot: snapshot)
     end
 

--- a/lib/nanoc/base/views/mixins/document_view_mixin.rb
+++ b/lib/nanoc/base/views/mixins/document_view_mixin.rb
@@ -32,24 +32,19 @@ module Nanoc
 
     # @see Hash#[]
     def [](key)
-      Nanoc::Int::NotificationCenter.post(:visit_started, unwrap)
-      Nanoc::Int::NotificationCenter.post(:visit_ended,   unwrap)
-
+      @context.dependency_tracker.bounce(unwrap)
       unwrap.attributes[key]
     end
 
     # @return [Hash]
     def attributes
-      Nanoc::Int::NotificationCenter.post(:visit_started, unwrap)
-      Nanoc::Int::NotificationCenter.post(:visit_ended,   unwrap)
-
+      @context.dependency_tracker.bounce(unwrap)
       unwrap.attributes
     end
 
     # @see Hash#fetch
     def fetch(key, fallback = NONE, &_block)
-      Nanoc::Int::NotificationCenter.post(:visit_started, unwrap)
-      Nanoc::Int::NotificationCenter.post(:visit_ended,   unwrap)
+      @context.dependency_tracker.bounce(unwrap)
 
       if unwrap.attributes.key?(key)
         unwrap.attributes[key]
@@ -66,9 +61,7 @@ module Nanoc
 
     # @see Hash#key?
     def key?(key)
-      Nanoc::Int::NotificationCenter.post(:visit_started, unwrap)
-      Nanoc::Int::NotificationCenter.post(:visit_ended,   unwrap)
-
+      @context.dependency_tracker.bounce(unwrap)
       unwrap.attributes.key?(key)
     end
 

--- a/lib/nanoc/base/views/view.rb
+++ b/lib/nanoc/base/views/view.rb
@@ -5,6 +5,7 @@ module Nanoc
       @context = context
     end
 
+    # @api private
     def _context
       @context
     end

--- a/lib/nanoc/base/views/view_context.rb
+++ b/lib/nanoc/base/views/view_context.rb
@@ -5,8 +5,7 @@ module Nanoc
     attr_reader :items
     attr_reader :dependency_tracker
 
-    # TODO: make dependency_tracker mandatory
-    def initialize(reps:, items:, dependency_tracker: nil)
+    def initialize(reps:, items:, dependency_tracker:)
       @reps = reps
       @items = items
       @dependency_tracker = dependency_tracker

--- a/lib/nanoc/base/views/view_context.rb
+++ b/lib/nanoc/base/views/view_context.rb
@@ -3,10 +3,13 @@ module Nanoc
   class ViewContext
     attr_reader :reps
     attr_reader :items
+    attr_reader :dependency_tracker
 
-    def initialize(reps:, items:)
+    # TODO: make dependency_tracker mandatory
+    def initialize(reps:, items:, dependency_tracker: nil)
       @reps = reps
       @items = items
+      @dependency_tracker = dependency_tracker
     end
   end
 end

--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -298,12 +298,6 @@ module Nanoc::CLI::Commands
         Nanoc::Int::NotificationCenter.on(:filtering_ended) do |rep, filter_name|
           puts "*** Ended filtering #{rep.inspect} with #{filter_name}"
         end
-        Nanoc::Int::NotificationCenter.on(:visit_started) do |item|
-          puts "*** Started visiting #{item.inspect}"
-        end
-        Nanoc::Int::NotificationCenter.on(:visit_ended) do |item|
-          puts "*** Ended visiting #{item.inspect}"
-        end
         Nanoc::Int::NotificationCenter.on(:dependency_created) do |src, dst|
           puts "*** Dependency created from #{src.inspect} onto #{dst.inspect}"
         end

--- a/lib/nanoc/extra/checking/check.rb
+++ b/lib/nanoc/extra/checking/check.rb
@@ -20,7 +20,7 @@ module Nanoc::Extra::Checking
       output_filenames = Dir[output_dir + '/**/*'].select { |f| File.file?(f) }
 
       # FIXME: ugly
-      view_context = site.compiler.create_view_context
+      view_context = site.compiler.create_view_context(Nanoc::Int::DependencyTracker::Null.new)
 
       context = {
         items: Nanoc::ItemCollectionWithRepsView.new(site.items, view_context),

--- a/lib/nanoc/helpers/capturing.rb
+++ b/lib/nanoc/helpers/capturing.rb
@@ -145,8 +145,8 @@ module Nanoc::Helpers
 
         # Create dependency
         if @item.nil? || item != @item.unwrap
-          Nanoc::Int::NotificationCenter.post(:visit_started, item)
-          Nanoc::Int::NotificationCenter.post(:visit_ended,   item)
+          dependency_tracker = @site._context.dependency_tracker
+          dependency_tracker.bounce(item)
 
           # This is an extremely ugly hack to get the compiler to recompile the
           # item from which we use content. For this, we need to manually edit

--- a/lib/nanoc/helpers/rendering.rb
+++ b/lib/nanoc/helpers/rendering.rb
@@ -80,8 +80,8 @@ module Nanoc::Helpers
       raise Nanoc::Int::Errors::UnknownLayout.new(identifier) if layout.nil?
 
       # Visit
-      Nanoc::Int::NotificationCenter.post(:visit_started, layout)
-      Nanoc::Int::NotificationCenter.post(:visit_ended,   layout)
+      dependency_tracker = @site._context.dependency_tracker
+      dependency_tracker.bounce(layout)
 
       # Capture content, if any
       captured_content = block_given? ? capture(&block) : nil

--- a/lib/nanoc/rule_dsl/action_provider.rb
+++ b/lib/nanoc/rule_dsl/action_provider.rb
@@ -48,7 +48,8 @@ module Nanoc::RuleDSL
     end
 
     def postprocess(site, reps)
-      view_context = Nanoc::ViewContext.new(reps: reps, items: site.items)
+      dependency_tracker = Nanoc::Int::DependencyTracker::Null.new
+      view_context = Nanoc::ViewContext.new(reps: reps, items: site.items, dependency_tracker: dependency_tracker)
       ctx = new_postprocessor_context(site, view_context)
 
       @rules_collection.postprocessors.each_value do |postprocessor|

--- a/lib/nanoc/rule_dsl/recording_executor.rb
+++ b/lib/nanoc/rule_dsl/recording_executor.rb
@@ -39,7 +39,9 @@ module Nanoc
         routing_rule = routing_rules[snapshot_name]
         return nil if routing_rule.nil?
 
-        basic_path = routing_rule.apply_to(rep, executor: nil, site: @site, view_context: nil)
+        dependency_tracker = Nanoc::Int::DependencyTracker::Null.new
+        view_context = Nanoc::ViewContext.new(reps: nil, items: nil, dependency_tracker: dependency_tracker)
+        basic_path = routing_rule.apply_to(rep, executor: nil, site: @site, view_context: view_context)
         if basic_path && !basic_path.start_with?('/')
           raise PathWithoutInitialSlashError.new(rep, basic_path)
         end

--- a/spec/nanoc/base/views/document_view_spec.rb
+++ b/spec/nanoc/base/views/document_view_spec.rb
@@ -1,7 +1,18 @@
 shared_examples 'a document view' do
+  let(:view) { described_class.new(document, view_context) }
+
+  let(:view_context) do
+    Nanoc::ViewContext.new(
+      reps: double(:reps),
+      items: double(:items),
+      dependency_tracker: dependency_tracker,
+    )
+  end
+
+  let(:dependency_tracker) { Nanoc::Int::DependencyTracker.new(double(:dependency_store)) }
+
   describe '#== and #eql?' do
     let(:document) { entity_class.new('content', {}, '/asdf/') }
-    let(:view) { described_class.new(document, nil) }
 
     context 'comparing with document with same identifier' do
       let(:other) { entity_class.new('content', {}, '/asdf/') }
@@ -51,13 +62,12 @@ shared_examples 'a document view' do
 
   describe '#[]' do
     let(:document) { entity_class.new('stuff', { animal: 'donkey' }, '/foo/') }
-    let(:view) { described_class.new(document, nil) }
 
     subject { view[key] }
 
     before do
-      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:visit_started, document).ordered
-      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:visit_ended, document).ordered
+      expect(dependency_tracker).to receive(:enter).with(document)
+      expect(dependency_tracker).to receive(:exit).with(document)
     end
 
     context 'with existant key' do
@@ -72,13 +82,9 @@ shared_examples 'a document view' do
   end
 
   describe '#attributes' do
+    # FIXME: rename :item to :document (and remove duplicate :view)
     let(:item) { entity_class.new('stuff', { animal: 'donkey' }, '/foo/') }
-    let(:view) { described_class.new(item, nil) }
-
-    before do
-      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:visit_started, item).ordered
-      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:visit_ended, item).ordered
-    end
+    let(:view) { described_class.new(item, view_context) }
 
     subject { view.attributes }
 
@@ -88,13 +94,9 @@ shared_examples 'a document view' do
   end
 
   describe '#fetch' do
+    # FIXME: rename :item to :document (and remove duplicate :view)
     let(:item) { entity_class.new('stuff', { animal: 'donkey' }, '/foo/') }
-    let(:view) { described_class.new(item, nil) }
-
-    before do
-      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:visit_started, item).ordered
-      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:visit_ended, item).ordered
-    end
+    let(:view) { described_class.new(item, view_context) }
 
     context 'with existant key' do
       let(:key) { :animal }
@@ -129,12 +131,6 @@ shared_examples 'a document view' do
 
   describe '#key?' do
     let(:document) { entity_class.new('stuff', { animal: 'donkey' }, '/foo/') }
-    let(:view) { described_class.new(document, nil) }
-
-    before do
-      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:visit_started, document).ordered
-      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:visit_ended, document).ordered
-    end
 
     subject { view.key?(key) }
 
@@ -151,7 +147,6 @@ shared_examples 'a document view' do
 
   describe '#hash' do
     let(:document) { double(:document, identifier: '/foo/') }
-    let(:view) { described_class.new(document, nil) }
 
     subject { view.hash }
 

--- a/spec/nanoc/base/views/document_view_spec.rb
+++ b/spec/nanoc/base/views/document_view_spec.rb
@@ -88,6 +88,11 @@ shared_examples 'a document view' do
 
     subject { view.attributes }
 
+    before do
+      expect(dependency_tracker).to receive(:enter).with(item)
+      expect(dependency_tracker).to receive(:exit).with(item)
+    end
+
     it 'returns attributes' do
       expect(subject).to eql(animal: 'donkey')
     end
@@ -97,6 +102,11 @@ shared_examples 'a document view' do
     # FIXME: rename :item to :document (and remove duplicate :view)
     let(:item) { entity_class.new('stuff', { animal: 'donkey' }, '/foo/') }
     let(:view) { described_class.new(item, view_context) }
+
+    before do
+      expect(dependency_tracker).to receive(:enter).with(item)
+      expect(dependency_tracker).to receive(:exit).with(item)
+    end
 
     context 'with existant key' do
       let(:key) { :animal }
@@ -133,6 +143,11 @@ shared_examples 'a document view' do
     let(:document) { entity_class.new('stuff', { animal: 'donkey' }, '/foo/') }
 
     subject { view.key?(key) }
+
+    before do
+      expect(dependency_tracker).to receive(:enter).with(document)
+      expect(dependency_tracker).to receive(:exit).with(document)
+    end
 
     context 'with existant key' do
       let(:key) { :animal }

--- a/spec/nanoc/base/views/item_rep_view_spec.rb
+++ b/spec/nanoc/base/views/item_rep_view_spec.rb
@@ -109,6 +109,11 @@ describe Nanoc::ItemRepView do
       Nanoc::Int::Item.new('content', {}, '/asdf.md')
     end
 
+    before do
+      expect(dependency_tracker).to receive(:enter).with(item)
+      expect(dependency_tracker).to receive(:exit).with(item)
+    end
+
     it { should eq('Hallo') }
   end
 
@@ -129,6 +134,11 @@ describe Nanoc::ItemRepView do
       Nanoc::Int::Item.new('content', {}, '/asdf.md')
     end
 
+    before do
+      expect(dependency_tracker).to receive(:enter).with(item)
+      expect(dependency_tracker).to receive(:exit).with(item)
+    end
+
     it { should eq('/about/') }
   end
 
@@ -147,6 +157,11 @@ describe Nanoc::ItemRepView do
 
     let(:item) do
       Nanoc::Int::Item.new('content', {}, '/asdf.md')
+    end
+
+    before do
+      expect(dependency_tracker).to receive(:enter).with(item)
+      expect(dependency_tracker).to receive(:exit).with(item)
     end
 
     it { should eq('output/about/index.html') }

--- a/spec/nanoc/base/views/item_rep_view_spec.rb
+++ b/spec/nanoc/base/views/item_rep_view_spec.rb
@@ -1,5 +1,9 @@
 describe Nanoc::ItemRepView do
-  let(:view_context) { double(:view_context) }
+  let(:view_context) { Nanoc::ViewContext.new(reps: reps, items: items, dependency_tracker: dependency_tracker) }
+
+  let(:reps) { double(:reps) }
+  let(:items) { double(:items) }
+  let(:dependency_tracker) { Nanoc::Int::DependencyTracker.new(double(:dependency_store)) }
 
   describe '#== and #eql?' do
     let(:item_rep) { Nanoc::Int::ItemRep.new(item, :jacques) }
@@ -38,7 +42,7 @@ describe Nanoc::ItemRepView do
 
     context 'comparing with item rep with same identifier' do
       let(:other_item) { double(:other_item, identifier: '/foo/') }
-      let(:other) { described_class.new(double(:other_item_rep, item: other_item, name: :jacques), nil) }
+      let(:other) { described_class.new(double(:other_item_rep, item: other_item, name: :jacques), view_context) }
 
       it 'is equal' do
         expect(view).to eq(other)
@@ -48,7 +52,7 @@ describe Nanoc::ItemRepView do
 
     context 'comparing with item rep with different identifier' do
       let(:other_item) { double(:other_item, identifier: '/bar/') }
-      let(:other) { described_class.new(double(:other_item_rep, item: other_item, name: :jacques), nil) }
+      let(:other) { described_class.new(double(:other_item_rep, item: other_item, name: :jacques), view_context) }
 
       it 'is not equal' do
         expect(view).not_to eq(other)
@@ -58,7 +62,7 @@ describe Nanoc::ItemRepView do
 
     context 'comparing with item rep with different name' do
       let(:other_item) { double(:other_item, identifier: '/foo/') }
-      let(:other) { described_class.new(double(:other_item_rep, item: other_item, name: :marvin), nil) }
+      let(:other) { described_class.new(double(:other_item_rep, item: other_item, name: :marvin), view_context) }
 
       it 'is not equal' do
         expect(view).not_to eq(other)
@@ -90,7 +94,7 @@ describe Nanoc::ItemRepView do
   describe '#compiled_content' do
     subject { view.compiled_content }
 
-    let(:view) { described_class.new(rep, nil) }
+    let(:view) { described_class.new(rep, view_context) }
 
     let(:rep) do
       Nanoc::Int::ItemRep.new(item, :default).tap do |ir|
@@ -105,20 +109,13 @@ describe Nanoc::ItemRepView do
       Nanoc::Int::Item.new('content', {}, '/asdf.md')
     end
 
-    before do
-      expect(Nanoc::Int::NotificationCenter).to receive(:post)
-        .with(:visit_started, item).ordered
-      expect(Nanoc::Int::NotificationCenter).to receive(:post)
-        .with(:visit_ended, item).ordered
-    end
-
     it { should eq('Hallo') }
   end
 
   describe '#path' do
     subject { view.path }
 
-    let(:view) { described_class.new(rep, nil) }
+    let(:view) { described_class.new(rep, view_context) }
 
     let(:rep) do
       Nanoc::Int::ItemRep.new(item, :default).tap do |ir|
@@ -132,20 +129,13 @@ describe Nanoc::ItemRepView do
       Nanoc::Int::Item.new('content', {}, '/asdf.md')
     end
 
-    before do
-      expect(Nanoc::Int::NotificationCenter).to receive(:post)
-        .with(:visit_started, item).ordered
-      expect(Nanoc::Int::NotificationCenter).to receive(:post)
-        .with(:visit_ended, item).ordered
-    end
-
     it { should eq('/about/') }
   end
 
   describe '#raw_path' do
     subject { view.raw_path }
 
-    let(:view) { described_class.new(rep, nil) }
+    let(:view) { described_class.new(rep, view_context) }
 
     let(:rep) do
       Nanoc::Int::ItemRep.new(item, :default).tap do |ir|
@@ -157,13 +147,6 @@ describe Nanoc::ItemRepView do
 
     let(:item) do
       Nanoc::Int::Item.new('content', {}, '/asdf.md')
-    end
-
-    before do
-      expect(Nanoc::Int::NotificationCenter).to receive(:post)
-        .with(:visit_started, item).ordered
-      expect(Nanoc::Int::NotificationCenter).to receive(:post)
-        .with(:visit_ended, item).ordered
     end
 
     it { should eq('output/about/index.html') }

--- a/spec/nanoc/base/views/item_view_spec.rb
+++ b/spec/nanoc/base/views/item_view_spec.rb
@@ -2,6 +2,11 @@ describe Nanoc::ItemWithRepsView do
   let(:entity_class) { Nanoc::Int::Item }
   it_behaves_like 'a document view'
 
+  let(:view_context) { Nanoc::ViewContext.new(reps: reps, items: items, dependency_tracker: dependency_tracker) }
+  let(:reps) { [] }
+  let(:items) { [] }
+  let(:dependency_tracker) { Nanoc::Int::DependencyTracker.new(double(:dependency_store)) }
+
   describe '#raw_content' do
     let(:item) { Nanoc::Int::Item.new('content', {}, '/asdf/') }
     let(:view) { described_class.new(item, nil) }
@@ -17,8 +22,6 @@ describe Nanoc::ItemWithRepsView do
     end
 
     let(:view) { described_class.new(item, view_context) }
-
-    let(:view_context) { Nanoc::ViewContext.new(reps: [], items: items) }
 
     let(:items) do
       Nanoc::Int::IdentifiableCollection.new({}).tap do |arr|
@@ -109,8 +112,6 @@ describe Nanoc::ItemWithRepsView do
 
     let(:view) { described_class.new(item, view_context) }
 
-    let(:view_context) { Nanoc::ViewContext.new(reps: [], items: items) }
-
     let(:items) do
       Nanoc::Int::IdentifiableCollection.new({}).tap do |arr|
         arr << item
@@ -158,7 +159,6 @@ describe Nanoc::ItemWithRepsView do
     end
 
     let(:view) { described_class.new(item, view_context) }
-    let(:view_context) { Nanoc::ViewContext.new(reps: reps, items: []) }
 
     subject { view.reps }
 
@@ -176,7 +176,6 @@ describe Nanoc::ItemWithRepsView do
     subject { view.compiled_content(params) }
 
     let(:view) { described_class.new(item, view_context) }
-    let(:view_context) { Nanoc::ViewContext.new(reps: reps, items: []) }
 
     let(:item) do
       Nanoc::Int::Item.new('content', {}, '/asdf/')
@@ -209,13 +208,6 @@ describe Nanoc::ItemWithRepsView do
     context 'requesting implicit default rep' do
       let(:params) { {} }
 
-      before do
-        expect(Nanoc::Int::NotificationCenter).to receive(:post)
-          .with(:visit_started, item).ordered
-        expect(Nanoc::Int::NotificationCenter).to receive(:post)
-          .with(:visit_ended, item).ordered
-      end
-
       it { is_expected.to eq('Pre Hallo') }
 
       context 'requesting explicit snapshot' do
@@ -227,13 +219,6 @@ describe Nanoc::ItemWithRepsView do
 
     context 'requesting explicit default rep' do
       let(:params) { { rep: :default } }
-
-      before do
-        expect(Nanoc::Int::NotificationCenter).to receive(:post)
-          .with(:visit_started, item).ordered
-        expect(Nanoc::Int::NotificationCenter).to receive(:post)
-          .with(:visit_ended, item).ordered
-      end
 
       it { is_expected.to eq('Pre Hallo') }
 
@@ -257,7 +242,6 @@ describe Nanoc::ItemWithRepsView do
     subject { view.path(params) }
 
     let(:view) { described_class.new(item, view_context) }
-    let(:view_context) { Nanoc::ViewContext.new(reps: reps, items: []) }
 
     let(:item) do
       Nanoc::Int::Item.new('content', {}, '/asdf.md')
@@ -281,13 +265,6 @@ describe Nanoc::ItemWithRepsView do
     context 'requesting implicit default rep' do
       let(:params) { {} }
 
-      before do
-        expect(Nanoc::Int::NotificationCenter).to receive(:post)
-          .with(:visit_started, item).ordered
-        expect(Nanoc::Int::NotificationCenter).to receive(:post)
-          .with(:visit_ended, item).ordered
-      end
-
       it { is_expected.to eq('/about/') }
 
       context 'requesting explicit snapshot' do
@@ -299,13 +276,6 @@ describe Nanoc::ItemWithRepsView do
 
     context 'requesting explicit default rep' do
       let(:params) { { rep: :default } }
-
-      before do
-        expect(Nanoc::Int::NotificationCenter).to receive(:post)
-          .with(:visit_started, item).ordered
-        expect(Nanoc::Int::NotificationCenter).to receive(:post)
-          .with(:visit_ended, item).ordered
-      end
 
       it { is_expected.to eq('/about/') }
 

--- a/spec/nanoc/base/views/item_view_spec.rb
+++ b/spec/nanoc/base/views/item_view_spec.rb
@@ -208,6 +208,11 @@ describe Nanoc::ItemWithRepsView do
     context 'requesting implicit default rep' do
       let(:params) { {} }
 
+      before do
+        expect(dependency_tracker).to receive(:enter).with(item)
+        expect(dependency_tracker).to receive(:exit).with(item)
+      end
+
       it { is_expected.to eq('Pre Hallo') }
 
       context 'requesting explicit snapshot' do
@@ -219,6 +224,11 @@ describe Nanoc::ItemWithRepsView do
 
     context 'requesting explicit default rep' do
       let(:params) { { rep: :default } }
+
+      before do
+        expect(dependency_tracker).to receive(:enter).with(item)
+        expect(dependency_tracker).to receive(:exit).with(item)
+      end
 
       it { is_expected.to eq('Pre Hallo') }
 
@@ -265,6 +275,11 @@ describe Nanoc::ItemWithRepsView do
     context 'requesting implicit default rep' do
       let(:params) { {} }
 
+      before do
+        expect(dependency_tracker).to receive(:enter).with(item)
+        expect(dependency_tracker).to receive(:exit).with(item)
+      end
+
       it { is_expected.to eq('/about/') }
 
       context 'requesting explicit snapshot' do
@@ -276,6 +291,11 @@ describe Nanoc::ItemWithRepsView do
 
     context 'requesting explicit default rep' do
       let(:params) { { rep: :default } }
+
+      before do
+        expect(dependency_tracker).to receive(:enter).with(item)
+        expect(dependency_tracker).to receive(:exit).with(item)
+      end
 
       it { is_expected.to eq('/about/') }
 

--- a/spec/nanoc/base/views/mutable_document_view_spec.rb
+++ b/spec/nanoc/base/views/mutable_document_view_spec.rb
@@ -1,7 +1,19 @@
 shared_examples 'a mutable document view' do
+  let(:view) { described_class.new(item, view_context) }
+
+  let(:view_context) do
+    Nanoc::ViewContext.new(
+      reps: double(:reps),
+      items: double(:items),
+      dependency_tracker: dependency_tracker,
+    )
+  end
+
+  let(:dependency_tracker) { Nanoc::Int::DependencyTracker.new(double(:dependency_store)) }
+
   describe '#[]=' do
+    # FIXME: rename :item to :document
     let(:item) { entity_class.new('content', {}, '/asdf/') }
-    let(:view) { described_class.new(item, nil) }
 
     it 'sets attributes' do
       view[:title] = 'Donkey'
@@ -31,7 +43,6 @@ shared_examples 'a mutable document view' do
 
   describe '#identifier=' do
     let(:item) { entity_class.new('content', {}, '/about.md') }
-    let(:view) { described_class.new(item, nil) }
 
     subject { view.identifier = arg }
 
@@ -64,7 +75,6 @@ shared_examples 'a mutable document view' do
 
   describe '#update_attributes' do
     let(:item) { entity_class.new('content', {}, '/asdf/') }
-    let(:view) { described_class.new(item, nil) }
 
     let(:update) { { friend: 'Giraffe' } }
 

--- a/spec/nanoc/helpers/blogging_spec.rb
+++ b/spec/nanoc/helpers/blogging_spec.rb
@@ -2,6 +2,11 @@ describe Nanoc::Helpers::Blogging do
   let(:ctx) { HelperContext.new(described_class) }
   let(:helper) { ctx.helper }
 
+  before do
+    allow(ctx.dependency_tracker).to receive(:enter)
+    allow(ctx.dependency_tracker).to receive(:exit)
+  end
+
   describe '#articles' do
     subject { helper.articles }
 

--- a/spec/nanoc/rule_dsl/rule_context_spec.rb
+++ b/spec/nanoc/rule_dsl/rule_context_spec.rb
@@ -13,7 +13,8 @@ describe(Nanoc::RuleDSL::RuleContext) do
   let(:site) { double(:site, items: items, layouts: layouts, config: config) }
   let(:executor) { double(:executor) }
   let(:reps) { double(:reps) }
-  let(:view_context) { Nanoc::ViewContext.new(reps: reps, items: items) }
+  let(:view_context) { Nanoc::ViewContext.new(reps: reps, items: items, dependency_tracker: dependency_tracker) }
+  let(:dependency_tracker) { double(:dependency_tracker) }
 
   describe '#initialize' do
     it 'wraps objects in view classes' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,11 +13,15 @@ end
 Nanoc::CLI.setup
 
 class HelperContext
+  attr_reader :dependency_tracker
+
   def initialize(mod)
+    @mod = mod
+
     @config = Nanoc::Int::Configuration.new
     @reps = Nanoc::Int::ItemRepRepo.new
     @items = Nanoc::Int::IdentifiableCollection.new(@config)
-    @mod = mod
+    @dependency_tracker = Nanoc::Int::DependencyTracker.new(Object.new)
   end
 
   def create_item(content, attributes, identifier, main: false)
@@ -47,7 +51,11 @@ class HelperContext
   private
 
   def view_context
-    Nanoc::ViewContext.new(reps: @reps, items: @items)
+    Nanoc::ViewContext.new(
+      reps: @reps,
+      items: @items,
+      dependency_tracker: @dependency_tracker,
+    )
   end
 
   def assigns

--- a/test/base/test_dependency_tracker.rb
+++ b/test/base/test_dependency_tracker.rb
@@ -86,23 +86,17 @@ class Nanoc::Int::DependencyTrackerTest < Nanoc::TestCase
     assert_contains_exactly [items[0]], store.objects_outdated_due_to(items[1])
   end
 
-  def test_start_and_stop
-    # Mock items
+  def test_enter_and_exit
     items = [mock, mock]
 
-    # Create
     store = Nanoc::Int::DependencyStore.new(items)
     tracker = Nanoc::Int::DependencyTracker.new(store)
 
-    # Start, do something and stop
-    tracker.run do
-      Nanoc::Int::NotificationCenter.post(:visit_started, items[0])
-      Nanoc::Int::NotificationCenter.post(:visit_started, items[1])
-      Nanoc::Int::NotificationCenter.post(:visit_ended,   items[1])
-      Nanoc::Int::NotificationCenter.post(:visit_ended,   items[0])
-    end
+    tracker.enter(items[0])
+    tracker.enter(items[1])
+    tracker.exit(items[1])
+    tracker.exit(items[0])
 
-    # Verify dependencies
     assert_contains_exactly [items[1]], store.objects_causing_outdatedness_of(items[0])
     assert_empty store.objects_causing_outdatedness_of(items[1])
   end

--- a/test/filters/test_less.rb
+++ b/test/filters/test_less.rb
@@ -1,8 +1,13 @@
 class Nanoc::Filters::LessTest < Nanoc::TestCase
+  def view_context
+    dependency_tracker = Nanoc::Int::DependencyTracker.new(nil)
+    Nanoc::ViewContext.new(reps: nil, items: nil, dependency_tracker: dependency_tracker)
+  end
+
   def test_filter
     if_have 'less' do
       # Create item
-      @item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'), nil)
+      @item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'), view_context)
 
       # Create filter
       filter = ::Nanoc::Filters::Less.new(item: @item, items: [@item])
@@ -20,7 +25,7 @@ class Nanoc::Filters::LessTest < Nanoc::TestCase
       File.open('content/foo/bar/imported_file.less', 'w') { |io| io.write('p { color: red; }') }
 
       # Create item
-      @item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'), nil)
+      @item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'), view_context)
 
       # Create filter
       filter = ::Nanoc::Filters::Less.new(item: @item, items: [@item])
@@ -39,7 +44,7 @@ class Nanoc::Filters::LessTest < Nanoc::TestCase
 
       # Create item
       File.open('content/foo/bar.txt', 'w') { |io| io.write('meh') }
-      @item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'), nil)
+      @item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'), view_context)
 
       # Create filter
       filter = ::Nanoc::Filters::Less.new(item: @item, items: [@item])
@@ -108,7 +113,7 @@ class Nanoc::Filters::LessTest < Nanoc::TestCase
   def test_compression
     if_have 'less' do
       # Create item
-      @item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'), nil)
+      @item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('blah', { content_filename: 'content/foo/bar.txt' }, '/foo/bar/'), view_context)
 
       # Create filter
       filter = ::Nanoc::Filters::Less.new(item: @item, items: [@item])

--- a/test/helpers/test_filtering.rb
+++ b/test/helpers/test_filtering.rb
@@ -1,6 +1,11 @@
 class Nanoc::Helpers::FilteringTest < Nanoc::TestCase
   include Nanoc::Helpers::Filtering
 
+  def view_context
+    dependency_tracker = Nanoc::Int::DependencyTracker.new(nil)
+    Nanoc::ViewContext.new(reps: nil, items: nil, dependency_tracker: dependency_tracker)
+  end
+
   def test_filter_simple
     if_have 'rubypants' do
       # Build content to be evaluated
@@ -11,7 +16,7 @@ class Nanoc::Helpers::FilteringTest < Nanoc::TestCase
 
       # Mock item and rep
       @item_rep = mock
-      @item_rep = Nanoc::ItemRepView.new(@item_rep, nil)
+      @item_rep = Nanoc::ItemRepView.new(@item_rep, view_context)
 
       # Evaluate content
       result = ::ERB.new(content).result(binding)
@@ -32,8 +37,8 @@ class Nanoc::Helpers::FilteringTest < Nanoc::TestCase
       item = Nanoc::Int::Item.new('stuff', { title: 'Bar...' }, '/foo.md')
       item_rep = Nanoc::Int::ItemRep.new(item, :default)
 
-      @item = Nanoc::ItemWithRepsView.new(item, nil)
-      @item_rep = Nanoc::ItemRepView.new(item_rep, nil)
+      @item = Nanoc::ItemWithRepsView.new(item, view_context)
+      @item_rep = Nanoc::ItemRepView.new(item_rep, view_context)
 
       result = ::ERB.new(content).result(binding)
 
@@ -64,7 +69,7 @@ class Nanoc::Helpers::FilteringTest < Nanoc::TestCase
 
       # Mock item and rep
       @item_rep = mock
-      @item_rep = Nanoc::ItemRepView.new(@item_rep, nil)
+      @item_rep = Nanoc::ItemRepView.new(@item_rep, view_context)
 
       # Evaluate content
       result = ::ERB.new(content).result(binding)
@@ -82,7 +87,7 @@ class Nanoc::Helpers::FilteringTest < Nanoc::TestCase
 
       # Mock item and rep
       @item_rep = mock
-      @item_rep = Nanoc::ItemRepView.new(@item_rep, nil)
+      @item_rep = Nanoc::ItemRepView.new(@item_rep, view_context)
 
       # Evaluate content
       result = ::Haml::Engine.new(content).render(binding)
@@ -102,7 +107,7 @@ class Nanoc::Helpers::FilteringTest < Nanoc::TestCase
 
     # Mock item and rep
     @item_rep = mock
-    @item_rep = Nanoc::ItemRepView.new(@item_rep, nil)
+    @item_rep = Nanoc::ItemRepView.new(@item_rep, view_context)
 
     ::ERB.new(content).result(binding)
 

--- a/test/helpers/test_rendering.rb
+++ b/test/helpers/test_rendering.rb
@@ -1,6 +1,11 @@
 class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
   include Nanoc::Helpers::Rendering
 
+  def view_context
+    dependency_tracker = Nanoc::Int::DependencyTracker.new(nil)
+    Nanoc::ViewContext.new(reps: nil, items: nil, dependency_tracker: dependency_tracker)
+  end
+
   def test_render
     with_site do |site|
       File.open('Rules', 'w') do |io|
@@ -12,8 +17,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
       end
 
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
-      @site = Nanoc::SiteView.new(site, nil)
-      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, nil)
+      @site = Nanoc::SiteView.new(site, view_context)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, view_context)
 
       assert_equal('This is the /foo/ layout.', render('/foo/'))
     end
@@ -30,8 +35,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
       end
 
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
-      @site = Nanoc::SiteView.new(site, nil)
-      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, nil)
+      @site = Nanoc::SiteView.new(site, view_context)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, view_context)
 
       assert_equal('This is the /foo/ layout.', render('/foo'))
     end
@@ -48,8 +53,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
       end
 
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
-      @site = Nanoc::SiteView.new(site, nil)
-      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, nil)
+      @site = Nanoc::SiteView.new(site, view_context)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, view_context)
 
       assert_equal('I am the Nanoc::LayoutView class.', render('/foo/'))
     end
@@ -66,8 +71,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
       end
 
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
-      @site = Nanoc::SiteView.new(site, nil)
-      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, nil)
+      @site = Nanoc::SiteView.new(site, view_context)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, view_context)
 
       assert_equal('I am the Nanoc::Int::Layout class.', render('/foo/'))
     end
@@ -76,8 +81,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
   def test_render_with_unknown_layout
     with_site do |site|
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
-      @site = Nanoc::SiteView.new(site, nil)
-      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, nil)
+      @site = Nanoc::SiteView.new(site, view_context)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, view_context)
 
       assert_raises(Nanoc::Int::Errors::UnknownLayout) do
         render '/dsfghjkl/'
@@ -94,8 +99,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
       File.open('layouts/foo.erb', 'w').close
 
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
-      @site = Nanoc::SiteView.new(site, nil)
-      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, nil)
+      @site = Nanoc::SiteView.new(site, view_context)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, view_context)
 
       assert_raises(Nanoc::Int::Errors::CannotDetermineFilter) do
         render '/foo/'
@@ -112,8 +117,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
       File.open('layouts/foo.erb', 'w').close
 
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
-      @site = Nanoc::SiteView.new(site, nil)
-      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, nil)
+      @site = Nanoc::SiteView.new(site, view_context)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, view_context)
 
       assert_raises(Nanoc::Int::Errors::UnknownFilter) do
         render '/foo/'
@@ -132,8 +137,8 @@ class Nanoc::Helpers::RenderingTest < Nanoc::TestCase
       end
 
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
-      @site = Nanoc::SiteView.new(site, nil)
-      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, nil)
+      @site = Nanoc::SiteView.new(site, view_context)
+      @layouts = Nanoc::LayoutCollectionView.new(site.layouts, view_context)
 
       _erbout = '[erbout-before]'
       result = render '/foo/' do

--- a/test/helpers/test_tagging.rb
+++ b/test/helpers/test_tagging.rb
@@ -1,9 +1,14 @@
 class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
   include Nanoc::Helpers::Tagging
 
+  def view_context
+    dependency_tracker = Nanoc::Int::DependencyTracker.new(nil)
+    Nanoc::ViewContext.new(reps: nil, items: nil, dependency_tracker: dependency_tracker)
+  end
+
   def test_tags_for_without_tags
     # Create item
-    item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('content', {}, '/path/'), nil)
+    item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('content', {}, '/path/'), view_context)
 
     # Check
     assert_equal(
@@ -14,7 +19,7 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
 
   def test_tags_for_with_custom_base_url
     # Create item
-    item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('content', { tags: %w(foo bar) }, '/path/'), nil)
+    item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('content', { tags: %w(foo bar) }, '/path/'), view_context)
 
     # Check
     assert_equal(
@@ -26,7 +31,7 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
 
   def test_tags_for_with_custom_none_text
     # Create item
-    item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('content', { tags: [] }, '/path/'), nil)
+    item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('content', { tags: [] }, '/path/'), view_context)
 
     # Check
     assert_equal(
@@ -37,7 +42,7 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
 
   def test_tags_for_with_custom_separator
     # Create item
-    item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('content', { tags: %w(foo bar) }, '/path/'), nil)
+    item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('content', { tags: %w(foo bar) }, '/path/'), view_context)
 
     # Check
     assert_equal(
@@ -49,7 +54,7 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
 
   def test_tags_for_without_base_url
     # Create item
-    item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('content', { tags: %w(foo bar) }, '/path/'), nil)
+    item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('content', { tags: %w(foo bar) }, '/path/'), view_context)
 
     # Check
     assert_equal('foo, bar', tags_for(item))
@@ -63,7 +68,7 @@ class Nanoc::Helpers::TaggingTest < Nanoc::TestCase
         Nanoc::Int::Item.new('item 2', { tags: [:bar]       }, '/item2/'),
         Nanoc::Int::Item.new('item 3', { tags: [:foo, :bar] }, '/item3/'),
       ],
-      nil,
+      view_context,
     )
 
     # Find items

--- a/test/helpers/test_xml_sitemap.rb
+++ b/test/helpers/test_xml_sitemap.rb
@@ -5,7 +5,8 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
     super
 
     @reps = Nanoc::Int::ItemRepRepo.new
-    @view_context = Nanoc::ViewContext.new(reps: @reps, items: nil)
+    dependency_tracker = Nanoc::Int::DependencyTracker.new(nil)
+    @view_context = Nanoc::ViewContext.new(reps: @reps, items: nil, dependency_tracker: dependency_tracker)
 
     @items = nil
     @item = nil


### PR DESCRIPTION
Rather than relying the dependency tracker of being available magically, and communicating with it through messages (notifications), inject the dependency tracker into the view context.

This is a step towards parallelism, because multiple parallel compilations will need their own dependency tracker—they can’t share the same stack used for dependency tracking.