### PR TITLE
Add #modified_reps and deprecate #modified

### DIFF
--- a/lib/nanoc/base/views/post_compile_item_view.rb
+++ b/lib/nanoc/base/views/post_compile_item_view.rb
@@ -1,7 +1,12 @@
 module Nanoc
   class PostCompileItemView < Nanoc::ItemWithRepsView
+    # @deprecated Use {#modified_reps} instead
     def modified
-      reps.select { |rep| rep.unwrap.modified }
+      modified_reps
+    end
+
+    def modified_reps
+      reps.select { |rep| rep.unwrap.modified? }
     end
   end
 end

--- a/spec/nanoc/base/views/post_compile_item_view_spec.rb
+++ b/spec/nanoc/base/views/post_compile_item_view_spec.rb
@@ -1,0 +1,36 @@
+describe Nanoc::PostCompileItemView do
+  shared_examples 'a method that returns modified reps only' do
+    let(:item) { Nanoc::Int::Item.new('blah', {}, '/foo.md') }
+    let(:rep_a) { Nanoc::Int::ItemRep.new(item, :no_mod) }
+    let(:rep_b) { Nanoc::Int::ItemRep.new(item, :modded).tap { |r| r.modified = true } }
+
+    let(:reps) do
+      Nanoc::Int::ItemRepRepo.new.tap do |reps|
+        reps << rep_a
+        reps << rep_b
+      end
+    end
+
+    let(:view_context) { double(:view_context, reps: reps) }
+    let(:view) { described_class.new(item, view_context) }
+
+    it 'returns only modified items' do
+      expect(subject.size).to eq(1)
+      expect(subject.map(&:name)).to eq(%i(modded))
+    end
+
+    it 'returns an array' do
+      expect(subject.class).to eql(Array)
+    end
+  end
+
+  describe '#modified_reps' do
+    subject { view.modified_reps }
+    it_behaves_like 'a method that returns modified reps only'
+  end
+
+  describe '#modified' do
+    subject { view.modified }
+    it_behaves_like 'a method that returns modified reps only'
+  end
+end


### PR DESCRIPTION
The `#modified` method is confusing. This PR introduces `#modified_reps` and deprecates `#modified`.