### PR TITLE
Support nanoc environments

### DIFF
--- a/lib/nanoc/base/entities/configuration.rb
+++ b/lib/nanoc/base/entities/configuration.rb
@@ -68,9 +68,6 @@ module Nanoc::Int
       # Load given environment configuration
       env_config = @wrapped[ENVIRONMENTS].fetch(env.to_sym, {})
 
-      # Handle specific properties
-      env_config[:output_dir] ||= File.join(@wrapped[:output_dir].to_s, env.to_s)
-
       self.class.new(@wrapped, env).merge(env_config)
     end
 

--- a/lib/nanoc/base/entities/configuration.rb
+++ b/lib/nanoc/base/entities/configuration.rb
@@ -33,13 +33,17 @@ module Nanoc::Int
       string_pattern_type: 'glob',
     }.freeze
 
+    # @return [String, nil] The active environment for the configuration
     attr_reader :env
+
+    # Configuration environments property key
+    ENVIRONMENTS = :environments
 
     contract Hash => C::Any
     # Creates a new configuration with the given hash.
     #
     # @param [Hash] hash The actual configuration hash
-    # @param [Symbol, String] env The active environment for this configuration
+    # @param [String, nil] env The active environment for this configuration
     def initialize(hash = {}, env = nil)
       @env = env
       @wrapped = hash.__nanoc_symbolize_keys_recursively
@@ -55,14 +59,14 @@ module Nanoc::Int
       self.class.new(new_wrapped)
     end
 
-    def with_environment(env = nil)
-      return self unless @wrapped.key? :environments
+    def with_environment
+      return self unless @wrapped.key?(ENVIRONMENTS)
 
       # Set active environment
-      env ||= ENV.fetch 'NANOC_ENVIRONMENT', :default
+      env = @env || ENV.fetch('NANOC_ENV', 'default')
 
       # Load given environment configuration
-      env_config = @wrapped[:environments][env.to_sym] || {}
+      env_config = @wrapped[ENVIRONMENTS].fetch(env.to_sym, {})
 
       # Handle specific properties
       env_config[:output_dir] ||= File.join(@wrapped[:output_dir].to_s, env.to_s)

--- a/lib/nanoc/base/entities/configuration.rb
+++ b/lib/nanoc/base/entities/configuration.rb
@@ -34,7 +34,7 @@ module Nanoc::Int
     }.freeze
 
     # @return [String, nil] The active environment for the configuration
-    attr_reader :env
+    attr_reader :env_name
 
     # Configuration environments property key
     ENVIRONMENTS = :environments
@@ -43,9 +43,9 @@ module Nanoc::Int
     # Creates a new configuration with the given hash.
     #
     # @param [Hash] hash The actual configuration hash
-    # @param [String, nil] env The active environment for this configuration
-    def initialize(hash = {}, env = nil)
-      @env = env
+    # @param [String, nil] env_name The active environment for this configuration
+    def initialize(hash = {}, env_name = nil)
+      @env_name = env_name
       @wrapped = hash.__nanoc_symbolize_keys_recursively
     end
 
@@ -63,12 +63,12 @@ module Nanoc::Int
       return self unless @wrapped.key?(ENVIRONMENTS)
 
       # Set active environment
-      env = @env || ENV.fetch('NANOC_ENV', 'default')
+      env_name = @env_name || ENV.fetch('NANOC_ENV', 'default')
 
       # Load given environment configuration
-      env_config = @wrapped[ENVIRONMENTS].fetch(env.to_sym, {})
+      env_config = @wrapped[ENVIRONMENTS].fetch(env_name.to_sym, {})
 
-      self.class.new(@wrapped, env).merge(env_config)
+      self.class.new(@wrapped, env_name).merge(env_config)
     end
 
     contract C::None => Hash
@@ -106,12 +106,12 @@ module Nanoc::Int
 
     contract C::Or[Hash, self] => self
     def merge(hash)
-      self.class.new(@wrapped.merge(hash.to_h), @env)
+      self.class.new(@wrapped.merge(hash.to_h), @env_name)
     end
 
     contract C::Any => self
     def without(key)
-      self.class.new(@wrapped.reject { |k, _v| k == key }, @env)
+      self.class.new(@wrapped.reject { |k, _v| k == key }, @env_name)
     end
 
     contract C::Any => self

--- a/lib/nanoc/base/entities/configuration.rb
+++ b/lib/nanoc/base/entities/configuration.rb
@@ -41,12 +41,12 @@ module Nanoc::Int
     NANOC_ENV = 'NANOC_ENV'.freeze
     NANOC_ENV_DEFAULT = 'default'.freeze
 
-    contract Hash, C::Maybe[String] => C::Any
+    contract C::KeywordArgs[hash: C::Optional[Hash], env_name: C::Maybe[String]] => C::Any
     # Creates a new configuration with the given hash.
     #
     # @param [Hash] hash The actual configuration hash
     # @param [String, nil] env_name The active environment for this configuration
-    def initialize(hash = {}, env_name = nil)
+    def initialize(hash: {}, env_name: nil)
       @env_name = env_name
       @wrapped = hash.__nanoc_symbolize_keys_recursively
     end
@@ -58,7 +58,7 @@ module Nanoc::Int
         DEFAULT_DATA_SOURCE_CONFIG.merge(ds)
       end
 
-      self.class.new(new_wrapped)
+      self.class.new(hash: new_wrapped)
     end
 
     def with_environment
@@ -70,7 +70,7 @@ module Nanoc::Int
       # Load given environment configuration
       env_config = @wrapped[ENVIRONMENTS_CONFIG_KEY].fetch(env_name.to_sym, {})
 
-      self.class.new(@wrapped, env_name).merge(env_config)
+      self.class.new(hash: @wrapped, env_name: env_name).merge(env_config)
     end
 
     contract C::None => Hash
@@ -108,12 +108,12 @@ module Nanoc::Int
 
     contract C::Or[Hash, self] => self
     def merge(hash)
-      self.class.new(@wrapped.merge(hash.to_h), @env_name)
+      self.class.new(hash: @wrapped.merge(hash.to_h), env_name: @env_name)
     end
 
     contract C::Any => self
     def without(key)
-      self.class.new(@wrapped.reject { |k, _v| k == key }, @env_name)
+      self.class.new(hash: @wrapped.reject { |k, _v| k == key }, env_name: @env_name)
     end
 
     contract C::Any => self

--- a/lib/nanoc/base/entities/configuration.rb
+++ b/lib/nanoc/base/entities/configuration.rb
@@ -39,7 +39,7 @@ module Nanoc::Int
     # Configuration environments property key
     ENVIRONMENTS = :environments
 
-    contract Hash => C::Any
+    contract Hash, C::Maybe[String] => C::Any
     # Creates a new configuration with the given hash.
     #
     # @param [Hash] hash The actual configuration hash

--- a/lib/nanoc/base/entities/configuration.rb
+++ b/lib/nanoc/base/entities/configuration.rb
@@ -37,7 +37,9 @@ module Nanoc::Int
     attr_reader :env_name
 
     # Configuration environments property key
-    ENVIRONMENTS = :environments
+    ENVIRONMENTS_CONFIG_KEY = :environments
+    NANOC_ENV = 'NANOC_ENV'.freeze
+    NANOC_ENV_DEFAULT = 'default'.freeze
 
     contract Hash, C::Maybe[String] => C::Any
     # Creates a new configuration with the given hash.
@@ -60,13 +62,13 @@ module Nanoc::Int
     end
 
     def with_environment
-      return self unless @wrapped.key?(ENVIRONMENTS)
+      return self unless @wrapped.key?(ENVIRONMENTS_CONFIG_KEY)
 
       # Set active environment
-      env_name = @env_name || ENV.fetch('NANOC_ENV', 'default')
+      env_name = @env_name || ENV.fetch(NANOC_ENV, NANOC_ENV_DEFAULT)
 
       # Load given environment configuration
-      env_config = @wrapped[ENVIRONMENTS].fetch(env_name.to_sym, {})
+      env_config = @wrapped[ENVIRONMENTS_CONFIG_KEY].fetch(env_name.to_sym, {})
 
       self.class.new(@wrapped, env_name).merge(env_config)
     end

--- a/lib/nanoc/base/repos/checksum_store.rb
+++ b/lib/nanoc/base/repos/checksum_store.rb
@@ -6,7 +6,7 @@ module Nanoc::Int
   class ChecksumStore < ::Nanoc::Int::Store
     # @param [Nanoc::Int::Site] site
     def initialize(site: nil)
-      super(Nanoc::Int::Store.tmp_path_for(env: (site.config.env if site), store_name: 'checksums'), 1)
+      super(Nanoc::Int::Store.tmp_path_for(env_name: (site.config.env_name if site), store_name: 'checksums'), 1)
 
       @site = site
 

--- a/lib/nanoc/base/repos/checksum_store.rb
+++ b/lib/nanoc/base/repos/checksum_store.rb
@@ -6,7 +6,7 @@ module Nanoc::Int
   class ChecksumStore < ::Nanoc::Int::Store
     # @param [Nanoc::Int::Site] site
     def initialize(site: nil)
-      super(Nanoc::Int::Store.tmp_path_for((site.config.env if site), 'checksums'), 1)
+      super(Nanoc::Int::Store.tmp_path_for(env: (site.config.env if site), store_name: 'checksums'), 1)
 
       @site = site
 

--- a/lib/nanoc/base/repos/checksum_store.rb
+++ b/lib/nanoc/base/repos/checksum_store.rb
@@ -6,7 +6,7 @@ module Nanoc::Int
   class ChecksumStore < ::Nanoc::Int::Store
     # @param [Nanoc::Int::Site] site
     def initialize(site: nil)
-      super(File.join('tmp', (site.config.env if site).to_s, 'checksums'), 1)
+      super(Nanoc::Int::Store.tmp_path_for((site.config.env if site), 'checksums'), 1)
 
       @site = site
 

--- a/lib/nanoc/base/repos/checksum_store.rb
+++ b/lib/nanoc/base/repos/checksum_store.rb
@@ -6,7 +6,7 @@ module Nanoc::Int
   class ChecksumStore < ::Nanoc::Int::Store
     # @param [Nanoc::Int::Site] site
     def initialize(site: nil)
-      super('tmp/checksums', 1)
+      super(File.join('tmp', (site.config.env if site).to_s, 'checksums'), 1)
 
       @site = site
 

--- a/lib/nanoc/base/repos/compiled_content_cache.rb
+++ b/lib/nanoc/base/repos/compiled_content_cache.rb
@@ -5,7 +5,7 @@ module Nanoc::Int
   # @api private
   class CompiledContentCache < ::Nanoc::Int::Store
     def initialize(env: nil)
-      super(Nanoc::Int::Store.tmp_path_for(env, 'compiled_content'), 2)
+      super(Nanoc::Int::Store.tmp_path_for(env: env, store_name: 'compiled_content'), 2)
 
       @cache = {}
     end

--- a/lib/nanoc/base/repos/compiled_content_cache.rb
+++ b/lib/nanoc/base/repos/compiled_content_cache.rb
@@ -4,8 +4,8 @@ module Nanoc::Int
   #
   # @api private
   class CompiledContentCache < ::Nanoc::Int::Store
-    def initialize(env: nil)
-      super(Nanoc::Int::Store.tmp_path_for(env: env, store_name: 'compiled_content'), 2)
+    def initialize(env_name: nil)
+      super(Nanoc::Int::Store.tmp_path_for(env_name: env_name, store_name: 'compiled_content'), 2)
 
       @cache = {}
     end

--- a/lib/nanoc/base/repos/compiled_content_cache.rb
+++ b/lib/nanoc/base/repos/compiled_content_cache.rb
@@ -5,7 +5,7 @@ module Nanoc::Int
   # @api private
   class CompiledContentCache < ::Nanoc::Int::Store
     def initialize(env: nil)
-      super(File.join('tmp', env.to_s, 'compiled_content'), 2)
+      super(Nanoc::Int::Store.tmp_path_for(env, 'compiled_content'), 2)
 
       @cache = {}
     end

--- a/lib/nanoc/base/repos/compiled_content_cache.rb
+++ b/lib/nanoc/base/repos/compiled_content_cache.rb
@@ -4,8 +4,8 @@ module Nanoc::Int
   #
   # @api private
   class CompiledContentCache < ::Nanoc::Int::Store
-    def initialize
-      super('tmp/compiled_content', 2)
+    def initialize(env: nil)
+      super(File.join('tmp', env.to_s, 'compiled_content'), 2)
 
       @cache = {}
     end

--- a/lib/nanoc/base/repos/config_loader.rb
+++ b/lib/nanoc/base/repos/config_loader.rb
@@ -38,7 +38,7 @@ module Nanoc::Int
 
       # Read
       apply_parent_config(
-        Nanoc::Int::Configuration.new(YAML.load_file(filename)),
+        Nanoc::Int::Configuration.new(hash: YAML.load_file(filename)),
         [filename],
       ).with_defaults.with_environment
     end
@@ -60,7 +60,7 @@ module Nanoc::Int
       end
 
       # Load
-      parent_config = Nanoc::Int::Configuration.new(YAML.load_file(parent_path))
+      parent_config = Nanoc::Int::Configuration.new(hash: YAML.load_file(parent_path))
       full_parent_config = apply_parent_config(parent_config, processed_paths + [parent_path])
       full_parent_config.merge(config.without(:parent_config_file))
     end

--- a/lib/nanoc/base/repos/config_loader.rb
+++ b/lib/nanoc/base/repos/config_loader.rb
@@ -40,7 +40,7 @@ module Nanoc::Int
       apply_parent_config(
         Nanoc::Int::Configuration.new(YAML.load_file(filename)),
         [filename],
-      ).with_defaults
+      ).with_defaults.with_environment
     end
 
     # @api private

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -5,8 +5,8 @@ module Nanoc::Int
     attr_accessor :objects
 
     # @param [Array<Nanoc::Int::Item, Nanoc::Int::Layout>] objects
-    def initialize(objects)
-      super('tmp/dependencies', 4)
+    def initialize(objects, env: nil)
+      super(File.join('tmp', env.to_s, 'dependencies'), 4)
 
       @objects = objects
       @graph   = Nanoc::Int::DirectedGraph.new([nil] + @objects)

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -6,7 +6,7 @@ module Nanoc::Int
 
     # @param [Array<Nanoc::Int::Item, Nanoc::Int::Layout>] objects
     def initialize(objects, env: nil)
-      super(Nanoc::Int::Store.tmp_path_for(env, 'dependencies'), 4)
+      super(Nanoc::Int::Store.tmp_path_for(env: env, store_name: 'dependencies'), 4)
 
       @objects = objects
       @graph   = Nanoc::Int::DirectedGraph.new([nil] + @objects)

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -6,7 +6,7 @@ module Nanoc::Int
 
     # @param [Array<Nanoc::Int::Item, Nanoc::Int::Layout>] objects
     def initialize(objects, env: nil)
-      super(File.join('tmp', env.to_s, 'dependencies'), 4)
+      super(Nanoc::Int::Store.tmp_path_for(env, 'dependencies'), 4)
 
       @objects = objects
       @graph   = Nanoc::Int::DirectedGraph.new([nil] + @objects)

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -5,8 +5,8 @@ module Nanoc::Int
     attr_accessor :objects
 
     # @param [Array<Nanoc::Int::Item, Nanoc::Int::Layout>] objects
-    def initialize(objects, env: nil)
-      super(Nanoc::Int::Store.tmp_path_for(env: env, store_name: 'dependencies'), 4)
+    def initialize(objects, env_name: nil)
+      super(Nanoc::Int::Store.tmp_path_for(env_name: env_name, store_name: 'dependencies'), 4)
 
       @objects = objects
       @graph   = Nanoc::Int::DirectedGraph.new([nil] + @objects)

--- a/lib/nanoc/base/repos/rule_memory_store.rb
+++ b/lib/nanoc/base/repos/rule_memory_store.rb
@@ -5,7 +5,7 @@ module Nanoc::Int
   # @api private
   class RuleMemoryStore < ::Nanoc::Int::Store
     def initialize(env: nil)
-      super(File.join('tmp', env.to_s, 'rule_memory'), 1)
+      super(Nanoc::Int::Store.tmp_path_for(env, 'rule_memory'), 1)
 
       @rule_memories = {}
     end

--- a/lib/nanoc/base/repos/rule_memory_store.rb
+++ b/lib/nanoc/base/repos/rule_memory_store.rb
@@ -5,7 +5,7 @@ module Nanoc::Int
   # @api private
   class RuleMemoryStore < ::Nanoc::Int::Store
     def initialize(env: nil)
-      super(Nanoc::Int::Store.tmp_path_for(env, 'rule_memory'), 1)
+      super(Nanoc::Int::Store.tmp_path_for(env: env, store_name: 'rule_memory'), 1)
 
       @rule_memories = {}
     end

--- a/lib/nanoc/base/repos/rule_memory_store.rb
+++ b/lib/nanoc/base/repos/rule_memory_store.rb
@@ -4,8 +4,8 @@ module Nanoc::Int
   #
   # @api private
   class RuleMemoryStore < ::Nanoc::Int::Store
-    def initialize(env: nil)
-      super(Nanoc::Int::Store.tmp_path_for(env: env, store_name: 'rule_memory'), 1)
+    def initialize(env_name: nil)
+      super(Nanoc::Int::Store.tmp_path_for(env_name: env_name, store_name: 'rule_memory'), 1)
 
       @rule_memories = {}
     end

--- a/lib/nanoc/base/repos/rule_memory_store.rb
+++ b/lib/nanoc/base/repos/rule_memory_store.rb
@@ -4,8 +4,8 @@ module Nanoc::Int
   #
   # @api private
   class RuleMemoryStore < ::Nanoc::Int::Store
-    def initialize
-      super('tmp/rule_memory', 1)
+    def initialize(env: nil)
+      super(File.join('tmp', env.to_s, 'rule_memory'), 1)
 
       @rule_memories = {}
     end

--- a/lib/nanoc/base/repos/site_loader.rb
+++ b/lib/nanoc/base/repos/site_loader.rb
@@ -5,7 +5,7 @@ module Nanoc::Int
     end
 
     def new_with_config(hash)
-      site_from_config(Nanoc::Int::Configuration.new(hash).with_defaults)
+      site_from_config(Nanoc::Int::Configuration.new(hash: hash).with_defaults)
     end
 
     def new_from_cwd

--- a/lib/nanoc/base/repos/store.rb
+++ b/lib/nanoc/base/repos/store.rb
@@ -38,9 +38,9 @@ module Nanoc::Int
 
     # Logic for building tmp path from active environment and store name
     # @api private
-    contract C::KeywordArgs[env: C::Maybe[String], store_name: String] => String
-    def self.tmp_path_for(env:, store_name:)
-      File.join('tmp', env.to_s, store_name)
+    contract C::KeywordArgs[env_name: C::Maybe[String], store_name: String] => String
+    def self.tmp_path_for(env_name:, store_name:)
+      File.join('tmp', env_name.to_s, store_name)
     end
 
     # @group Loading and storing data

--- a/lib/nanoc/base/repos/store.rb
+++ b/lib/nanoc/base/repos/store.rb
@@ -34,6 +34,12 @@ module Nanoc::Int
       @version  = version
     end
 
+    # Logic for building tmp path from active environment and store name
+    # @api private
+    def self.tmp_path_for(env, store)
+      File.join('tmp', env.to_s, store)
+    end
+
     # @group Loading and storing data
 
     # @return The data that should be written to the disk

--- a/lib/nanoc/base/repos/store.rb
+++ b/lib/nanoc/base/repos/store.rb
@@ -12,6 +12,8 @@ module Nanoc::Int
   #
   # @api private
   class Store
+    include Nanoc::Int::ContractsSupport
+
     # @return [String] The name of the file where data will be loaded from and
     #   stored to.
     attr_reader :filename
@@ -36,8 +38,9 @@ module Nanoc::Int
 
     # Logic for building tmp path from active environment and store name
     # @api private
-    def self.tmp_path_for(env, store)
-      File.join('tmp', env.to_s, store)
+    contract C::KeywordArgs[env: C::Maybe[String], store_name: String] => String
+    def self.tmp_path_for(env:, store_name:)
+      File.join('tmp', env.to_s, store_name)
     end
 
     # @group Loading and storing data

--- a/lib/nanoc/base/services/compiler_loader.rb
+++ b/lib/nanoc/base/services/compiler_loader.rb
@@ -2,10 +2,10 @@ module Nanoc::Int
   # @api private
   class CompilerLoader
     def load(site)
-      rule_memory_store = Nanoc::Int::RuleMemoryStore.new(env: site.config.env)
+      rule_memory_store = Nanoc::Int::RuleMemoryStore.new(env_name: site.config.env_name)
 
       dependency_store =
-        Nanoc::Int::DependencyStore.new(site.items.to_a + site.layouts.to_a, env: site.config.env)
+        Nanoc::Int::DependencyStore.new(site.items.to_a + site.layouts.to_a, env_name: site.config.env_name)
 
       checksum_store =
         Nanoc::Int::ChecksumStore.new(site: site)
@@ -25,7 +25,7 @@ module Nanoc::Int
         )
 
       params = {
-        compiled_content_cache: Nanoc::Int::CompiledContentCache.new(env: site.config.env),
+        compiled_content_cache: Nanoc::Int::CompiledContentCache.new(env_name: site.config.env_name),
         checksum_store: checksum_store,
         rule_memory_store: rule_memory_store,
         dependency_store: dependency_store,

--- a/lib/nanoc/base/services/compiler_loader.rb
+++ b/lib/nanoc/base/services/compiler_loader.rb
@@ -2,10 +2,10 @@ module Nanoc::Int
   # @api private
   class CompilerLoader
     def load(site)
-      rule_memory_store = Nanoc::Int::RuleMemoryStore.new
+      rule_memory_store = Nanoc::Int::RuleMemoryStore.new env: site.config.env
 
       dependency_store =
-        Nanoc::Int::DependencyStore.new(site.items.to_a + site.layouts.to_a)
+        Nanoc::Int::DependencyStore.new(site.items.to_a + site.layouts.to_a, env: site.config.env)
 
       checksum_store =
         Nanoc::Int::ChecksumStore.new(site: site)
@@ -25,7 +25,7 @@ module Nanoc::Int
         )
 
       params = {
-        compiled_content_cache: Nanoc::Int::CompiledContentCache.new,
+        compiled_content_cache: Nanoc::Int::CompiledContentCache.new(env: site.config.env),
         checksum_store: checksum_store,
         rule_memory_store: rule_memory_store,
         dependency_store: dependency_store,

--- a/lib/nanoc/base/services/compiler_loader.rb
+++ b/lib/nanoc/base/services/compiler_loader.rb
@@ -2,7 +2,7 @@ module Nanoc::Int
   # @api private
   class CompilerLoader
     def load(site)
-      rule_memory_store = Nanoc::Int::RuleMemoryStore.new env: site.config.env
+      rule_memory_store = Nanoc::Int::RuleMemoryStore.new(env: site.config.env)
 
       dependency_store =
         Nanoc::Int::DependencyStore.new(site.items.to_a + site.layouts.to_a, env: site.config.env)

--- a/lib/nanoc/cli/commands/nanoc.rb
+++ b/lib/nanoc/cli/commands/nanoc.rb
@@ -10,8 +10,8 @@ opt :d, :debug, 'enable debugging' do
   Nanoc::CLI.debug = true
 end
 
-opt :e, :env, 'set environment', argument: :optional do |value|
-  ENV.store 'NANOC_ENVIRONMENT', value || :default
+opt :e, :env, 'set environment', argument: :required do |value|
+  ENV.store('NANOC_ENV', value)
 end
 
 opt :h, :help, 'show the help message and quit' do |_value, cmd|

--- a/lib/nanoc/cli/commands/nanoc.rb
+++ b/lib/nanoc/cli/commands/nanoc.rb
@@ -10,6 +10,10 @@ opt :d, :debug, 'enable debugging' do
   Nanoc::CLI.debug = true
 end
 
+opt :e, :env, 'set environment', argument: :optional do |value|
+  ENV.store 'NANOC_ENVIRONMENT', value || :default
+end
+
 opt :h, :help, 'show the help message and quit' do |_value, cmd|
   puts cmd.help
   exit 0

--- a/spec/nanoc/base/checksummer_spec.rb
+++ b/spec/nanoc/base/checksummer_spec.rb
@@ -158,7 +158,7 @@ describe Nanoc::Int::Checksummer do
   end
 
   context 'Nanoc::Int::Configuration' do
-    let(:obj) { Nanoc::Int::Configuration.new({ 'foo' => 'bar' }) }
+    let(:obj) { Nanoc::Int::Configuration.new(hash: { 'foo' => 'bar' }) }
     it { is_expected.to eql('Nanoc::Int::Configuration<Symbol<foo>=String<bar>,>') }
   end
 
@@ -241,7 +241,7 @@ describe Nanoc::Int::Checksummer do
 
   context 'Nanoc::ConfigView' do
     let(:obj) { Nanoc::ConfigView.new(config, nil) }
-    let(:config) { Nanoc::Int::Configuration.new({ 'foo' => 'bar' }) }
+    let(:config) { Nanoc::Int::Configuration.new(hash: { 'foo' => 'bar' }) }
 
     it { is_expected.to eql('Nanoc::ConfigView<Nanoc::Int::Configuration<Symbol<foo>=String<bar>,>>') }
   end
@@ -249,7 +249,7 @@ describe Nanoc::Int::Checksummer do
   context 'Nanoc::ItemCollectionWithRepsView' do
     let(:obj) { Nanoc::ItemCollectionWithRepsView.new(wrapped, nil) }
 
-    let(:config) { Nanoc::Int::Configuration.new({ 'foo' => 'bar' }) }
+    let(:config) { Nanoc::Int::Configuration.new(hash: { 'foo' => 'bar' }) }
 
     let(:wrapped) do
       Nanoc::Int::IdentifiableCollection.new(config).tap do |arr|
@@ -264,7 +264,7 @@ describe Nanoc::Int::Checksummer do
   context 'Nanoc::ItemCollectionWithoutRepsView' do
     let(:obj) { Nanoc::ItemCollectionWithoutRepsView.new(wrapped, nil) }
 
-    let(:config) { Nanoc::Int::Configuration.new({ 'foo' => 'bar' }) }
+    let(:config) { Nanoc::Int::Configuration.new(hash: { 'foo' => 'bar' }) }
 
     let(:wrapped) do
       Nanoc::Int::IdentifiableCollection.new(config).tap do |arr|

--- a/spec/nanoc/base/entities/configuration_spec.rb
+++ b/spec/nanoc/base/entities/configuration_spec.rb
@@ -18,12 +18,12 @@ describe Nanoc::Int::Configuration do
 
   context 'with environments defined' do
     let(:hash) { { foo: 'bar', environments: { test: { foo: 'test-bar' }, default: { foo: 'default-bar' } } } }
-    let(:config) { described_class.new(hash).with_environment(env) }
+    let(:config) { described_class.new(hash, env).with_environment }
 
     subject { config }
 
     context 'with existing environment' do
-      let(:env) { :test }
+      let(:env) { 'test' }
 
       it 'inherits options from given environment' do
         expect(subject[:foo]).to eq('test-bar')
@@ -31,7 +31,7 @@ describe Nanoc::Int::Configuration do
     end
 
     context 'with unknown environment' do
-      let(:env) { :wtf }
+      let(:env) { 'wtf' }
 
       it 'does not inherits options from any environment' do
         expect(subject[:foo]).to eq('bar')

--- a/spec/nanoc/base/entities/configuration_spec.rb
+++ b/spec/nanoc/base/entities/configuration_spec.rb
@@ -1,10 +1,9 @@
 describe Nanoc::Int::Configuration do
-  let(:configuration) { described_class.new(hash) }
-
   let(:hash) { { foo: 'bar' } }
+  let(:config) { described_class.new(hash) }
 
   describe '#key?' do
-    subject { configuration.key?(key) }
+    subject { config.key?(key) }
 
     context 'non-existent key' do
       let(:key) { :donkey }
@@ -14,6 +13,37 @@ describe Nanoc::Int::Configuration do
     context 'existent key' do
       let(:key) { :foo }
       it { is_expected.to be }
+    end
+  end
+
+  context 'with environments defined' do
+    let(:hash) { { foo: 'bar', environments: { test: { foo: 'test-bar' }, default: { foo: 'default-bar' } } } }
+    let(:config) { described_class.new(hash).with_environment(env) }
+
+    subject { config }
+
+    context 'with existing environment' do
+      let(:env) { :test }
+
+      it 'inherits options from given environment' do
+        expect(subject[:foo]).to eq('test-bar')
+      end
+    end
+
+    context 'with unknown environment' do
+      let(:env) { :wtf }
+
+      it 'does not inherits options from any environment' do
+        expect(subject[:foo]).to eq('bar')
+      end
+    end
+
+    context 'without given environment' do
+      let(:env) { nil }
+
+      it 'inherits options from default environment' do
+        expect(subject[:foo]).to eq('default-bar')
+      end
     end
   end
 end

--- a/spec/nanoc/base/entities/configuration_spec.rb
+++ b/spec/nanoc/base/entities/configuration_spec.rb
@@ -18,12 +18,12 @@ describe Nanoc::Int::Configuration do
 
   context 'with environments defined' do
     let(:hash) { { foo: 'bar', environments: { test: { foo: 'test-bar' }, default: { foo: 'default-bar' } } } }
-    let(:config) { described_class.new(hash, env).with_environment }
+    let(:config) { described_class.new(hash, env_name).with_environment }
 
     subject { config }
 
     context 'with existing environment' do
-      let(:env) { 'test' }
+      let(:env_name) { 'test' }
 
       it 'inherits options from given environment' do
         expect(subject[:foo]).to eq('test-bar')
@@ -31,7 +31,7 @@ describe Nanoc::Int::Configuration do
     end
 
     context 'with unknown environment' do
-      let(:env) { 'wtf' }
+      let(:env_name) { 'wtf' }
 
       it 'does not inherits options from any environment' do
         expect(subject[:foo]).to eq('bar')
@@ -39,7 +39,7 @@ describe Nanoc::Int::Configuration do
     end
 
     context 'without given environment' do
-      let(:env) { nil }
+      let(:env_name) { nil }
 
       it 'inherits options from default environment' do
         expect(subject[:foo]).to eq('default-bar')

--- a/spec/nanoc/base/entities/configuration_spec.rb
+++ b/spec/nanoc/base/entities/configuration_spec.rb
@@ -1,6 +1,6 @@
 describe Nanoc::Int::Configuration do
   let(:hash) { { foo: 'bar' } }
-  let(:config) { described_class.new(hash) }
+  let(:config) { described_class.new(hash: hash) }
 
   describe '#key?' do
     subject { config.key?(key) }
@@ -18,7 +18,7 @@ describe Nanoc::Int::Configuration do
 
   context 'with environments defined' do
     let(:hash) { { foo: 'bar', environments: { test: { foo: 'test-bar' }, default: { foo: 'default-bar' } } } }
-    let(:config) { described_class.new(hash, env_name).with_environment }
+    let(:config) { described_class.new(hash: hash, env_name: env_name).with_environment }
 
     subject { config }
 

--- a/spec/nanoc/base/repos/config_loader_spec.rb
+++ b/spec/nanoc/base/repos/config_loader_spec.rb
@@ -55,11 +55,15 @@ describe Nanoc::Int::ConfigLoader do
 
     context 'config file present and environment defined' do
       before do
-        File.write('nanoc.yaml', YAML.dump({ foo: 'bar', environments: { test: { foo: 'test-bar' }, default: { foo: 'default-bar' } } }))
+        File.write('nanoc.yaml', YAML.dump({ foo: 'bar', tofoo: 'bar', environments: { test: { foo: 'test-bar' }, default: { foo: 'default-bar' } } }))
       end
 
       it 'returns the configuration' do
         expect(subject).to be_a(Nanoc::Int::Configuration)
+      end
+
+      it 'has option defined not within environments' do
+        expect(subject[:tofoo]).to eq('bar')
       end
 
       it 'has the test environment custom option' do

--- a/spec/nanoc/base/repos/config_loader_spec.rb
+++ b/spec/nanoc/base/repos/config_loader_spec.rb
@@ -63,7 +63,7 @@ describe Nanoc::Int::ConfigLoader do
       end
 
       it 'has the test environment custom option' do
-        allow(ENV).to receive(:fetch).with('NANOC_ENVIRONMENT', :default).and_return('test')
+        allow(ENV).to receive(:fetch).with('NANOC_ENV', 'default').and_return('test')
         expect(subject[:foo]).to eq('test-bar')
       end
 

--- a/spec/nanoc/base/repos/config_loader_spec.rb
+++ b/spec/nanoc/base/repos/config_loader_spec.rb
@@ -63,7 +63,7 @@ describe Nanoc::Int::ConfigLoader do
       end
 
       it 'has the test environment custom option' do
-        allow(ENV).to receive(:fetch).with('NANOC_ENV', 'default').and_return('test')
+        allow(ENV).to receive(:fetch).with(Nanoc::Int::Configuration::NANOC_ENV, Nanoc::Int::Configuration::NANOC_ENV_DEFAULT).and_return('test')
         expect(subject[:foo]).to eq('test-bar')
       end
 

--- a/spec/nanoc/base/repos/config_loader_spec.rb
+++ b/spec/nanoc/base/repos/config_loader_spec.rb
@@ -52,6 +52,25 @@ describe Nanoc::Int::ConfigLoader do
         expect(subject[:parent_config_file]).to be_nil
       end
     end
+
+    context 'config file present and environment defined' do
+      before do
+        File.write('nanoc.yaml', YAML.dump({ foo: 'bar', environments: { test: { foo: 'test-bar' }, default: { foo: 'default-bar' } } }))
+      end
+
+      it 'returns the configuration' do
+        expect(subject).to be_a(Nanoc::Int::Configuration)
+      end
+
+      it 'has the test environment custom option' do
+        allow(ENV).to receive(:fetch).with('NANOC_ENVIRONMENT', :default).and_return('test')
+        expect(subject[:foo]).to eq('test-bar')
+      end
+
+      it 'has the default environment custom option' do
+        expect(subject[:foo]).to eq('default-bar')
+      end
+    end
   end
 
   describe '.cwd_is_nanoc_site? + .config_filename_for_cwd' do

--- a/spec/nanoc/base/repos/config_loader_spec.rb
+++ b/spec/nanoc/base/repos/config_loader_spec.rb
@@ -107,7 +107,7 @@ describe Nanoc::Int::ConfigLoader do
   describe '#apply_parent_config' do
     subject { loader.apply_parent_config(config, processed_paths) }
 
-    let(:config) { Nanoc::Int::Configuration.new(foo: 'bar') }
+    let(:config) { Nanoc::Int::Configuration.new(hash: { foo: 'bar' }) }
 
     let(:processed_paths) { ['nanoc.yaml'] }
 
@@ -119,10 +119,7 @@ describe Nanoc::Int::ConfigLoader do
 
     context 'parent config file is set' do
       let(:config) do
-        Nanoc::Int::Configuration.new(
-          parent_config_file: 'foo.yaml',
-          foo: 'bar',
-        )
+        Nanoc::Int::Configuration.new(hash: { parent_config_file: 'foo.yaml', foo: 'bar' })
       end
 
       context 'parent config file is not present' do

--- a/spec/nanoc/base/views/config_view_spec.rb
+++ b/spec/nanoc/base/views/config_view_spec.rb
@@ -1,6 +1,6 @@
 describe Nanoc::ConfigView do
   let(:config) do
-    Nanoc::Int::Configuration.new(hash)
+    Nanoc::Int::Configuration.new(hash: hash)
   end
 
   let(:hash) { { amount: 9000, animal: 'donkey' } }

--- a/test/base/test_store.rb
+++ b/test/base/test_store.rb
@@ -32,4 +32,16 @@ class Nanoc::Int::StoreTest < Nanoc::TestCase
     store.load
     assert_equal(nil, store.data)
   end
+
+  def test_tmp_path_with_nil_env
+    tmp_path_for_checksum = Nanoc::Int::Store.tmp_path_for(nil, 'checksum')
+    assert_equal('tmp/checksum', tmp_path_for_checksum)
+  end
+
+  def test_tmp_path_with_test_env
+    tmp_path_for_checksum = Nanoc::Int::Store.tmp_path_for('test', 'checksum')
+    tmp_path_for_dependencies = Nanoc::Int::Store.tmp_path_for(:test, 'dependencies')
+    assert_equal('tmp/test/checksum', tmp_path_for_checksum)
+    assert_equal('tmp/test/dependencies', tmp_path_for_dependencies)
+  end
 end

--- a/test/base/test_store.rb
+++ b/test/base/test_store.rb
@@ -34,13 +34,13 @@ class Nanoc::Int::StoreTest < Nanoc::TestCase
   end
 
   def test_tmp_path_with_nil_env
-    tmp_path_for_checksum = Nanoc::Int::Store.tmp_path_for(nil, 'checksum')
+    tmp_path_for_checksum = Nanoc::Int::Store.tmp_path_for(env: nil, store_name: 'checksum')
     assert_equal('tmp/checksum', tmp_path_for_checksum)
   end
 
   def test_tmp_path_with_test_env
-    tmp_path_for_checksum = Nanoc::Int::Store.tmp_path_for('test', 'checksum')
-    tmp_path_for_dependencies = Nanoc::Int::Store.tmp_path_for(:test, 'dependencies')
+    tmp_path_for_checksum = Nanoc::Int::Store.tmp_path_for(env: 'test', store_name: 'checksum')
+    tmp_path_for_dependencies = Nanoc::Int::Store.tmp_path_for(env: 'test', store_name: 'dependencies')
     assert_equal('tmp/test/checksum', tmp_path_for_checksum)
     assert_equal('tmp/test/dependencies', tmp_path_for_dependencies)
   end

--- a/test/base/test_store.rb
+++ b/test/base/test_store.rb
@@ -35,13 +35,23 @@ class Nanoc::Int::StoreTest < Nanoc::TestCase
 
   def test_tmp_path_with_nil_env
     tmp_path_for_checksum = Nanoc::Int::Store.tmp_path_for(env_name: nil, store_name: 'checksum')
+    tmp_path_for_rule_memory = Nanoc::Int::Store.tmp_path_for(env_name: nil, store_name: 'rule_memory')
+    tmp_path_for_dependencies = Nanoc::Int::Store.tmp_path_for(env_name: nil, store_name: 'dependencies')
+    tmp_path_for_compiled_content = Nanoc::Int::Store.tmp_path_for(env_name: nil, store_name: 'compiled_content')
     assert_equal('tmp/checksum', tmp_path_for_checksum)
+    assert_equal('tmp/rule_memory', tmp_path_for_rule_memory)
+    assert_equal('tmp/dependencies', tmp_path_for_dependencies)
+    assert_equal('tmp/compiled_content', tmp_path_for_compiled_content)
   end
 
   def test_tmp_path_with_test_env
     tmp_path_for_checksum = Nanoc::Int::Store.tmp_path_for(env_name: 'test', store_name: 'checksum')
+    tmp_path_for_rule_memory = Nanoc::Int::Store.tmp_path_for(env_name: 'test', store_name: 'rule_memory')
     tmp_path_for_dependencies = Nanoc::Int::Store.tmp_path_for(env_name: 'test', store_name: 'dependencies')
+    tmp_path_for_compiled_content = Nanoc::Int::Store.tmp_path_for(env_name: 'test', store_name: 'compiled_content')
     assert_equal('tmp/test/checksum', tmp_path_for_checksum)
+    assert_equal('tmp/test/rule_memory', tmp_path_for_rule_memory)
     assert_equal('tmp/test/dependencies', tmp_path_for_dependencies)
+    assert_equal('tmp/test/compiled_content', tmp_path_for_compiled_content)
   end
 end

--- a/test/base/test_store.rb
+++ b/test/base/test_store.rb
@@ -34,13 +34,13 @@ class Nanoc::Int::StoreTest < Nanoc::TestCase
   end
 
   def test_tmp_path_with_nil_env
-    tmp_path_for_checksum = Nanoc::Int::Store.tmp_path_for(env: nil, store_name: 'checksum')
+    tmp_path_for_checksum = Nanoc::Int::Store.tmp_path_for(env_name: nil, store_name: 'checksum')
     assert_equal('tmp/checksum', tmp_path_for_checksum)
   end
 
   def test_tmp_path_with_test_env
-    tmp_path_for_checksum = Nanoc::Int::Store.tmp_path_for(env: 'test', store_name: 'checksum')
-    tmp_path_for_dependencies = Nanoc::Int::Store.tmp_path_for(env: 'test', store_name: 'dependencies')
+    tmp_path_for_checksum = Nanoc::Int::Store.tmp_path_for(env_name: 'test', store_name: 'checksum')
+    tmp_path_for_dependencies = Nanoc::Int::Store.tmp_path_for(env_name: 'test', store_name: 'dependencies')
     assert_equal('tmp/test/checksum', tmp_path_for_checksum)
     assert_equal('tmp/test/dependencies', tmp_path_for_dependencies)
   end


### PR DESCRIPTION
# Description

Introduce support for nanoc environment and addresses https://github.com/nanoc/nanoc/issues/676.

- nanoc command is updated to include `--env` argument
- site config is overriden using the active environment if any and fallback to 'default'
- if environments is provided, `tmp` directory is updated to `tmp/{{env_name}}`

Setting environments is done in nanoc.yaml using the `environments` property.
Example usage is:

```
output_dir: output

environments:
  default: &default
    base_url: ...
    ...
  development:
    <<: *default
    base_url: ...
  production:
    <<: *default
    base_url: ...
  yet_another_env:
    <<: *default
    base_url: ...
    output_dir: build
```

Selecting working environment can be done:
- using environment variable `NANOC_ENVIRONMENT`
- using `nanoc --env=[<value>]`

# Progress

- [x] Main Nanoc command (cli/commands/nanoc.rb) is updated to include `--env` option
- [x] ```Nanoc::Int::Configuration``` is updated to provide `with_environment(env = nil)`
- [x] unless define in environment, output_dir is set as `{{output_dir}}/{{env_name}}`, if `environments` is not defined then `output_dir` remains unchanged
- [x] if environments is provided, `tmp` directory is updated to `tmp/{{env_name}}`
- [x] New tests are added