### PR TITLE
Add ChildParent helper

### DIFF
--- a/lib/nanoc/helpers.rb
+++ b/lib/nanoc/helpers.rb
@@ -2,6 +2,7 @@ module Nanoc::Helpers
   autoload 'Blogging',    'nanoc/helpers/blogging'
   autoload 'Breadcrumbs', 'nanoc/helpers/breadcrumbs'
   autoload 'Capturing',   'nanoc/helpers/capturing'
+  autoload 'ChildParent', 'nanoc/helpers/child_parent'
   autoload 'Filtering',   'nanoc/helpers/filtering'
   autoload 'HTMLEscape',  'nanoc/helpers/html_escape'
   autoload 'LinkTo',      'nanoc/helpers/link_to'

--- a/lib/nanoc/helpers/child_parent.rb
+++ b/lib/nanoc/helpers/child_parent.rb
@@ -1,0 +1,51 @@
+module Nanoc::Helpers
+  # Provides functionality for fetching the children and the parent of a given
+  # item. This works for both full identifiers and legacy identifiers.
+  module ChildParent
+    # Returns the parent of the given item.
+    #
+    # For items with legacy identifiers, the parent is the item where the
+    # identifier contains one less component than the identifier of the given
+    # item. For # example, the parent of the “/projects/nanoc/” item is the
+    # “/projects/” item.
+    #
+    # For items with full identifiers, the parent is the item where the
+    # identifier contains one less component than the identifier of the given
+    # item, and ends with any extension. For example, the parent of the
+    # “/projects/nanoc.md” item could be the “/projects.md” item, or the
+    # “/projects.html” item, etc. Note that the parent is ambiguous for items
+    # that have a full identifier; only the first candidate parent item will be
+    # returned.
+    def parent_of(item)
+      if item.identifier.legacy?
+        item.parent
+      else
+        path_without_last_component = item.identifier.to_s.sub(/[^\/]+$/, '').chop
+        @items[path_without_last_component + '.*']
+      end
+    end
+
+    # Returns the children of the given item.
+    #
+    # For items with legacy identifiers, the children are the items where the
+    # identifier contains one more component than the identifier of the given
+    # item. For example, the children of the “/projects/” item could be
+    # “/projects/nanoc/” and “/projects/cri/”, but not “/about/” nor
+    # “/projects/nanoc/history/”.
+    #
+    # For items with full identifiers, the children are the item where the
+    # identifier starts with the identifier of the given item, minus the
+    # extension, followed by a slash. For example, the children of the
+    # “/projects.md” item could be the “/projects/nanoc.md” and
+    # “/projects/cri.adoc” items , but not “/about.md” nor
+    # “/projects/nanoc/history.md”.
+    def children_of(item)
+      if item.identifier.legacy?
+        item.children
+      else
+        pattern = item.identifier.without_ext + '/*'
+        @items.find_all(pattern)
+      end
+    end
+  end
+end

--- a/lib/nanoc/spec.rb
+++ b/lib/nanoc/spec.rb
@@ -13,7 +13,7 @@ module Nanoc
 
         @erbout = ''
         @rule_memory = {}
-        @config = Nanoc::Int::Configuration.new
+        @config = Nanoc::Int::Configuration.new.with_defaults
         @reps = Nanoc::Int::ItemRepRepo.new
         @items = Nanoc::Int::IdentifiableCollection.new(@config)
         @layouts = Nanoc::Int::IdentifiableCollection.new(@config)

--- a/spec/nanoc/helpers/child_parent_spec.rb
+++ b/spec/nanoc/helpers/child_parent_spec.rb
@@ -1,0 +1,105 @@
+describe Nanoc::Helpers::ChildParent, helper: true do
+  describe '#children_of' do
+    subject { helper.children_of(item) }
+
+    let(:item) { ctx.create_item('some content', {}, identifier) }
+
+    context 'legacy identifier' do
+      let(:identifier) { Nanoc::Identifier.new('/foo/', type: :legacy) }
+
+      let!(:child_item) do
+        ctx.create_item('abc', {}, Nanoc::Identifier.new('/foo/a/', type: :legacy))
+      end
+
+      let!(:grandchild_item) do
+        ctx.create_item('def', {}, Nanoc::Identifier.new('/foo/a/b/', type: :legacy))
+      end
+
+      let!(:sibling_item) do
+        ctx.create_item('xyz', {}, Nanoc::Identifier.new('/bar/', type: :legacy))
+      end
+
+      it 'returns only direct children' do
+        expect(subject).to eql([child_item])
+      end
+    end
+
+    context 'full identifier' do
+      let(:identifier) { Nanoc::Identifier.new('/foo.md', type: :full) }
+
+      let!(:child_item) do
+        ctx.create_item('abc', {}, Nanoc::Identifier.new('/foo/a.md', type: :full))
+      end
+
+      let!(:grandchild_item) do
+        ctx.create_item('def', {}, Nanoc::Identifier.new('/foo/a/b.md', type: :full))
+      end
+
+      let!(:sibling_item) do
+        ctx.create_item('xyz', {}, Nanoc::Identifier.new('/bar.md', type: :full))
+      end
+
+      let!(:index_child_item) do
+        ctx.create_item('xyz', {}, Nanoc::Identifier.new('/foo/a/index.md', type: :full))
+      end
+
+      it 'returns only direct children' do
+        expect(subject).to eql([child_item])
+      end
+    end
+  end
+
+  describe '#parent_of' do
+    subject { helper.parent_of(item) }
+
+    let(:item) { ctx.create_item('some content', {}, identifier) }
+
+    context 'legacy identifier' do
+      let(:identifier) { Nanoc::Identifier.new('/foo/bar/', type: :legacy) }
+
+      let!(:parent_item) do
+        ctx.create_item('abc', {}, Nanoc::Identifier.new('/foo/', type: :legacy))
+      end
+
+      let!(:sibling_item) do
+        ctx.create_item('def', {}, Nanoc::Identifier.new('/foo/qux/', type: :legacy))
+      end
+
+      let!(:child_item) do
+        ctx.create_item('xyz', {}, Nanoc::Identifier.new('/foo/bar/asdf/', type: :legacy))
+      end
+
+      let!(:grandparent_item) do
+        ctx.create_item('opq', {}, Nanoc::Identifier.new('/', type: :legacy))
+      end
+
+      it 'returns parent' do
+        expect(subject).to eql(parent_item)
+      end
+    end
+
+    context 'full identifier' do
+      let(:identifier) { Nanoc::Identifier.new('/foo/bar.md', type: :full) }
+
+      let!(:parent_item) do
+        ctx.create_item('abc', {}, Nanoc::Identifier.new('/foo.md', type: :full))
+      end
+
+      let!(:sibling_item) do
+        ctx.create_item('def', {}, Nanoc::Identifier.new('/foo/qux.md', type: :full))
+      end
+
+      let!(:child_item) do
+        ctx.create_item('xyz', {}, Nanoc::Identifier.new('/foo/bar/asdf.md', type: :full))
+      end
+
+      let!(:grandparent_item) do
+        ctx.create_item('opq', {}, Nanoc::Identifier.new('/index.md', type: :full))
+      end
+
+      it 'returns parent' do
+        expect(subject).to eql(parent_item)
+      end
+    end
+  end
+end

--- a/spec/nanoc/helpers/tagging_spec.rb
+++ b/spec/nanoc/helpers/tagging_spec.rb
@@ -2,8 +2,7 @@ describe Nanoc::Helpers::Tagging, helper: true do
   describe '#tags_for' do
     subject { helper.tags_for(item, params) }
 
-    # FIXME: why does /me.* not work?
-    let(:item) { ctx.items['/me.md'] }
+    let(:item) { ctx.items['/me.*'] }
     let(:params) { {} }
     let(:item_attributes) { {} }
 


### PR DESCRIPTION
This adds `#children_of` and `#parent_of`, which works with both legacy *and* full identifiers. For example:

```rhtml
<%= link_to(parent_of(@item)) %>
```

```rhtml
<ul>
<% children_of(@item).each do |child| %>
  <li><%= link_to(child[:title], child) %></li>
<% end %>
</ul>
```

This allows getting rid of the ugly piece of upgrade advice that tells people to replace `@item.parent` with `@items[@item.identifier.to_s.sub(/[^\/]+$/, '').chop + '.*']`.