### PR TITLE
Use snapshots for captured content

### DIFF
--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -232,7 +232,7 @@ module Nanoc::Int
 
     # @return [Boolean]
     def can_reuse_content_for_rep?(rep)
-      !rep.item.forced_outdated? && !outdatedness_checker.outdated?(rep) && compiled_content_cache[rep]
+      !outdatedness_checker.outdated?(rep) && compiled_content_cache[rep]
     end
 
     # @return [void]

--- a/lib/nanoc/base/entities/item.rb
+++ b/lib/nanoc/base/entities/item.rb
@@ -4,8 +4,6 @@ module Nanoc::Int
     # @see Document#initialize
     def initialize(content, attributes, identifier)
       super
-
-      @forced_outdated_status = ForcedOutdatedStatus.new
     end
 
     # Returns an object that can be used for uniquely identifying objects.
@@ -15,30 +13,6 @@ module Nanoc::Int
     # @return [Object] An unique reference to this object
     def reference
       [:item, identifier.to_s]
-    end
-
-    # Hack to allow a frozen item to still have modifiable frozen status.
-    #
-    # FIXME: Remove this.
-    class ForcedOutdatedStatus
-      attr_accessor :bool
-
-      def initialize
-        @bool = false
-      end
-
-      def freeze
-      end
-    end
-
-    # @api private
-    def forced_outdated=(bool)
-      @forced_outdated_status.bool = bool
-    end
-
-    # @api private
-    def forced_outdated?
-      @forced_outdated_status.bool
     end
   end
 end

--- a/lib/nanoc/base/entities/item_rep.rb
+++ b/lib/nanoc/base/entities/item_rep.rb
@@ -1,7 +1,7 @@
 module Nanoc::Int
   # @api private
   class ItemRep
-    # @return [Hash<Symbol,Nanoc::Int::Content]
+    # @return [Hash<Symbol,Nanoc::Int::Content>]
     attr_accessor :snapshot_contents
 
     # @return [Boolean]

--- a/lib/nanoc/helpers/capturing.rb
+++ b/lib/nanoc/helpers/capturing.rb
@@ -25,40 +25,6 @@ module Nanoc::Helpers
   #     <%= content_for(@item, :summary) || '(no summary)' %>
   #   </div>
   module Capturing
-    # @api private
-    class CapturesStore
-      def initialize
-        @store = {}
-      end
-
-      def []=(item, name, content)
-        @store[item.identifier] ||= {}
-        @store[item.identifier][name] = content
-      end
-
-      def [](item, name)
-        @store[item.identifier] ||= {}
-        @store[item.identifier][name]
-      end
-
-      def reset_for(item)
-        @store[item.identifier] = {}
-      end
-    end
-
-    class ::Nanoc::Int::Site
-      # @api private
-      def captures_store
-        @captures_store ||= CapturesStore.new
-      end
-
-      # @api private
-      def captures_store_compiled_items
-        require 'set'
-        @captures_store_compiled_items ||= Set.new
-      end
-    end
-
     # @overload content_for(name, params = {}, &block)
     #
     #   Captures the content inside the block and stores it so that it can be

--- a/test/helpers/test_capturing.rb
+++ b/test/helpers/test_capturing.rb
@@ -1,6 +1,20 @@
 class Nanoc::Helpers::CapturingTest < Nanoc::TestCase
   include Nanoc::Helpers::Capturing
 
+  def item_rep_repo_for(item)
+    Nanoc::Int::ItemRepRepo.new.tap do |repo|
+      repo << Nanoc::Int::ItemRep.new(item, :default)
+    end
+  end
+
+  def view_context_for(item)
+    Nanoc::ViewContext.new(
+      reps: item_rep_repo_for(item),
+      items: :__irrelevant__,
+      dependency_tracker: :__irrelevant__,
+    )
+  end
+
   def test_content_for
     require 'erb'
 
@@ -18,7 +32,7 @@ class Nanoc::Helpers::CapturingTest < Nanoc::TestCase
     site = Nanoc::Int::SiteLoader.new.new_empty
     item = Nanoc::Int::Item.new('moo', {}, '/blah/')
     @site = Nanoc::SiteView.new(Nanoc::Int::SiteLoader.new.new_empty, nil)
-    @item = Nanoc::ItemWithRepsView.new(item, nil)
+    @item = Nanoc::ItemWithRepsView.new(item, view_context_for(item))
 
     # Evaluate content
     result = ::ERB.new(content).result(binding)
@@ -33,7 +47,8 @@ class Nanoc::Helpers::CapturingTest < Nanoc::TestCase
 
     # Build site
     @site = Nanoc::SiteView.new(Nanoc::Int::SiteLoader.new.new_empty, nil)
-    @item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('moo', {}, '/blah/'), nil)
+    item = Nanoc::Int::Item.new('moo', {}, '/blah/')
+    @item = Nanoc::ItemWithRepsView.new(item, view_context_for(item))
 
     # Capture
     _erbout = 'foo'
@@ -67,7 +82,8 @@ foot
 EOS
 
     @site = Nanoc::SiteView.new(Nanoc::Int::SiteLoader.new.new_empty, nil)
-    @item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('content', {}, '/'), nil)
+    item = Nanoc::Int::Item.new('content', {}, '/')
+    @item = Nanoc::ItemWithRepsView.new(item, view_context_for(item))
 
     result = ::ERB.new(content).result(binding)
 
@@ -85,7 +101,8 @@ EOS
     end
 
     @site = Nanoc::SiteView.new(Nanoc::Int::SiteLoader.new.new_empty, nil)
-    @item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('content', {}, '/'), nil)
+    item = Nanoc::Int::Item.new('content', {}, '/')
+    @item = Nanoc::ItemWithRepsView.new(item, view_context_for(item))
     content = '<% content_for :a do %>Content One<% end %>'
     ::ERB.new(content).result(binding)
 
@@ -93,7 +110,8 @@ EOS
     assert_equal nil,           content_for(@item, :b)
 
     @site = Nanoc::SiteView.new(Nanoc::Int::SiteLoader.new.new_empty, nil)
-    @item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('content', {}, '/'), nil)
+    item = Nanoc::Int::Item.new('content', {}, '/')
+    @item = Nanoc::ItemWithRepsView.new(item, view_context_for(item))
     content = '<% content_for :b do %>Content Two<% end %>'
     ::ERB.new(content).result(binding)
 


### PR DESCRIPTION
By using snapshots for captured content rather than relying on a separate “captures store”, there will no longer be a need force-recompile an item when its captures are requested.

Goodbye, tech debt!