### PR TITLE
Fix show-data crash

### DIFF
--- a/lib/nanoc/cli/commands/show-data.rb
+++ b/lib/nanoc/cli/commands/show-data.rb
@@ -40,7 +40,7 @@ module Nanoc::CLI::Commands
     def sorted_reps_with_prev(items)
       prev = nil
       items.sort_by(&:identifier).each do |item|
-        item.reps.sort_by { |r| r.name.to_s }.each do |rep|
+        site.compiler.reps[item].sort_by { |r| r.name.to_s }.each do |rep|
           yield(rep, prev)
           prev = rep
         end

--- a/spec/nanoc/regressions/gh_833_spec.rb
+++ b/spec/nanoc/regressions/gh_833_spec.rb
@@ -1,0 +1,14 @@
+describe 'GH-815', site: true, stdio: true do
+  before do
+    File.write('content/foo.md', 'stuff')
+    File.write('Rules', <<EOS)
+  compile '/**/*' do
+    write item.identifier.without_ext + '.txt'
+  end
+EOS
+  end
+
+  it 'runs show-data without crashing' do
+    Nanoc::CLI.run(['show-data'])
+  end
+end


### PR DESCRIPTION
Fixes #833.

This PR has a fix and a regression test, but I’d like to take the time to write a proper spec for the `show-data` command. That command has been around for a while and has always “just worked”—until now, apparently, and I’d like to ensure that it keeps on working.