### PR TITLE
Revert "Only recompile outdated reps"

### DIFF
--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -191,8 +191,7 @@ module Nanoc::Int
       end
 
       # Find item reps to compile and compile them
-      outdated_reps = @reps.select { |r| outdatedness_checker.outdated?(r) }
-      selector = Nanoc::Int::ItemRepSelector.new(outdated_reps)
+      selector = Nanoc::Int::ItemRepSelector.new(@reps)
       selector.each do |rep|
         @stack = []
         compile_rep(rep)

--- a/test/base/test_compiler.rb
+++ b/test/base/test_compiler.rb
@@ -208,6 +208,21 @@ class Nanoc::Int::CompilerTest < Nanoc::TestCase
     end
   end
 
+  def test_compile_should_recompile_all_reps
+    Nanoc::CLI.run %w(create_site bar)
+
+    FileUtils.cd('bar') do
+      Nanoc::CLI.run %w(compile)
+
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+      site.compile
+
+      # At this point, even the already compiled items in the previous pass
+      # should have their compiled content assigned, so this should work:
+      site.compiler.reps[site.items['/index.*']][0].compiled_content
+    end
+  end
+
   def test_disallow_multiple_snapshots_with_the_same_name
     # Create site
     Nanoc::CLI.run %w(create_site bar)


### PR DESCRIPTION
Reverting, because when a postprocessor exist, all reps need to be compiled.

A better solution would be to compile item reps on-demand in the postprocessor, but that’s an optimisation left for later.

Fixes #913.
Reverts #894.