### PR TITLE
Fix prune crash when output dir does not exist

### DIFF
--- a/lib/nanoc/extra/pruner.rb
+++ b/lib/nanoc/extra/pruner.rb
@@ -26,6 +26,8 @@ module Nanoc::Extra
     def run
       require 'find'
 
+      return unless File.directory?(site.config[:output_dir])
+
       # Get compiled files
       # FIXME: requires #build_reps to have been called
       all_raw_paths = site.compiler.reps.flat_map { |r| r.raw_paths.values }

--- a/spec/nanoc/regressions/gh_948_spec.rb
+++ b/spec/nanoc/regressions/gh_948_spec.rb
@@ -1,0 +1,16 @@
+describe 'GH-948', site: true, stdio: true do
+  before do
+    File.write('content/foo.md', 'Foo!')
+
+    File.open('nanoc.yaml', 'w') do |io|
+      io << 'prune:' << "\n"
+      io << '  auto_prune: true' << "\n"
+    end
+
+    FileUtils.rm_rf('output')
+  end
+
+  it 'does not crash when output dir is not present' do
+    Nanoc::CLI.run(%w(compile))
+  end
+end


### PR DESCRIPTION
When `auto_prune: true` and the output directory does not exist, `compile` will crash.

Fixes #948.