### PR TITLE
Handle Sass::Importers::Filesystem in checksummer

### DIFF
--- a/lib/nanoc/base/checksummer.rb
+++ b/lib/nanoc/base/checksummer.rb
@@ -194,6 +194,12 @@ module Nanoc::Int
 
     class RescueUpdateBehavior < UpdateBehavior
       def self.update(obj, digest)
+        if obj.class.to_s == 'Sass::Importers::Filesystem'
+          digest.update('root=')
+          digest.update(obj.root)
+          return
+        end
+
         data = begin
           Marshal.dump(obj)
         rescue

--- a/spec/nanoc/base/checksummer_spec.rb
+++ b/spec/nanoc/base/checksummer_spec.rb
@@ -276,6 +276,14 @@ describe Nanoc::Int::Checksummer do
     it { is_expected.to eql('Nanoc::ItemCollectionWithoutRepsView<Nanoc::Int::IdentifiableCollection<Nanoc::Int::Item<content=Nanoc::Int::TextualContent<String<foo>>,attributes=Hash<>,identifier=Nanoc::Identifier<String</foo.md>>>,Nanoc::Int::Item<content=Nanoc::Int::TextualContent<String<bar>>,attributes=Hash<>,identifier=Nanoc::Identifier<String</foo.md>>>,>>') }
   end
 
+  context 'Sass::Importers::Filesystem' do
+    let(:obj) { Sass::Importers::Filesystem.new('/foo') }
+
+    before { require 'sass' }
+
+    it { is_expected.to eql('Sass::Importers::Filesystem<root=/foo>') }
+  end
+
   context 'other marshal-able classes' do
     let(:obj) { klass.new('hello') }
 


### PR DESCRIPTION
This will reduce the number of unnecessary recompiles when `Sass::Importers::Filesystem` is involved (typically via Compass).

Fixes #866.