### PR TITLE
Hide env behind feature flag

### DIFF
--- a/lib/nanoc/base/feature.rb
+++ b/lib/nanoc/base/feature.rb
@@ -2,6 +2,7 @@ module Nanoc
   # @api private
   module Feature
     PROFILER = 'profiler'.freeze
+    ENVIRONMENTS = 'environments'.freeze
 
     def self.enabled_features
       @enabled_features ||= Set.new(ENV.fetch('NANOC_FEATURES', '').split(','))

--- a/lib/nanoc/base/repos/config_loader.rb
+++ b/lib/nanoc/base/repos/config_loader.rb
@@ -37,10 +37,18 @@ module Nanoc::Int
       raise NoConfigFileFoundError if filename.nil?
 
       # Read
-      apply_parent_config(
-        Nanoc::Int::Configuration.new(hash: YAML.load_file(filename)),
-        [filename],
-      ).with_defaults.with_environment
+      config =
+        apply_parent_config(
+          Nanoc::Int::Configuration.new(hash: YAML.load_file(filename)),
+          [filename],
+        ).with_defaults
+
+      # Load environment
+      if Nanoc::Feature.enabled?(Nanoc::Feature::ENVIRONMENTS)
+        config.with_environment
+      else
+        config
+      end
     end
 
     # @api private

--- a/spec/nanoc/base/repos/config_loader_spec.rb
+++ b/spec/nanoc/base/repos/config_loader_spec.rb
@@ -56,7 +56,11 @@ describe Nanoc::Int::ConfigLoader do
     context 'config file present and environment defined' do
       before do
         File.write('nanoc.yaml', YAML.dump({ foo: 'bar', tofoo: 'bar', environments: { test: { foo: 'test-bar' }, default: { foo: 'default-bar' } } }))
+        expect(Nanoc::Feature).to receive(:enabled?).with('environments').and_return(true)
+        expect(ENV).to receive(:fetch).with('NANOC_ENV', 'default').and_return(active_env_name)
       end
+
+      let(:active_env_name) { 'default' }
 
       it 'returns the configuration' do
         expect(subject).to be_a(Nanoc::Int::Configuration)
@@ -66,9 +70,12 @@ describe Nanoc::Int::ConfigLoader do
         expect(subject[:tofoo]).to eq('bar')
       end
 
-      it 'has the test environment custom option' do
-        allow(ENV).to receive(:fetch).with(Nanoc::Int::Configuration::NANOC_ENV, Nanoc::Int::Configuration::NANOC_ENV_DEFAULT).and_return('test')
-        expect(subject[:foo]).to eq('test-bar')
+      context 'current env is test' do
+        let(:active_env_name) { 'test' }
+
+        it 'has the test environment custom option' do
+          expect(subject[:foo]).to eq('test-bar')
+        end
       end
 
       it 'has the default environment custom option' do

--- a/spec/nanoc/base/repos/site_loader_spec.rb
+++ b/spec/nanoc/base/repos/site_loader_spec.rb
@@ -158,6 +158,38 @@ describe Nanoc::Int::SiteLoader do
       end
     end
 
+    context 'environments defined' do
+      before do
+        File.write('nanoc.yaml', <<-EOS.gsub(/^ {10}/, ''))
+          animal: donkey
+          environments:
+            staging:
+              animal: giraffe
+        EOS
+      end
+
+      context 'environments feature disabled' do
+        before do
+          expect(Nanoc::Feature).to receive(:enabled?).with('environments').and_return(false)
+        end
+
+        it 'does not load environment' do
+          expect(subject.config[:animal]).to eq('donkey')
+        end
+      end
+
+      context 'environments feature enabled' do
+        before do
+          expect(Nanoc::Feature).to receive(:enabled?).with('environments').and_return(true)
+          expect(ENV).to receive(:fetch).with('NANOC_ENV', 'default').and_return('staging')
+        end
+
+        it 'does not load environment' do
+          expect(subject.config[:animal]).to eq('giraffe')
+        end
+      end
+    end
+
     context 'code snippet with data source implementation' do
       before do
         FileUtils.mkdir_p('lib')


### PR DESCRIPTION
This hides the environment behind a feature flag, so that it can be part of the next patch release as a pre-release feature.

Also see nanoc/rfcs#5.