### PR TITLE
Pass view context with dependency tracker to rule mem calculator

### DIFF
--- a/lib/nanoc/rule_dsl/rule_memory_calculator.rb
+++ b/lib/nanoc/rule_dsl/rule_memory_calculator.rb
@@ -59,12 +59,15 @@ module Nanoc::RuleDSL
     def new_rule_memory_for_rep(rep)
       # FIXME: What if #compilation_rule_for returns nil?
 
+      dependency_tracker = Nanoc::Int::DependencyTracker::Null.new
+      view_context = @site.compiler.create_view_context(dependency_tracker)
+
       executor = Nanoc::RuleDSL::RecordingExecutor.new(rep, @rules_collection, @site)
       rule = @rules_collection.compilation_rule_for(rep)
 
       executor.snapshot(rep, :raw)
       executor.snapshot(rep, :pre, final: false)
-      rule.apply_to(rep, executor: executor, site: @site, view_context: nil)
+      rule.apply_to(rep, executor: executor, site: @site, view_context: view_context)
       if executor.rule_memory.any_layouts?
         executor.snapshot(rep, :post)
       end

--- a/spec/nanoc/regressions/gh_807_spec.rb
+++ b/spec/nanoc/regressions/gh_807_spec.rb
@@ -1,0 +1,17 @@
+describe 'GH-897', site: true, stdio: true do
+  before do
+    File.write('content/item.md', 'Stuff!')
+    File.write('Rules', <<EOS)
+  compile '/**/*' do
+    filter :erb if item[:dynamic]
+    write item.identifier.without_ext + '.html'
+  end
+EOS
+  end
+
+  it 'does not crash' do
+    Nanoc::CLI.run(['compile'])
+
+    expect(File.read('output/item.html')).to eql('Stuff!')
+  end
+end

--- a/spec/nanoc/rule_dsl/rule_memory_calculator_spec.rb
+++ b/spec/nanoc/rule_dsl/rule_memory_calculator_spec.rb
@@ -16,7 +16,9 @@ describe(Nanoc::RuleDSL::RuleMemoryCalculator) do
       let(:config) { Nanoc::Int::Configuration.new.with_defaults }
       let(:items) { Nanoc::Int::IdentifiableCollection.new(config) }
       let(:layouts) { Nanoc::Int::IdentifiableCollection.new(config) }
-      let(:site) { double(:site, items: items, layouts: layouts, config: config) }
+      let(:site) { double(:site, items: items, layouts: layouts, config: config, compiler: compiler) }
+      let(:compiler) { double(:compiler) }
+      let(:view_context) { double(:view_context) }
 
       before do
         rules_proc = proc do
@@ -26,6 +28,8 @@ describe(Nanoc::RuleDSL::RuleMemoryCalculator) do
         end
         rule = Nanoc::RuleDSL::Rule.new(Nanoc::Int::Pattern.from('/list.*'), :csv, rules_proc)
         rules_collection.add_item_compilation_rule(rule)
+
+        expect(compiler).to receive(:create_view_context).and_return(view_context)
       end
 
       example do
@@ -112,7 +116,9 @@ describe(Nanoc::RuleDSL::RuleMemoryCalculator) do
     let(:config) { Nanoc::Int::Configuration.new.with_defaults }
     let(:items) { Nanoc::Int::IdentifiableCollection.new(config) }
     let(:layouts) { Nanoc::Int::IdentifiableCollection.new(config) }
-    let(:site) { double(:site, items: items, layouts: layouts, config: config) }
+    let(:site) { double(:site, items: items, layouts: layouts, config: config, compiler: compiler) }
+    let(:compiler) { double(:compiler) }
+    let(:view_context) { double(:view_context) }
 
     before do
       rules_proc = proc do
@@ -122,6 +128,8 @@ describe(Nanoc::RuleDSL::RuleMemoryCalculator) do
       end
       rule = Nanoc::RuleDSL::Rule.new(Nanoc::Int::Pattern.from('/list.*'), :csv, rules_proc)
       rules_collection.add_item_compilation_rule(rule)
+
+      expect(compiler).to receive(:create_view_context).and_return(view_context)
     end
 
     example do


### PR DESCRIPTION
No actual dependency tracking needs to be done at this point. If anything would cause a dependency to be created, it’d either do so at a later stage, or would cause the rule memory to change.

Fixes #807.