### PR TITLE
Add fish autocompleter

### DIFF
--- a/lib/nanoc/cli/commands/autocomplete.rb
+++ b/lib/nanoc/cli/commands/autocomplete.rb
@@ -1,0 +1,35 @@
+usage 'autocomplete [options] [category]'
+summary 'print possible values for the given category'
+description "
+Print all possible values for the given category. Supported categories are `checks` and `deploy_configs`, which will print all available check names and deployment targets, respectively.
+
+This command is intended to facilitate the construction of autocompletions for shells.
+"
+
+module Nanoc::CLI::Commands
+  class Autocomplete < ::Nanoc::CLI::CommandRunner
+    def run
+      if arguments.size != 1
+        raise Nanoc::Int::Errors::GenericTrivial, "expected 1 argument, but #{arguments.size} were given"
+      end
+
+      case arguments[0]
+      when 'checks'
+        if site
+          runner = Nanoc::Extra::Checking::Runner.new(site)
+          runner.load_dsl_if_available
+          checks = runner.all_check_classes
+          puts checks.map(&:identifier).join("\n")
+        end
+      when 'deploy_configs'
+        if site
+          puts site.config.fetch(:deploy, {}).keys.join("\n")
+        end
+      else
+        raise Nanoc::Int::Errors::GenericTrivial, "unknown entity_type: #{arguments[0]}"
+      end
+    end
+  end
+end
+
+runner Nanoc::CLI::Commands::Autocomplete

--- a/lib/nanoc/extra.rb
+++ b/lib/nanoc/extra.rb
@@ -11,3 +11,4 @@ end
 require 'nanoc/extra/core_ext'
 require 'nanoc/extra/deployer'
 require 'nanoc/extra/deployers'
+require 'nanoc/extra/fish_autocompletion'

--- a/lib/nanoc/extra/fish_autocompletion.rb
+++ b/lib/nanoc/extra/fish_autocompletion.rb
@@ -1,0 +1,127 @@
+module Nanoc::Extra
+  # @api private
+  module FishAutocompletion
+    def generate
+      root_cmd = Nanoc::CLI.root_command
+
+      buf = ''
+
+      # global options
+      buf << "# global options\n"
+      root_cmd.option_definitions.each do |opt_def|
+        buf << 'complete -c nanoc'
+        buf << ' -s ' << quote(opt_def[:short]) if opt_def[:short]
+        buf << ' -l ' << quote(opt_def[:long]) if opt_def[:long]
+        buf << ' -d ' << quote(opt_def[:desc])
+        buf << ' -f'
+        buf << "\n"
+      end
+      buf << "\n"
+
+      # subcommands
+      buf << "# subcommands\n"
+      root_cmd.subcommands.each do |cmd|
+        buf << "complete -c nanoc -n '__fish_use_subcommand' -xa "
+        buf << quote(cmd.name)
+        buf << ' -d ' << quote(cmd.summary)
+        buf << ' -f'
+        buf << "\n"
+      end
+      buf << "\n"
+
+      # subcommand option details
+      each_command(root_cmd) do |cmd, name|
+        if cmd.option_definitions.any?
+          buf << "# subcommand: #{name} -- option details\n"
+          cmd.option_definitions.sort_by { |h| h[:short] || h[:long] }.each do |opt_def|
+            buf << "complete -c nanoc -n 'contains #{quote name} (commandline -poc)'"
+            buf << ' -s ' << quote(opt_def[:short]) if opt_def[:short]
+            buf << ' -l ' << quote(opt_def[:long]) if opt_def[:long]
+            buf << ' -d ' << quote(opt_def[:desc])
+            values = values_for_option_definition(cmd, opt_def)
+            if values
+              buf << ' -x -a ' << quote(values)
+            else
+              buf << ' -f'
+            end
+            buf << "\n"
+          end
+          buf << "\n"
+        end
+      end
+
+      # subcommand argument details
+      each_command(root_cmd) do |cmd, name|
+        values = values_for_command(cmd)
+        if values
+          buf << "# subcommand: #{name} -- argument details\n"
+          case values
+          when String
+            buf << "complete -c nanoc -n 'contains #{name} (commandline -poc)'"
+            buf << ' -x -a ' << quote(values)
+            buf << "\n"
+          when Array
+            values.each do |(arg, desc)|
+              buf << "complete -c nanoc -n 'contains #{name} (commandline -poc)'"
+              buf << ' -x -a ' << quote(arg)
+              buf << ' -d ' << quote(desc)
+              buf << "\n"
+            end
+          end
+
+          buf << "\n"
+        end
+      end
+
+      buf
+    end
+    module_function :generate
+
+    private
+
+    def each_command(root_cmd)
+      root_cmd.subcommands.each do |cmd|
+        [cmd.name, *cmd.aliases].each do |name|
+          yield(cmd, name)
+        end
+      end
+    end
+    module_function :each_command
+
+    # Returns either a string, or a list of argument-description pairs
+    def values_for_command(cmd)
+      case cmd.name
+      when 'check'
+        '(nanoc autocomplete checks 2> /dev/null)'
+      when 'help'
+        Nanoc::CLI.root_command.subcommands.map { |c| [c.name, c.summary] }
+      when 'deploy'
+        '(nanoc autocomplete deploy_configs 2> /dev/null)'
+      else
+        nil
+      end
+    end
+    module_function :values_for_command
+
+    # Returns a string
+    def values_for_option_definition(cmd, opt_def)
+      case [cmd.name, opt_def[:long]]
+      when %w(deploy target)
+        '(nanoc autocomplete deploy_configs 2> /dev/null)'
+      else
+        nil
+      end
+    end
+    module_function :values_for_option_definition
+
+    def quote(s)
+      '"' + escape(s) + '"'
+    end
+    module_function :quote
+
+    def escape(s)
+      s.gsub('\\', '\\\\').gsub('"', '\\"')
+    end
+    module_function :escape
+  end
+end

--- a/scripts/gen-autocompletion
+++ b/scripts/gen-autocompletion
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+require 'nanoc'
+require 'nanoc/cli'
+
+if File.file?('Gemfile') && !defined?(Bundler)
+  warn 'A Gemfile was detected, but Bundler is not loaded. This is probably not what you want. To run Nanoc with Bundler, use `bundle exec nanoc`.'
+end
+
+Nanoc::CLI.setup
+
+if ARGV.size != 1
+  $stderr.puts "usage: #{$0} [shell_name]"
+  exit 1
+end
+
+case ARGV[0]
+when 'fish'
+  puts Nanoc::Extra::FishAutocompletion.generate
+else
+  $stderr.puts "unknown shell name: #{ARGV[0]}"
+  exit 1
+end


### PR DESCRIPTION
This adds a mechanism for automatically generating autocompletions for [fish](https://fishshell.com/).
- [ ] Tests
- [ ] Read custom commands from site
- [ ] Documentation
- [ ] Feature flags

Problems:

* Autocompletion stops when `bundle exec` is prepended to a command.

Some examples of the autocompletion in action:

![autocompletion_examples](https://cloud.githubusercontent.com/assets/6269/19828904/7e13a664-9dd3-11e6-8733-ba2a29e8776d.png)
