### PR TITLE
Add checksum parameter to Document

### DIFF
--- a/lib/nanoc/base/checksummer.rb
+++ b/lib/nanoc/base/checksummer.rb
@@ -91,14 +91,18 @@ module Nanoc::Int
         when Nanoc::Int::BinaryContent
           update(Pathname.new(obj.filename), digest)
         when Nanoc::Int::Item, Nanoc::Int::Layout
-          digest.update('content=')
-          update(obj.content, digest)
+          if obj.checksum_data
+            digest.update('checksum_data=' + obj.checksum_data)
+          else
+            digest.update('content=')
+            update(obj.content, digest)
 
-          digest.update(',attributes=')
-          update(obj.attributes, digest, visited + [obj])
+            digest.update(',attributes=')
+            update(obj.attributes, digest, visited + [obj])
 
-          digest.update(',identifier=')
-          update(obj.identifier, digest)
+            digest.update(',identifier=')
+            update(obj.identifier, digest)
+          end
         when Nanoc::ItemWithRepsView, Nanoc::ItemWithoutRepsView, Nanoc::LayoutView, Nanoc::ConfigView, Nanoc::IdentifiableCollectionView
           update(obj.unwrap, digest)
         else

--- a/lib/nanoc/base/entities/document.rb
+++ b/lib/nanoc/base/entities/document.rb
@@ -11,15 +11,21 @@ module Nanoc
       # @return [Nanoc::Identifier]
       attr_accessor :identifier
 
+      # @return [String, nil]
+      attr_accessor :checksum_data
+
       # @param [String, Nanoc::Int::Content] content
       #
       # @param [Hash] attributes
       #
       # @param [String, Nanoc::Identifier] identifier
-      def initialize(content, attributes, identifier)
+      #
+      # @param [String, nil] checksum_data Used to determine whether the document has changed
+      def initialize(content, attributes, identifier, checksum_data: nil)
         @content = Nanoc::Int::Content.create(content)
         @attributes = attributes.__nanoc_symbolize_keys_recursively
         @identifier = Nanoc::Identifier.from(identifier)
+        @checksum_data = checksum_data
       end
 
       # @return [void]

--- a/lib/nanoc/base/repos/data_source.rb
+++ b/lib/nanoc/base/repos/data_source.rb
@@ -139,9 +139,11 @@ module Nanoc
     # @param [String] identifier This item's identifier.
     #
     # @param [Boolean] binary Whether or not this item is binary
-    def new_item(content, attributes, identifier, binary: false)
+    #
+    # @param [String, nil] checksum_data Used to determine whether the item has changed
+    def new_item(content, attributes, identifier, binary: false, checksum_data: nil)
       content = Nanoc::Int::Content.create(content, binary: binary)
-      Nanoc::Int::Item.new(content, attributes, identifier)
+      Nanoc::Int::Item.new(content, attributes, identifier, checksum_data: checksum_data)
     end
 
     # Creates a new in-memory layout instance. This is intended for use within
@@ -152,8 +154,10 @@ module Nanoc
     # @param [Hash] attributes A hash containing this layout's attributes.
     #
     # @param [String] identifier This layout's identifier.
-    def new_layout(raw_content, attributes, identifier)
-      Nanoc::Int::Layout.new(raw_content, attributes, identifier)
+    #
+    # @param [String, nil] checksum_data Used to determine whether the layout has changed
+    def new_layout(raw_content, attributes, identifier, checksum_data: nil)
+      Nanoc::Int::Layout.new(raw_content, attributes, identifier, checksum_data: checksum_data)
     end
   end
 end

--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -61,7 +61,8 @@ module Nanoc::DataSources
           elsif is_binary && klass == Nanoc::Int::Layout
             raise "The layout file '#{content_filename}' is a binary file, but layouts can only be textual"
           else
-            meta, content_or_filename = parse(content_filename, meta_filename, kind)
+            meta, content_or_filename, meta_raw = parse(content_filename, meta_filename, kind)
+            checksum_data = "content=#{content_or_filename},meta=#{meta_raw}"
           end
 
           # Get attributes
@@ -105,7 +106,7 @@ module Nanoc::DataSources
             end
 
           # Create object
-          res << klass.new(content, attributes, identifier)
+          res << klass.new(content, attributes, identifier, checksum_data: checksum_data)
         end
       end
 
@@ -207,8 +208,8 @@ module Nanoc::DataSources
     end
 
     # Parses the file named `filename` and returns an array with its first
-    # element a hash with the file's metadata, and with its second element the
-    # file content itself.
+    # element a hash with the file's metadata, its second element the
+    # file content itself, and its third element the metadata content.
     def parse(content_filename, meta_filename, _kind)
       # Read content and metadata from separate files
       if meta_filename
@@ -249,7 +250,7 @@ module Nanoc::DataSources
       content = pieces[4]
 
       # Done
-      [meta, content]
+      [meta, content, meta_raw]
     end
 
     class InvalidMetadataError < Nanoc::Error

--- a/spec/nanoc/base/checksummer_spec.rb
+++ b/spec/nanoc/base/checksummer_spec.rb
@@ -190,6 +190,12 @@ describe Nanoc::Int::Checksummer do
 
       it { is_expected.to eql('Nanoc::Int::Item<content=Nanoc::Int::TextualContent<String<asdf>>,attributes=Hash<Symbol<foo>=Nanoc::Int::Item<recur>,>,identifier=Nanoc::Identifier<String</foo.md>>>') }
     end
+
+    context 'with checksum' do
+      let(:obj) { Nanoc::Int::Item.new('asdf', { 'foo' => 'bar' }, '/foo.md', checksum_data: 'abcdef') }
+
+      it { is_expected.to eql('Nanoc::Int::Item<checksum_data=abcdef>') }
+    end
   end
 
   context 'Nanoc::Int::Layout' do
@@ -203,6 +209,12 @@ describe Nanoc::Int::Checksummer do
       end
 
       it { is_expected.to eql('Nanoc::Int::Layout<content=Nanoc::Int::TextualContent<String<asdf>>,attributes=Hash<Symbol<foo>=Nanoc::Int::Layout<recur>,>,identifier=Nanoc::Identifier<String</foo.md>>>') }
+    end
+
+    context 'with checksum' do
+      let(:obj) { Nanoc::Int::Layout.new('asdf', { 'foo' => 'bar' }, '/foo.md', checksum_data: 'abcdef') }
+
+      it { is_expected.to eql('Nanoc::Int::Layout<checksum_data=abcdef>') }
     end
   end
 

--- a/spec/nanoc/base/entities/document_spec.rb
+++ b/spec/nanoc/base/entities/document_spec.rb
@@ -3,8 +3,9 @@ shared_examples 'a document' do
     let(:content_arg) { 'Hello world' }
     let(:attributes_arg) { { 'title' => 'Home' } }
     let(:identifier_arg) { '/home.md' }
+    let(:checksum_data_arg) { 'abcdef' }
 
-    subject { described_class.new(content_arg, attributes_arg, identifier_arg) }
+    subject { described_class.new(content_arg, attributes_arg, identifier_arg, checksum_data: checksum_data_arg) }
 
     describe 'content arg' do
       context 'string' do
@@ -43,6 +44,12 @@ shared_examples 'a document' do
         it 'retains identifier' do
           expect(subject.identifier).to equal(identifier_arg)
         end
+      end
+    end
+
+    describe 'checksum_data arg' do
+      it 'reuses checksum_data' do
+        expect(subject.checksum_data).to eql(checksum_data_arg)
       end
     end
   end

--- a/test/base/test_data_source.rb
+++ b/test/base/test_data_source.rb
@@ -33,18 +33,20 @@ class Nanoc::DataSourceTest < Nanoc::TestCase
   def test_new_item
     data_source = Nanoc::DataSource.new(nil, nil, nil, nil)
 
-    item = data_source.new_item('stuff', { title: 'Stuff!' }, '/asdf/')
+    item = data_source.new_item('stuff', { title: 'Stuff!' }, '/asdf/', checksum_data: 'abcdef')
     assert_equal 'stuff', item.content.string
     assert_equal 'Stuff!', item.attributes[:title]
     assert_equal Nanoc::Identifier.new('/asdf/'), item.identifier
+    assert_equal 'abcdef', item.checksum_data
   end
 
   def test_new_layout
     data_source = Nanoc::DataSource.new(nil, nil, nil, nil)
 
-    layout = data_source.new_layout('stuff', { title: 'Stuff!' }, '/asdf/')
+    layout = data_source.new_layout('stuff', { title: 'Stuff!' }, '/asdf/', checksum_data: 'abcdef')
     assert_equal 'stuff', layout.content.string
     assert_equal 'Stuff!', layout.attributes[:title]
     assert_equal Nanoc::Identifier.new('/asdf/'), layout.identifier
+    assert_equal 'abcdef', layout.checksum_data
   end
 end


### PR DESCRIPTION
As suggested in #790, this pull request allows a `Document` to specify a pre-calculated checksum. This gives data sources the ability to determine a checksum for the items and layouts they create.
This pull request:

- adds a `checksum` parameter to the initializer of `Document` (as well as `new_item` and `new_layout`)
- modifies `Checksummer` to use the `checksum` on `Item` and `Layout` if present
- modifies the filesystem datasource to set the size/modification time as checksum

This realizes a major compilation speed gain for my website (from 11s to 3s if nothing is changed), and paves the way for lazy loading of items, which could bring down compilation time even further.