### PR TITLE
Fix create-site test

### DIFF
--- a/test/cli/commands/test_create_site.rb
+++ b/test/cli/commands/test_create_site.rb
@@ -74,7 +74,7 @@ class Nanoc::CLI::Commands::CreateSiteTest < Nanoc::TestCase
 
     FileUtils.cd('foo') do
       # Try with encoding = default encoding = utf-8
-      File.open('content/index.html', 'w') { |io| io.write("Hello <\xD6>!\n") }
+      File.open('content/index.html', 'w') { |io| io.write('Hello ' + 0xD6.chr + "!\n") }
       exception = assert_raises(RuntimeError) do
         Nanoc::Int::SiteLoader.new.new_from_cwd
       end


### PR DESCRIPTION
RuboCop on Travis CI (but not locally?!) errors because of a parse error regarding non-UTF-8 characters. This is an attempt at a fix.