### PR TITLE
Fix outdatedness reason for item

### DIFF
--- a/lib/nanoc/base/compilation/outdatedness_checker.rb
+++ b/lib/nanoc/base/compilation/outdatedness_checker.rb
@@ -5,6 +5,8 @@ module Nanoc::Int
   class OutdatednessChecker
     extend Nanoc::Int::Memoization
 
+    include Nanoc::Int::ContractsSupport
+
     attr_reader :checksum_store
     attr_reader :dependency_store
     attr_reader :rule_memory_store
@@ -73,6 +75,7 @@ module Nanoc::Int
       !basic_outdatedness_reason_for(obj).nil?
     end
 
+    contract C::Or[Nanoc::Int::Item, Nanoc::Int::ItemRep, Nanoc::Int::Layout] => C::Maybe[Reasons::Generic]
     # Calculates the reason why the given object is outdated. This method does
     # not take dependencies into account; use {#outdatedness_reason_for?} if
     # you want to include dependencies in the outdatedness check.
@@ -107,7 +110,7 @@ module Nanoc::Int
         # Not outdated
         nil
       when Nanoc::Int::Item
-        @reps[obj].find { |rep| basic_outdatedness_reason_for(rep) }
+        @reps[obj].lazy.map { |rep| basic_outdatedness_reason_for(rep) }.find { |s| s }
       when Nanoc::Int::Layout
         # Outdated if rules outdated
         return Reasons::RulesModified if

--- a/spec/nanoc/base/services/outdatedness_checker_spec.rb
+++ b/spec/nanoc/base/services/outdatedness_checker_spec.rb
@@ -1,0 +1,89 @@
+describe Nanoc::Int::OutdatednessChecker do
+  let(:outdatedness_checker) do
+    described_class.new(
+      site: site,
+      checksum_store: checksum_store,
+      dependency_store: dependency_store,
+      rule_memory_store: rule_memory_store,
+      action_provider: action_provider,
+      reps: reps,
+    )
+  end
+
+  let(:site) { double(:site) }
+  let(:checksum_store) { double(:checksum_store) }
+  let(:dependency_store) { double(:dependency_store) }
+
+  let(:rule_memory_store) do
+    Nanoc::Int::RuleMemoryStore.new.tap do |store|
+      store[item_rep] = old_memory_for_item_rep.serialize
+    end
+  end
+
+  let(:old_memory_for_item_rep) do
+    Nanoc::Int::RuleMemory.new(item_rep).tap do |mem|
+      mem.add_filter(:erb, {})
+    end
+  end
+
+  let(:new_memory_for_item_rep) { old_memory_for_item_rep }
+
+  let(:action_provider) { double(:action_provider) }
+
+  let(:reps) do
+    Nanoc::Int::ItemRepRepo.new.tap do |repo|
+      repo << item_rep
+    end
+  end
+
+  let(:item_rep) { Nanoc::Int::ItemRep.new(item, :default) }
+  let(:item) { Nanoc::Int::Item.new('stuff', {}, '/foo.md') }
+
+  before do
+    allow(action_provider).to receive(:memory_for).with(item_rep).and_return(new_memory_for_item_rep)
+  end
+
+  describe '#basic_outdatedness_reason_for' do
+    subject { outdatedness_checker.send(:basic_outdatedness_reason_for, obj) }
+
+    context 'with item' do
+      let(:obj) { item }
+
+      context 'rule memory differs' do
+        let(:new_memory_for_item_rep) do
+          Nanoc::Int::RuleMemory.new(item_rep).tap do |mem|
+            mem.add_filter(:super_erb, {})
+          end
+        end
+
+        it 'is outdated due to rule differences' do
+          expect(subject).to eql(Nanoc::Int::OutdatednessReasons::RulesModified)
+        end
+      end
+
+      # …
+    end
+
+    context 'with item rep' do
+      let(:obj) { item_rep }
+
+      context 'rule memory differs' do
+        let(:new_memory_for_item_rep) do
+          Nanoc::Int::RuleMemory.new(item_rep).tap do |mem|
+            mem.add_filter(:super_erb, {})
+          end
+        end
+
+        it 'is outdated due to rule differences' do
+          expect(subject).to eql(Nanoc::Int::OutdatednessReasons::RulesModified)
+        end
+      end
+
+      # …
+    end
+
+    context 'with layout' do
+      # …
+    end
+  end
+end


### PR DESCRIPTION
When requesting the outdatedness reason for an item, the first outdated item rep would be returned, rather than the outdatedness reason.

This has no effective impact, but is still wrong.