### PR TITLE
Discover external commands through Bundler

### DIFF
--- a/lib/nanoc/cli.rb
+++ b/lib/nanoc/cli.rb
@@ -110,6 +110,11 @@ module Nanoc::CLI
       cmd = load_command_at(cmd_filename)
       add_command(cmd)
     end
+
+    if defined?(Bundler)
+      # Discover external commands through Bundler
+      Bundler.require(:nanoc)
+    end
   end
 
   # Loads site-specific commands.


### PR DESCRIPTION
Other gems may want to add commands to the nanoc CLI. To do this
they need to run Nanoc::CLI.add_after_setup_proc. Currently, there
is no way to hook into the CLI. This commit adds such a way by
utilizing Bundler. E.g. the gem guard-nanoc could introduce new
commands when added to the Gemfile in this way:

    gem 'nanoc'
    group :nanoc do
      gem 'guard-nanoc'
    end

Presence of any gems in the group :nanoc will cause the library with
the same name as the gem to be required by Bundler during
the initialization of the CLI.

A special group :nanoc is used for two reasons:
  * nanoc may not be the only or primary user of the Gemfile,
    and requiring many unrelated gems will slow down every invocation
    of nanoc with no workaround;
  * existing Gemfiles may include specifications for gems that cannot
    be successfully required, so using the group :default would
    break such existing nanoc installations.