### PR TITLE
Add exclude_origins option to internal links checker

### DIFF
--- a/lib/nanoc/extra/checking/checks/internal_links.rb
+++ b/lib/nanoc/extra/checking/checks/internal_links.rb
@@ -34,7 +34,7 @@ module Nanoc::Extra::Checking::Checks
       return true if href == '.'
 
       # Skip hrefs that are specified in the exclude configuration
-      return true if excluded?(href)
+      return true if excluded?(href, origin)
 
       # Remove target
       path = href.sub(/#.*$/, '')
@@ -65,9 +65,20 @@ module Nanoc::Extra::Checking::Checks
       false
     end
 
-    def excluded?(href)
-      excludes = @config.fetch(:checks, {}).fetch(:internal_links, {}).fetch(:exclude, [])
+    def excluded?(href, origin)
+      config = @config.fetch(:checks, {}).fetch(:internal_links, {})
+      excluded_target?(href, config) || excluded_origin?(origin, config)
+    end
+
+    def excluded_target?(href, config)
+      excludes = config.fetch(:exclude_targets, config.fetch(:exclude, []))
       excludes.any? { |pattern| Regexp.new(pattern).match(href) }
+    end
+
+    def excluded_origin?(origin, config)
+      relative_origin = origin[@config[:output_dir].size..-1]
+      excludes = config.fetch(:exclude_origins, [])
+      excludes.any? { |pattern| Regexp.new(pattern).match(relative_origin) }
     end
   end
 end

--- a/test/extra/checking/checks/test_internal_links.rb
+++ b/test/extra/checking/checks/test_internal_links.rb
@@ -63,6 +63,31 @@ class Nanoc::Extra::Checking::Checks::InternalLinksTest < Nanoc::TestCase
     end
   end
 
+  def test_exclude_targets
+    with_site do |site|
+      # Create check
+      check = Nanoc::Extra::Checking::Checks::InternalLinks.create(site)
+      site.config.update({ checks: { internal_links: { exclude_targets: ['^/excluded\d+'] } } })
+
+      # Test
+      assert check.send(:valid?, '/excluded1', 'output/origin')
+      assert check.send(:valid?, '/excluded2', 'output/origin')
+      assert !check.send(:valid?, '/excluded_not', 'output/origin')
+    end
+  end
+
+  def test_exclude_origins
+    with_site do |site|
+      # Create check
+      check = Nanoc::Extra::Checking::Checks::InternalLinks.create(site)
+      site.config.update({ checks: { internal_links: { exclude_origins: ['^/excluded'] } } })
+
+      # Test
+      assert check.send(:valid?, '/foo', 'output/excluded')
+      assert !check.send(:valid?, '/foo', 'output/not_excluded')
+    end
+  end
+
   def test_unescape_url
     with_site do |site|
       FileUtils.mkdir_p('output/stuff')


### PR DESCRIPTION
The internal links checker has an `exclude` configuration option, which matches hrefs. This is often not enough, as sometimes it is useful to ignore all links in a file. This PR adds a configuration option `exclude_origins`, which is used for exactly that purpose.

For example, the following excludes all files under `/api` from the internal links checker, perhaps because it’s auto-generated and is known to be broken:

```yaml
checks:
  internal_links:
    exclude_origins: ^/api/
```