### PR TITLE
Improve trailing-slash error message

### DIFF
--- a/lib/nanoc/extra/deployers/fog.rb
+++ b/lib/nanoc/extra/deployers/fog.rb
@@ -84,8 +84,9 @@ module Nanoc::Extra::Deployers
       path     = config[:path]
       cdn_id   = config[:cdn_id]
 
-      # FIXME: confusing error message
-      raise 'The path requires no trailing slash' if path && path[-1, 1] == '/'
+      if path && path.end_with?('/')
+        raise "The path `#{path}` is not supposed to have a trailing slash"
+      end
 
       connection = connect
       directory = get_or_create_bucket(connection, bucket, path)

--- a/spec/nanoc/extra/deployers/fog_spec.rb
+++ b/spec/nanoc/extra/deployers/fog_spec.rb
@@ -85,7 +85,7 @@ describe Nanoc::Extra::Deployers::Fog, stdio: true do
         end
 
         it 'raises' do
-          expect { subject }.to raise_error('The path requires no trailing slash')
+          expect { subject }.to raise_error('The path `foo/` is not supposed to have a trailing slash')
         end
       end
 


### PR DESCRIPTION
Before:

```
The path requires no trailing slash
```

After:

```
The path `foo/` is not supposed to have a trailing slash
```