### PR TITLE
Preprocess in deploy/prune only

### DIFF
--- a/lib/nanoc/cli/command_runner.rb
+++ b/lib/nanoc/cli/command_runner.rb
@@ -22,7 +22,6 @@ module Nanoc::CLI
       @site ||= nil
       if self.is_in_site_dir? && @site.nil?
         @site = Nanoc::Int::SiteLoader.new.new_from_cwd
-        @site.compiler.action_provider.preprocess(@site)
       end
 
       @site

--- a/lib/nanoc/cli/commands/deploy.rb
+++ b/lib/nanoc/cli/commands/deploy.rb
@@ -14,6 +14,8 @@ module Nanoc::CLI::Commands
   class Deploy < ::Nanoc::CLI::CommandRunner
     def run
       load_site
+      # FIXME: ugly to preprocess here
+      site.compiler.action_provider.preprocess(site)
 
       # List deployers
       if options[:'list-deployers']

--- a/lib/nanoc/cli/commands/prune.rb
+++ b/lib/nanoc/cli/commands/prune.rb
@@ -16,6 +16,8 @@ module Nanoc::CLI::Commands
   class Prune < ::Nanoc::CLI::CommandRunner
     def run
       load_site
+      # FIXME: ugly to preprocess here
+      site.compiler.action_provider.preprocess(site)
       site.compiler.build_reps
 
       if options.key?(:yes)

--- a/spec/nanoc/regressions/gh_787_spec.rb
+++ b/spec/nanoc/regressions/gh_787_spec.rb
@@ -1,0 +1,19 @@
+describe 'GH-787', site: true, stdio: true do
+  before do
+    File.write('Rules', <<EOS)
+  preprocess do
+    @items.create('foo', {}, '/pig.md')
+  end
+
+  compile '/**/*' do
+    write '/oink.html'
+  end
+
+  layout '/foo.*', :erb
+EOS
+  end
+
+  it 'runs the preprocessor only once' do
+    expect { Nanoc::CLI.run(['compile']) }.not_to raise_error
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,21 @@ RSpec.configure do |c|
     end
   end
 
+  c.around(:each, stdio: true) do |example|
+    orig_stdout = $stdout
+    orig_stderr = $stderr
+
+    unless ENV['QUIET'] == 'false'
+      $stdout = StringIO.new
+      $stderr = StringIO.new
+    end
+
+    example.run
+
+    $stdout = orig_stdout
+    $stderr = orig_stderr
+  end
+
   c.before(:each, site: true) do
     FileUtils.mkdir_p('content')
     FileUtils.mkdir_p('layouts')


### PR DESCRIPTION
Running the preprocessor every time a site is loaded is problematic because invoking the `compile` command will run the preprocessor twice.

Fixes #787.