### PR TITLE
Lock ruby_dep to 1.3.x on Ruby 2.1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'json', '~> 2.0'
+gem 'ruby_dep', (RUBY_VERSION =~ /\A2.1/ ? '~> 1.3.1' : '~> 1.4')
 
 group :devel do
   gem 'contracts', '~> 0.14'


### PR DESCRIPTION
Recent version  of `ruby_dep` require Ruby 2.2+. Since Nanoc still runs tests on Ruby 2.1, let’s lock ruby_dep to 1.3.x on Ruby 2.1.x.