### PR TITLE
Add Filter.define

### DIFF
--- a/lib/nanoc/base/compilation/filter.rb
+++ b/lib/nanoc/base/compilation/filter.rb
@@ -38,6 +38,13 @@ module Nanoc
     extend Nanoc::Int::PluginRegistry::PluginMethods
 
     class << self
+      def define(ident)
+        filter_class = Class.new(::Nanoc::Filter) { identifier(ident) }
+        filter_class.send(:define_method, :run) do |content, params|
+          yield(content, params)
+        end
+      end
+
       # Sets the new type for the filter. The type can be `:binary` (default)
       # or `:text`. The given argument can either be a symbol indicating both
       # “from” and “to” types, or a hash where the only key is the “from” type

--- a/spec/nanoc/base/filter_spec.rb
+++ b/spec/nanoc/base/filter_spec.rb
@@ -1,0 +1,17 @@
+describe Nanoc::Filter do
+  describe '.define' do
+    before do
+      Nanoc::Filter.define(:nanoc_filter_define_sample) do |content, _params|
+        content.upcase
+      end
+    end
+
+    it 'defines a filter' do
+      expect(Nanoc::Filter.named(:nanoc_filter_define_sample)).not_to be_nil
+    end
+
+    it 'defines a callable filter' do
+      expect(Nanoc::Filter.named(:nanoc_filter_define_sample).new.run('foo', {})).to eql('FOO')
+    end
+  end
+end


### PR DESCRIPTION
This makes filter easier to define.

Before:

```ruby
Class.new(Nanoc::Filter) do
  identifier :upcase

  def run(content, params={})
    content.upcase
  end
end
```

After:

```ruby
Nanoc::Filter.define(:upcase) do |content, params|
  content.upcase
end
```