### PR TITLE
Allow querying path in compilation rule

### DIFF
--- a/lib/nanoc/base/services/action_provider.rb
+++ b/lib/nanoc/base/services/action_provider.rb
@@ -18,5 +18,9 @@ module Nanoc::Int
     def snapshots_defs_for(_rep)
       raise NotImplementedError
     end
+
+    def paths_for(_rep)
+      raise NotImplementedError
+    end
   end
 end

--- a/lib/nanoc/base/services/item_rep_router.rb
+++ b/lib/nanoc/base/services/item_rep_router.rb
@@ -20,13 +20,13 @@ module Nanoc::Int
       @reps.each do |rep|
         mem = @action_provider.memory_for(rep)
         mem.snapshot_actions.each do |snapshot_action|
-          route_rep(rep, snapshot_action, paths_to_reps)
+          route_rep(rep, snapshot_action.path, snapshot_action.snapshot_name, paths_to_reps)
         end
       end
     end
 
-    def route_rep(rep, snapshot_action, paths_to_reps)
-      basic_path = snapshot_action.path
+    def route_rep(rep, path, snapshot_name, paths_to_reps)
+      basic_path = path
       return if basic_path.nil?
       basic_path = basic_path.encode('UTF-8')
 
@@ -37,8 +37,8 @@ module Nanoc::Int
         paths_to_reps[basic_path] = rep
       end
 
-      rep.raw_paths[snapshot_action.snapshot_name] = @site.config[:output_dir] + basic_path
-      rep.paths[snapshot_action.snapshot_name] = strip_index_filename(basic_path)
+      rep.raw_paths[snapshot_name] = @site.config[:output_dir] + basic_path
+      rep.paths[snapshot_name] = strip_index_filename(basic_path)
     end
 
     def strip_index_filename(basic_path)

--- a/lib/nanoc/base/services/item_rep_router.rb
+++ b/lib/nanoc/base/services/item_rep_router.rb
@@ -18,9 +18,8 @@ module Nanoc::Int
     def run
       paths_to_reps = {}
       @reps.each do |rep|
-        mem = @action_provider.memory_for(rep)
-        mem.snapshot_actions.each do |snapshot_action|
-          route_rep(rep, snapshot_action.path, snapshot_action.snapshot_name, paths_to_reps)
+        @action_provider.paths_for(rep).each do |snapshot_name, path|
+          route_rep(rep, path, snapshot_name, paths_to_reps)
         end
       end
     end

--- a/lib/nanoc/rule_dsl/action_provider.rb
+++ b/lib/nanoc/rule_dsl/action_provider.rb
@@ -40,6 +40,10 @@ module Nanoc::RuleDSL
       @rule_memory_calculator.snapshots_defs_for(rep)
     end
 
+    def paths_for(rep)
+      @rule_memory_calculator.paths_for_rep(rep)
+    end
+
     def preprocess(site)
       ctx = new_preprocessor_context(site)
 

--- a/lib/nanoc/rule_dsl/rule_memory_calculator.rb
+++ b/lib/nanoc/rule_dsl/rule_memory_calculator.rb
@@ -89,12 +89,12 @@ module Nanoc::RuleDSL
       executor.rule_memory
     end
 
-    # TODO: unify with #snapshots_defs_for maybe? (extend SnapshotDef with path?)
+    # @param [Nanoc::Int::ItemRep] rep The item representation to get the rule
+    #   memory for
+    #
+    # @return [Hash<Symbol, String>] Pairs of snapshot name and path
     def paths_for_rep(rep)
-      snapshot_actions =
-        new_rule_memory_for_rep(rep)
-        .select { |a| a.is_a?(Nanoc::Int::RuleMemoryActions::Snapshot) }
-
+      snapshot_actions = new_rule_memory_for_rep(rep).snapshot_actions
       snapshot_actions.each_with_object({}) do |action, paths|
         paths[action.snapshot_name] = action.path
       end

--- a/lib/nanoc/rule_dsl/rule_memory_calculator.rb
+++ b/lib/nanoc/rule_dsl/rule_memory_calculator.rb
@@ -89,6 +89,17 @@ module Nanoc::RuleDSL
       executor.rule_memory
     end
 
+    # TODO: unify with #snapshots_defs_for maybe? (extend SnapshotDef with path?)
+    def paths_for_rep(rep)
+      snapshot_actions =
+        new_rule_memory_for_rep(rep)
+        .select { |a| a.is_a?(Nanoc::Int::RuleMemoryActions::Snapshot) }
+
+      snapshot_actions.each_with_object({}) do |action, paths|
+        paths[action.snapshot_name] = action.path
+      end
+    end
+
     # @param [Nanoc::Int::Layout] layout
     #
     # @return [Nanoc::Int::RuleMemory]

--- a/spec/nanoc/base/services/item_rep_router_spec.rb
+++ b/spec/nanoc/base/services/item_rep_router_spec.rb
@@ -18,25 +18,17 @@ describe(Nanoc::Int::ItemRepRouter) do
       ]
     end
 
-    let(:rule_memory_0) do
-      Nanoc::Int::RuleMemory.new(reps[0]).tap do |rm|
-        rm.add_filter(:erb, {})
-        rm.add_snapshot(:last, true, '/foo/index.html')
-      end
+    let(:paths_0) do
+      { last: '/foo/index.html' }
     end
 
-    let(:rule_memory_1) do
-      Nanoc::Int::RuleMemory.new(reps[1]).tap do |rm|
-        rm.add_snapshot(:pre, false, nil)
-        rm.add_filter(:erb, {})
-        rm.add_layout('/default.*', {})
-        rm.add_snapshot(:last, true, '/bar.html')
-      end
+    let(:paths_1) do
+      { last: '/bar.html' }
     end
 
     example do
-      expect(action_provider).to receive(:memory_for).with(reps[0]).and_return(rule_memory_0)
-      expect(action_provider).to receive(:memory_for).with(reps[1]).and_return(rule_memory_1)
+      expect(action_provider).to receive(:paths_for).with(reps[0]).and_return(paths_0)
+      expect(action_provider).to receive(:paths_for).with(reps[1]).and_return(paths_1)
 
       subject
 

--- a/spec/nanoc/base/services/item_rep_router_spec.rb
+++ b/spec/nanoc/base/services/item_rep_router_spec.rb
@@ -49,9 +49,10 @@ describe(Nanoc::Int::ItemRepRouter) do
   end
 
   describe '#route_rep' do
-    subject { item_rep_router.route_rep(rep, snapshot_action, paths_to_reps) }
+    subject { item_rep_router.route_rep(rep, path, snapshot_name, paths_to_reps) }
 
-    let(:snapshot_action) { Nanoc::Int::RuleMemoryActions::Snapshot.new(:foo, true, basic_path) }
+    let(:path) { basic_path }
+    let(:snapshot_name) { :foo }
     let(:rep) { Nanoc::Int::ItemRep.new(item, :default) }
     let(:item) { Nanoc::Int::Item.new('content', {}, '/foo.md') }
     let(:paths_to_reps) { {} }

--- a/spec/nanoc/regressions/gh_954_spec.rb
+++ b/spec/nanoc/regressions/gh_954_spec.rb
@@ -1,0 +1,33 @@
+describe 'GH-951', site: true, stdio: true do
+  before do
+    File.write('content/foo.md', 'foo <a href="/">root</a>')
+    File.write('content/bar.md', 'bar <a href="/">root</a>')
+    File.write('content/bar-copy.md', '<%= @items["/bar.*"].compiled_content(snapshot: :last) %>')
+
+    File.write('Rules', <<EOS)
+compile '/foo.*' do
+  filter :relativize_paths, type: :html unless rep.path.nil?
+  write item.identifier.without_ext + '.html'
+end
+
+compile '/bar.*' do
+  filter :relativize_paths, type: :html unless rep.path.nil?
+end
+
+compile '/bar-copy.*' do
+  filter :erb
+  write item.identifier.without_ext + '.html'
+end
+EOS
+  end
+
+  it 'properly filters foo.md' do
+    Nanoc::CLI.run(%w(compile))
+
+    # Path is relativized
+    expect(File.read('output/foo.html')).to eq('foo <a href="./">root</a>')
+
+    # Path is not relativized
+    expect(File.read('output/bar-copy.html')).to eq('bar <a href="/">root</a>')
+  end
+end


### PR DESCRIPTION
This makes `rep.path` in compilation rules not be nil when the rep gets a route assigned to it later on.

### To do

* [x] Tests
* [x] Refactoring

### Detailed description

The following now behaves as expected:

```ruby
compile '/**/*' do
  filter :relativize_paths, type: :html unless rep.path.nil?
  write item.identifier.without_ext + '.html'
end
```

The `:relativize_paths` filter _will_ now be executed, even though the path is only assigned later.

This happens because compilation is now done in three steps:

1. Calculate rule memory, and build snapshot-path pairs for each rep
2. Recalculate rule memory using snapshot-path pairs calculated before
3. Perform actual compilation

Previously, there were only two steps:

1. Calculate rule memory
2. Perform actual compilation

The rule memory depends on the paths, and so the extra step is necessary.

### Related issues

Fixes #954.