### PR TITLE
Do not call Listener#stop when #start failed

### DIFF
--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -49,6 +49,18 @@ module Nanoc::CLI::Commands
       # @return [void]
       def stop
       end
+
+      # @api private
+      def start_safely
+        start
+        @_started = true
+      end
+
+      # @api private
+      def stop_safely
+        stop if @_started
+        @_started = false
+      end
     end
 
     # Generates diffs for every output file written
@@ -401,7 +413,7 @@ module Nanoc::CLI::Commands
         .select { |klass| klass.enable_for?(self) }
         .map    { |klass| klass.new(reps: reps) }
 
-      @listeners.each(&:start)
+      @listeners.each(&:start_safely)
     end
 
     def listeners
@@ -416,7 +428,7 @@ module Nanoc::CLI::Commands
     end
 
     def teardown_listeners
-      @listeners.each(&:stop)
+      @listeners.each(&:stop_safely)
     end
 
     def reps

--- a/spec/nanoc/cli/commands/compile_spec.rb
+++ b/spec/nanoc/cli/commands/compile_spec.rb
@@ -1,0 +1,64 @@
+describe Nanoc::CLI::Commands::Compile::Listener do
+  let(:klass) do
+    Class.new(described_class) do
+      attr_reader :started
+      attr_reader :stopped
+
+      def initialize
+        @started = false
+        @stopped = false
+      end
+
+      def start
+        @started = true
+      end
+
+      def stop
+        @stopped = true
+      end
+    end
+  end
+
+  subject { klass.new }
+
+  it 'starts' do
+    subject.start
+    expect(subject.started).to be
+  end
+
+  it 'stops' do
+    subject.start
+    subject.stop
+    expect(subject.stopped).to be
+  end
+
+  it 'starts safely' do
+    subject.start_safely
+    expect(subject.started).to be
+  end
+
+  it 'stops safely' do
+    subject.start_safely
+    subject.stop_safely
+    expect(subject.stopped).to be
+  end
+
+  context 'listener that does not start or stop properly' do
+    let(:klass) do
+      Class.new(described_class) do
+        def start
+          raise 'boom'
+        end
+
+        def stop
+          raise 'boom'
+        end
+      end
+    end
+
+    it 'raises on start, but not stop' do
+      expect { subject.start_safely }.to raise_error(RuntimeError)
+      expect { subject.stop_safely }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
This makes exceptions that occur in `#start` not be turned into weird `#stop` errors.