### PR TITLE
Remove type coercion in #eql?

### DIFF
--- a/lib/nanoc/base/entities/document.rb
+++ b/lib/nanoc/base/entities/document.rb
@@ -69,7 +69,11 @@ module Nanoc
       def ==(other)
         other.respond_to?(:identifier) && identifier == other.identifier
       end
-      alias eql? ==
+
+      contract C::Any => C::Bool
+      def eql?(other)
+        other.is_a?(self.class) && identifier == other.identifier
+      end
     end
   end
 end

--- a/lib/nanoc/base/entities/identifier.rb
+++ b/lib/nanoc/base/entities/identifier.rb
@@ -76,7 +76,11 @@ module Nanoc
         false
       end
     end
-    alias eql? ==
+
+    contract C::Any => C::Bool
+    def eql?(other)
+      other.is_a?(self.class) && to_s == other.to_s
+    end
 
     contract C::None => C::Num
     def hash

--- a/lib/nanoc/base/views/item_rep_view.rb
+++ b/lib/nanoc/base/views/item_rep_view.rb
@@ -15,7 +15,13 @@ module Nanoc
     def ==(other)
       other.respond_to?(:item) && other.respond_to?(:name) && item == other.item && name == other.name
     end
-    alias eql? ==
+
+    # @see Object#eql?
+    def eql?(other)
+      other.is_a?(self.class) &&
+        item.eql?(other.item) &&
+        name.eql?(other.name)
+    end
 
     # @see Object#hash
     def hash

--- a/lib/nanoc/base/views/mixins/document_view_mixin.rb
+++ b/lib/nanoc/base/views/mixins/document_view_mixin.rb
@@ -18,7 +18,11 @@ module Nanoc
     def ==(other)
       other.respond_to?(:identifier) && identifier == other.identifier
     end
-    alias eql? ==
+
+    # @see Object#eql?
+    def eql?(other)
+      other.is_a?(self.class) && identifier.eql?(other.identifier)
+    end
 
     # @see Object#hash
     def hash

--- a/spec/nanoc/base/entities/identifier_spec.rb
+++ b/spec/nanoc/base/entities/identifier_spec.rb
@@ -128,8 +128,11 @@ describe Nanoc::Identifier do
       let(:identifier_a) { described_class.new('//foo/bar/', type: :legacy) }
       let(:identifier_b) { described_class.new('/foo/bar//', type: :legacy) }
 
-      it 'is equal' do
+      it 'is ==' do
         expect(identifier_a).to eq(identifier_b)
+      end
+
+      it 'is eql?' do
         expect(identifier_a).to eql(identifier_b)
       end
     end
@@ -138,9 +141,12 @@ describe Nanoc::Identifier do
       let(:identifier_a) { described_class.new('//foo/bar/', type: :legacy) }
       let(:identifier_b) { '/foo/bar/' }
 
-      it 'is equal' do
+      it 'is ==' do
         expect(identifier_a).to eq(identifier_b.to_s)
-        expect(identifier_a).to eql(identifier_b.to_s)
+      end
+
+      it 'is not eql?' do
+        expect(identifier_a).not_to eql(identifier_b.to_s)
       end
     end
 
@@ -148,8 +154,11 @@ describe Nanoc::Identifier do
       let(:identifier_a) { described_class.new('//foo/bar/', type: :legacy) }
       let(:identifier_b) { described_class.new('/baz/qux//', type: :legacy) }
 
-      it 'is not equal' do
+      it 'is not ==' do
         expect(identifier_a).not_to eq(identifier_b)
+      end
+
+      it 'is not eql?' do
         expect(identifier_a).not_to eql(identifier_b)
       end
     end
@@ -160,6 +169,9 @@ describe Nanoc::Identifier do
 
       it 'is not equal' do
         expect(identifier_a).not_to eq(identifier_b)
+      end
+
+      it 'is not eql?' do
         expect(identifier_a).not_to eql(identifier_b)
       end
     end

--- a/spec/nanoc/base/views/document_view_spec.rb
+++ b/spec/nanoc/base/views/document_view_spec.rb
@@ -33,35 +33,47 @@ shared_examples 'a document view' do
     context 'comparing with document with same identifier' do
       let(:other) { entity_class.new('content', {}, '/asdf/') }
 
-      it 'is equal' do
+      it 'is ==' do
         expect(view).to eq(other)
-        expect(view).to eql(other)
+      end
+
+      it 'is not eql?' do
+        expect(view).not_to eql(other)
       end
     end
 
     context 'comparing with document with different identifier' do
       let(:other) { entity_class.new('content', {}, '/fdsa/') }
 
-      it 'is not equal' do
+      it 'is not ==' do
         expect(view).not_to eq(other)
+      end
+
+      it 'is not eql?' do
         expect(view).not_to eql(other)
       end
     end
 
     context 'comparing with document view with same identifier' do
-      let(:other) { Nanoc::LayoutView.new(entity_class.new('content', {}, '/asdf/'), nil) }
+      let(:other) { other_view_class.new(entity_class.new('content', {}, '/asdf/'), nil) }
 
-      it 'is equal' do
+      it 'is ==' do
         expect(view).to eq(other)
-        expect(view).to eql(other)
+      end
+
+      it 'is not eql?' do
+        expect(view).not_to eql(other)
       end
     end
 
     context 'comparing with document view with different identifier' do
-      let(:other) { Nanoc::LayoutView.new(entity_class.new('content', {}, '/fdsa/'), nil) }
+      let(:other) { other_view_class.new(entity_class.new('content', {}, '/fdsa/'), nil) }
 
-      it 'is not equal' do
+      it 'is not ==' do
         expect(view).not_to eq(other)
+      end
+
+      it 'is not eql?' do
         expect(view).not_to eql(other)
       end
     end
@@ -69,8 +81,11 @@ shared_examples 'a document view' do
     context 'comparing with other object' do
       let(:other) { nil }
 
-      it 'is not equal' do
+      it 'is not ==' do
         expect(view).not_to eq(other)
+      end
+
+      it 'is not eql?' do
         expect(view).not_to eql(other)
       end
     end

--- a/spec/nanoc/base/views/item_rep_view_spec.rb
+++ b/spec/nanoc/base/views/item_rep_view_spec.rb
@@ -32,9 +32,12 @@ describe Nanoc::ItemRepView do
       let(:other_item) { double(:other_item, identifier: '/foo/') }
       let(:other) { double(:other_item_rep, item: other_item, name: :jacques) }
 
-      it 'is equal' do
+      it 'is ==' do
         expect(view).to eq(other)
-        expect(view).to eql(other)
+      end
+
+      it 'is eql?' do
+        expect(view).not_to eql(other)
       end
     end
 
@@ -42,8 +45,11 @@ describe Nanoc::ItemRepView do
       let(:other_item) { double(:other_item, identifier: '/bar/') }
       let(:other) { double(:other_item_rep, item: other_item, name: :jacques) }
 
-      it 'is not equal' do
+      it 'is not ==' do
         expect(view).not_to eq(other)
+      end
+
+      it 'is not eql?' do
         expect(view).not_to eql(other)
       end
     end
@@ -52,8 +58,11 @@ describe Nanoc::ItemRepView do
       let(:other_item) { double(:other_item, identifier: '/foo/') }
       let(:other) { double(:other_item_rep, item: other_item, name: :marvin) }
 
-      it 'is not equal' do
+      it 'is not ==' do
         expect(view).not_to eq(other)
+      end
+
+      it 'is not eql?' do
         expect(view).not_to eql(other)
       end
     end
@@ -62,9 +71,12 @@ describe Nanoc::ItemRepView do
       let(:other_item) { double(:other_item, identifier: '/foo/') }
       let(:other) { described_class.new(double(:other_item_rep, item: other_item, name: :jacques), view_context) }
 
-      it 'is equal' do
+      it 'is ==' do
         expect(view).to eq(other)
-        expect(view).to eql(other)
+      end
+
+      it 'is eql?' do
+        expect(view).not_to eql(other)
       end
     end
 

--- a/spec/nanoc/base/views/item_view_spec.rb
+++ b/spec/nanoc/base/views/item_view_spec.rb
@@ -1,5 +1,6 @@
 describe Nanoc::ItemWithRepsView do
   let(:entity_class) { Nanoc::Int::Item }
+  let(:other_view_class) { Nanoc::LayoutView }
   it_behaves_like 'a document view'
 
   let(:view_context) { Nanoc::ViewContext.new(reps: reps, items: items, dependency_tracker: dependency_tracker, compiler: compiler) }

--- a/spec/nanoc/base/views/layout_view_spec.rb
+++ b/spec/nanoc/base/views/layout_view_spec.rb
@@ -1,4 +1,5 @@
 describe Nanoc::LayoutView do
   let(:entity_class) { Nanoc::Int::Layout }
+  let(:other_view_class) { Nanoc::ItemWithRepsView }
   it_behaves_like 'a document view'
 end

--- a/spec/nanoc/helpers/blogging_spec.rb
+++ b/spec/nanoc/helpers/blogging_spec.rb
@@ -33,7 +33,7 @@ describe Nanoc::Helpers::Blogging, helper: true do
     end
 
     it 'returns the two articles in descending order' do
-      expect(subject.map(&:identifier)).to eql(['/2/', '/1/'])
+      expect(subject.map(&:identifier)).to eq(['/2/', '/1/'])
     end
   end
 


### PR DESCRIPTION
* `#==` can do type coercion (e.g. `2.0 == 2` &rarr; true)
* `#eql?` does not do type coercion (e.g. `2.0.eql?(2)` &rarr; false)

For this reason, `#eql?` in `Nanoc::Identifier` should not do type coercion either. This is important for correctness, as `#eql?` is used in `Hamster::Set`.