### PR TITLE
Avoid double calculation of checksum

### DIFF
--- a/lib/nanoc/base/compilation/outdatedness_checker.rb
+++ b/lib/nanoc/base/compilation/outdatedness_checker.rb
@@ -172,12 +172,20 @@ module Nanoc::Int
     end
     memoize :rule_memory_differs_for
 
+    # @param obj The object to create a checksum for
+    #
+    # @return [String] The digest
+    def calc_checksum(obj)
+      Nanoc::Int::Checksummer.calc(obj)
+    end
+    memoize :calc_checksum
+
     # @param obj
     #
     # @return [Boolean] false if either the new or the old checksum for the
     #   given object is not available, true if both checksums are available
     def checksums_available?(obj)
-      checksum_store[obj] && Nanoc::Int::Checksummer.calc(obj)
+      checksum_store[obj] && calc_checksum(obj)
     end
     memoize :checksums_available?
 
@@ -186,7 +194,7 @@ module Nanoc::Int
     # @return [Boolean] false if the old and new checksums for the given
     #   object differ, true if they are identical
     def checksums_identical?(obj)
-      checksum_store[obj] == Nanoc::Int::Checksummer.calc(obj)
+      checksum_store[obj] == calc_checksum(obj)
     end
     memoize :checksums_identical?
 


### PR DESCRIPTION
The new checksum of objects is currently calculated twice:

1. for `checksums_available?`
2. for `checksums_identical?`

Since checksum calculation can be costly, this commit memoizes its calculation.

This speeds up the compilation of my site with 20% in case of no changes.