### PR TITLE
Cache filename-to-item mapping in Sass

### DIFF
--- a/lib/nanoc/filters/sass.rb
+++ b/lib/nanoc/filters/sass.rb
@@ -18,11 +18,24 @@ module Nanoc::Filters
       engine.render
     end
 
+    def self.item_filename_map_for_site(site, items)
+      @item_filename_map ||= {}
+      @item_filename_map[site] ||=
+        {}.tap do |map|
+          items.each do |item|
+            if item.raw_filename
+              path = Pathname.new(item.raw_filename).realpath.to_s
+              map[path] = item
+            end
+          end
+        end
+    end
+
     def imported_filename_to_item(filename)
-      @items.find do |i|
-        i.raw_filename &&
-          Pathname.new(i.raw_filename).realpath == Pathname.new(filename).realpath
-      end
+      realpath = Pathname.new(filename).realpath.to_s
+
+      map = self.class.item_filename_map_for_site(@site, @items)
+      map[realpath]
     end
   end
 end


### PR DESCRIPTION
This caches the filename-to-item mapping, so that `#imported_filename_to_item` is significantly faster.

This is a per-site cache, which will stick around in memory, which I feel is okay for now. This could be updated to use `WeakRef`s.

* * *

Compilation speeds without cache:

```
Site compiled in 14.32s.
Site compiled in 13.85s.
Site compiled in 14.15s.
Site compiled in 15.27s.
Site compiled in 15.52s.
```

Method profile without cache:

```
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      3560  (36.4%)        1778  (18.2%)     Nanoc::Filters::Sass#uncached_imported_filename_to_item
      3220  (34.4%)        1606  (17.2%)     Nanoc::Filters::Sass#uncached_imported_filename_to_item
      3368  (35.7%)        1679  (17.8%)     Nanoc::Filters::Sass#uncached_imported_filename_to_item
      3996  (38.0%)        1990  (18.9%)     Nanoc::Filters::Sass#uncached_imported_filename_to_item
      4630  (42.7%)        2309  (21.3%)     Nanoc::Filters::Sass#uncached_imported_filename_to_item
```

Compilation speeds with cache:

```
Site compiled in 12.68s.
Site compiled in 13.23s.
Site compiled in 13.51s.
Site compiled in 13.14s.
Site compiled in 12.51s.
```

Method profile with cache:

```
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
        43   (0.5%)          33   (0.4%)     Nanoc::Filters::Sass#cached_imported_filename_to_item
        51   (0.5%)          34   (0.4%)     Nanoc::Filters::Sass#cached_imported_filename_to_item
        40   (0.4%)          33   (0.3%)     Nanoc::Filters::Sass#cached_imported_filename_to_item
        53   (0.6%)          33   (0.4%)     Nanoc::Filters::Sass#cached_imported_filename_to_item
        46   (0.5%)          39   (0.4%)     Nanoc::Filters::Sass#cached_imported_filename_to_item
```