### PR TITLE
Fix specs on Ruby 2.4

### DIFF
--- a/spec/nanoc/base/checksummer_spec.rb
+++ b/spec/nanoc/base/checksummer_spec.rb
@@ -132,9 +132,9 @@ describe Nanoc::Int::Checksummer do
     it { is_expected.to eql('Float<3.14>') }
   end
 
-  context 'Fixnum' do
+  context 'Fixnum/Integer' do
     let(:obj) { 3 }
-    it { is_expected.to eql('Fixnum<3>') }
+    it { is_expected.to match(/\A(Integer|Fixnum)<3>\z/) }
   end
 
   context 'Nanoc::Identifier' do

--- a/spec/nanoc/base/entities/rule_memory_spec.rb
+++ b/spec/nanoc/base/entities/rule_memory_spec.rb
@@ -96,17 +96,17 @@ describe Nanoc::Int::RuleMemory do
     subject { rule_memory.serialize }
 
     before do
-      rule_memory.add_filter(:erb, { awesomeness: 123 })
+      rule_memory.add_filter(:erb, { awesomeness: 'high' })
       rule_memory.add_snapshot(:bar, true, '/foo.md')
-      rule_memory.add_layout('/default.erb', { somelayoutparam: 444 })
+      rule_memory.add_layout('/default.erb', { somelayoutparam: 'yes' })
     end
 
     example do
       expect(subject).to eql(
         [
-          [:filter, :erb, 'y9yyZGXu0J04TcDR9oFI3EJM4Vk='],
+          [:filter, :erb, 'PeWUm2PtXYtqeHJdTqnY7kkwAow='],
           [:snapshot, :bar, true, '/foo.md'],
-          [:layout, '/default.erb', 'PGQes7wXm3+K06vSBPYUJft57sM='],
+          [:layout, '/default.erb', '97LAe1pYTLKczxBsu+x4MmvqdkU='],
         ],
       )
     end


### PR DESCRIPTION
Ruby 2.4 no longer has `Fixnum`, but has `Integer` instead.

Sadly, the tests are broken on Ruby 2.4 due to a non-updated YAJL:

```
yajl_ext.c:881:22: error: ‘rb_cFixnum’ undeclared (first use in this function)
```