### PR TITLE
Improve missing deploy target error message

### DIFF
--- a/lib/nanoc/cli/commands/deploy.rb
+++ b/lib/nanoc/cli/commands/deploy.rb
@@ -62,8 +62,7 @@ module Nanoc::CLI::Commands
 
       target = options.fetch(:target, :default).to_sym
       deploy_configs.fetch(target) do
-        # FIXME: target name is unobvious
-        raise Nanoc::Int::Errors::GenericTrivial, "The site has no deployment configuration for #{target}."
+        raise Nanoc::Int::Errors::GenericTrivial, "The site has no deployment configuration named `#{target}`."
       end
     end
 

--- a/spec/nanoc/cli/commands/deploy_spec.rb
+++ b/spec/nanoc/cli/commands/deploy_spec.rb
@@ -202,7 +202,7 @@ describe Nanoc::CLI::Commands::Shell, site: true, stdio: true do
             it 'errors' do
               expect { run }.to raise_error(
                 Nanoc::Int::Errors::GenericTrivial,
-                'The site has no deployment configuration for default.',
+                'The site has no deployment configuration named `default`.',
               )
             end
 
@@ -257,7 +257,7 @@ describe Nanoc::CLI::Commands::Shell, site: true, stdio: true do
             it 'errors' do
               expect { run }.to raise_error(
                 Nanoc::Int::Errors::GenericTrivial,
-                'The site has no deployment configuration for production.',
+                'The site has no deployment configuration named `production`.',
               )
             end
 


### PR DESCRIPTION
Before:

```
The site has no deployment configuration for staging.
```

After:

```
The site has no deployment configuration named `staging`.
```