### PR TITLE
Freeze filter arguments

### DIFF
--- a/lib/nanoc/base/services/executor.rb
+++ b/lib/nanoc/base/services/executor.rb
@@ -21,6 +21,7 @@ module Nanoc
           # Run filter
           last = rep.snapshot_contents[:last]
           source = rep.binary? ? last.filename : last.string
+          filter_args.freeze
           result = filter.setup_and_run(source, filter_args)
           rep.snapshot_contents[:last] =
             if filter.class.to_binary?
@@ -48,6 +49,7 @@ module Nanoc
           raise Nanoc::Int::Errors::Generic, "Cannot find rule for layout matching #{layout_identifier}"
         end
         filter_args = filter_args.merge(extra_filter_args || {})
+        filter_args.freeze
 
         # Check whether item can be laid out
         raise Nanoc::Int::Errors::CannotLayoutBinaryItem.new(rep) if rep.binary?

--- a/lib/nanoc/cli/error_handler.rb
+++ b/lib/nanoc/cli/error_handler.rb
@@ -233,11 +233,9 @@ module Nanoc::CLI
         end
       when RuntimeError
         if error.message =~ /^can't modify frozen/
-          'You attempted to modify immutable data. Some data, such as ' \
-          'item/layout attributes and raw item/layout content, can not ' \
-          'be modified once compilation has started. (This was ' \
-          'unintentionally possible in 3.1.x and before, but has been ' \
-          'disabled in 3.2.x in order to allow compiler optimisations.)'
+          'You attempted to modify immutable data. Some data cannot ' \
+          'be modified once compilation has started. Such data includes ' \
+          'content and attributes of items and layouts, and filter arguments.'
         end
       end
     end

--- a/spec/nanoc/base/services/executor_spec.rb
+++ b/spec/nanoc/base/services/executor_spec.rb
@@ -217,6 +217,22 @@ describe Nanoc::Int::Executor do
 
       expect { executor.filter(rep, :whatever) }.to raise_frozen_error
     end
+
+    it 'receives frozen filter args' do
+      filter_class = Class.new(::Nanoc::Filter) do
+        def run(_content, params = {})
+          params[:foo] = 'bar'
+          'asdf'
+        end
+      end
+
+      item = Nanoc::Int::Item.new('foo bar', {}, '/foo/')
+      rep = Nanoc::Int::ItemRep.new(item, :default)
+
+      expect(Nanoc::Filter).to receive(:named).with(:whatever) { filter_class }
+
+      expect { executor.filter(rep, :whatever) }.to raise_frozen_error
+    end
   end
 
   describe '#layout' do
@@ -360,6 +376,19 @@ describe Nanoc::Int::Executor do
       it 'raises' do
         expect { subject }.to raise_error(Nanoc::Int::Errors::CannotLayoutBinaryItem)
       end
+    end
+
+    it 'receives frozen filter args' do
+      filter_class = Class.new(::Nanoc::Filter) do
+        def run(_content, params = {})
+          params[:foo] = 'bar'
+          'asdf'
+        end
+      end
+
+      expect(Nanoc::Filter).to receive(:named).with(:erb) { filter_class }
+
+      expect { subject }.to raise_frozen_error
     end
   end
 


### PR DESCRIPTION
Potential fix for #866.

Mutating the filter arguments will break the outdatedness checker (this has always been the case).

* [x] Test
* [x] Improve error message