### PR TITLE
Kramdown warnings

### DIFF
--- a/lib/nanoc/filters/kramdown.rb
+++ b/lib/nanoc/filters/kramdown.rb
@@ -12,8 +12,11 @@ module Nanoc::Filters
     def run(content, params = {})
       document = ::Kramdown::Document.new(content, params)
 
-      document.warnings.each do |warning|
-        $stderr.puts "kramdown warning: #{warning}"
+      if document.warnings.length != 0
+        $stderr.puts "kramdown warning(s) for #{@item_rep.inspect}"
+        document.warnings.each do |warning|
+          $stderr.puts "  #{warning}"
+        end
       end
 
       document.to_html

--- a/lib/nanoc/filters/kramdown.rb
+++ b/lib/nanoc/filters/kramdown.rb
@@ -10,11 +10,20 @@ module Nanoc::Filters
     #
     # @return [String] The filtered content
     def run(content, params = {})
+      params = params.dup
+      warning_filters = params.delete(:warning_filters)
       document = ::Kramdown::Document.new(content, params)
 
-      if document.warnings.length != 0
+      if warning_filters
+        r = Regexp.union(warning_filters)
+        warnings = document.warnings.reject { |warning| r =~ warning }
+      else
+        warnings = document.warnings
+      end
+
+      if warnings.any?
         $stderr.puts "kramdown warning(s) for #{@item_rep.inspect}"
-        document.warnings.each do |warning|
+        warnings.each do |warning|
           $stderr.puts "  #{warning}"
         end
       end

--- a/test/filters/test_kramdown.rb
+++ b/test/filters/test_kramdown.rb
@@ -12,15 +12,21 @@ class Nanoc::Filters::KramdownTest < Nanoc::TestCase
 
   def test_warnings
     if_have 'kramdown' do
+      # Create item
+      item = Nanoc::Int::Item.new('foo', {}, '/foo.md')
+      item_view = Nanoc::ItemWithRepsView.new(item, nil)
+      item_rep = Nanoc::Int::ItemRep.new(item, :default)
+      item_rep_view = Nanoc::ItemRepView.new(item_rep, nil)
+
       # Create filter
-      filter = ::Nanoc::Filters::Kramdown.new
+      filter = ::Nanoc::Filters::Kramdown.new(item: item_view, item_rep: item_rep_view)
 
       # Run filter
       io = capturing_stdio do
         filter.setup_and_run('{:foo}this is bogus')
       end
       assert_empty io[:stdout]
-      assert_equal "kramdown warning: Found span IAL after text - ignoring it\n", io[:stderr]
+      assert_equal "kramdown warning(s) for #{item_rep_view.inspect}\n  Found span IAL after text - ignoring it\n", io[:stderr]
     end
   end
 end

--- a/test/filters/test_kramdown.rb
+++ b/test/filters/test_kramdown.rb
@@ -29,4 +29,24 @@ class Nanoc::Filters::KramdownTest < Nanoc::TestCase
       assert_equal "kramdown warning(s) for #{item_rep_view.inspect}\n  Found span IAL after text - ignoring it\n", io[:stderr]
     end
   end
+
+  def test_warning_filters
+    if_have 'kramdown' do
+      # Create item
+      item = Nanoc::Int::Item.new('foo', {}, '/foo.md')
+      item_view = Nanoc::ItemWithRepsView.new(item, nil)
+      item_rep = Nanoc::Int::ItemRep.new(item, :default)
+      item_rep_view = Nanoc::ItemRepView.new(item_rep, nil)
+
+      # Create filter
+      filter = ::Nanoc::Filters::Kramdown.new(item: item_view, item_rep: item_rep_view)
+
+      # Run filter
+      io = capturing_stdio do
+        filter.setup_and_run("{:foo}this is bogus\n[foo]: http://foo.com\n", warning_filters: 'No link definition')
+      end
+      assert_empty io[:stdout]
+      assert_equal "kramdown warning(s) for #{item_rep_view.inspect}\n  Found span IAL after text - ignoring it\n", io[:stderr]
+    end
+  end
 end


### PR DESCRIPTION
### Summary

This PR does two things in two commits:
  - tell which item and rep produces a kramdown warning
  - implements warning filtering (see #675) as kramdown itself as no warning switches

### To do

The `:warning_filters` array should be documented on https://nanoc.ws as part of the filters reference documentation.