### PR TITLE
Let `nanoc view` serve /index.xhtml

### DIFF
--- a/lib/nanoc/cli/commands/view.rb
+++ b/lib/nanoc/cli/commands/view.rb
@@ -44,7 +44,9 @@ module Nanoc::CLI::Commands
         use Rack::ShowExceptions
         use Rack::Lint
         use Rack::Head
-        use Adsf::Rack::IndexFileFinder, root: site.config[:output_dir]
+        use Adsf::Rack::IndexFileFinder,
+            root: site.config[:output_dir],
+            index_filenames: %w(index.html index.xhtml)
         run Rack::File.new(site.config[:output_dir])
       end.to_app
 

--- a/spec/nanoc/cli/commands/view_spec.rb
+++ b/spec/nanoc/cli/commands/view_spec.rb
@@ -25,5 +25,19 @@ describe Nanoc::CLI::Commands::View, site: true, stdio: true do
         expect(Net::HTTP.get('0.0.0.0', '/', 50_385)).to eql('Hello there! Nanoc loves you! <3')
       end
     end
+
+    it 'serves /index.xhtml as /' do
+      File.write('output/index.xhtml', 'Hello there! Nanoc loves you! <3')
+      run_nanoc_cmd(['view', '--port', '50385']) do
+        expect(Net::HTTP.get('0.0.0.0', '/', 50_385)).to eql('Hello there! Nanoc loves you! <3')
+      end
+    end
+
+    it 'does not serve other files as /' do
+      File.write('output/index.html666', 'Hello there! Nanoc loves you! <3')
+      run_nanoc_cmd(['view', '--port', '50385']) do
+        expect(Net::HTTP.get('0.0.0.0', '/', 50_385)).to eql("File not found: /\n")
+      end
+    end
   end
 end


### PR DESCRIPTION
This lets `nanoc view` serve `index.xhtml` when a directory is requested, rather than only `index.html`.

Implements #986.