### PR TITLE
Write status information to stderr

### DIFF
--- a/lib/nanoc/cli/command_runner.rb
+++ b/lib/nanoc/cli/command_runner.rb
@@ -45,8 +45,8 @@ module Nanoc::CLI
     #
     # @return [void]
     def load_site(preprocess: false)
-      print 'Loading site… '
-      $stdout.flush
+      $stderr.print 'Loading site… '
+      $stderr.flush
 
       if site.nil?
         raise ::Nanoc::Int::Errors::GenericTrivial, 'The current working directory does not seem to be a Nanoc site.'
@@ -56,7 +56,7 @@ module Nanoc::CLI
         site.compiler.action_provider.preprocess(site)
       end
 
-      puts 'done'
+      $stderr.puts 'done'
     end
 
     # @return [Boolean] true if debug output is enabled, false if not

--- a/spec/nanoc/cli/commands/show_rules_spec.rb
+++ b/spec/nanoc/cli/commands/show_rules_spec.rb
@@ -1,4 +1,4 @@
-describe Nanoc::CLI::Commands::ShowRules do
+describe Nanoc::CLI::Commands::ShowRules, stdio: true do
   describe '#run' do
     subject { runner.run }
 
@@ -73,7 +73,6 @@ describe Nanoc::CLI::Commands::ShowRules do
 
     let(:expected_out) do
       <<-EOS
-        Loading site… done
         \e[1m\e[33mItem /about.md\e[0m:
           Rep default: /*.md
           Rep text: /**/*
@@ -98,8 +97,12 @@ describe Nanoc::CLI::Commands::ShowRules do
         .gsub(/^ {8}/, '')
     end
 
-    it 'outputs item and layout rules' do
+    it 'writes item and layout rules to stdout' do
       expect { subject }.to output(expected_out).to_stdout
+    end
+
+    it 'writes status informaion to stderr' do
+      expect { subject }.to output("Loading site… done\n").to_stderr
     end
   end
 end


### PR DESCRIPTION
This makes “Loading site… done” be written to stderr rather than stdout.