### PR TITLE
Prune before compiling (fixes #942)

### DIFF
--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -403,8 +403,8 @@ module Nanoc::CLI::Commands
 
       puts 'Compiling site…'
       run_listeners_while do
-        site.compile
         prune
+        site.compile
       end
 
       time_after = Time.now

--- a/spec/nanoc/regressions/gh_942_spec.rb
+++ b/spec/nanoc/regressions/gh_942_spec.rb
@@ -1,0 +1,21 @@
+describe 'GH-942', site: true, stdio: true do
+  before do
+    File.write('content/foo.md', 'Foo!')
+    File.write('Rules', <<EOS)
+  compile '/foo.*' do
+    write '/parent/foo'
+  end
+EOS
+
+    File.open('nanoc.yaml', 'w') do |io|
+      io << 'prune:' << "\n"
+      io << '  auto_prune: true' << "\n"
+    end
+  end
+
+  example do
+    File.write('output/parent', 'Hahaaa! I am a file and not a directory!')
+    Nanoc::CLI.run(%w(compile))
+    expect(File.read('output/parent/foo')).to eq('Foo!')
+  end
+end


### PR DESCRIPTION
Prune before compiling, to delete any files/directories that could interfere with new files/directories being generated. Fixes #942.
