### PR TITLE
Use soft ref rather than weak ref

### DIFF
--- a/lib/nanoc.rb
+++ b/lib/nanoc.rb
@@ -22,6 +22,7 @@ end
 
 # Load external dependencies
 require 'hamster'
+require 'ref'
 
 # Load general requirements
 require 'digest'

--- a/nanoc.gemspec
+++ b/nanoc.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('cri', '~> 2.3')
   s.add_runtime_dependency('hamster', '~> 3.0')
+  s.add_runtime_dependency('ref', '~> 2.0')
 
   s.add_development_dependency('bundler', '>= 1.7.10', '< 2.0')
 end


### PR DESCRIPTION
Using soft references rather than weak references will hopefully prevent memoized values from being garbage collected too eagerly.