### PR TITLE
Raise a better error when no String is given in #html_escape

### DIFF
--- a/lib/nanoc/helpers/html_escape.rb
+++ b/lib/nanoc/helpers/html_escape.rb
@@ -35,7 +35,7 @@ module Nanoc::Helpers
         buffer << escaped_data
       elsif string
         unless string.is_a? String
-          raise 'The #html_escape or #h function needs either a ' \
+          raise ArgumentError, 'The #html_escape or #h function needs either a ' \
             "string or a block to HTML-escape, but #{string.class} was given"
         end
 

--- a/lib/nanoc/helpers/html_escape.rb
+++ b/lib/nanoc/helpers/html_escape.rb
@@ -34,6 +34,11 @@ module Nanoc::Helpers
         buffer = eval('_erbout', block.binding)
         buffer << escaped_data
       elsif string
+        unless string.is_a? String
+          raise 'The #html_escape or #h function needs either a ' \
+            "string or a block to HTML-escape, but #{string.class} was given"
+        end
+
         string
           .gsub('&', '&amp;')
           .gsub('<', '&lt;')

--- a/spec/nanoc/helpers/html_escape_spec.rb
+++ b/spec/nanoc/helpers/html_escape_spec.rb
@@ -23,5 +23,13 @@ describe Nanoc::Helpers::HTMLEscape, helper: true do
         expect { subject }.to raise_error(RuntimeError)
       end
     end
+
+    context 'given argument that is not a string' do
+      let(:string) { 1 }
+
+      it 'raises an ArgumentError' do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
   end
 end


### PR DESCRIPTION
Nanoc::Helpers::HTMLEscape#html_escape breaks when the given parameter
is not a String.

The following message appeared:

~~~~~
Captain! We’ve been hit!

Message:
NoMethodError: undefined method `gsub' for 1:Fixnum

Stack trace:
0. […]/nanoc-4.1.4/lib/nanoc/helpers/html_escape.rb:38:in `html_escape'
1. […]/nanoc-4.1.4/lib/nanoc/helpers/link_to.rb:59:in `block in link_to'
2. […]/nanoc-4.1.4/lib/nanoc/helpers/link_to.rb:58:in `each'
3. […]/nanoc-4.1.4/lib/nanoc/helpers/link_to.rb:58:in `reduce'
4. […]/nanoc-4.1.4/lib/nanoc/helpers/link_to.rb:58:in `link_to'
5. layout /default/:84:in `block in render'
~~~~~

After I tried something similar to the following:

~~~~~ruby
link_to 'Homepage', @items['/'].path, {accesskey: 1}
~~~~~~

To fix this issue I had multiple ideas:

I first wanted to use `value.to_s` in the Nanoc Helper link_to
(currently on line 59). But it is not garanteed, that `to_s` results in
a useful output.

https://github.com/nanoc/nanoc/blob/master/lib/nanoc/helpers/link_to.rb#L59

My second thought was to use `string.to_s` in #html_escape, `unless
string.is_a? String`. But again, it is not clear, if the result is what
the user expected.

So I came up with my third idea, to raise a RuntimeError with slightly
more helpful error message. This commit adds an error message, that
points the user to the origin of his error. Using the stack trace, it
should not be to hard to investigate the source of your mistake.

---

I based this from branch `master`, because the commit doesn’t really
fix an error, it just enhances the error message.