### PR TITLE
Ensure dependency graph includes preprocessor items

### DIFF
--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -98,6 +98,10 @@ module Nanoc::Int
     end
 
     def load_stores
+      # FIXME: icky hack to update the dependency store’s list of objects
+      # (does not include preprocessed objects otherwise)
+      dependency_store.objects = site.items.to_a + site.layouts.to_a
+
       stores.each(&:load)
     end
 

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -2,7 +2,7 @@ module Nanoc::Int
   # @api private
   class DependencyStore < ::Nanoc::Int::Store
     # @return [Array<Nanoc::Int::Item, Nanoc::Int::Layout>]
-    attr_reader :objects
+    attr_accessor :objects
 
     # @param [Array<Nanoc::Int::Item, Nanoc::Int::Layout>] objects
     def initialize(objects)

--- a/spec/nanoc/regressions/gh_885_spec.rb
+++ b/spec/nanoc/regressions/gh_885_spec.rb
@@ -1,0 +1,30 @@
+describe 'GH-885', site: true, stdio: true do
+  before do
+    File.write(
+      'content/index.html',
+      "<%= @items['/hello.*'].compiled_content %> - <%= Time.now.to_f %>",
+    )
+
+    File.write('Rules', <<EOS)
+  preprocess do
+    items.create('hi!', {}, '/hello.html')
+  end
+
+  compile '/**/*' do
+    filter :erb
+    write item.identifier.without_ext + '.html'
+  end
+EOS
+  end
+
+  example do
+    Nanoc::CLI.run(%w(compile))
+    before = File.read('output/index.html')
+
+    sleep(0.1)
+    Nanoc::CLI.run(%w(compile))
+    after = File.read('output/index.html')
+    expect(after).to eql(before)
+    expect(after).to match(/\Ahi! - \d+/)
+  end
+end

--- a/spec/nanoc/regressions/gh_891_spec.rb
+++ b/spec/nanoc/regressions/gh_891_spec.rb
@@ -1,0 +1,26 @@
+describe 'GH-891', site: true, stdio: true do
+  before do
+    File.write('layouts/foo.erb', 'giraffes? <%= yield %>')
+    File.write('Rules', <<EOS)
+  preprocess do
+    items.create('yes!', {}, '/hello.html')
+  end
+
+  compile '/**/*' do
+    layout '/foo.*'
+    write item.identifier.without_ext + '.html'
+  end
+
+  layout '/foo.*', :erb
+EOS
+  end
+
+  example do
+    Nanoc::CLI.run(%w(compile))
+    expect(File.read('output/hello.html')).to include('giraffes?')
+
+    File.write('layouts/foo.erb', 'donkeys? <%= yield %>')
+    Nanoc::CLI.run(%w(compile))
+    expect(File.read('output/hello.html')).to include('donkeys?')
+  end
+end


### PR DESCRIPTION
Fixes #885, #891.

This is not a pretty fix, but I fear that solving this properly might require some rethinking and rearchitecting. We’ll see!