### PR TITLE
Build the reps in the show commands so they can be described

### DIFF
--- a/lib/nanoc/cli/commands/show-data.rb
+++ b/lib/nanoc/cli/commands/show-data.rb
@@ -20,6 +20,9 @@ module Nanoc::CLI::Commands
       compiler.load_stores
       dependency_store = compiler.dependency_store
 
+      # Build reps
+      compiler.build_reps
+
       # Print data
       print_item_dependencies(items, dependency_store)
       print_item_rep_paths(items)

--- a/lib/nanoc/cli/commands/show-rules.rb
+++ b/lib/nanoc/cli/commands/show-rules.rb
@@ -11,7 +11,10 @@ module Nanoc::CLI::Commands
       load_site
 
       @c = Nanoc::CLI::ANSIStringColorizer
-      @reps = site.compiler.reps
+
+      compiler = site.compiler
+      compiler.build_reps
+      @reps = compiler.reps
 
       action_provider = site.compiler.action_provider
       unless action_provider.respond_to?(:rules_collection)

--- a/spec/nanoc/cli/commands/show_rules_spec.rb
+++ b/spec/nanoc/cli/commands/show_rules_spec.rb
@@ -97,6 +97,10 @@ describe Nanoc::CLI::Commands::ShowRules, stdio: true do
         .gsub(/^ {8}/, '')
     end
 
+    before do
+      expect(compiler).to receive(:build_reps).once
+    end
+
     it 'writes item and layout rules to stdout' do
       expect { subject }.to output(expected_out).to_stdout
     end


### PR DESCRIPTION
### Summary

The `show-{data,rules}` commands do not load or describe the item reps. This pull request builds the reps in the setup of the command so they can be described.

### To do

* [x] Tests for `show-rules`
* [ ] Tests for `show-data`

### Detailed description

The `show-{data,rules}` commands do not load or describe the item reps, so the methods that use the reps in these commands are actually operating on an empty `Nanoc::Int::ItemRepRepo` and do not output anything helpful.

I'm not sure whether this is the best way to accomplish loading the reps, but this simple change enables these two commands to work as expected. 

~~About the lack of tests, the [existing test for `show-rules`](https://github.com/nanoc/nanoc/blob/e148ecc699406fa50c5839645ae60d64df2cc93f/spec/nanoc/cli/commands/show_rules_spec.rb) creates stubs for the item reps, and does not test the actual setup of the command. I'm willing to create tests for this if you can give me some direction.~~ Looking closer at the tests (sorry I goofed), the setup is mocked. I've added a block to expect that `build_reps` is called.

Anyways, thanks for a great project!
