### PR TITLE
Fix rdoc support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :devel do
   gem 'mocha'
   gem 'pry'
   gem 'rake'
-  gem 'rdoc'
+  gem 'rdoc', '~> 5.0'
   gem 'rspec'
   gem 'rspec-mocks'
   gem 'rubocop'

--- a/lib/nanoc/filters/rdoc.rb
+++ b/lib/nanoc/filters/rdoc.rb
@@ -3,11 +3,6 @@ module Nanoc::Filters
   class RDoc < Nanoc::Filter
     requires 'rdoc'
 
-    def self.setup
-      gem 'rdoc', '~> 4.0'
-      super
-    end
-
     # Runs the content through [RDoc::Markup](http://docs.seattlerb.org/rdoc/RDoc/Markup.html).
     # This method takes no options.
     #


### PR DESCRIPTION
RDoc is at 5.x now, which leads to dependency version conflicts.

I’m unsure why the `:rdoc` filter does the odd `gem` setup dance, so I got rid of it.