### PR TITLE
Freeze views

### DIFF
--- a/lib/nanoc/base/entities/configuration.rb
+++ b/lib/nanoc/base/entities/configuration.rb
@@ -88,7 +88,8 @@ module Nanoc::Int
       self
     end
 
-    def __nanoc_freeze_recursively
+    def freeze
+      super
       @wrapped.__nanoc_freeze_recursively
     end
 

--- a/lib/nanoc/base/entities/identifiable_collection.rb
+++ b/lib/nanoc/base/entities/identifiable_collection.rb
@@ -18,6 +18,7 @@ module Nanoc::Int
 
     def freeze
       @objects.freeze
+      @objects.each(&:freeze)
       build_mapping
       super
     end

--- a/lib/nanoc/base/entities/site.rb
+++ b/lib/nanoc/base/entities/site.rb
@@ -41,9 +41,10 @@ module Nanoc::Int
     #
     # @return [void]
     def freeze
-      config.__nanoc_freeze_recursively
-      items.each(&:freeze)
-      layouts.each(&:freeze)
+      config.freeze
+      items.freeze
+      layouts.freeze
+      code_snippets.__nanoc_freeze_recursively
     end
 
     def ensure_identifier_uniqueness(objects, type)

--- a/lib/nanoc/base/views/item_without_reps_view.rb
+++ b/lib/nanoc/base/views/item_without_reps_view.rb
@@ -33,7 +33,7 @@ module Nanoc
 
       parent = @context.items[parent_identifier]
 
-      parent && self.class.new(parent, @context).freeze
+      parent && self.class.new(parent, @context)
     end
 
     # @return [Boolean] True if the item is binary, false otherwise

--- a/lib/nanoc/base/views/view.rb
+++ b/lib/nanoc/base/views/view.rb
@@ -8,5 +8,19 @@ module Nanoc
     def _context
       @context
     end
+
+    # @api private
+    def unwrap
+      raise NotImplementedError
+    end
+
+    # True if the wrapped object is frozen; false otherwise.
+    #
+    # @return [Boolean]
+    #
+    # @see Object#frozen?
+    def frozen?
+      unwrap.frozen?
+    end
   end
 end

--- a/spec/nanoc/base/entities/site_spec.rb
+++ b/spec/nanoc/base/entities/site_spec.rb
@@ -1,0 +1,73 @@
+describe Nanoc::Int::Site do
+  describe '#freeze' do
+    let(:site) do
+      described_class.new(
+        config: config,
+        code_snippets: code_snippets,
+        items: items,
+        layouts: layouts,
+      )
+    end
+
+    let(:config) do
+      Nanoc::Int::Configuration.new.with_defaults
+    end
+
+    let(:code_snippets) do
+      [
+        Nanoc::Int::CodeSnippet.new('FOO = 123', 'hello.rb'),
+        Nanoc::Int::CodeSnippet.new('BAR = 123', 'hi.rb'),
+      ]
+    end
+
+    let(:items) do
+      Nanoc::Int::IdentifiableCollection.new(config).tap do |coll|
+        coll << Nanoc::Int::Item.new('foo', {}, '/foo.md')
+        coll << Nanoc::Int::Item.new('bar', {}, '/bar.md')
+      end
+    end
+
+    let(:layouts) do
+      Nanoc::Int::IdentifiableCollection.new(config).tap do |coll|
+        coll << Nanoc::Int::Layout.new('foo', {}, '/foo.md')
+        coll << Nanoc::Int::Layout.new('bar', {}, '/bar.md')
+      end
+    end
+
+    before do
+      site.freeze
+    end
+
+    it 'freezes the configuration' do
+      expect(site.config).to be_frozen
+    end
+
+    it 'freezes the configuration contents' do
+      expect(site.config[:output_dir]).to be_frozen
+    end
+
+    it 'freezes items collection' do
+      expect(site.items).to be_frozen
+    end
+
+    it 'freezes individual items' do
+      expect(site.items).to all(be_frozen)
+    end
+
+    it 'freezes layouts collection' do
+      expect(site.layouts).to be_frozen
+    end
+
+    it 'freezes individual layouts' do
+      expect(site.layouts).to all(be_frozen)
+    end
+
+    it 'freezes code snippets collection' do
+      expect(site.code_snippets).to be_frozen
+    end
+
+    it 'freezes individual code snippets' do
+      expect(site.code_snippets).to all(be_frozen)
+    end
+  end
+end

--- a/spec/nanoc/base/views/config_view_spec.rb
+++ b/spec/nanoc/base/views/config_view_spec.rb
@@ -5,6 +5,19 @@ describe Nanoc::ConfigView do
 
   let(:view) { described_class.new(config, nil) }
 
+  describe '#frozen?' do
+    subject { view.frozen? }
+
+    context 'non-frozen config' do
+      it { is_expected.to be(false) }
+    end
+
+    context 'frozen config' do
+      before { config.freeze }
+      it { is_expected.to be(true) }
+    end
+  end
+
   describe '#[]' do
     subject { view[key] }
 

--- a/spec/nanoc/base/views/document_view_spec.rb
+++ b/spec/nanoc/base/views/document_view_spec.rb
@@ -1,4 +1,20 @@
 shared_examples 'a document view' do
+  describe '#frozen?' do
+    let(:document) { entity_class.new('content', {}, '/asdf/') }
+    let(:view) { described_class.new(document, nil) }
+
+    subject { view.frozen? }
+
+    context 'non-frozen document' do
+      it { is_expected.to be(false) }
+    end
+
+    context 'frozen document' do
+      before { document.freeze }
+      it { is_expected.to be(true) }
+    end
+  end
+
   describe '#== and #eql?' do
     let(:document) { entity_class.new('content', {}, '/asdf/') }
     let(:view) { described_class.new(document, nil) }

--- a/spec/nanoc/base/views/identifiable_collection_view_spec.rb
+++ b/spec/nanoc/base/views/identifiable_collection_view_spec.rb
@@ -8,6 +8,30 @@ shared_examples 'an identifiable collection' do
     { string_pattern_type: 'glob' }
   end
 
+  describe '#frozen?' do
+    let(:wrapped) do
+      Nanoc::Int::IdentifiableCollection.new(config).tap do |arr|
+        arr << double(:identifiable, identifier: Nanoc::Identifier.new('/foo'))
+        arr << double(:identifiable, identifier: Nanoc::Identifier.new('/bar'))
+      end
+    end
+
+    subject { view.frozen? }
+
+    context 'non-frozen collection' do
+      it { is_expected.to be(false) }
+    end
+
+    context 'frozen collection' do
+      before do
+        wrapped.each { |o| expect(o).to receive(:freeze) }
+        wrapped.freeze
+      end
+
+      it { is_expected.to be(true) }
+    end
+  end
+
   describe '#unwrap' do
     let(:wrapped) do
       Nanoc::Int::IdentifiableCollection.new(config).tap do |arr|

--- a/spec/nanoc/base/views/item_rep_collection_view_spec.rb
+++ b/spec/nanoc/base/views/item_rep_collection_view_spec.rb
@@ -17,6 +17,19 @@ describe Nanoc::ItemRepCollectionView do
     it { should equal(wrapped) }
   end
 
+  describe '#frozen?' do
+    subject { view.frozen? }
+
+    context 'non-frozen collection' do
+      it { is_expected.to be(false) }
+    end
+
+    context 'frozen collection' do
+      before { wrapped.freeze }
+      it { is_expected.to be(true) }
+    end
+  end
+
   describe '#each' do
     it 'yields' do
       actual = [].tap { |res| view.each { |v| res << v } }

--- a/spec/nanoc/base/views/item_rep_view_spec.rb
+++ b/spec/nanoc/base/views/item_rep_view_spec.rb
@@ -1,6 +1,23 @@
 describe Nanoc::ItemRepView do
   let(:view_context) { double(:view_context) }
 
+  describe '#frozen?' do
+    let(:item_rep) { Nanoc::Int::ItemRep.new(item, :jacques) }
+    let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo/') }
+    let(:view) { described_class.new(item_rep, view_context) }
+
+    subject { view.frozen? }
+
+    context 'non-frozen item rep' do
+      it { is_expected.to be(false) }
+    end
+
+    context 'frozen item rep' do
+      before { item_rep.freeze }
+      it { is_expected.to be(true) }
+    end
+  end
+
   describe '#== and #eql?' do
     let(:item_rep) { Nanoc::Int::ItemRep.new(item, :jacques) }
     let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo/') }

--- a/spec/nanoc/base/views/item_view_spec.rb
+++ b/spec/nanoc/base/views/item_view_spec.rb
@@ -58,7 +58,14 @@ describe Nanoc::ItemWithRepsView do
           expect(subject._context).to equal(view_context)
         end
 
-        it { is_expected.to be_frozen }
+        context 'frozen parent' do
+          before { parent_item.freeze }
+          it { is_expected.to be_frozen }
+        end
+
+        context 'non-frozen parent' do
+          it { is_expected.not_to be_frozen }
+        end
 
         context 'with root parent' do
           let(:parent_item) { Nanoc::Int::Item.new('parent', {}, '/') }

--- a/spec/nanoc/regressions/gh_795_spec.rb
+++ b/spec/nanoc/regressions/gh_795_spec.rb
@@ -1,0 +1,19 @@
+describe 'GH-795', site: true, stdio: true do
+  before do
+    File.write('content/items.md', 'Frozen? <%= @items.unwrap.frozen? %>!')
+    File.write('content/items-view.md', 'Frozen? <%= @items.frozen? %>!')
+    File.write('Rules', <<EOS)
+  compile '/**/*' do
+    filter :erb
+    write item.identifier.without_ext + '.html'
+  end
+EOS
+  end
+
+  it 'freezes @items' do
+    Nanoc::CLI.run(['compile'])
+
+    expect(File.read('output/items.html')).to eql('Frozen? true!')
+    expect(File.read('output/items-view.html')).to eql('Frozen? true!')
+  end
+end


### PR DESCRIPTION
This ensures that views are marked as frozen when their backing entity is marked as frozen.

In order for this to work, the item and layout collections needed to be frozen; only their contents were frozen until now. In addition, code snippets are now frozen as well.

Fixes #795.