### PR TITLE
Use absolute filename for Checks file

### DIFF
--- a/lib/nanoc/extra/checking/dsl.rb
+++ b/lib/nanoc/extra/checking/dsl.rb
@@ -5,7 +5,8 @@ module Nanoc::Extra::Checking
 
     def self.from_file(filename)
       dsl = new
-      dsl.instance_eval(File.read(filename), filename)
+      absolute_filename = File.expand_path(filename)
+      dsl.instance_eval(File.read(filename), absolute_filename)
       dsl
     end
 

--- a/test/extra/checking/test_dsl.rb
+++ b/test/extra/checking/test_dsl.rb
@@ -20,4 +20,12 @@ class Nanoc::Extra::Checking::DSLTest < Nanoc::TestCase
       assert_equal 'hello', $greeting
     end
   end
+
+  def test_has_absolute_path
+    with_site do |_site|
+      File.write('Checks', '$stuff = __FILE__')
+      Nanoc::Extra::Checking::DSL.from_file('Checks')
+      assert($stuff.start_with?('/'))
+    end
+  end
 end


### PR DESCRIPTION
This sets `__FILE__` to an absolute path in the Checks file, which allows doing e.g. `File.dirname(__FILE__)`.

### To do

* [x] Tests
