### PR TITLE
Allow routing to identifier

### DIFF
--- a/lib/nanoc/rule_dsl/recording_executor.rb
+++ b/lib/nanoc/rule_dsl/recording_executor.rb
@@ -1,6 +1,8 @@
 module Nanoc
   module RuleDSL
     class RecordingExecutor
+      include Nanoc::Int::ContractsSupport
+
       class PathWithoutInitialSlashError < ::Nanoc::Error
         def initialize(rep, basic_path)
           super("The path returned for the #{rep.inspect} item representation, “#{basic_path}”, does not start with a slash. Please ensure that all routing rules return a path that starts with a slash.")
@@ -33,9 +35,13 @@ module Nanoc
         @rule_memory.add_layout(layout_identifier, extra_filter_args)
       end
 
+      Pathlike = C::Maybe[C::Or[String, Nanoc::Identifier]]
+      contract C::Any, Symbol, C::KeywordArgs[path: C::Optional[Pathlike], final: C::Optional[C::Bool]] => nil
       def snapshot(rep, snapshot_name, final: true, path: nil)
-        actual_path = final ? (path || basic_path_from_rules_for(rep, snapshot_name)) : nil
+        pathlike = final ? (path || basic_path_from_rules_for(rep, snapshot_name)) : nil
+        actual_path = pathlike && pathlike.to_s
         @rule_memory.add_snapshot(snapshot_name, final, actual_path)
+        nil
       end
 
       def basic_path_from_rules_for(rep, snapshot_name)

--- a/spec/nanoc/regressions/gh_974_spec.rb
+++ b/spec/nanoc/regressions/gh_974_spec.rb
@@ -1,0 +1,17 @@
+describe 'GH-974', site: true, stdio: true do
+  before do
+    File.write('content/foo.md', 'foo')
+
+    File.write('Rules', <<EOS)
+compile '/foo.*' do
+  write item.identifier
+end
+EOS
+  end
+
+  it 'writes to path corresponding to identifier' do
+    Nanoc::CLI.run(%w(compile))
+
+    expect(File.file?('output/foo.md')).to eq(true)
+  end
+end

--- a/spec/nanoc/rule_dsl/recording_executor_spec.rb
+++ b/spec/nanoc/rule_dsl/recording_executor_spec.rb
@@ -109,8 +109,21 @@ describe Nanoc::RuleDSL::RecordingExecutor do
             end
           end
 
-          context 'explicit path given' do
+          context 'explicit path given as string' do
             let(:path) { '/routed-foo.html' }
+
+            it 'records' do
+              subject
+              expect(executor.rule_memory.size).to eql(1)
+              expect(executor.rule_memory[0]).to be_a(Nanoc::Int::RuleMemoryActions::Snapshot)
+              expect(executor.rule_memory[0].snapshot_name).to eql(:foo)
+              expect(executor.rule_memory[0].path).to eql('/routed-foo.html')
+              expect(executor.rule_memory[0]).to be_final
+            end
+          end
+
+          context 'explicit path given as identifier' do
+            let(:path) { Nanoc::Identifier.from('/routed-foo.html') }
 
             it 'records' do
               subject


### PR DESCRIPTION
This allows paths to be specified as an identifier.

For routing rules, `#write` calls and `#snapshot` calls with a path, this is particularly useful.

Fixes #974.