### PR TITLE
Add resource uris to ilinks check

### DIFF
--- a/lib/nanoc/base/compilation/filter.rb
+++ b/lib/nanoc/base/compilation/filter.rb
@@ -38,6 +38,13 @@ module Nanoc
     extend Nanoc::Int::PluginRegistry::PluginMethods
 
     class << self
+      def define(ident)
+        filter_class = Class.new(::Nanoc::Filter) { identifier(ident) }
+        filter_class.send(:define_method, :run) do |content, params|
+          yield(content, params)
+        end
+      end
+
       # Sets the new type for the filter. The type can be `:binary` (default)
       # or `:text`. The given argument can either be a symbol indicating both
       # “from” and “to” types, or a hash where the only key is the “from” type

--- a/lib/nanoc/extra/checking/checks/internal_links.rb
+++ b/lib/nanoc/extra/checking/checks/internal_links.rb
@@ -15,7 +15,10 @@ module Nanoc::Extra::Checking::Checks
       # TODO: de-duplicate this (duplicated in external links check)
       filenames = output_filenames.select { |f| File.extname(f) == '.html' }
       hrefs_with_filenames = ::Nanoc::Extra::LinkCollector.new(filenames, :internal).filenames_per_href
-      hrefs_with_filenames.each_pair do |href, fns|
+      resource_uris_with_filenames = ::Nanoc::Extra::LinkCollector.new(filenames, :internal).filenames_per_resource_uri
+
+      uris = hrefs_with_filenames.merge(resource_uris_with_filenames)
+      uris.each_pair do |href, fns|
         fns.each do |filename|
           next if valid?(href, filename)
 

--- a/lib/nanoc/helpers/breadcrumbs.rb
+++ b/lib/nanoc/helpers/breadcrumbs.rb
@@ -1,6 +1,5 @@
 module Nanoc::Helpers
-  # Provides support for breadcrumbs, which allow the user to go up in the
-  # page hierarchy.
+  # @see http://nanoc.ws/doc/reference/helpers/#breadcrumbs
   module Breadcrumbs
     class CannotGetBreadcrumbsForNonLegacyItem < Nanoc::Int::Errors::Generic
       def initialize(identifier)
@@ -8,14 +7,7 @@ module Nanoc::Helpers
       end
     end
 
-    # Creates a breadcrumb trail leading from the current item to its parent,
-    # to its parent’s parent, etc, until the root item is reached. This
-    # function does not require that each intermediate item exist; for
-    # example, if there is no `/foo/` item, breadcrumbs for a `/foo/bar/` item
-    # will contain a `nil` element.
-    #
-    # @return [Array] The breadcrumbs, starting with the root item and ending
-    #   with the item itself
+    # @return [Array]
     def breadcrumbs_trail
       unless @item.identifier.legacy?
         raise CannotGetBreadcrumbsForNonLegacyItem.new(@item.identifier)

--- a/lib/nanoc/helpers/capturing.rb
+++ b/lib/nanoc/helpers/capturing.rb
@@ -1,64 +1,14 @@
 module Nanoc::Helpers
-  # Provides functionality for “capturing” content in one place and reusing
-  # this content elsewhere.
-  #
-  # For example, suppose you want the sidebar of your site to contain a short
-  # summary of the item. You could put the summary in the meta file, but
-  # that’s not possible when the summary contains eRuby. You could also put
-  # the sidebar inside the actual item, but that’s not very pretty. Instead,
-  # you write the summary on the item itself, but capture it, and print it in
-  # the sidebar layout.
-  #
-  # This helper has been tested with ERB and Haml. Other filters may not work
-  # correctly.
-  #
-  # @example Capturing content for a summary
-  #
-  #   <% content_for :summary do %>
-  #     <p>On this item, Nanoc is introduced, blah blah.</p>
-  #   <% end %>
-  #
-  # @example Showing captured content in a sidebar
-  #
-  #   <div id="sidebar">
-  #     <h3>Summary</h3>
-  #     <%= content_for(@item, :summary) || '(no summary)' %>
-  #   </div>
+  # @see http://nanoc.ws/doc/reference/helpers/#capturing
   module Capturing
     # @overload content_for(name, params = {}, &block)
-    #
-    #   Captures the content inside the block and stores it so that it can be
-    #   referenced later on. The same method, {#content_for}, is used for
-    #   getting the captured content as well as setting it. When capturing,
-    #   the content of the block itself will not be outputted.
-    #
-    #   By default, capturing content with the same name will raise an error if the newly captured
-    #   content differs from the previously captured content. This behavior can be changed by
-    #   providing a different `:existing` option to this method:
-    #
-    #   * `:error`: When content already exists and is not identical, raise an error.
-    #
-    #   * `:overwrite`: Overwrite the previously captured content with the newly captured content.
-    #
-    #   * `:append`: Append the newly captured content to the previously captured content.
-    #
-    #   @param [Symbol, String] name The base name of the attribute into which
-    #     the content should be stored
-    #
-    #   @option params [Symbol] existing Can be either `:error`, `:overwrite`, or `:append`
-    #
+    #   @param [Symbol, String] name
+    #   @option params [Symbol] existing
     #   @return [void]
     #
     # @overload content_for(item, name)
-    #
-    #   Fetches the capture with the given name from the given item and
-    #   returns it.
-    #
-    #   @param [Nanoc::Int::Item] item The item for which to get the capture
-    #
-    #   @param [Symbol, String] name The name of the capture to fetch
-    #
-    #   @return [String] The stored captured content
+    #   @param [Symbol, String] name
+    #   @return [String]
     def content_for(*args, &block)
       if block_given? # Set content
         # Get args
@@ -125,10 +75,7 @@ module Nanoc::Helpers
       end
     end
 
-    # Evaluates the given block and returns its contents. The contents of the
-    # block is not outputted.
-    #
-    # @return [String] The captured result
+    # @return [String]
     def capture(&block)
       # Get erbout so far
       erbout = eval('_erbout', block.binding)

--- a/lib/nanoc/helpers/child_parent.rb
+++ b/lib/nanoc/helpers/child_parent.rb
@@ -1,21 +1,6 @@
 module Nanoc::Helpers
-  # Provides functionality for fetching the children and the parent of a given
-  # item. This works for both full identifiers and legacy identifiers.
+  # @see http://nanoc.ws/doc/reference/helpers/#childparent
   module ChildParent
-    # Returns the parent of the given item.
-    #
-    # For items with legacy identifiers, the parent is the item where the
-    # identifier contains one less component than the identifier of the given
-    # item. For # example, the parent of the “/projects/nanoc/” item is the
-    # “/projects/” item.
-    #
-    # For items with full identifiers, the parent is the item where the
-    # identifier contains one less component than the identifier of the given
-    # item, and ends with any extension. For example, the parent of the
-    # “/projects/nanoc.md” item could be the “/projects.md” item, or the
-    # “/projects.html” item, etc. Note that the parent is ambiguous for items
-    # that have a full identifier; only the first candidate parent item will be
-    # returned.
     def parent_of(item)
       if item.identifier.legacy?
         item.parent
@@ -25,20 +10,6 @@ module Nanoc::Helpers
       end
     end
 
-    # Returns the children of the given item.
-    #
-    # For items with legacy identifiers, the children are the items where the
-    # identifier contains one more component than the identifier of the given
-    # item. For example, the children of the “/projects/” item could be
-    # “/projects/nanoc/” and “/projects/cri/”, but not “/about/” nor
-    # “/projects/nanoc/history/”.
-    #
-    # For items with full identifiers, the children are the item where the
-    # identifier starts with the identifier of the given item, minus the
-    # extension, followed by a slash. For example, the children of the
-    # “/projects.md” item could be the “/projects/nanoc.md” and
-    # “/projects/cri.adoc” items , but not “/about.md” nor
-    # “/projects/nanoc/history.md”.
     def children_of(item)
       if item.identifier.legacy?
         item.children

--- a/lib/nanoc/helpers/filtering.rb
+++ b/lib/nanoc/helpers/filtering.rb
@@ -1,27 +1,11 @@
 module Nanoc::Helpers
-  # Provides functionality for filtering parts of an item or a layout.
+  # @see http://nanoc.ws/doc/reference/helpers/#filtering
   module Filtering
     require 'nanoc/helpers/capturing'
     include Nanoc::Helpers::Capturing
 
-    # Filters the content in the given block and outputs it. This function
-    # does not return anything; instead, the filtered contents is directly
-    # appended to the output buffer (`_erbout`).
-    #
-    # This function has been tested with ERB and Haml. Other filters may not
-    # work correctly.
-    #
-    # @example Running a filter on a part of an item or layout
-    #
-    #   <p>Lorem ipsum dolor sit amet...</p>
-    #   <% filter :rubypants do %>
-    #     <p>Consectetur adipisicing elit...</p>
-    #   <% end %>
-    #
-    # @param [Symbol] filter_name The name of the filter to run on the
-    #   contents of the block
-    #
-    # @param [Hash] arguments Arguments to pass to the filter
+    # @param [Symbol] filter_name
+    # @param [Hash] arguments
     #
     # @return [void]
     def filter(filter_name, arguments = {}, &block)

--- a/lib/nanoc/helpers/html_escape.rb
+++ b/lib/nanoc/helpers/html_escape.rb
@@ -1,29 +1,12 @@
 module Nanoc::Helpers
-  # Contains functionality for HTML-escaping strings.
+  # @see http://nanoc.ws/doc/reference/helpers/#filtering
   module HTMLEscape
     require 'nanoc/helpers/capturing'
     include Nanoc::Helpers::Capturing
 
-    # Returns the HTML-escaped representation of the given string or the given
-    # block. Only `&`, `<`, `>` and `"` are escaped. When given a block, the
-    # contents of the block will be escaped and appended to the output buffer,
-    # `_erbout`.
+    # @param [String] string
     #
-    # @example Escaping a string
-    #
-    #     h('<br>')
-    #     # => '&lt;br&gt;'
-    #
-    # @example Escaping with a block
-    #
-    #     <% h do %>
-    #       <h1>Hello <em>world</em>!</h1>
-    #     <% end %>
-    #     # The buffer will now contain “&lt;h1&gt;Hello &lt;em&gt;world&lt;/em&gt;!&lt;/h1&gt;”
-    #
-    # @param [String] string The string to escape
-    #
-    # @return [String] The escaped string
+    # @return [String]
     def html_escape(string = nil, &block)
       if block_given?
         # Capture and escape block

--- a/lib/nanoc/helpers/link_to.rb
+++ b/lib/nanoc/helpers/link_to.rb
@@ -1,46 +1,14 @@
 module Nanoc::Helpers
-  # Contains functions for linking to items and item representations.
+  # @see http://nanoc.ws/doc/reference/helpers/#linkto
   module LinkTo
     require 'nanoc/helpers/html_escape'
     include Nanoc::Helpers::HTMLEscape
 
-    # Creates a HTML link to the given path or item representation, and with
-    # the given text. All attributes of the `a` element, including the `href`
-    # attribute, will be HTML-escaped; the contents of the `a` element, which
-    # can contain markup, will not be HTML-escaped. The HTML-escaping is done
-    # using {Nanoc::Helpers::HTMLEscape#html_escape}.
+    # @param [String] text
     #
-    # @param [String] text The visible link text
+    # @param [Hash] attributes
     #
-    # @param [String, Nanoc::Int::Item, Nanoc::Int::ItemRep] target The path/URL,
-    #   item or item representation that should be linked to
-    #
-    # @param [Hash] attributes A hash containing HTML attributes (e.g.
-    #   `rel`, `title`, …) that will be added to the link.
-    #
-    # @return [String] The link text
-    #
-    # @example Linking to a path
-    #
-    #   link_to('Blog', '/blog/')
-    #   # => '<a href="/blog/">Blog</a>'
-    #
-    # @example Linking to an item
-    #
-    #   about = @items.find { |i| i.identifier == '/about/' }
-    #   link_to('About Me', about)
-    #   # => '<a href="/about.html">About Me</a>'
-    #
-    # @example Linking to an item representation
-    #
-    #   about = @items.find { |i| i.identifier == '/about/' }
-    #   link_to('My vCard', about.rep(:vcard))
-    #   # => '<a href="/about.vcf">My vCard</a>'
-    #
-    # @example Linking with custom attributes
-    #
-    #   link_to('Blog', '/blog/', :title => 'My super cool blog')
-    #   # => '<a title="My super cool blog" href="/blog/">Blog</a>'
+    # @return [String]
     def link_to(text, target, attributes = {})
       # Find path
       path =
@@ -63,30 +31,11 @@ module Nanoc::Helpers
       "<a #{attributes}href=\"#{h path}\">#{text}</a>"
     end
 
-    # Creates a HTML link using {#link_to}, except when the linked item is
-    # the current one. In this case, a span element with class “active” and
-    # with the given text will be returned. The HTML-escaping rules for
-    # {#link_to} apply here as well.
+    # @param [String] text
     #
-    # @param [String] text The visible link text
+    # @param [Hash] attributes
     #
-    # @param [String, Nanoc::Int::Item, Nanoc::Int::ItemRep] target The path/URL,
-    #   item or item representation that should be linked to
-    #
-    # @param [Hash] attributes A hash containing HTML attributes (e.g.
-    #   `rel`, `title`, …) that will be added to the link.
-    #
-    # @return [String] The link text
-    #
-    # @example Linking to a different page
-    #
-    #   link_to_unless_current('Blog', '/blog/')
-    #   # => '<a href="/blog/">Blog</a>'
-    #
-    # @example Linking to the same page
-    #
-    #   link_to_unless_current('This Item', @item)
-    #   # => '<span class="active">This Item</span>'
+    # @return [String]
     def link_to_unless_current(text, target, attributes = {})
       # Find path
       path = target.is_a?(String) ? target : target.path
@@ -99,20 +48,7 @@ module Nanoc::Helpers
       end
     end
 
-    # Returns the relative path from the current item to the given path or
-    # item representation. The returned path will not be HTML-escaped.
-    #
-    # @param [String, Nanoc::Int::Item, Nanoc::Int::ItemRep] target The path/URL,
-    #   item or item representation to which the relative path should be
-    #   generated
-    #
-    # @return [String] The relative path to the target
-    #
-    # @example
-    #
-    #   # if the current item's path is /foo/bar/
-    #   relative_path_to('/foo/qux/')
-    #   # => '../qux/'
+    # @return [String]
     def relative_path_to(target)
       require 'pathname'
 

--- a/lib/nanoc/helpers/rendering.rb
+++ b/lib/nanoc/helpers/rendering.rb
@@ -1,78 +1,16 @@
 module Nanoc::Helpers
-  # Provides functionality for rendering layouts as partials.
+  # @see http://nanoc.ws/doc/reference/helpers/#rendering
   module Rendering
     include Nanoc::Helpers::Capturing
 
-    # Renders the given layout. The given layout will be run through the first
-    # matching layout rule.
+    # @param [String] identifier
+    # @param [Hash] other_assigns
     #
-    # When this method is invoked _without_ a block, the return value will be
-    # the rendered layout (a string)  and `_erbout` will not be modified.
+    # @raise [Nanoc::Int::Errors::UnknownLayout]
+    # @raise [Nanoc::Int::Errors::CannotDetermineFilter]
+    # @raise [Nanoc::Int::Errors::UnknownFilter]
     #
-    # When this method is invoked _with_ a block, an empty string will be
-    # returned and the rendered content will be appended to `_erbout`. In this
-    # case, the content of the block will be captured (using the
-    # {Nanoc::Helpers::Capturing} helper) and this content will be made
-    # available with `yield`. In other words, a `yield` inside the partial
-    # will output the content of the block passed to the method.
-    #
-    # (For the curious: the reason why {#render} with a block has this
-    # behaviour of returning an empty string and modifying `_erbout` is
-    # because ERB does not support combining the `<%= ... %>` form with a
-    # method call that takes a block.)
-    #
-    # The assigns (`@item`, `@config`, …) will be available in the partial. It
-    # is also possible to pass custom assigns to the method; these assigns
-    # will be made available as instance variables inside the partial.
-    #
-    # @param [String] identifier The identifier of the layout that should be
-    #   rendered
-    #
-    # @param [Hash] other_assigns A hash containing extra assigns that will be
-    #   made available as instance variables in the partial
-    #
-    # @example Rendering a head and a foot partial around some text
-    #
-    #   <%= render 'head' %> - MIDDLE - <%= render 'foot' %>
-    #   # => "HEAD - MIDDLE - FOOT"
-    #
-    # @example Rendering a head partial with a custom title
-    #
-    #   # The 'head' layout
-    #   <h1><%= @title %></h1>
-    #
-    #   # The item/layout where the partial is rendered
-    #   <%= render 'head', :title => 'Foo' %>
-    #   # => "<h1>Foo</h1>"
-    #
-    # @example Yielding inside a partial
-    #
-    #   # The 'box' partial
-    #   <div class="box">
-    #     <%= yield %>
-    #   </div>
-    #
-    #   # The item/layout where the partial is rendered
-    #   <% render 'box' do %>
-    #     I'm boxy! Luvz!
-    #   <% end %>
-    #
-    #   # Result
-    #   <div class="box">
-    #     I'm boxy! Luvz!
-    #   </div>
-    #
-    # @raise [Nanoc::Int::Errors::UnknownLayout] if the given layout does not
-    #   exist
-    #
-    # @raise [Nanoc::Int::Errors::CannotDetermineFilter] if there is no layout
-    #   rule for the given layout
-    #
-    # @raise [Nanoc::Int::Errors::UnknownFilter] if the layout rule for the given
-    #   layout specifies an unknown filter
-    #
-    # @return [String, nil] The rendered partial, or nil if this method was
-    #   invoked with a block
+    # @return [String, nil]
     def render(identifier, other_assigns = {}, &block)
       # Find layout
       layout = @layouts[identifier]

--- a/lib/nanoc/helpers/tagging.rb
+++ b/lib/nanoc/helpers/tagging.rb
@@ -1,31 +1,14 @@
 module Nanoc::Helpers
-  # Provides support for managing tags added to items.
-  #
-  # To add tags to items, set the `tags` attribute to an array of tags that
-  # should be applied to the item.
-  #
-  # @example Adding tags to an item
-  #
-  #   tags: [ 'foo', 'bar', 'baz' ]
+  # @see http://nanoc.ws/doc/reference/helpers/#tagging
   module Tagging
     require 'nanoc/helpers/html_escape'
     include Nanoc::Helpers::HTMLEscape
 
-    # Returns a formatted list of tags for the given item as a string. The
-    # tags will be linked using the {#link_for_tag} function; the
-    # HTML-escaping rules for {#link_for_tag} apply here as well.
+    # @param [String] base_url
+    # @param [String] none_text
+    # @param [String] separator
     #
-    # @param [String] base_url The URL to which the tag will be appended
-    #   to construct the link URL. This URL must have a trailing slash. The
-    #   function will return a tags string without tag page link if the param
-    #   is not provided.
-    #
-    # @param [String] none_text The text to display when
-    #   the item has no tags
-    #
-    # @param [String] separator The separator to put between tags
-    #
-    # @return [String] A hyperlinked list of tags for the given item
+    # @return [String]
     def tags_for(item, base_url: nil, none_text: '(none)', separator: ', ')
       if item[:tags].nil? || item[:tags].empty?
         none_text
@@ -34,26 +17,17 @@ module Nanoc::Helpers
       end
     end
 
-    # Find all items with the given tag.
+    # @param [String] tag
     #
-    # @param [String] tag The tag for which to find all items
-    #
-    # @return [Array] All items with the given tag
+    # @return [Array]
     def items_with_tag(tag)
       @items.select { |i| (i[:tags] || []).include?(tag) }
     end
 
-    # Returns a link to to the specified tag. The link is marked up using the
-    # rel-tag microformat. The `href` attribute of the link will be HTML-
-    # escaped, as will the content of the `a` element.
+    # @param [String] tag
+    # @param [String] base_url
     #
-    # @param [String] tag The name of the tag, which should consist of letters
-    #   and numbers (no spaces, slashes, or other special characters).
-    #
-    # @param [String] base_url The URL to which the tag will be appended to
-    #   construct the link URL. This URL must have a trailing slash.
-    #
-    # @return [String] A link for the given tag and the given base URL
+    # @return [String]
     def link_for_tag(tag, base_url)
       %(<a href="#{h base_url}#{h tag}" rel="tag">#{h tag}</a>)
     end

--- a/lib/nanoc/helpers/text.rb
+++ b/lib/nanoc/helpers/text.rb
@@ -1,19 +1,11 @@
 module Nanoc::Helpers
-  # Contains several useful text-related helper functions.
+  # @see http://nanoc.ws/doc/reference/helpers/#text
   module Text
-    # Returns an excerpt for the given string. HTML tags are ignored, so if
-    # you don't want them to turn up, they should be stripped from the string
-    # before passing it to the excerpt function.
+    # @param [String] string
+    # @param [Number] length
+    # @param [String] omission
     #
-    # @param [String] string The string for which to build an excerpt
-    #
-    # @param [Number] length The maximum number of characters
-    #   this excerpt can contain, including the omission.
-    #
-    # @param [String] omission The string to append to the
-    #   excerpt when the excerpt is shorter than the original string
-    #
-    # @return [String] The excerpt of the given string
+    # @return [String]
     def excerptize(string, length: 25, omission: '...')
       if string.length > length
         excerpt_length = [0, length - omission.length].max
@@ -23,11 +15,9 @@ module Nanoc::Helpers
       end
     end
 
-    # Strips all HTML tags out of the given string.
+    # @param [String] string
     #
-    # @param [String] string The string from which to strip all HTML
-    #
-    # @return [String] The given string with all HTML stripped
+    # @return [String]
     def strip_html(string)
       # FIXME: will need something more sophisticated than this, because it sucks
       string.gsub(/<[^>]*(>+|\s*\z)/m, '').strip

--- a/lib/nanoc/helpers/xml_sitemap.rb
+++ b/lib/nanoc/helpers/xml_sitemap.rb
@@ -1,40 +1,10 @@
 module Nanoc::Helpers
-  # Contains functionality for building XML sitemaps that will be crawled by
-  # search engines. See the [Sitemaps protocol site](http://www.sitemaps.org)
-  # for details.
+  # @see http://nanoc.ws/doc/reference/helpers/#xmlsitemap
   module XMLSitemap
-    # Builds an XML sitemap and returns it.
+    # @option params [Array] :items
+    # @option params [Proc] :rep_select
     #
-    # The following attributes can optionally be set on items to change the
-    # behaviour of the sitemap:
-    #
-    # * `changefreq` — The estimated change frequency as defined by the
-    #   Sitemaps protocol
-    #
-    # * `priority` — The item's priority, ranging from 0.0 to 1.0, as defined
-    #   by the Sitemaps protocol
-    #
-    # The sitemap will also include dates on which the items were updated.
-    # These are generated automatically; the way this happens depends on the
-    # used data source (the filesystem data source checks the file mtimes, for
-    # instance).
-    #
-    # The site configuration will need to have the following attributes:
-    #
-    # * `base_url` — The URL to the site, without trailing slash. For example,
-    #   if the site is at "http://example.com/", the `base_url` would be
-    #   "http://example.com".
-    #
-    # @example Excluding binary items from the sitemap
-    #
-    #   <%= xml_sitemap :items => @items.reject{ |i| i[:is_hidden] || i.binary? } %>
-    #
-    # @option params [Array] :items A list of items to include in the sitemap
-    #
-    # @option params [Proc] :rep_select A proc to filter reps through. If the
-    #   proc returns true, the rep will be included; otherwise, it will not.
-    #
-    # @return [String] The XML sitemap
+    # @return [String]
     def xml_sitemap(params = {})
       require 'builder'
 

--- a/lib/nanoc/spec.rb
+++ b/lib/nanoc/spec.rb
@@ -47,8 +47,9 @@ module Nanoc
       # @param [Nanoc::ItemWithRepsView] item The item to create a represetation for
       #
       # @param [String] path The path of the `:last` snapshot of this item representation
-      def create_rep(item, path)
-        rep = Nanoc::Int::ItemRep.new(item.unwrap, :default)
+      # @param [Symbol] rep The rep name to create
+      def create_rep(item, path, rep = :default)
+        rep = Nanoc::Int::ItemRep.new(item.unwrap, rep)
         rep.paths[:last] = path
         @reps << rep
         Nanoc::ItemRepView.new(rep, view_context)

--- a/spec/nanoc/base/filter_spec.rb
+++ b/spec/nanoc/base/filter_spec.rb
@@ -1,0 +1,17 @@
+describe Nanoc::Filter do
+  describe '.define' do
+    before do
+      Nanoc::Filter.define(:nanoc_filter_define_sample) do |content, _params|
+        content.upcase
+      end
+    end
+
+    it 'defines a filter' do
+      expect(Nanoc::Filter.named(:nanoc_filter_define_sample)).not_to be_nil
+    end
+
+    it 'defines a callable filter' do
+      expect(Nanoc::Filter.named(:nanoc_filter_define_sample).new.run('foo', {})).to eql('FOO')
+    end
+  end
+end

--- a/test/extra/checking/checks/test_internal_links.rb
+++ b/test/extra/checking/checks/test_internal_links.rb
@@ -16,6 +16,21 @@ class Nanoc::Extra::Checking::Checks::InternalLinksTest < Nanoc::TestCase
     end
   end
 
+  def test_resource_uris
+    with_site do |site|
+      # Create files
+      FileUtils.mkdir_p('output')
+      File.open('output/bar.html', 'w') { |io| io.write('<link rel="stylesheet" href="/styledinges.css">') }
+
+      # Create check
+      check = Nanoc::Extra::Checking::Checks::InternalLinks.create(site)
+      check.run
+
+      # Test
+      assert check.issues.size == 1
+    end
+  end
+
   def test_valid?
     with_site do |site|
       # Create files


### PR DESCRIPTION
Right now the ilinks check only checks for internal links in `a` and `img` tags. Just as an example: I recently refactored the locations of my assets, and wanted to locate all the places in my code where these references were broken, but `nanoc check ilinks` stated everything was a-ok.

This PR makes `nanoc check ilinks` also check for resource links (`style`, `script`, ...)