### PR TITLE
Improve feature flag implementation

### DIFF
--- a/lib/nanoc/base/feature.rb
+++ b/lib/nanoc/base/feature.rb
@@ -1,11 +1,16 @@
 module Nanoc
   # @api private
   module Feature
-    TRUES = %w(y yes 1 t true).freeze
+    FEATURES_VAR_NAME = 'NANOC_FEATURES'.freeze
+    ALL_VALUE = 'all'.freeze
 
-    def self.enabled?(name)
-      env_name = "NANOC_FEATURE_#{name.upcase}"
-      TRUES.include?(ENV.fetch(env_name, 'f').downcase)
+    def self.enabled_features
+      Set.new(ENV.fetch(FEATURES_VAR_NAME, '').split(','))
+    end
+
+    def self.enabled?(feature_name)
+      enabled_features.include?(feature_name) ||
+        enabled_features.include?(ALL_VALUE)
     end
   end
 end

--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -14,7 +14,7 @@ IDENTICAL - The item was deemed outdated and has been recompiled, but the compil
 SKIP - The item was deemed not outdated and was therefore not recompiled
 
 EOS
-flag nil, :profile, 'profile compilation' if Nanoc::Feature.enabled?('PROFILER')
+flag nil, :profile, 'profile compilation' if Nanoc::Feature.enabled?('profiler')
 
 module Nanoc::CLI::Commands
   class Compile < ::Nanoc::CLI::CommandRunner

--- a/spec/nanoc/base/feature_spec.rb
+++ b/spec/nanoc/base/feature_spec.rb
@@ -4,26 +4,25 @@ describe Nanoc::Feature do
 
     let(:feature_name) { 'magic' }
 
-    context 'disabled' do
-      context 'not set' do
-        it { is_expected.not_to be }
-      end
+    before { ENV['NANOC_FEATURES'] = '' }
 
-      %w(0 n N no No NO false False fAlSe FALSE donkey).each do |val|
-        context "set to #{val}" do
-          before { ENV['NANOC_FEATURE_MAGIC'] = val }
-          it { is_expected.not_to be }
-        end
-      end
+    context 'not set' do
+      it { is_expected.not_to be }
     end
 
-    context 'enabled' do
-      %w(1 y Y yes yEs YES t True tRuE TRUE).each do |val|
-        context "set to #{val}" do
-          before { ENV['NANOC_FEATURE_MAGIC'] = val }
-          it { is_expected.to be }
-        end
-      end
+    context 'set to list not including feature' do
+      before { ENV['NANOC_FEATURES'] = 'foo,bar' }
+      it { is_expected.not_to be }
+    end
+
+    context 'set to all' do
+      before { ENV['NANOC_FEATURES'] = 'all' }
+      it { is_expected.to be }
+    end
+
+    context 'set to list including feature' do
+      before { ENV['NANOC_FEATURES'] = 'foo,magic,bar' }
+      it { is_expected.to be }
     end
   end
 end

--- a/ugh.diff
+++ b/ugh.diff
@@ -1,0 +1,85 @@
+diff --git a/lib/nanoc/base/feature.rb b/lib/nanoc/base/feature.rb
+index 7cfd169..53ec191 100644
+--- a/lib/nanoc/base/feature.rb
++++ b/lib/nanoc/base/feature.rb
+@@ -1,11 +1,16 @@
+ module Nanoc
+   # @api private
+   module Feature
+-    TRUES = %w(y yes 1 t true).freeze
++    FEATURES_VAR_NAME = 'NANOC_FEATURES'.freeze
++    ALL_VALUE = 'all'.freeze
+ 
+-    def self.enabled?(name)
+-      env_name = "NANOC_FEATURE_#{name.upcase}"
+-      TRUES.include?(ENV.fetch(env_name, 'f').downcase)
++    def self.enabled_features
++      Set.new(ENV.fetch(FEATURES_VAR_NAME, '').split(','))
++    end
++
++    def self.enabled?(feature_name)
++      enabled_features.include?(feature_name) ||
++        enabled_features.include?(ALL_VALUE)
+     end
+   end
+ end
+diff --git a/lib/nanoc/cli/commands/compile.rb b/lib/nanoc/cli/commands/compile.rb
+index f111810..3e0861c 100644
+--- a/lib/nanoc/cli/commands/compile.rb
++++ b/lib/nanoc/cli/commands/compile.rb
+@@ -14,7 +14,7 @@ IDENTICAL - The item was deemed outdated and has been recompiled, but the compil
+ SKIP - The item was deemed not outdated and was therefore not recompiled
+ 
+ EOS
+-flag nil, :profile, 'profile compilation' if Nanoc::Feature.enabled?('PROFILER')
++flag nil, :profile, 'profile compilation' if Nanoc::Feature.enabled?('profiler')
+ 
+ module Nanoc::CLI::Commands
+   class Compile < ::Nanoc::CLI::CommandRunner
+diff --git a/spec/nanoc/base/feature_spec.rb b/spec/nanoc/base/feature_spec.rb
+index efccb8e..a35b94b 100644
+--- a/spec/nanoc/base/feature_spec.rb
++++ b/spec/nanoc/base/feature_spec.rb
+@@ -4,26 +4,25 @@ describe Nanoc::Feature do
+ 
+     let(:feature_name) { 'magic' }
+ 
+-    context 'disabled' do
+-      context 'not set' do
+-        it { is_expected.not_to be }
+-      end
++    before { ENV['NANOC_FEATURES'] = '' }
+ 
+-      %w(0 n N no No NO false False fAlSe FALSE donkey).each do |val|
+-        context "set to #{val}" do
+-          before { ENV['NANOC_FEATURE_MAGIC'] = val }
+-          it { is_expected.not_to be }
+-        end
+-      end
++    context 'not set' do
++      it { is_expected.not_to be }
+     end
+ 
+-    context 'enabled' do
+-      %w(1 y Y yes yEs YES t True tRuE TRUE).each do |val|
+-        context "set to #{val}" do
+-          before { ENV['NANOC_FEATURE_MAGIC'] = val }
+-          it { is_expected.to be }
+-        end
+-      end
++    context 'set to list not including feature' do
++      before { ENV['NANOC_FEATURES'] = 'foo,bar' }
++      it { is_expected.not_to be }
++    end
++
++    context 'set to all' do
++      before { ENV['NANOC_FEATURES'] = 'all' }
++      it { is_expected.to be }
++    end
++
++    context 'set to list including feature' do
++      before { ENV['NANOC_FEATURES'] = 'foo,magic,bar' }
++      it { is_expected.to be }
+     end
+   end
+ end


### PR DESCRIPTION
This uses `NANOC_FEATURES` to specify features, rather than `NANOC_FEATURE_abc` (where `abc` is the feature name.

See nanoc/rfcs#5 for details on the design.