### PR TITLE
Fix generated Atom tags being timezone-dependent

### DIFF
--- a/lib/nanoc/extra/core_ext/time.rb
+++ b/lib/nanoc/extra/core_ext/time.rb
@@ -2,7 +2,7 @@
 module Nanoc::Extra::TimeExtensions
   # @return [String] The time in an ISO-8601 date format.
   def __nanoc_to_iso8601_date
-    strftime('%Y-%m-%d')
+    getutc.strftime('%Y-%m-%d')
   end
 
   # @return [String] The time in an ISO-8601 time format.


### PR DESCRIPTION
The [`atom_tag_for`](https://github.com/nanoc/nanoc/blob/master/lib/nanoc/helpers/blogging.rb#L230-L237) function uses a timezone-dependent conversion function `__nanoc_to_iso8601_date` to generate the Atom tag from `created_at`. For example:

```
$ TZ=Europe/Amsterdam ruby -rnanoc -ryaml -e "extend Nanoc::Helpers::Blogging;puts attribute_to_time(YAML::load('2015-03-09 00:00:00')).to_iso8601_date"
2015-03-09
$ TZ=America/Los_Angeles ruby -rnanoc -ryaml -e "extend Nanoc::Helpers::Blogging;puts attribute_to_time(YAML::load('2015-03-09 00:00:00')).to_iso8601_date"
2015-03-08
```

`to_iso8601_time` already uses getutc, so I think `to_iso8601_date` should do the same.

Note: this fix might result in people's tags being changed once when they update nanoc if they were originally running their code in a timezone different from UTC.