### PR TITLE
Generate diff for correct path

### DIFF
--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -70,7 +70,7 @@ module Nanoc::CLI::Commands
           unless rep.binary?
             new_contents = File.file?(path) ? File.read(path) : nil
             if old_contents[rep] && new_contents
-              generate_diff_for(rep, old_contents[rep], new_contents)
+              generate_diff_for(path, old_contents[rep], new_contents)
             end
             old_contents.delete(rep)
           end
@@ -95,14 +95,14 @@ module Nanoc::CLI::Commands
         @diff_threads.each(&:join)
       end
 
-      def generate_diff_for(rep, old_content, new_content)
+      def generate_diff_for(path, old_content, new_content)
         return if old_content == new_content
 
         @diff_threads << Thread.new do
           # Generate diff
           diff = diff_strings(old_content, new_content)
-          diff.sub!(/^--- .*/,    '--- ' + rep.raw_path)
-          diff.sub!(/^\+\+\+ .*/, '+++ ' + rep.raw_path)
+          diff.sub!(/^--- .*/,    '--- ' + path)
+          diff.sub!(/^\+\+\+ .*/, '+++ ' + path)
 
           # Write diff
           @diff_lock.synchronize do

--- a/spec/nanoc/regressions/gh_813_spec.rb
+++ b/spec/nanoc/regressions/gh_813_spec.rb
@@ -1,0 +1,22 @@
+describe 'GH-813', site: true, stdio: true do
+  before do
+    File.write('nanoc.yaml', "enable_output_diff: true\n")
+    File.write('content/greeting.md', 'Hallöchen!')
+    File.write('Rules', <<EOS)
+  compile '/**/*' do
+    snapshot :donkey, path: '/donkey.html'
+    filter :kramdown
+  end
+EOS
+
+    Nanoc::CLI.run(['compile'])
+  end
+
+  specify 'Nanoc generates diff for proper path' do
+    File.write('content/greeting.md', 'Hellosies!')
+    Nanoc::CLI.run(['compile'])
+
+    diff = File.read('output.diff')
+    expect(diff).to start_with("--- output/donkey.html\n+++ output/donkey.html\n")
+  end
+end


### PR DESCRIPTION
`rep.raw_path` will only be the correct path if the snapshot is `:last`, but that’s not guaranteed.

Fixes #813.