### PR TITLE
Improve Nanoc::Feature API

### DIFF
--- a/lib/nanoc/base/feature.rb
+++ b/lib/nanoc/base/feature.rb
@@ -1,20 +1,77 @@
 module Nanoc
   # @api private
+  #
+  # @example Defining a feature and checking its enabledness
+  #
+  #     Nanoc::Feature.define('environments', version: '4.3')
+  #     Nanoc::Feaure.enabled?(Nanoc::Feature::ENVIRONMENTS)
+  #
   module Feature
-    PROFILER = 'profiler'.freeze
-    ENVIRONMENTS = 'environments'.freeze
-
-    def self.enabled_features
-      @enabled_features ||= Set.new(ENV.fetch('NANOC_FEATURES', '').split(','))
+    # Defines a new feature with the given name, experimental in the given
+    # version. The feature will be made available as a constant with the same
+    # name, in uppercase, on the Nanoc::Feature module.
+    #
+    # @example Defining Nanoc::Feature::ENVIRONMENTS
+    #
+    #     Nanoc::Feature.define('environments', version: '4.3')
+    #
+    # @param name The name of the feature
+    #
+    # @param version The minor version in which the feature is considered
+    #   experimental.
+    #
+    # @return [void]
+    def self.define(name, version:)
+      repo[name] = version
+      const_set(name.upcase, name)
     end
 
+    # Undefines the feature with the given name. For testing purposes only.
+    #
+    # @param name The name of the feature
+    #
+    # @return [void]
+    #
+    # @private
+    def self.undefine(name)
+      repo.delete(name)
+      remove_const(name.upcase)
+    end
+
+    # @param [String] feature_name
+    #
+    # @return [Boolean] Whether or not the feature with the given name is enabled
     def self.enabled?(feature_name)
       enabled_features.include?(feature_name) ||
         enabled_features.include?('all')
     end
 
+    # @api private
     def self.reset_caches
       @enabled_features = nil
     end
+
+    # @api private
+    def self.enabled_features
+      @enabled_features ||= Set.new(ENV.fetch('NANOC_FEATURES', '').split(','))
+    end
+
+    # @api private
+    def self.repo
+      @repo ||= {}
+    end
+
+    # @return [Enumerable<String>] Names of features that still exist, but
+    #   should not be considered as experimental in the current version of
+    #   Nanoc.
+    def self.all_outdated
+      repo.keys.reject do |name|
+        version = repo[name]
+        Nanoc::VERSION.start_with?(version)
+      end
+    end
   end
 end
+
+Nanoc::Feature.define('profiler', version: '4.3')
+Nanoc::Feature.define('environments', version: '4.3')

--- a/spec/nanoc/base/feature_spec.rb
+++ b/spec/nanoc/base/feature_spec.rb
@@ -28,4 +28,35 @@ describe Nanoc::Feature do
       it { is_expected.to be }
     end
   end
+
+  describe '.all_outdated' do
+    it 'refuses outdated features' do
+      # If this spec fails, there are features marked as experimental in the previous minor or major
+      # release, but not in the current one. Either remove the feature, or mark it as experimental
+      # in the current release.
+      expect(Nanoc::Feature.all_outdated).to be_empty
+    end
+
+    describe 'fake outdated features' do
+      before { Nanoc::Feature.define('abc', version: '4.2.x') }
+      after { Nanoc::Feature.undefine('abc') }
+
+      it 'detects outdated features' do
+        expect(Nanoc::Feature.all_outdated).to eq(['abc'])
+      end
+    end
+  end
+
+  describe '.define and .undefine' do
+    it 'can define' do
+      Nanoc::Feature.define('testing123', version: '4.3.x')
+      expect(Nanoc::Feature::TESTING123).not_to be_nil
+    end
+
+    it 'can undefine' do
+      Nanoc::Feature.define('testing123', version: '4.3.x')
+      Nanoc::Feature.undefine('testing123')
+      expect { Nanoc::Feature::TESTING123 }.to raise_error(NameError)
+    end
+  end
 end


### PR DESCRIPTION
Allows defining features tied to a specific version.

### Detailed description

Features are defined this way:

```ruby
Nanoc::Feature.define('profiler', version: '4.3')
```

The version describes when (in this case, 4.3.x) the feature is considered experimental. A new test ensures that no features are defined for past or future versions.

### Open questions

* How will we ensure that the tests are run *after* changing the version number? This needs to happen in order to verify feature versions.