### PR TITLE
Expose reps and paths in shell command

### DIFF
--- a/spec/nanoc/cli/commands/shell_spec.rb
+++ b/spec/nanoc/cli/commands/shell_spec.rb
@@ -17,19 +17,38 @@ describe Nanoc::CLI::Commands::Shell, site: true, stdio: true do
   describe '#env_for_site' do
     subject { described_class.env_for_site(site) }
 
+    before do
+      File.write('content/hello.md', 'Hello!')
+      File.write('layouts/default.erb', '<title>MY SITE!</title><%= yield %>')
+    end
+
     let(:site) do
-      double(
-        :site,
-        items: [],
-        layouts: [],
-        config: nil,
-      )
+      Nanoc::Int::SiteLoader.new.new_from_cwd
     end
 
     it 'returns views' do
       expect(subject[:items]).to be_a(Nanoc::ItemCollectionWithRepsView)
       expect(subject[:layouts]).to be_a(Nanoc::LayoutCollectionView)
       expect(subject[:config]).to be_a(Nanoc::ConfigView)
+    end
+
+    it 'returns correct items' do
+      expect(subject[:items].size).to eq(1)
+      expect(subject[:items].first.identifier.to_s).to eq('/hello.md')
+    end
+
+    it 'returns correct layouts' do
+      expect(subject[:layouts].size).to eq(1)
+      expect(subject[:layouts].first.identifier.to_s).to eq('/default.erb')
+    end
+
+    it 'returns items with reps' do
+      expect(subject[:items].first.reps).not_to be_nil
+      expect(subject[:items].first.reps.first.name).to eq(:default)
+    end
+
+    it 'returns items with rep paths' do
+      expect(subject[:items].first.reps.first.path).to eq('/hello.md')
     end
   end
 end


### PR DESCRIPTION
This makes the `shell` command load item reps, and thus makes paths available. For example, the following now works:

```ruby
@items.find_all('/doc/*.dmark').map { |i| i.path.to_s }
```

### To do

* [x] Tests
* [x] Refactoring

### Related issues

Fixes #955.
