### PR TITLE
Add Nanoc::Feature.enable

### DIFF
--- a/lib/nanoc/base/feature.rb
+++ b/lib/nanoc/base/feature.rb
@@ -47,6 +47,22 @@ module Nanoc
     end
 
     # @api private
+    def self.enable(feature_name)
+      raise ArgumentError, 'no block given' unless block_given?
+
+      if enabled?(feature_name)
+        yield
+      else
+        begin
+          enabled_features << feature_name
+          yield
+        ensure
+          enabled_features.delete(feature_name)
+        end
+      end
+    end
+
+    # @api private
     def self.reset_caches
       @enabled_features = nil
     end

--- a/spec/nanoc/base/feature_spec.rb
+++ b/spec/nanoc/base/feature_spec.rb
@@ -29,6 +29,48 @@ describe Nanoc::Feature do
     end
   end
 
+  describe '.enable' do
+    subject do
+      described_class.enable(feature_name) do
+        Nanoc::Feature.enabled?(feature_name)
+      end
+    end
+
+    let(:feature_name) { 'magic' }
+
+    before do
+      Nanoc::Feature.reset_caches
+      ENV['NANOC_FEATURES'] = ''
+    end
+
+    context 'not set' do
+      it { is_expected.to be }
+
+      it 'unsets afterwards' do
+        expect(Nanoc::Feature.enabled?(feature_name)).not_to be
+      end
+    end
+
+    context 'set to list not including feature' do
+      before { ENV['NANOC_FEATURES'] = 'foo,bar' }
+      it { is_expected.to be }
+
+      it 'unsets afterwards' do
+        expect(Nanoc::Feature.enabled?(feature_name)).not_to be
+      end
+    end
+
+    context 'set to all' do
+      before { ENV['NANOC_FEATURES'] = 'all' }
+      it { is_expected.to be }
+    end
+
+    context 'set to list including feature' do
+      before { ENV['NANOC_FEATURES'] = 'foo,magic,bar' }
+      it { is_expected.to be }
+    end
+  end
+
   describe '.all_outdated' do
     it 'refuses outdated features' do
       # If this spec fails, there are features marked as experimental in the previous minor or major


### PR DESCRIPTION
This adds `Nanoc::Feature.enable`, which executes a given block with a give feature enabled. For example:

```ruby
Nanoc::Feature.enable(Nanoc::Feature::SHELL_EXEC) do
  # …
end
```

This is intended for tests which require these features to be enabled. For this reason, this PR also modifies the existing tests to make use of this new functionality.