### PR TITLE
Allow specifying deploy target as argument

### DIFF
--- a/lib/nanoc/cli/commands/deploy.rb
+++ b/lib/nanoc/cli/commands/deploy.rb
@@ -1,4 +1,4 @@
-usage 'deploy [options]'
+usage 'deploy [target] [options]'
 summary 'deploy the compiled site'
 description "
 Deploys the compiled site. The compiled site contents in the output directory will be uploaded to the destination, which is specified using the `--target` option.
@@ -60,8 +60,18 @@ module Nanoc::CLI::Commands
         raise Nanoc::Int::Errors::GenericTrivial, 'The site has no deployment configurations.'
       end
 
-      target = options.fetch(:target, :default).to_sym
-      deploy_configs.fetch(target) do
+      if arguments.length > 1
+        raise Nanoc::Int::Errors::GenericTrivial, "usage: #{command.usage}"
+      end
+
+      target_from_arguments = arguments[0]
+      target_from_options = options.fetch(:target, nil)
+      if target_from_arguments && target_from_options
+        raise Nanoc::Int::Errors::GenericTrivial, 'Only one deployment target can be specified on the command line.'
+      end
+
+      target = target_from_arguments || target_from_options || :default
+      deploy_configs.fetch(target.to_sym) do
         raise Nanoc::Int::Errors::GenericTrivial, "The site has no deployment configuration named `#{target}`."
       end
     end

--- a/spec/nanoc/cli/commands/deploy_spec.rb
+++ b/spec/nanoc/cli/commands/deploy_spec.rb
@@ -250,9 +250,7 @@ describe Nanoc::CLI::Commands::Shell, site: true, stdio: true do
           end
         end
 
-        context 'non-default target' do
-          let(:command) { %w(deploy --target production) }
-
+        shared_examples 'deploy with non-default target' do
           context 'requested deploy config does not exist' do
             it 'errors' do
               expect { run }.to raise_error(
@@ -302,6 +300,27 @@ describe Nanoc::CLI::Commands::Shell, site: true, stdio: true do
               let(:command) { (super() + ['--dry-run']) }
               include_examples 'no effective deploy'
             end
+          end
+        end
+
+        context 'non-default target, specified as argument' do
+          let(:command) { %w(deploy production) }
+          include_examples 'deploy with non-default target'
+        end
+
+        context 'non-default target, specified as option (--target)' do
+          let(:command) { %w(deploy --target production) }
+          include_examples 'deploy with non-default target'
+        end
+
+        context 'multiple targets specified' do
+          let(:command) { %w(deploy --target staging production) }
+
+          it 'errors' do
+            expect { run }.to raise_error(
+              Nanoc::Int::Errors::GenericTrivial,
+              'Only one deployment target can be specified on the command line.',
+            )
           end
         end
       end


### PR DESCRIPTION
This change allows the deploy target to be specified as an argument, in addition to an option. This makes the command easier to use, as `-t` (or `--target`) is not necessary. For example,

```
nanoc deploy staging
```

can now be used in addition to

```
nanoc deploy --target staging
nanoc deploy -t staging
```

As this is an enhancement to an existing feature,  this’ll go in the next patch release (4.3.3).