### PR TITLE
Use Hamster::Set in checksummer for speed

### DIFF
--- a/lib/nanoc/base/checksummer.rb
+++ b/lib/nanoc/base/checksummer.rb
@@ -1,3 +1,5 @@
+require 'hamster'
+
 module Nanoc::Int
   # Creates checksums for given objects.
   #
@@ -46,14 +48,14 @@ module Nanoc::Int
 
       private
 
-      def update(obj, digest, visited = Set.new)
+      def update(obj, digest, visited = Hamster::Set.new)
         digest.update(obj.class.to_s)
 
         if visited.include?(obj)
           digest.update('<recur>')
         else
           digest.update('<')
-          behavior_for(obj).update(obj, digest) { |o| update(o, digest, visited + [obj]) }
+          behavior_for(obj).update(obj, digest) { |o| update(o, digest, visited.add(obj)) }
           digest.update('>')
         end
       end

--- a/nanoc.gemspec
+++ b/nanoc.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.1.0'
 
   s.add_runtime_dependency('cri', '~> 2.3')
+  s.add_runtime_dependency('hamster', '~> 3.0')
 
   s.add_development_dependency('bundler', '>= 1.7.10', '< 2.0')
 end


### PR DESCRIPTION
Using Ruby’s `Set` in an immutable way is slow. `Hamster::Set`, from [Hamster](https://github.com/hamstergem/hamster), is significantly faster.

Example: 1138s &rarr; 50s

Fixes #864.