### PR TITLE
Fix timezone issues in #attribute_to_time/#to_iso8601_date

### DIFF
--- a/lib/nanoc/extra/core_ext/time.rb
+++ b/lib/nanoc/extra/core_ext/time.rb
@@ -2,7 +2,7 @@
 module Nanoc::Extra::TimeExtensions
   # @return [String] The time in an ISO-8601 date format.
   def __nanoc_to_iso8601_date
-    strftime('%Y-%m-%d')
+    getutc.strftime('%Y-%m-%d')
   end
 
   # @return [String] The time in an ISO-8601 time format.

--- a/lib/nanoc/helpers/blogging.rb
+++ b/lib/nanoc/helpers/blogging.rb
@@ -244,7 +244,7 @@ module Nanoc::Helpers
       when DateTime
         arg.to_time
       when Date
-        Time.local(arg.year, arg.month, arg.day)
+        Time.utc(arg.year, arg.month, arg.day)
       when String
         Time.parse(arg)
       else

--- a/spec/nanoc/helpers/blogging_spec.rb
+++ b/spec/nanoc/helpers/blogging_spec.rb
@@ -139,7 +139,7 @@ describe Nanoc::Helpers::Blogging, helper: true do
 
     let(:around_noon_local) { Time.at(noon_s - Time.at(noon_s).utc_offset) }
     let(:around_noon_utc) { Time.at(noon_s) }
-    let(:beginning_of_day_local) { Time.at(beginning_of_day_s - Time.at(beginning_of_day_s).utc_offset) }
+    let(:beginning_of_day_utc) { Time.at(beginning_of_day_s) }
 
     context 'with Time instance' do
       let(:arg) { around_noon_utc }
@@ -148,7 +148,7 @@ describe Nanoc::Helpers::Blogging, helper: true do
 
     context 'with Date instance' do
       let(:arg) { Date.new(2015, 11, 7) }
-      it { is_expected.to eql(beginning_of_day_local) }
+      it { is_expected.to eql(beginning_of_day_utc) }
     end
 
     context 'with DateTime instance' do

--- a/test/extra/core_ext/test_time.rb
+++ b/test/extra/core_ext/test_time.rb
@@ -1,6 +1,10 @@
 class Nanoc::ExtraCoreExtTimeTest < Nanoc::TestCase
-  def test___nanoc_to_iso8601_date
+  def test___nanoc_to_iso8601_date_utc
     assert_equal('2008-05-19', Time.utc(2008, 5, 19, 14, 20, 0, 0).__nanoc_to_iso8601_date)
+  end
+
+  def test___nanoc_to_iso8601_date_non_utc
+    assert_equal('2008-05-18', Time.new(2008, 5, 19, 0, 0, 0, '+02:00').__nanoc_to_iso8601_date)
   end
 
   def test___nanoc_to_iso8601_time

--- a/test/helpers/test_xml_sitemap.rb
+++ b/test/helpers/test_xml_sitemap.rb
@@ -30,7 +30,7 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
       @items << item
 
       # Create item 3
-      attrs = { mtime: Time.parse('2004-07-12'), changefreq: 'daily', priority: 0.5 }
+      attrs = { mtime: Time.parse('2004-07-12 00:00:00 +02:00'), changefreq: 'daily', priority: 0.5 }
       item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('some content 3', attrs, '/item-three/'), @view_context)
       @items << item
       create_item_rep(item.unwrap, :three_a, '/item-three/a/')
@@ -70,8 +70,8 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
       assert_equal '0.5',                              urls[3].css('> priority').inner_text
       assert_equal '',                                 urls[0].css('> lastmod').inner_text
       assert_equal '',                                 urls[1].css('> lastmod').inner_text
-      assert_equal '2004-07-12',                       urls[2].css('> lastmod').inner_text
-      assert_equal '2004-07-12',                       urls[3].css('> lastmod').inner_text
+      assert_equal '2004-07-11',                       urls[2].css('> lastmod').inner_text
+      assert_equal '2004-07-11',                       urls[3].css('> lastmod').inner_text
     end
   end
 


### PR DESCRIPTION
## Summary

* Make `#attribute_to_time` convert `Date` to UTC (rather than local) `Time`
* Make `#to_iso8601_date` return UTC representation

## Detailed description

`#to_iso8601_date` currently deliberately does not convert to UTC, because the date is supposed to be timezone-agnostic.

For example, if I were to write `2016-10-22`, then I intend that specific day, no matter where I am, and what time it is. Converting this date to UTC first could change that date to `2016-10-21` or `2016-10-23`, which is not what’s intended.

Unfortunately, this does not hold up when I write a `Time` (e.g. `2016-10-22 10:15:00`) rather than a `Date` and then run it through `#to_iso8601_date`.

In order to make both cases work,  this PR converts `Date` to UTC `Time`s rather than local `Time`s, and then makes `#to_iso8601_date` convert to UTC.

This PR also uncovered an interesting case in the XML sitemap helper (arguably a bug), which is now also fixed.

## See also

* #862 (original fix for this issue)