### PR TITLE
Fix support for legacy patterns combined with full identifiers

### DIFF
--- a/lib/nanoc/rule_dsl/compiler_dsl.rb
+++ b/lib/nanoc/rule_dsl/compiler_dsl.rb
@@ -278,9 +278,15 @@ module Nanoc::RuleDSL
         # Add leading/trailing slashes if necessary
         new_identifier = identifier.dup
         new_identifier[/^/] = '/' if identifier[0, 1] != '/'
-        new_identifier[/$/] = '/' unless ['*', '/'].include?(identifier[-1, 1])
+        new_identifier[/$/] = '/?' unless ['*', '/'].include?(identifier[-1, 1])
 
-        /^#{new_identifier.gsub('*', '(.*?)').gsub('+', '(.+?)')}$/
+        regex_string =
+          new_identifier
+          .gsub('.', '\.')
+          .gsub('*', '(.*?)')
+          .gsub('+', '(.+?)')
+
+        /^#{regex_string}$/
       else
         identifier
       end

--- a/spec/nanoc/regressions/gh_951_spec.rb
+++ b/spec/nanoc/regressions/gh_951_spec.rb
@@ -1,0 +1,19 @@
+describe 'GH-951', site: true, stdio: true do
+  before do
+    File.write('content/foo.md', 'Foo!')
+
+    File.open('nanoc.yaml', 'w') do |io|
+      io << 'string_pattern_type: legacy' << "\n"
+    end
+
+    File.write('Rules', <<EOS)
+  passthrough '/foo.md'
+EOS
+  end
+
+  it 'copies foo.md' do
+    Nanoc::CLI.run(%w(compile))
+
+    expect(File.file?('output/foo.md')).to eq(true)
+  end
+end

--- a/test/rule_dsl/test_compiler_dsl.rb
+++ b/test/rule_dsl/test_compiler_dsl.rb
@@ -319,7 +319,7 @@ EOS
     compiler_dsl = Nanoc::RuleDSL::CompilerDSL.new(nil, {})
 
     actual   = compiler_dsl.instance_eval { identifier_to_regex('foo') }
-    expected = %r{^/foo/$}
+    expected = %r{^/foo/?$}
 
     assert_equal(expected.to_s,      actual.to_s)
     assert_equal(expected.source,    actual.source)
@@ -333,7 +333,7 @@ EOS
     compiler_dsl = Nanoc::RuleDSL::CompilerDSL.new(nil, {})
 
     actual   = compiler_dsl.instance_eval { identifier_to_regex('foo/*/bar') }
-    expected = %r{^/foo/(.*?)/bar/$}
+    expected = %r{^/foo/(.*?)/bar/?$}
 
     assert_equal(expected.to_s,      actual.to_s)
     assert_equal(expected.source,    actual.source)
@@ -347,7 +347,7 @@ EOS
     compiler_dsl = Nanoc::RuleDSL::CompilerDSL.new(nil, {})
 
     actual   = compiler_dsl.instance_eval { identifier_to_regex('foo/*/bar/*/qux') }
-    expected = %r{^/foo/(.*?)/bar/(.*?)/qux/$}
+    expected = %r{^/foo/(.*?)/bar/(.*?)/qux/?$}
 
     assert_equal(expected.to_s,      actual.to_s)
     assert_equal(expected.source,    actual.source)
@@ -403,7 +403,7 @@ EOS
     compiler_dsl = Nanoc::RuleDSL::CompilerDSL.new(nil, {})
 
     actual   = compiler_dsl.instance_eval { identifier_to_regex('/foo/+') }
-    expected = %r{^/foo/(.+?)/$}
+    expected = %r{^/foo/(.+?)/?$}
 
     assert_equal(expected.to_s,      actual.to_s)
     assert_equal(expected.source,    actual.source)
@@ -412,6 +412,20 @@ EOS
     assert_equal(expected.options,   actual.options)
     assert('/foo/bar/' =~ actual)
     refute('/foo/' =~ actual)
+  end
+
+  def test_identifier_to_regex_with_full_identifier
+    # Create compiler DSL
+    compiler_dsl = Nanoc::RuleDSL::CompilerDSL.new(nil, {})
+
+    actual   = compiler_dsl.instance_eval { identifier_to_regex('/favicon.ico') }
+    expected = %r{^/favicon\.ico/?$}
+
+    assert_equal(expected.to_s, actual.to_s)
+
+    assert('/favicon.ico' =~ actual)
+    assert('/favicon.ico/' =~ actual)
+    refute('/faviconxico' =~ actual)
   end
 
   def test_dsl_has_no_access_to_compiler


### PR DESCRIPTION
Fixes #951.

The regex generated from legacy patterns now makes the trailing slash optional. In addition, it escapes periods, which are intended to be literal.