### PR TITLE
Add #inspect method to views

### DIFF
--- a/lib/nanoc/base/views/item_rep_view.rb
+++ b/lib/nanoc/base/views/item_rep_view.rb
@@ -77,5 +77,9 @@ module Nanoc
     def binary?
       @item_rep.binary?
     end
+
+    def inspect
+      "<#{self.class} item.identifier=#{item.identifier} name=#{name}>"
+    end
   end
 end

--- a/lib/nanoc/base/views/mixins/document_view_mixin.rb
+++ b/lib/nanoc/base/views/mixins/document_view_mixin.rb
@@ -76,5 +76,9 @@ module Nanoc
     def raw_content
       unwrap.content.string
     end
+
+    def inspect
+      "<#{self.class} identifier=#{unwrap.identifier}>"
+    end
   end
 end

--- a/lib/nanoc/base/views/view.rb
+++ b/lib/nanoc/base/views/view.rb
@@ -23,5 +23,9 @@ module Nanoc
     def frozen?
       unwrap.frozen?
     end
+
+    def inspect
+      "<#{self.class}>"
+    end
   end
 end

--- a/spec/nanoc/base/views/config_view_spec.rb
+++ b/spec/nanoc/base/views/config_view_spec.rb
@@ -88,4 +88,9 @@ describe Nanoc::ConfigView do
       expect(res).to eql([[:amount, 9000], [:animal, 'donkey']])
     end
   end
+
+  describe '#inspect' do
+    subject { view.inspect }
+    it { is_expected.to eql('<Nanoc::ConfigView>') }
+  end
 end

--- a/spec/nanoc/base/views/item_collection_view_spec.rb
+++ b/spec/nanoc/base/views/item_collection_view_spec.rb
@@ -1,4 +1,19 @@
+# FIXME: fix name
 describe Nanoc::ItemCollectionWithRepsView do
   let(:view_class) { Nanoc::ItemWithRepsView }
   it_behaves_like 'an identifiable collection'
+
+  describe '#inspect' do
+    let(:wrapped) do
+      Nanoc::Int::IdentifiableCollection.new(config)
+    end
+
+    let(:view) { described_class.new(wrapped, view_context) }
+    let(:view_context) { double(:view_context) }
+    let(:config) { { string_pattern_type: 'glob' } }
+
+    subject { view.inspect }
+
+    it { is_expected.to eql('<Nanoc::ItemCollectionWithRepsView>') }
+  end
 end

--- a/spec/nanoc/base/views/item_rep_collection_view_spec.rb
+++ b/spec/nanoc/base/views/item_rep_collection_view_spec.rb
@@ -129,4 +129,10 @@ describe Nanoc::ItemRepCollectionView do
       end
     end
   end
+
+  describe '#inspect' do
+    subject { view.inspect }
+
+    it { is_expected.to eql('<Nanoc::ItemRepCollectionView>') }
+  end
 end

--- a/spec/nanoc/base/views/item_rep_view_spec.rb
+++ b/spec/nanoc/base/views/item_rep_view_spec.rb
@@ -212,4 +212,14 @@ describe Nanoc::ItemRepView do
       expect(subject._context).to equal(view_context)
     end
   end
+
+  describe '#inspect' do
+    let(:item_rep) { Nanoc::Int::ItemRep.new(item, :jacques) }
+    let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo/') }
+    let(:view) { described_class.new(item_rep, view_context) }
+
+    subject { view.inspect }
+
+    it { is_expected.to eql('<Nanoc::ItemRepView item.identifier=/foo/ name=jacques>') }
+  end
 end

--- a/spec/nanoc/base/views/item_view_spec.rb
+++ b/spec/nanoc/base/views/item_view_spec.rb
@@ -331,4 +331,13 @@ describe Nanoc::ItemWithRepsView do
   describe '#raw_filename' do
     # TODO: implement
   end
+
+  describe '#inspect' do
+    let(:item) { Nanoc::Int::Item.new('content', {}, '/asdf/') }
+    let(:view) { described_class.new(item, nil) }
+
+    subject { view.inspect }
+
+    it { is_expected.to eql('<Nanoc::ItemWithRepsView identifier=/asdf/>') }
+  end
 end

--- a/spec/nanoc/base/views/layout_collection_view_spec.rb
+++ b/spec/nanoc/base/views/layout_collection_view_spec.rb
@@ -1,4 +1,18 @@
 describe Nanoc::LayoutCollectionView do
   let(:view_class) { Nanoc::LayoutView }
   it_behaves_like 'an identifiable collection'
+
+  describe '#inspect' do
+    let(:wrapped) do
+      Nanoc::Int::IdentifiableCollection.new(config)
+    end
+
+    let(:view) { described_class.new(wrapped, view_context) }
+    let(:view_context) { double(:view_context) }
+    let(:config) { { string_pattern_type: 'glob' } }
+
+    subject { view.inspect }
+
+    it { is_expected.to eql('<Nanoc::LayoutCollectionView>') }
+  end
 end

--- a/spec/nanoc/base/views/layout_view_spec.rb
+++ b/spec/nanoc/base/views/layout_view_spec.rb
@@ -2,4 +2,13 @@ describe Nanoc::LayoutView do
   let(:entity_class) { Nanoc::Int::Layout }
   let(:other_view_class) { Nanoc::ItemWithRepsView }
   it_behaves_like 'a document view'
+
+  describe '#inspect' do
+    let(:item) { Nanoc::Int::Layout.new('content', {}, '/asdf/') }
+    let(:view) { described_class.new(item, nil) }
+
+    subject { view.inspect }
+
+    it { is_expected.to eql('<Nanoc::LayoutView identifier=/asdf/>') }
+  end
 end

--- a/spec/nanoc/base/views/mutable_config_view_spec.rb
+++ b/spec/nanoc/base/views/mutable_config_view_spec.rb
@@ -1,11 +1,16 @@
 describe Nanoc::MutableConfigView do
-  describe '#[]=' do
-    let(:config) { {} }
-    let(:view) { described_class.new(config, nil) }
+  let(:config) { {} }
+  let(:view) { described_class.new(config, nil) }
 
+  describe '#[]=' do
     it 'sets attributes' do
       view[:awesomeness] = 'rather high'
       expect(config[:awesomeness]).to eq('rather high')
     end
+  end
+
+  describe '#inspect' do
+    subject { view.inspect }
+    it { is_expected.to eql('<Nanoc::MutableConfigView>') }
   end
 end

--- a/spec/nanoc/base/views/mutable_item_collection_view_spec.rb
+++ b/spec/nanoc/base/views/mutable_item_collection_view_spec.rb
@@ -32,4 +32,18 @@ describe Nanoc::MutableItemCollectionView do
       expect(ret).to equal(view)
     end
   end
+
+  describe '#inspect' do
+    let(:wrapped) do
+      Nanoc::Int::IdentifiableCollection.new(config)
+    end
+
+    let(:view) { described_class.new(wrapped, view_context) }
+    let(:view_context) { double(:view_context) }
+    let(:config) { { string_pattern_type: 'glob' } }
+
+    subject { view.inspect }
+
+    it { is_expected.to eql('<Nanoc::MutableItemCollectionView>') }
+  end
 end

--- a/spec/nanoc/base/views/mutable_item_view_spec.rb
+++ b/spec/nanoc/base/views/mutable_item_view_spec.rb
@@ -10,4 +10,13 @@ describe Nanoc::MutableItemView do
     expect(view).not_to respond_to(:path)
     expect(view).not_to respond_to(:reps)
   end
+
+  describe '#inspect' do
+    let(:item) { Nanoc::Int::Item.new('content', {}, '/asdf/') }
+    let(:view) { described_class.new(item, nil) }
+
+    subject { view.inspect }
+
+    it { is_expected.to eql('<Nanoc::MutableItemView identifier=/asdf/>') }
+  end
 end

--- a/spec/nanoc/base/views/mutable_layout_collection_view_spec.rb
+++ b/spec/nanoc/base/views/mutable_layout_collection_view_spec.rb
@@ -32,4 +32,18 @@ describe Nanoc::MutableLayoutCollectionView do
       expect(ret).to equal(view)
     end
   end
+
+  describe '#inspect' do
+    let(:wrapped) do
+      Nanoc::Int::IdentifiableCollection.new(config)
+    end
+
+    let(:view) { described_class.new(wrapped, view_context) }
+    let(:view_context) { double(:view_context) }
+    let(:config) { { string_pattern_type: 'glob' } }
+
+    subject { view.inspect }
+
+    it { is_expected.to eql('<Nanoc::MutableLayoutCollectionView>') }
+  end
 end

--- a/spec/nanoc/base/views/mutable_layout_view_spec.rb
+++ b/spec/nanoc/base/views/mutable_layout_view_spec.rb
@@ -1,4 +1,13 @@
 describe Nanoc::MutableLayoutView do
   let(:entity_class) { Nanoc::Int::Layout }
   it_behaves_like 'a mutable document view'
+
+  describe '#inspect' do
+    let(:item) { Nanoc::Int::Item.new('content', {}, '/asdf/') }
+    let(:view) { described_class.new(item, nil) }
+
+    subject { view.inspect }
+
+    it { is_expected.to eql('<Nanoc::MutableLayoutView identifier=/asdf/>') }
+  end
 end


### PR DESCRIPTION
This prevents the risk of an `#inspect` call accidentally printing the world.

Also se #877.