### PR TITLE
Add support for Rouge 2.x

### DIFF
--- a/lib/nanoc/filters/colorize_syntax.rb
+++ b/lib/nanoc/filters/colorize_syntax.rb
@@ -314,6 +314,10 @@ module Nanoc::Filters
 
       formatter_options = {
         css_class: params.fetch(:css_class, 'highlight'),
+        inline_theme: params.fetch(:inline_theme, nil),
+        line_numbers: params.fetch(:line_numbers, false),
+        start_line: params.fetch(:start_line, 1),
+        wrap: params.fetch(:wrap, false),
       }
       formatter = Rouge::Formatters::HTML.new(formatter_options)
       lexer = Rouge::Lexer.find_fancy(language, code) || Rouge::Lexers::PlainText

--- a/lib/nanoc/filters/colorize_syntax.rb
+++ b/lib/nanoc/filters/colorize_syntax.rb
@@ -319,7 +319,8 @@ module Nanoc::Filters
         start_line: params.fetch(:start_line, 1),
         wrap: params.fetch(:wrap, false),
       }
-      formatter = Rouge::Formatters::HTML.new(formatter_options)
+      formatter_cls = Rouge::Formatters.const_get(Rouge.version > '2' ? 'HTMLLegacy' : 'HTML')
+      formatter = formatter_cls.new(formatter_options)
       lexer = Rouge::Lexer.find_fancy(language, code) || Rouge::Lexers::PlainText
       formatter.format(lexer.lex(code))
     end


### PR DESCRIPTION
This commit introduces support for Rouge 2.x.

When `Rouge > 2` is detected Nanoc fallback to Rouge:Formatters::HTMLLegacy.
Options remain the same as Rouge 1.x.

**Note**: this PR needs https://github.com/nanoc/nanoc/pull/875 since by default Rouge use `wrap: true`.