### PR TITLE
Force UTF-8 for item rep paths

### DIFF
--- a/lib/nanoc/base/services/item_rep_router.rb
+++ b/lib/nanoc/base/services/item_rep_router.rb
@@ -28,6 +28,7 @@ module Nanoc::Int
     def route_rep(rep, snapshot_action, paths_to_reps)
       basic_path = snapshot_action.path
       return if basic_path.nil?
+      basic_path = basic_path.encode('UTF-8')
 
       # Check for duplicate paths
       if paths_to_reps.key?(basic_path)

--- a/spec/nanoc/base/services/item_rep_router_spec.rb
+++ b/spec/nanoc/base/services/item_rep_router_spec.rb
@@ -87,6 +87,22 @@ describe(Nanoc::Int::ItemRepRouter) do
           subject
           expect(paths_to_reps).to have_key('/foo/index.html')
         end
+
+        context 'path is not UTF-8' do
+          let(:basic_path) { '/foo/index.html'.encode('ISO-8859-1') }
+
+          it 'sets the path as UTF-8' do
+            subject
+            expect(rep.paths).to eql(foo: '/foo/')
+            expect(rep.paths[:foo].encoding.to_s).to eql('UTF-8')
+          end
+
+          it 'sets the raw path as UTF-8' do
+            subject
+            expect(rep.raw_paths).to eql(foo: 'output/foo/index.html')
+            expect(rep.raw_paths[:foo].encoding.to_s).to eql('UTF-8')
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #837.

I can’t find a good high-level test case for this.