### PR TITLE
Use fstat for filesystem data source checksum

### DIFF
--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -121,11 +121,21 @@ module Nanoc::DataSources
       else
         parse_result = parse(content_filename, meta_filename)
 
+        filenames = [content_filename, meta_filename]
+        checksum_data = filenames.map do |filename|
+          if filename && File.file?(filename)
+            stat = File::Stat.new(filename)
+            "size=#{stat.size},mtime=#{stat.mtime}"
+          else
+            '?'
+          end
+        end.join(' ')
+
         ProtoDocument.new(
           is_binary: false,
           content: parse_result.content,
           attributes: parse_result.attributes,
-          checksum_data: "content=#{parse_result.content},meta=#{parse_result.attributes_data}",
+          checksum_data: checksum_data,
         )
       end
     end

--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -347,8 +347,6 @@ module Nanoc::DataSources
     # @return [ParseResult]
     def parse_with_frontmatter(content_filename)
       lv = Nanoc::Int::LazyValue.new(-> { read(content_filename) }).map do |data|
-        puts "READING #{content_filename}"
-
         if data !~ /\A-{3,5}\s*$/
           [data, {}]
         else

--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -339,7 +339,7 @@ module Nanoc::DataSources
 
     # @return [ParseResult]
     def parse_with_separate_meta_filename(content_filename, meta_filename)
-      content = content_filename ? read(content_filename) : ''
+      content = content_filename ? lazy_read(content_filename) : ''
       meta_raw = read(meta_filename)
       meta = parse_metadata(meta_raw, meta_filename)
       ParseResult.new(content: content, attributes: meta, attributes_data: meta_raw)
@@ -401,6 +401,10 @@ module Nanoc::DataSources
       return if meta.is_a?(Hash)
 
       raise InvalidMetadataError.new(filename, meta.class)
+    end
+
+    def lazy_read(filename)
+      -> { read(filename) }
     end
 
     # Reads the content of the file with the given name and returns a string

--- a/spec/nanoc/base/entities/lazy_value_spec.rb
+++ b/spec/nanoc/base/entities/lazy_value_spec.rb
@@ -10,6 +10,29 @@ describe Nanoc::Int::LazyValue do
     end
 
     context 'proc' do
+      let(:value_arg) { double(:proc) }
+
+      it 'does not call the proc immediately' do
+        expect(value_arg).not_to receive(:call)
+
+        lazy_value
+      end
+
+      it 'returns proc return value' do
+        expect(value_arg).to receive(:call).once.and_return('Hello proc')
+
+        expect(subject).to eq('Hello proc')
+      end
+
+      it 'only calls the proc once' do
+        expect(value_arg).to receive(:call).once.and_return('Hello proc')
+
+        subject
+        subject
+      end
+    end
+
+    context 'proc' do
       it 'does not call the proc immediately' do
         lazy_value
       end

--- a/spec/nanoc/base/entities/lazy_value_spec.rb
+++ b/spec/nanoc/base/entities/lazy_value_spec.rb
@@ -1,11 +1,13 @@
 describe Nanoc::Int::LazyValue do
   describe '#value' do
-    let(:value_arg) { 'Hello world' }
+    let(:value_arg) { raise 'override me' }
     let(:lazy_value) { described_class.new(value_arg) }
 
     subject { lazy_value.value }
 
     context 'object' do
+      let(:value_arg) { 'Hello world' }
+
       it { is_expected.to equal(value_arg) }
     end
 
@@ -27,23 +29,6 @@ describe Nanoc::Int::LazyValue do
       it 'only calls the proc once' do
         expect(value_arg).to receive(:call).once.and_return('Hello proc')
 
-        subject
-        subject
-      end
-    end
-
-    context 'proc' do
-      it 'does not call the proc immediately' do
-        lazy_value
-      end
-
-      it 'returns proc return value' do
-        expect(value_arg).to receive(:call).once.and_return('Hello proc')
-        subject
-      end
-
-      it 'only calls the proc once' do
-        expect(value_arg).to receive(:call).once.and_return('Hello proc')
         subject
         subject
       end

--- a/test/data_sources/test_filesystem.rb
+++ b/test/data_sources/test_filesystem.rb
@@ -985,7 +985,7 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
     # Parse it
     result = data_source.instance_eval { parse('test.html', 'test.yaml') }
     assert_equal({ 'foo' => 'bar' }, result.attributes)
-    assert_equal('blah blah', result.content)
+    assert_equal('blah blah', result.content.call)
   end
 
   def test_parse_internal_bad_metadata

--- a/test/helpers/test_capturing.rb
+++ b/test/helpers/test_capturing.rb
@@ -34,6 +34,7 @@ class Nanoc::Helpers::CapturingTest < Nanoc::TestCase
       File.open('content/includee.erb', 'w') do |io|
         io.write '{<% content_for :blah do %>Old content<% end %>}'
       end
+      FileUtils.touch('content/includee.erb', mtime: Time.now - 1)
       Nanoc::CLI.run(%w(compile))
       assert_equal '[Old content]', File.read('output/includer/index.html')
 
@@ -99,6 +100,7 @@ EOS
       File.open('content/includee.erb', 'w') do |io|
         io.write '{<% content_for :blah do %>Old content<% end %>}'
       end
+      FileUtils.touch('content/includee.erb', mtime: Time.now - 1)
       Nanoc::CLI.run(%w(compile))
       assert_equal '{[nil-Old content]}', File.read('output/includer/index.html')
 
@@ -150,6 +152,7 @@ EOS
       File.open('content/includer.erb', 'w') do |io|
         io.write 'Old-<%= content_for(@items.find { |i| i.identifier == \'/includee/\' }, :blah) %>'
       end
+      FileUtils.touch('content/includer.erb', mtime: Time.now - 1)
       Nanoc::CLI.run(%w(compile))
       assert_equal '{}', File.read('output/includee/index.html')
       assert_equal 'Old-Content', File.read('output/includer/index.html')


### PR DESCRIPTION
**Experimental**

Speed differences:

```
4.1.5

Site compiled in 2.32s.
Site compiled in 2.05s.
Site compiled in 1.98s.
Site compiled in 1.96s.
Site compiled in 2.01s.
Site compiled in 1.98s.
Site compiled in 2.03s.
Site compiled in 2.00s.
Site compiled in 1.97s.
Site compiled in 1.97s.

---

master

Site compiled in 1.78s.
Site compiled in 1.69s.
Site compiled in 1.87s.
Site compiled in 1.74s.
Site compiled in 1.80s.
Site compiled in 1.73s.
Site compiled in 1.72s.
Site compiled in 1.75s.
Site compiled in 1.85s.
Site compiled in 1.75s.

---

fstat

Site compiled in 1.75s.
Site compiled in 1.79s.
Site compiled in 1.77s.
Site compiled in 1.71s.
Site compiled in 1.75s.
Site compiled in 1.75s.
Site compiled in 1.75s.
Site compiled in 1.75s.
Site compiled in 1.78s.
Site compiled in 1.75s.
```