### PR TITLE
Let #breadcrumbs_trail raise for full identifiers

### DIFF
--- a/lib/nanoc/helpers/breadcrumbs.rb
+++ b/lib/nanoc/helpers/breadcrumbs.rb
@@ -2,6 +2,12 @@ module Nanoc::Helpers
   # Provides support for breadcrumbs, which allow the user to go up in the
   # page hierarchy.
   module Breadcrumbs
+    class CannotGetBreadcrumbsForNonLegacyItem < Nanoc::Int::Errors::Generic
+      def initialize(identifier)
+        super("You cannot build a breadcrumbs trail for an item that has a “full” identifier (#{identifier}). Doing so is only possible for items that have a legacy identifier.")
+      end
+    end
+
     # Creates a breadcrumb trail leading from the current item to its parent,
     # to its parent’s parent, etc, until the root item is reached. This
     # function does not require that each intermediate item exist; for
@@ -11,6 +17,10 @@ module Nanoc::Helpers
     # @return [Array] The breadcrumbs, starting with the root item and ending
     #   with the item itself
     def breadcrumbs_trail
+      unless @item.identifier.legacy?
+        raise CannotGetBreadcrumbsForNonLegacyItem.new(@item.identifier)
+      end
+
       trail      = []
       idx_start  = 0
 

--- a/test/helpers/test_breadcrumbs.rb
+++ b/test/helpers/test_breadcrumbs.rb
@@ -3,7 +3,7 @@ class Nanoc::Helpers::BreadcrumbsTest < Nanoc::TestCase
 
   def test_breadcrumbs_trail_at_root
     @items = Nanoc::Int::IdentifiableCollection.new({})
-    item = Nanoc::Int::Item.new('root', {}, '/')
+    item = Nanoc::Int::Item.new('root', {}, Nanoc::Identifier.new('/', type: :legacy))
     @items << item
     @item = item
 
@@ -12,8 +12,8 @@ class Nanoc::Helpers::BreadcrumbsTest < Nanoc::TestCase
 
   def test_breadcrumbs_trail_with_1_parent
     @items = Nanoc::Int::IdentifiableCollection.new({})
-    parent_item = Nanoc::Int::Item.new('parent', {}, '/')
-    child_item  = Nanoc::Int::Item.new('child',  {}, '/foo/')
+    parent_item = Nanoc::Int::Item.new('parent', {}, Nanoc::Identifier.new('/', type: :legacy))
+    child_item  = Nanoc::Int::Item.new('child',  {}, Nanoc::Identifier.new('/foo/', type: :legacy))
     @items << parent_item
     @items << child_item
     @item = child_item
@@ -23,9 +23,9 @@ class Nanoc::Helpers::BreadcrumbsTest < Nanoc::TestCase
 
   def test_breadcrumbs_trail_with_many_parents
     @items = Nanoc::Int::IdentifiableCollection.new({})
-    grandparent_item = Nanoc::Int::Item.new('grandparent', {}, '/')
-    parent_item      = Nanoc::Int::Item.new('parent',      {}, '/foo/')
-    child_item       = Nanoc::Int::Item.new('child',       {}, '/foo/bar/')
+    grandparent_item = Nanoc::Int::Item.new('grandparent', {}, Nanoc::Identifier.new('/', type: :legacy))
+    parent_item      = Nanoc::Int::Item.new('parent',      {}, Nanoc::Identifier.new('/foo/', type: :legacy))
+    child_item       = Nanoc::Int::Item.new('child',       {}, Nanoc::Identifier.new('/foo/bar/', type: :legacy))
     @items << grandparent_item
     @items << parent_item
     @items << child_item
@@ -36,12 +36,25 @@ class Nanoc::Helpers::BreadcrumbsTest < Nanoc::TestCase
 
   def test_breadcrumbs_trail_with_nils
     @items = Nanoc::Int::IdentifiableCollection.new({})
-    grandparent_item = Nanoc::Int::Item.new('grandparent', {}, '/')
-    child_item       = Nanoc::Int::Item.new('child',       {}, '/foo/bar/')
+    grandparent_item = Nanoc::Int::Item.new('grandparent', {}, Nanoc::Identifier.new('/', type: :legacy))
+    child_item       = Nanoc::Int::Item.new('child',       {}, Nanoc::Identifier.new('/foo/bar/', type: :legacy))
     @items << grandparent_item
     @items << child_item
     @item = child_item
 
     assert_equal [grandparent_item, nil, child_item], breadcrumbs_trail
+  end
+
+  def test_breadcrumbs_trail_with_non_legacy_identifiers
+    @items = Nanoc::Int::IdentifiableCollection.new({})
+    parent_item = Nanoc::Int::Item.new('parent', {}, '/')
+    child_item  = Nanoc::Int::Item.new('child',  {}, '/foo/')
+    @items << parent_item
+    @items << child_item
+    @item = child_item
+
+    assert_raises Nanoc::Helpers::Breadcrumbs::CannotGetBreadcrumbsForNonLegacyItem do
+      breadcrumbs_trail
+    end
   end
 end


### PR DESCRIPTION
`#breadcrumbs_trail` will fail silently for full identifiers. To prevent that from happening, let’s make it raise an error.

Fixes #781.