### PR TITLE
BUGFIX: Bundler::GemfileNotFound

### DIFF
--- a/lib/nanoc/cli.rb
+++ b/lib/nanoc/cli.rb
@@ -106,7 +106,13 @@ module Nanoc::CLI
 
     if defined?(Bundler)
       # Discover external commands through Bundler
-      Bundler.require(:nanoc)
+      begin
+        Bundler.require(:nanoc)
+      rescue Bundler::GemfileNotFound
+        # When running nanoc with Bundler being defined but
+        # no gemfile being present (rubygems automatically loads
+        # Bundler when executing from command line), don't crash.
+      end
     end
   end
 


### PR DESCRIPTION
### Summary

In #910, some interaction with Bundler was introduced. However, when running nanoc from commandline immediately, without a Gemfile or .bundle directory being present (when creating a new site, for example), a script created by rubygems gets called, which includes Bundler. This would give the following error any time nanoc gets called from CLI

```
☁  Projects  nanoc create-site cv

Captain! We’ve been hit!

Message:

Bundler::GemfileNotFound: Could not locate Gemfile or .bundle/ directory
````

### Detailed description

We add a rescue block in order to prevent nanoc from crashing. If there's no Gemfile, nothing should happen anyway.

### Crashlog

https://gist.github.com/werthen/ffa7610068ea5afa956fe5f12c8d20ea
