### PR TITLE
Use hard dependencies to pick reps to recompile

### DIFF
--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -207,11 +207,15 @@ module Nanoc::Int
 
       # Find item reps to compile
       outdated_reps = @reps.select { |r| outdatedness_checker.outdated?(r) }
-      dependent_reps = outdated_reps.flat_map { |r| @dependency_store.objects_needed_for_compiled_content_of(r) }
+      outdated_reps.each { |r| puts "+++ Found outdated rep to recompile: #{r.inspect}" }
+      dependent_items = outdated_reps.flat_map { |r| @dependency_store.objects_needed_for_compiled_content_of(r.item) }
+      dependent_items.each { |i| puts "+++ Found dependent item to recompile: #{i.inspect}" }
+      dependent_reps = dependent_items.flat_map { |i| @reps[i] }
+      dependent_reps.each { |r| puts "+++ Found dependent rep to recompile: #{r.inspect}" }
       reps_to_compile = Set.new(outdated_reps + dependent_reps)
 
       # Compile
-      selector = Nanoc::Int::ItemRepSelector.new(reps_to_compile)
+      selector = Nanoc::Int::ItemRepSelector.new(reps_to_compile, @dependency_store)
       selector.each do |rep|
         @stack = []
         compile_rep(rep)

--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -205,9 +205,13 @@ module Nanoc::Int
         rep.snapshot_defs = action_provider.snapshots_defs_for(rep)
       end
 
-      # Find item reps to compile and compile them
+      # Find item reps to compile
       outdated_reps = @reps.select { |r| outdatedness_checker.outdated?(r) }
-      selector = Nanoc::Int::ItemRepSelector.new(outdated_reps)
+      dependent_reps = outdated_reps.flat_map { |r| @dependency_store.objects_needed_for_compiled_content_of(r) }
+      reps_to_compile = Set.new(outdated_reps + dependent_reps)
+
+      # Compile
+      selector = Nanoc::Int::ItemRepSelector.new(reps_to_compile)
       selector.each do |rep|
         @stack = []
         compile_rep(rep)

--- a/lib/nanoc/base/compilation/dependency_tracker.rb
+++ b/lib/nanoc/base/compilation/dependency_tracker.rb
@@ -22,7 +22,7 @@ module Nanoc::Int
     contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout], C::KeywordArgs[hard: C::Optional[C::Bool]] => C::Any
     def enter(obj, hard: false)
       unless @stack.empty?
-        Nanoc::Int::NotificationCenter.post(:dependency_created, @stack.last, obj)
+        Nanoc::Int::NotificationCenter.post(:dependency_created, @stack.last, obj, hard)
         @dependency_store.record_dependency(@stack.last, obj, hard: hard)
       end
 

--- a/lib/nanoc/base/compilation/dependency_tracker.rb
+++ b/lib/nanoc/base/compilation/dependency_tracker.rb
@@ -23,7 +23,7 @@ module Nanoc::Int
     def enter(obj, hard: false)
       unless @stack.empty?
         Nanoc::Int::NotificationCenter.post(:dependency_created, @stack.last, obj)
-        @dependency_store.record_dependency(@stack.last, obj)
+        @dependency_store.record_dependency(@stack.last, obj, hard: hard)
       end
 
       @stack.push(obj)

--- a/lib/nanoc/base/compilation/dependency_tracker.rb
+++ b/lib/nanoc/base/compilation/dependency_tracker.rb
@@ -19,8 +19,8 @@ module Nanoc::Int
       @stack = []
     end
 
-    contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout] => C::Any
-    def enter(obj)
+    contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout], C::KeywordArgs[hard: C::Optional[C::Bool]] => C::Any
+    def enter(obj, hard: false)
       unless @stack.empty?
         Nanoc::Int::NotificationCenter.post(:dependency_created, @stack.last, obj)
         @dependency_store.record_dependency(@stack.last, obj)
@@ -34,9 +34,9 @@ module Nanoc::Int
       @stack.pop
     end
 
-    contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout] => C::Any
-    def bounce(obj)
-      enter(obj)
+    contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout], C::KeywordArgs[hard: C::Optional[C::Bool]] => C::Any
+    def bounce(obj, hard: false)
+      enter(obj, hard: hard)
       exit(obj)
     end
   end

--- a/lib/nanoc/base/compilation/filter.rb
+++ b/lib/nanoc/base/compilation/filter.rb
@@ -195,7 +195,7 @@ module Nanoc
 
       # Notify
       dependency_tracker = @assigns[:item]._context.dependency_tracker
-      items.each { |item| dependency_tracker.bounce(item) }
+      items.each { |item| dependency_tracker.bounce(item, hard: true) }
 
       # Raise unmet dependency error if necessary
       items.each do |item|

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -9,7 +9,9 @@ module Nanoc::Int
       super(Nanoc::Int::Store.tmp_path_for(env_name: env_name, store_name: 'dependencies'), 4)
 
       @objects = objects
-      @graph   = Nanoc::Int::DirectedGraph.new([nil] + @objects)
+
+      @graph = Nanoc::Int::DirectedGraph.new([nil] + @objects)
+      @hard_graph = Nanoc::Int::DirectedGraph.new([nil] + @objects)
     end
 
     # Returns the direct dependencies for the given object.
@@ -31,6 +33,11 @@ module Nanoc::Int
     #   the given object
     def objects_causing_outdatedness_of(object)
       @graph.direct_predecessors_of(object)
+    end
+
+    # TODO: document
+    def objects_needed_for_compiled_content_of(object)
+      @hard_graph.direct_predecessors_of(object)
     end
 
     # Returns the direct inverse dependencies for the given object.
@@ -62,11 +69,12 @@ module Nanoc::Int
     #
     # @return [void]
     def record_dependency(src, dst, hard:)
-      # Warning! dst and src are *reversed* here!
-      @graph.add_edge(dst, src) unless src == dst
+      unless src == dst
+        @graph.add_edge(dst, src)
 
-      if hard
-        # TODO: also add to @hard_graph
+        if hard
+          @hard_graph.add_edge(dst, src)
+        end
       end
     end
 
@@ -81,6 +89,8 @@ module Nanoc::Int
     # @return [void]
     def forget_dependencies_for(object)
       @graph.delete_edges_to(object)
+
+      # FIXME: also for @hard_graph?
     end
 
     protected

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -61,9 +61,13 @@ module Nanoc::Int
     #   outdated if the destination is outdated
     #
     # @return [void]
-    def record_dependency(src, dst)
+    def record_dependency(src, dst, hard:)
       # Warning! dst and src are *reversed* here!
       @graph.add_edge(dst, src) unless src == dst
+
+      if hard
+        # TODO: also add to @hard_graph
+      end
     end
 
     # Empties the list of dependencies for the given object. This is necessary

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -89,8 +89,7 @@ module Nanoc::Int
     # @return [void]
     def forget_dependencies_for(object)
       @graph.delete_edges_to(object)
-
-      # FIXME: also for @hard_graph?
+      @hard_graph.delete_edges_to(object)
     end
 
     protected

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -99,11 +99,14 @@ module Nanoc::Int
       {
         edges: @graph.edges,
         vertices: @graph.vertices.map { |obj| obj && obj.reference },
+        hard_edges: @hard_graph.edges,
+        hard_vertices: @hard_graph.vertices.map { |obj| obj && obj.reference },
       }
     end
 
     def data=(new_data)
       @graph = load_graph_from(new_data[:vertices], new_data[:edges])
+      @hard_graph = load_graph_from(new_data[:hard_vertices], new_data[:hard_edges])
     end
 
     def load_graph_from(vertices_data, edges_data)

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -69,6 +69,8 @@ module Nanoc::Int
     #
     # @return [void]
     def record_dependency(src, dst, hard:)
+      # src “is needed for” dst
+
       unless src == dst
         @graph.add_edge(dst, src)
 
@@ -89,7 +91,6 @@ module Nanoc::Int
     # @return [void]
     def forget_dependencies_for(object)
       @graph.delete_edges_to(object)
-      @hard_graph.delete_edges_to(object)
     end
 
     protected

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -103,20 +103,23 @@ module Nanoc::Int
     end
 
     def data=(new_data)
-      # Create new graph
-      @graph = Nanoc::Int::DirectedGraph.new([nil] + @objects)
+      @graph = load_graph_from(new_data[:vertices], new_data[:edges])
+    end
+
+    def load_graph_from(vertices_data, edges_data)
+      graph = Nanoc::Int::DirectedGraph.new([nil] + @objects)
 
       # Load vertices
-      previous_objects = new_data[:vertices].map do |reference|
+      previous_objects = vertices_data.map do |reference|
         @objects.find { |obj| reference == obj.reference }
       end
 
       # Load edges
-      new_data[:edges].each do |edge|
+      edges_data.each do |edge|
         from_index, to_index = *edge
         from = from_index && previous_objects[from_index]
         to   = to_index && previous_objects[to_index]
-        @graph.add_edge(from, to)
+        graph.add_edge(from, to)
       end
 
       # Record dependency from all items on new items
@@ -124,9 +127,11 @@ module Nanoc::Int
       new_objects.each do |new_obj|
         @objects.each do |obj|
           next unless obj.is_a?(Nanoc::Int::Item)
-          @graph.add_edge(new_obj, obj)
+          graph.add_edge(new_obj, obj)
         end
       end
+
+      graph
     end
   end
 end

--- a/lib/nanoc/base/services/item_rep_selector.rb
+++ b/lib/nanoc/base/services/item_rep_selector.rb
@@ -31,10 +31,13 @@ module Nanoc::Int
 
     def handle_dependency_error(e, rep, graph)
       other_rep = e.rep
+
       graph.add_edge(other_rep, rep)
       unless graph.vertices.include?(other_rep)
         graph.add_vertex(other_rep)
       end
+
+      @dependency_store.record_dependency(rep.item, other_rep.item, hard: true)
     end
   end
 end

--- a/lib/nanoc/base/services/item_rep_selector.rb
+++ b/lib/nanoc/base/services/item_rep_selector.rb
@@ -3,8 +3,9 @@ module Nanoc::Int
   #
   # @api private
   class ItemRepSelector
-    def initialize(reps)
+    def initialize(reps, dependency_store)
       @reps = reps
+      @dependency_store = dependency_store
     end
 
     def each
@@ -12,7 +13,7 @@ module Nanoc::Int
 
       loop do
         break if graph.roots.empty?
-        rep = graph.roots.each { |e| break e }
+        rep = graph.roots.min_by { |e| @dependency_store.objects_needed_for_compiled_content_of(e).size }
 
         begin
           yield(rep)

--- a/lib/nanoc/base/views/item_rep_view.rb
+++ b/lib/nanoc/base/views/item_rep_view.rb
@@ -42,7 +42,7 @@ module Nanoc
     #
     # @return [String] The content at the given snapshot.
     def compiled_content(snapshot: nil)
-      @context.dependency_tracker.bounce(unwrap.item)
+      @context.dependency_tracker.bounce(unwrap.item, hard: true)
       @item_rep.compiled_content(snapshot: snapshot)
     end
 

--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -285,8 +285,8 @@ module Nanoc::CLI::Commands
         Nanoc::Int::NotificationCenter.on(:filtering_ended) do |rep, filter_name|
           puts "*** Ended filtering #{rep.inspect} with #{filter_name}"
         end
-        Nanoc::Int::NotificationCenter.on(:dependency_created) do |src, dst|
-          puts "*** Dependency created from #{src.inspect} onto #{dst.inspect}"
+        Nanoc::Int::NotificationCenter.on(:dependency_created) do |src, dst, hard|
+          puts "*** Dependency (#{hard ? 'hard' : 'soft'}) created from #{src.inspect} onto #{dst.inspect}"
         end
       end
     end

--- a/lib/nanoc/helpers/capturing.rb
+++ b/lib/nanoc/helpers/capturing.rb
@@ -64,7 +64,7 @@ module Nanoc::Helpers
         # Create dependency
         if @item.nil? || item != @item.unwrap
           dependency_tracker = @config._context.dependency_tracker
-          dependency_tracker.bounce(item.unwrap)
+          dependency_tracker.bounce(item.unwrap, hard: true)
 
           unless rep.compiled?
             raise Nanoc::Int::Errors::UnmetDependency.new(rep)

--- a/spec/nanoc/base/services/executor_spec.rb
+++ b/spec/nanoc/base/services/executor_spec.rb
@@ -293,7 +293,7 @@ describe Nanoc::Int::Executor do
       let(:layout_content) { 'head <%= @layout[:bug] %> foot' }
 
       it 'exposes @layout as view' do
-        allow(dependency_tracker).to receive(:enter).with(layout)
+        allow(dependency_tracker).to receive(:enter).with(layout, hard: false)
         allow(dependency_tracker).to receive(:exit).with(layout)
         subject
         expect(rep.snapshot_contents[:last].string).to eq('head Gum Emperor foot')

--- a/spec/nanoc/helpers/capturing_spec.rb
+++ b/spec/nanoc/helpers/capturing_spec.rb
@@ -100,7 +100,7 @@ describe Nanoc::Helpers::Capturing, helper: true do
 
         context 'other item is not yet compiled' do
           it 'raises an unmet dependency error' do
-            expect(ctx.dependency_tracker).to receive(:bounce).with(item.unwrap)
+            expect(ctx.dependency_tracker).to receive(:bounce).with(item.unwrap, hard: true)
             expect { subject }.to raise_error(Nanoc::Int::Errors::UnmetDependency)
           end
         end
@@ -112,7 +112,7 @@ describe Nanoc::Helpers::Capturing, helper: true do
           end
 
           it 'returns the captured content' do
-            expect(ctx.dependency_tracker).to receive(:bounce).with(item.unwrap)
+            expect(ctx.dependency_tracker).to receive(:bounce).with(item.unwrap, hard: true)
             expect(subject).to eql('other captured foo')
           end
         end

--- a/spec/nanoc/helpers/rendering_spec.rb
+++ b/spec/nanoc/helpers/rendering_spec.rb
@@ -30,7 +30,7 @@ describe Nanoc::Helpers::Rendering, helper: true do
           it { is_expected.to eql('blah') }
 
           it 'tracks proper dependencies' do
-            expect(ctx.dependency_tracker).to receive(:enter).with(layout)
+            expect(ctx.dependency_tracker).to receive(:enter).with(layout, hard: false)
             subject
           end
         end

--- a/test/base/test_dependency_tracker.rb
+++ b/test/base/test_dependency_tracker.rb
@@ -19,7 +19,7 @@ class Nanoc::Int::DependencyTrackerTest < Nanoc::TestCase
     store = Nanoc::Int::DependencyStore.new(items)
 
     # Record some dependencies
-    store.record_dependency(items[0], items[1])
+    store.record_dependency(items[0], items[1], hard: false)
 
     # Verify dependencies
     assert_contains_exactly [items[1]], store.objects_causing_outdatedness_of(items[0])
@@ -33,8 +33,8 @@ class Nanoc::Int::DependencyTrackerTest < Nanoc::TestCase
     store = Nanoc::Int::DependencyStore.new(items)
 
     # Record some dependencies
-    store.record_dependency(items[0], items[0])
-    store.record_dependency(items[0], items[1])
+    store.record_dependency(items[0], items[0], hard: false)
+    store.record_dependency(items[0], items[1], hard: false)
 
     # Verify dependencies
     assert_contains_exactly [items[1]], store.objects_causing_outdatedness_of(items[0])
@@ -48,9 +48,9 @@ class Nanoc::Int::DependencyTrackerTest < Nanoc::TestCase
     store = Nanoc::Int::DependencyStore.new(items)
 
     # Record some dependencies
-    store.record_dependency(items[0], items[1])
-    store.record_dependency(items[0], items[1])
-    store.record_dependency(items[0], items[1])
+    store.record_dependency(items[0], items[1], hard: false)
+    store.record_dependency(items[0], items[1], hard: false)
+    store.record_dependency(items[0], items[1], hard: false)
 
     # Verify dependencies
     assert_contains_exactly [items[1]], store.objects_causing_outdatedness_of(items[0])
@@ -64,8 +64,8 @@ class Nanoc::Int::DependencyTrackerTest < Nanoc::TestCase
     store = Nanoc::Int::DependencyStore.new(items)
 
     # Record some dependencies
-    store.record_dependency(items[0], items[1])
-    store.record_dependency(items[1], items[2])
+    store.record_dependency(items[0], items[1], hard: false)
+    store.record_dependency(items[1], items[2], hard: false)
 
     # Verify dependencies
     assert_contains_exactly [items[1]], store.objects_causing_outdatedness_of(items[0])
@@ -79,8 +79,8 @@ class Nanoc::Int::DependencyTrackerTest < Nanoc::TestCase
     store = Nanoc::Int::DependencyStore.new(items)
 
     # Record some dependencies
-    store.record_dependency(items[0], items[1])
-    store.record_dependency(items[1], items[2])
+    store.record_dependency(items[0], items[1], hard: false)
+    store.record_dependency(items[1], items[2], hard: false)
 
     # Verify dependencies
     assert_contains_exactly [items[0]], store.objects_outdated_due_to(items[1])
@@ -99,9 +99,9 @@ class Nanoc::Int::DependencyTrackerTest < Nanoc::TestCase
     store = Nanoc::Int::DependencyStore.new(items)
 
     # Record some dependencies
-    store.record_dependency(items[0], items[1])
-    store.record_dependency(items[1], items[2])
-    store.record_dependency(items[1], items[3])
+    store.record_dependency(items[0], items[1], hard: false)
+    store.record_dependency(items[1], items[2], hard: false)
+    store.record_dependency(items[1], items[3], hard: false)
 
     # Store
     store.store
@@ -137,9 +137,9 @@ class Nanoc::Int::DependencyTrackerTest < Nanoc::TestCase
     store = Nanoc::Int::DependencyStore.new(old_items)
 
     # Record some dependencies
-    store.record_dependency(old_items[0], old_items[1])
-    store.record_dependency(old_items[1], old_items[2])
-    store.record_dependency(old_items[1], old_items[3])
+    store.record_dependency(old_items[0], old_items[1], hard: false)
+    store.record_dependency(old_items[1], old_items[2], hard: false)
+    store.record_dependency(old_items[1], old_items[3], hard: false)
 
     # Store
     store.store
@@ -169,8 +169,8 @@ class Nanoc::Int::DependencyTrackerTest < Nanoc::TestCase
     store = Nanoc::Int::DependencyStore.new(items)
 
     # Record some dependencies
-    store.record_dependency(items[0], items[1])
-    store.record_dependency(items[1], nil)
+    store.record_dependency(items[0], items[1], hard: false)
+    store.record_dependency(items[1], nil, hard: false)
 
     # Store
     store.store
@@ -199,8 +199,8 @@ class Nanoc::Int::DependencyTrackerTest < Nanoc::TestCase
     store = Nanoc::Int::DependencyStore.new(items)
 
     # Record some dependencies
-    store.record_dependency(items[0], items[1])
-    store.record_dependency(nil,      items[2])
+    store.record_dependency(items[0], items[1], hard: false)
+    store.record_dependency(nil,      items[2], hard: false)
 
     # Store
     store.store
@@ -225,8 +225,8 @@ class Nanoc::Int::DependencyTrackerTest < Nanoc::TestCase
     store = Nanoc::Int::DependencyStore.new(items)
 
     # Record some dependencies
-    store.record_dependency(items[0], items[1])
-    store.record_dependency(items[1], items[2])
+    store.record_dependency(items[0], items[1], hard: false)
+    store.record_dependency(items[1], items[2], hard: false)
     assert_contains_exactly [items[1]], store.objects_causing_outdatedness_of(items[0])
 
     # Forget dependencies


### PR DESCRIPTION
⚠️ **EXPERIMENTAL** ⚠️

1. Add support for hard dependencies to the dependency tracking mechanism. A hard dependency indicates that the dependent item needs to be compiled in order for the dependency to be fulfilled. An `UnmetDependency` error will always result in such a hard dependency.

2. Make the compiler not just compile all outdated items, but also all item reps with a hard dependency from any of these. This fixes #977.

Further work could include making the item rep selector use this hard dependency graph as a hint for which item rep to compile next. This is out of scope for this PR, however.