### PR TITLE
Tear down DiffGenerator notifications

### DIFF
--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -63,10 +63,10 @@ module Nanoc::CLI::Commands
         require 'tempfile'
         setup_diffs
         old_contents = {}
-        Nanoc::Int::NotificationCenter.on(:will_write_rep) do |rep, path|
+        Nanoc::Int::NotificationCenter.on(:will_write_rep, self) do |rep, path|
           old_contents[rep] = File.file?(path) ? File.read(path) : nil
         end
-        Nanoc::Int::NotificationCenter.on(:rep_written) do |rep, path, _is_created, _is_modified|
+        Nanoc::Int::NotificationCenter.on(:rep_written, self) do |rep, path, _is_created, _is_modified|
           unless rep.binary?
             new_contents = File.file?(path) ? File.read(path) : nil
             if old_contents[rep] && new_contents
@@ -80,6 +80,10 @@ module Nanoc::CLI::Commands
       # @see Listener#stop
       def stop
         super
+
+        Nanoc::Int::NotificationCenter.remove(:will_write_rep, self)
+        Nanoc::Int::NotificationCenter.remove(:rep_written, self)
+
         teardown_diffs
       end
 


### PR DESCRIPTION
This prevents the tests from generating `output.diff`.