### PR TITLE
Remove GCController

### DIFF
--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -257,36 +257,6 @@ module Nanoc::CLI::Commands
       end
     end
 
-    # Controls garbage collection so that it only occurs once every 20 items
-    class GCController < Listener
-      # @see Listener#enable_for?
-      def self.enable_for?(_command_runner)
-        !ENV.key?('TRAVIS')
-      end
-
-      def initialize(*)
-        @gc_count = 0
-      end
-
-      # @see Listener#start
-      def start
-        Nanoc::Int::NotificationCenter.on(:compilation_started) do |_rep|
-          if (@gc_count % 20).zero?
-            GC.enable
-            GC.start
-            GC.disable
-          end
-          @gc_count += 1
-        end
-      end
-
-      # @see Listener#stop
-      def stop
-        super
-        GC.enable
-      end
-    end
-
     # Prints debug information (compilation started/ended, filtering started/ended, …)
     class DebugPrinter < Listener
       # @see Listener#enable_for?
@@ -418,7 +388,6 @@ module Nanoc::CLI::Commands
         Nanoc::CLI::Commands::Compile::DiffGenerator,
         Nanoc::CLI::Commands::Compile::DebugPrinter,
         Nanoc::CLI::Commands::Compile::TimingRecorder,
-        Nanoc::CLI::Commands::Compile::GCController,
         Nanoc::CLI::Commands::Compile::FileActionPrinter,
         Nanoc::CLI::Commands::Compile::StackProfProfiler,
       ]


### PR DESCRIPTION
Stop playing around with the GC manually.

### Detailed description

Previous versions of Nanoc (3.x) had the problem of occasionally running very slowly due to spending large amounts of time in the garbage collector (79% for one site).

As a temporary workaround until either Nanoc and/or Ruby improved memory handling, I added a `GCController` which disables and enables the GC at certain times in order to eliminate needless GC activity. I knew from the start that this was a hack and would cause problems, but luckily very few people reported having problems with it—until now, I guess (#972).

Ruby 2.2 and up have generational GC, which greatly reduces the demand on the garbage collector. This should eliminate the need for this GC hack.

### Related issues

* #972 — “Getting "Killed" on Ubuntu 16.04.1 LTS”