### PR TITLE
Replace LazyValue#transform with #map

### DIFF
--- a/lib/nanoc/base/entities/document.rb
+++ b/lib/nanoc/base/entities/document.rb
@@ -25,7 +25,7 @@ module Nanoc
       # @param [String, nil] checksum_data Used to determine whether the document has changed
       def initialize(content, attributes, identifier, checksum_data: nil)
         @content = Nanoc::Int::Content.create(content)
-        @attributes = LazyAttributesValue.new(attributes)
+        @attributes = Nanoc::Int::LazyValue.new(attributes).map(&:__nanoc_symbolize_keys_recursively)
         @identifier = Nanoc::Identifier.from(identifier)
         @checksum_data = checksum_data
       end
@@ -56,12 +56,6 @@ module Nanoc
         other.respond_to?(:identifier) && identifier == other.identifier
       end
       alias eql? ==
-    end
-
-    class LazyAttributesValue < ::Nanoc::Int::LazyValue
-      def transform(value)
-        value.__nanoc_symbolize_keys_recursively
-      end
     end
   end
 end

--- a/lib/nanoc/base/entities/lazy_value.rb
+++ b/lib/nanoc/base/entities/lazy_value.rb
@@ -12,17 +12,19 @@ module Nanoc::Int
     def value
       if @value.key?(:raw)
         value = @value.delete(:raw)
-        @value[:final] = transform(value.respond_to?(:call) ? value.call : value)
+        @value[:final] = value.respond_to?(:call) ? value.call : value
         @value.__nanoc_freeze_recursively if frozen?
       end
       @value[:final]
     end
 
-    # @param [Object, Proc] value A value to be transformed
+    # Returns a new lazy value that will apply the given transformation when the value is requested.
     #
-    # @return [Object] The original value (override for more specific behavior)
-    def transform(value)
-      value
+    # @yield resolved value
+    #
+    # @return [Nanoc::Int::LazyValue]
+    def map
+      Nanoc::Int::LazyValue.new(-> { yield(value) })
     end
 
     # @return [void]

--- a/spec/nanoc/base/entities/lazy_value_spec.rb
+++ b/spec/nanoc/base/entities/lazy_value_spec.rb
@@ -1,42 +1,28 @@
 describe Nanoc::Int::LazyValue do
-  describe '#initialize' do
+  describe '#value' do
     let(:value_arg) { 'Hello world' }
+    let(:lazy_value) { described_class.new(value_arg) }
 
-    subject { described_class.new(value_arg) }
+    subject { lazy_value.value }
 
-    describe 'value arg' do
-      context 'object' do
-        it 'returns value' do
-          expect(subject.value).to equal(value_arg)
-        end
+    context 'object' do
+      it { is_expected.to equal(value_arg) }
+    end
+
+    context 'proc' do
+      it 'does not call the proc immediately' do
+        lazy_value
       end
 
-      context 'proc' do
-        call_count = 0
-        let(:value_arg) do
-          proc do
-            call_count += 1
-            'Hello proc'
-          end
-        end
+      it 'returns proc return value' do
+        expect(value_arg).to receive(:call).once.and_return('Hello proc')
+        subject
+      end
 
-        before do
-          call_count = 0
-        end
-
-        it 'does not call the proc immediately' do
-          expect(call_count).to eql(0)
-        end
-
-        it 'returns proc return value' do
-          expect(subject.value).to eq('Hello proc')
-        end
-
-        it 'only calls the proc once' do
-          subject.value
-          subject.value
-          expect(call_count).to eql(1)
-        end
+      it 'only calls the proc once' do
+        expect(value_arg).to receive(:call).once.and_return('Hello proc')
+        subject
+        subject
       end
     end
   end

--- a/spec/nanoc/base/entities/lazy_value_spec.rb
+++ b/spec/nanoc/base/entities/lazy_value_spec.rb
@@ -27,57 +27,29 @@ describe Nanoc::Int::LazyValue do
     end
   end
 
-  describe '#transform' do
-    class TransformedLazyValue < described_class
-      attr_accessor :transform_count
+  describe '#map' do
+    let(:value_arg) { -> { 'Hello world' } }
+    let(:lazy_value) { described_class.new(value_arg) }
 
-      def initialize(value)
-        super(value)
-        @transform_count = 0
-      end
+    subject { lazy_value.map(&:upcase) }
 
-      def transform(value)
-        @transform_count += 1
-        'transformed ' + value
-      end
+    it 'does not call the proc immediately' do
+      expect(value_arg).not_to receive(:call)
+
+      subject
     end
 
-    let(:value_arg) { 'value' }
+    it 'returns proc return value' do
+      expect(value_arg).to receive(:call).once.and_return('Hello proc')
 
-    subject { TransformedLazyValue.new(value_arg) }
-
-    context 'object' do
-      it 'does not call transform immediately' do
-        expect(subject.transform_count).to eql(0)
-      end
-
-      it 'transforms the value' do
-        expect(subject.value).to eq('transformed value')
-      end
-
-      it 'only transforms once' do
-        subject.value
-        subject.value
-        expect(subject.transform_count).to eql(1)
-      end
+      expect(subject.value).to eql('HELLO PROC')
     end
 
-    context 'proc' do
-      let(:value_arg) { proc { 'value' } }
+    it 'only calls the proc once' do
+      expect(value_arg).to receive(:call).once.and_return('Hello proc')
 
-      it 'does not call transform immediately' do
-        expect(subject.transform_count).to eql(0)
-      end
-
-      it 'transforms the value' do
-        expect(subject.value).to eq('transformed value')
-      end
-
-      it 'only transforms once' do
-        subject.value
-        subject.value
-        expect(subject.transform_count).to eql(1)
-      end
+      expect(subject.value).to eql('HELLO PROC')
+      expect(subject.value).to eql('HELLO PROC')
     end
   end
 


### PR DESCRIPTION
This removes `#transform` and provides a more composable `#map`:

```ruby
lv = Nanoc::Int::LazyValue.new(-> { sleep 1; 'Hello' })
lv_uppercase = lv.map(&:upcase)
p lv_uppercase.value
p lv_uppercase.value
```

This eliminates the need for subclassing `LazyValue` to specify custom transformations, and it allows chaining transformations.

Next up: updating the filesystem data source to make use of these new lazy values.

CC @RubenVerborgh — this will likely break your customisations since I believe they depend on `#transform`