### PR TITLE
Drop Ruby 2.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
-  - 2.2.2
-  - 2.3.0
+  - 2.2.3
+  - 2.3.1
   - ruby-head
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.1.2
   - 2.2.2
   - 2.3.0
   - ruby-head


### PR DESCRIPTION
Ruby 2.1 is [EOL as of March](https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/).

This PR also upgrades the Ruby versions for 2.2 and 2.3 as Listen requires a more recent version.