### PR TITLE
Add Context#include

### DIFF
--- a/lib/nanoc/base/context.rb
+++ b/lib/nanoc/base/context.rb
@@ -40,5 +40,10 @@ module Nanoc::Int
     def get_binding
       binding
     end
+
+    def include(mod)
+      metaclass = class << self; self; end
+      metaclass.instance_eval { include(mod) }
+    end
   end
 end

--- a/test/base/test_context.rb
+++ b/test/base/test_context.rb
@@ -22,4 +22,10 @@ class Nanoc::Int::ContextTest < Nanoc::TestCase
     # Run
     assert_examples_correct 'Nanoc::Int::Context#initialize'
   end
+
+  def test_include
+    context = Nanoc::Int::Context.new({})
+    eval('include Nanoc::Helpers::HTMLEscape', context.get_binding)
+    assert_equal('&lt;&gt;', eval('h("<>")', context.get_binding))
+  end
 end


### PR DESCRIPTION
This adds `Context#include`, which makes it possible to call `include` directly from the `shell` command:

```
% bundle exec nanoc shell
Loading site… done
> include Nanoc::Helpers::HTMLEscape
=> #<Class:…>
> link_to 'not where you want to go', @items['/404.*']
=> "<a href=\"/404.html\">not where you want to go</a>"
```