### PR TITLE
More granular dependencies

### DIFF
--- a/lib/nanoc/base/compilation/outdatedness_checker.rb
+++ b/lib/nanoc/base/compilation/outdatedness_checker.rb
@@ -141,7 +141,7 @@ module Nanoc::Int
             raw_content: true,
             attributes: true,
             compiled_content: true,
-            path: true,
+            path: false, # FIXME
           )
         end
 
@@ -152,7 +152,7 @@ module Nanoc::Int
             raw_content: true,
             attributes: true,
             compiled_content: true,
-            path: true,
+            path: false, # FIXME
           )
         end
 
@@ -272,6 +272,7 @@ module Nanoc::Int
           true
         else
           basic_details = basic_outdatedness_details_for(other)
+          # p [obj, other, basic_details, dependency]
           dependency_matches =
             basic_details && (
               (basic_details.raw_content_outdated? && dependency.raw_content?) ||
@@ -280,7 +281,22 @@ module Nanoc::Int
               (basic_details.path_outdated? && dependency.path?)
             )
 
-          dependency_matches || outdated_due_to_dependencies?(other, processed.merge([obj]))
+          red = "\e[31m"
+          green = "\e[32m"
+          reset = "\e[0m"
+
+          p [obj, other]
+          print(dependency_matches ? red : green)
+          puts "dependency_matches=#{dependency_matches}"
+          print reset
+
+          outdated_due_to_dependencies = outdated_due_to_dependencies?(other, processed.merge([obj]))
+          print(outdated_due_to_dependencies ? red : green)
+          puts "outdated_due_to_dependencies=#{outdated_due_to_dependencies}"
+          print reset
+          puts
+
+          dependency_matches || outdated_due_to_dependencies
         end
       end
 

--- a/lib/nanoc/base/entities/directed_graph.rb
+++ b/lib/nanoc/base/entities/directed_graph.rb
@@ -218,8 +218,8 @@ module Nanoc::Int
     def edges
       result = []
       @vertices.each_pair do |v1, i1|
-        direct_successors_of(v1).map { |v2| @vertices[v2] }.each do |i2|
-          result << [i1, i2]
+        direct_successors_of(v1).map { |v2| [@vertices[v2], v2] }.each do |i2, v2|
+          result << [i1, i2, @edge_props[[v1, v2]]]
         end
       end
       result

--- a/lib/nanoc/base/entities/directed_graph.rb
+++ b/lib/nanoc/base/entities/directed_graph.rb
@@ -206,6 +206,11 @@ module Nanoc::Int
       @successors[from] ||= recursively_find_vertices(from, :direct_successors_of)
     end
 
+    def props_for(from, to)
+      # TODO: test
+      @edge_props[[from, to]]
+    end
+
     # @return [Array] The list of all vertices in this graph.
     def vertices
       @vertices.keys.sort_by { |v| @vertices[v] }

--- a/lib/nanoc/base/entities/directed_graph.rb
+++ b/lib/nanoc/base/entities/directed_graph.rb
@@ -41,6 +41,8 @@ module Nanoc::Int
       @from_graph = {}
       @to_graph   = {}
 
+      @edge_props = {}
+
       @roots = Set.new(@vertices.keys)
 
       invalidate_caches
@@ -55,7 +57,7 @@ module Nanoc::Int
     # @param to   Vertex where the edge should end
     #
     # @return [void]
-    def add_edge(from, to)
+    def add_edge(from, to, props: nil)
       add_vertex(from)
       add_vertex(to)
 
@@ -64,6 +66,10 @@ module Nanoc::Int
 
       @to_graph[to] ||= Set.new
       @to_graph[to] << from
+
+      if props
+        @edge_props[[from, to]] = props
+      end
 
       @roots.delete(to)
 
@@ -86,6 +92,8 @@ module Nanoc::Int
 
       @to_graph[to] ||= Set.new
       @to_graph[to].delete(from)
+
+      @edge_props.delete([from, to])
 
       @roots.add(to) if @to_graph[to].empty?
 
@@ -119,6 +127,7 @@ module Nanoc::Int
 
       @from_graph[from].each do |to|
         @to_graph[to].delete(from)
+        @edge_props.delete([from, to])
         @roots.add(to) if @to_graph[to].empty?
       end
       @from_graph.delete(from)
@@ -134,6 +143,7 @@ module Nanoc::Int
 
       @to_graph[to].each do |from|
         @from_graph[from].delete(to)
+        @edge_props.delete([from, to])
       end
       @to_graph.delete(to)
       @roots.add(to)

--- a/lib/nanoc/base/entities/directed_graph.rb
+++ b/lib/nanoc/base/entities/directed_graph.rb
@@ -208,7 +208,7 @@ module Nanoc::Int
 
     def props_for(from, to)
       # TODO: test
-      @edge_props[[from, to]]
+      @edge_props.fetch([from, to], {})
     end
 
     # @return [Array] The list of all vertices in this graph.

--- a/lib/nanoc/base/repos/checksum_store.rb
+++ b/lib/nanoc/base/repos/checksum_store.rb
@@ -8,7 +8,7 @@ module Nanoc::Int
 
     # @param [Nanoc::Int::Site] site
     def initialize(site: nil)
-      super(Nanoc::Int::Store.tmp_path_for(env_name: (site.config.env_name if site), store_name: 'checksums'), 1)
+      super(Nanoc::Int::Store.tmp_path_for(env_name: (site.config.env_name if site), store_name: 'checksums'), 2)
 
       @site = site
 

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -155,10 +155,10 @@ module Nanoc::Int
 
       # Load edges
       new_data[:edges].each do |edge|
-        from_index, to_index, _props = *edge
+        from_index, to_index, props = *edge
         from = from_index && previous_objects[from_index]
         to   = to_index && previous_objects[to_index]
-        @graph.add_edge(from, to)
+        @graph.add_edge(from, to, props: props)
       end
 
       # Record dependency from all items on new items

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -183,6 +183,7 @@ module Nanoc::Int
       # Load edges
       new_data[:edges].each do |edge|
         from_index, to_index, props = *edge
+
         from = from_index && previous_objects[from_index]
         to   = to_index && previous_objects[to_index]
         @graph.add_edge(from, to, props: props)

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -63,6 +63,31 @@ module Nanoc::Int
       def path?
         @path
       end
+
+      def eql?(other)
+        from == other.from &&
+        to == other.to &&
+        raw_content? == other.raw_content? &&
+        attributes? == other.attributes? &&
+        compiled_content? == other.compiled_content? &&
+        path? == other.path?
+      end
+
+      def ==(other)
+        eql?(other)
+      end
+
+      def hash
+        [
+          self.class,
+          @from,
+          @to,
+          @raw_content,
+          @attributes,
+          @compiled_content,
+          @path,
+        ].hash
+      end
     end
 
     contract C::Or[Nanoc::Int::Item, Nanoc::Int::ItemRep, Nanoc::Int::Layout] => C::ArrayOf[Dependency]
@@ -70,13 +95,15 @@ module Nanoc::Int
       objects_causing_outdatedness_of(object).map do |other_object|
         # TODO: Find proper details
 
+        props = @graph.props_for(other_object, object)
+
         Dependency.new(
           from: other_object,
           to: object,
-          raw_content: true,
-          attributes: true,
-          compiled_content: true,
-          path: true,
+          raw_content: props[:raw_content],
+          attributes: props[:attributes],
+          compiled_content: props[:compiled_content],
+          path: props[:path],
         )
       end
     end

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -1,6 +1,8 @@
 module Nanoc::Int
   # @api private
   class DependencyStore < ::Nanoc::Int::Store
+    include Nanoc::Int::ContractsSupport
+
     # @return [Array<Nanoc::Int::Item, Nanoc::Int::Layout>]
     attr_accessor :objects
 
@@ -31,6 +33,52 @@ module Nanoc::Int
     #   the given object
     def objects_causing_outdatedness_of(object)
       @graph.direct_predecessors_of(object)
+    end
+
+    class Dependency
+      attr_reader :from
+      attr_reader :to
+
+      def initialize(from:, to:, raw_content:, attributes:, compiled_content:, path:)
+        @from             = from
+        @to               = to
+        @raw_content      = raw_content
+        @attributes       = attributes
+        @compiled_content = compiled_content
+        @path             = path
+      end
+
+      def raw_content?
+        @raw_content
+      end
+
+      def attributes?
+        @attributes
+      end
+
+      def compiled_content?
+        @compiled_content
+      end
+
+      def path?
+        @path
+      end
+    end
+
+    contract C::Or[Nanoc::Int::Item, Nanoc::Int::ItemRep, Nanoc::Int::Layout] => C::ArrayOf[Dependency]
+    def dependencies_causing_outdatedness_of(object)
+      objects_causing_outdatedness_of(object).map do |other_object|
+        # TODO: Find proper details
+
+        Dependency.new(
+          from: other_object,
+          to: object,
+          raw_content: true,
+          attributes: true,
+          compiled_content: true,
+          path: true,
+        )
+      end
     end
 
     # Returns the direct inverse dependencies for the given object.

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -111,8 +111,15 @@ module Nanoc::Int
     #
     # @return [void]
     def record_dependency(src, dst, raw_content: false, attributes: false, compiled_content: false, path: false)
+      props = {
+        raw_content: raw_content,
+        attributes: attributes,
+        compiled_content: compiled_content,
+        path: path,
+      }
+
       # Warning! dst and src are *reversed* here!
-      @graph.add_edge(dst, src) unless src == dst
+      @graph.add_edge(dst, src, props: props) unless src == dst
     end
 
     # Empties the list of dependencies for the given object. This is necessary

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -184,6 +184,13 @@ module Nanoc::Int
       new_data[:edges].each do |edge|
         from_index, to_index, props = *edge
 
+        props = {
+          raw_content: props.fetch(:raw_content, true),
+          attributes: props.fetch(:attributes, true),
+          compiled_content: props.fetch(:compiled_content, true),
+          path: props.fetch(:path, true),
+        }
+
         from = from_index && previous_objects[from_index]
         to   = to_index && previous_objects[to_index]
         @graph.add_edge(from, to, props: props)

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -98,6 +98,7 @@ module Nanoc::Int
       @graph.direct_successors_of(object).compact
     end
 
+    contract C::Maybe[C::Or[Nanoc::Int::Item, Nanoc::Int::Layout]], C::Maybe[C::Or[Nanoc::Int::Item, Nanoc::Int::Layout]], C::KeywordArgs[raw_content: C::Optional[C::Bool], attributes: C::Optional[C::Bool], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]] => C::Any
     # Records a dependency from `src` to `dst` in the dependency graph. When
     # `dst` is oudated, `src` will also become outdated.
     #
@@ -109,7 +110,7 @@ module Nanoc::Int
     #   outdated if the destination is outdated
     #
     # @return [void]
-    def record_dependency(src, dst)
+    def record_dependency(src, dst, raw_content: false, attributes: false, compiled_content: false, path: false)
       # Warning! dst and src are *reversed* here!
       @graph.add_edge(dst, src) unless src == dst
     end

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -66,11 +66,11 @@ module Nanoc::Int
 
       def eql?(other)
         from == other.from &&
-        to == other.to &&
-        raw_content? == other.raw_content? &&
-        attributes? == other.attributes? &&
-        compiled_content? == other.compiled_content? &&
-        path? == other.path?
+          to == other.to &&
+          raw_content? == other.raw_content? &&
+          attributes? == other.attributes? &&
+          compiled_content? == other.compiled_content? &&
+          path? == other.path?
       end
 
       def ==(other)

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -138,11 +138,12 @@ module Nanoc::Int
     #
     # @return [void]
     def record_dependency(src, dst, raw_content: false, attributes: false, compiled_content: false, path: false)
+      existing_props = @graph.props_for(dst, src)
       props = {
-        raw_content: raw_content,
-        attributes: attributes,
-        compiled_content: compiled_content,
-        path: path,
+        raw_content: raw_content || existing_props.fetch(:raw_content, false),
+        attributes: attributes || existing_props.fetch(:attributes, false),
+        compiled_content: compiled_content || existing_props.fetch(:compiled_content, false),
+        path: path || existing_props.fetch(:path, false),
       }
 
       # Warning! dst and src are *reversed* here!

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -193,7 +193,16 @@ module Nanoc::Int
       new_objects.each do |new_obj|
         @objects.each do |obj|
           next unless obj.is_a?(Nanoc::Int::Item)
-          @graph.add_edge(new_obj, obj)
+          @graph.add_edge(
+            new_obj,
+            obj,
+            props: {
+              raw_content: true,
+              attributes: true,
+              compiled_content: true,
+              path: true,
+            },
+          )
         end
       end
     end

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -155,7 +155,7 @@ module Nanoc::Int
 
       # Load edges
       new_data[:edges].each do |edge|
-        from_index, to_index = *edge
+        from_index, to_index, _props = *edge
         from = from_index && previous_objects[from_index]
         to   = to_index && previous_objects[to_index]
         @graph.add_edge(from, to)

--- a/lib/nanoc/base/services/dependency_tracker.rb
+++ b/lib/nanoc/base/services/dependency_tracker.rb
@@ -24,8 +24,8 @@ module Nanoc::Int
       @stack = []
     end
 
-    contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout] => C::Any
-    def enter(obj)
+    contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout], C::KeywordArgs[raw_content: C::Optional[C::Bool], attributes: C::Optional[C::Bool], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]] => C::Any
+    def enter(obj, raw_content: false, attributes: false, compiled_content: false, path: false)
       unless @stack.empty?
         Nanoc::Int::NotificationCenter.post(:dependency_created, @stack.last, obj)
         @dependency_store.record_dependency(@stack.last, obj)
@@ -39,9 +39,9 @@ module Nanoc::Int
       @stack.pop
     end
 
-    contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout] => C::Any
-    def bounce(obj)
-      enter(obj)
+    contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout], C::KeywordArgs[raw_content: C::Optional[C::Bool], attributes: C::Optional[C::Bool], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]] => C::Any
+    def bounce(obj, raw_content: false, attributes: false, compiled_content: false, path: false)
+      enter(obj, raw_content: raw_content, attributes: attributes, compiled_content: compiled_content, path: path)
       exit
     end
   end

--- a/lib/nanoc/base/services/dependency_tracker.rb
+++ b/lib/nanoc/base/services/dependency_tracker.rb
@@ -4,16 +4,16 @@ module Nanoc::Int
     class Null
       include Nanoc::Int::ContractsSupport
 
-      contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout] => C::Any
-      def enter(_obj)
+      contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout], C::KeywordArgs[raw_content: C::Optional[C::Bool], attributes: C::Optional[C::Bool], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]] => C::Any
+      def enter(_obj, raw_content: false, attributes: false, compiled_content: false, path: false)
       end
 
       contract C::None => C::Any
       def exit
       end
 
-      contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout] => C::Any
-      def bounce(_obj)
+      contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout], C::KeywordArgs[raw_content: C::Optional[C::Bool], attributes: C::Optional[C::Bool], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]] => C::Any
+      def bounce(_obj, raw_content: false, attributes: false, compiled_content: false, path: false)
       end
     end
 

--- a/lib/nanoc/base/services/dependency_tracker.rb
+++ b/lib/nanoc/base/services/dependency_tracker.rb
@@ -28,7 +28,14 @@ module Nanoc::Int
     def enter(obj, raw_content: false, attributes: false, compiled_content: false, path: false)
       unless @stack.empty?
         Nanoc::Int::NotificationCenter.post(:dependency_created, @stack.last, obj)
-        @dependency_store.record_dependency(@stack.last, obj)
+        @dependency_store.record_dependency(
+          @stack.last,
+          obj,
+          raw_content: raw_content,
+          attributes: attributes,
+          compiled_content: compiled_content,
+          path: path,
+        )
       end
 
       @stack.push(obj)

--- a/lib/nanoc/base/services/executor.rb
+++ b/lib/nanoc/base/services/executor.rb
@@ -67,7 +67,10 @@ module Nanoc
         filter = klass.new(assigns_for(rep).merge({ layout: layout_view }))
 
         # Visit
-        @dependency_tracker.bounce(layout)
+        @dependency_tracker.bounce(
+          layout,
+          raw_content: true, attributes: false, compiled_content: false, path: false,
+        )
 
         begin
           # Notify start

--- a/lib/nanoc/base/services/filter.rb
+++ b/lib/nanoc/base/services/filter.rb
@@ -195,7 +195,12 @@ module Nanoc
 
       # Notify
       dependency_tracker = @assigns[:item]._context.dependency_tracker
-      items.each { |item| dependency_tracker.bounce(item) }
+      items.each do |item|
+        dependency_tracker.bounce(
+          item,
+          raw_content: true, attributes: true, compiled_content: true, path: true,
+        )
+      end
 
       # Raise unmet dependency error if necessary
       items.each do |item|

--- a/lib/nanoc/base/views/item_rep_view.rb
+++ b/lib/nanoc/base/views/item_rep_view.rb
@@ -42,7 +42,7 @@ module Nanoc
     #
     # @return [String] The content at the given snapshot.
     def compiled_content(snapshot: nil)
-      @context.dependency_tracker.bounce(unwrap.item)
+      @context.dependency_tracker.bounce(unwrap.item, compiled_content: true)
       @item_rep.compiled_content(snapshot: snapshot)
     end
 
@@ -56,7 +56,7 @@ module Nanoc
     #
     # @return [String] The item rep’s path.
     def path(snapshot: :last)
-      @context.dependency_tracker.bounce(unwrap.item)
+      @context.dependency_tracker.bounce(unwrap.item, path: true)
       @item_rep.path(snapshot: snapshot)
     end
 
@@ -69,7 +69,7 @@ module Nanoc
 
     # @api private
     def raw_path(snapshot: :last)
-      @context.dependency_tracker.bounce(unwrap.item)
+      @context.dependency_tracker.bounce(unwrap.item, path: true)
       @item_rep.raw_path(snapshot: snapshot)
     end
 

--- a/lib/nanoc/base/views/mixins/document_view_mixin.rb
+++ b/lib/nanoc/base/views/mixins/document_view_mixin.rb
@@ -36,19 +36,19 @@ module Nanoc
 
     # @see Hash#[]
     def [](key)
-      @context.dependency_tracker.bounce(unwrap)
+      @context.dependency_tracker.bounce(unwrap, attributes: true)
       unwrap.attributes[key]
     end
 
     # @return [Hash]
     def attributes
-      @context.dependency_tracker.bounce(unwrap)
+      @context.dependency_tracker.bounce(unwrap, attributes: true)
       unwrap.attributes
     end
 
     # @see Hash#fetch
     def fetch(key, fallback = NONE, &_block)
-      @context.dependency_tracker.bounce(unwrap)
+      @context.dependency_tracker.bounce(unwrap, attributes: true)
 
       if unwrap.attributes.key?(key)
         unwrap.attributes[key]
@@ -63,7 +63,7 @@ module Nanoc
 
     # @see Hash#key?
     def key?(key)
-      @context.dependency_tracker.bounce(unwrap)
+      @context.dependency_tracker.bounce(unwrap, attributes: true)
       unwrap.attributes.key?(key)
     end
 

--- a/lib/nanoc/helpers/capturing.rb
+++ b/lib/nanoc/helpers/capturing.rb
@@ -64,7 +64,7 @@ module Nanoc::Helpers
         # Create dependency
         if @item.nil? || item != @item.unwrap
           dependency_tracker = @config._context.dependency_tracker
-          dependency_tracker.bounce(item.unwrap)
+          dependency_tracker.bounce(item.unwrap, raw_content: true, attributes: true, compiled_content: true, path: true)
 
           unless rep.compiled?
             Fiber.yield(Nanoc::Int::Errors::UnmetDependency.new(rep))

--- a/lib/nanoc/helpers/rendering.rb
+++ b/lib/nanoc/helpers/rendering.rb
@@ -20,7 +20,7 @@ module Nanoc::Helpers
 
       # Visit
       dependency_tracker = @config._context.dependency_tracker
-      dependency_tracker.bounce(layout)
+      dependency_tracker.bounce(layout, raw_content: true, attributes: true, compiled_content: true, path: true)
 
       # Capture content, if any
       captured_content = block_given? ? capture(&block) : nil

--- a/spec/nanoc/base/filter_spec.rb
+++ b/spec/nanoc/base/filter_spec.rb
@@ -69,7 +69,8 @@ describe Nanoc::Filter do
     before do
       reps << rep
 
-      expect(dependency_tracker).to receive(:bounce).with(item)
+      expect(dependency_tracker).to receive(:bounce)
+        .with(item, raw_content: true, attributes: true, compiled_content: true, path: true)
     end
 
     context 'rep is compiled' do

--- a/spec/nanoc/base/services/dependency_tracker_spec.rb
+++ b/spec/nanoc/base/services/dependency_tracker_spec.rb
@@ -200,8 +200,8 @@ describe Nanoc::Int::DependencyTracker do
                 attributes: false,
                 compiled_content: false,
                 path: true,
-              )
-            ]
+              ),
+            ],
           )
       end
     end

--- a/spec/nanoc/base/services/dependency_tracker_spec.rb
+++ b/spec/nanoc/base/services/dependency_tracker_spec.rb
@@ -35,7 +35,7 @@ describe Nanoc::Int::DependencyTracker do
     end
   end
 
-  describe '#enter and exit' do
+  describe '#enter and #exit' do
     context 'enter' do
       subject do
         tracker.enter(item_a)
@@ -175,6 +175,34 @@ describe Nanoc::Int::DependencyTracker do
 
       example do
         expect { subject }.not_to change { store.objects_outdated_due_to(item_a) }
+      end
+    end
+  end
+
+  describe '#enter and #exit with props' do
+    context 'enter + bounce' do
+      subject do
+        tracker.enter(item_a, compiled_content: true)
+        tracker.bounce(item_b, path: true)
+      end
+
+      it_behaves_like 'a null dependency tracker'
+
+      it 'changes predecessors of item A' do
+        expect { subject }.to change { store.dependencies_causing_outdatedness_of(item_a) }
+          .from([])
+          .to(
+            [
+              Nanoc::Int::DependencyStore::Dependency.new(
+                from: item_b,
+                to: item_a,
+                raw_content: false,
+                attributes: false,
+                compiled_content: false,
+                path: true,
+              )
+            ]
+          )
       end
     end
   end

--- a/spec/nanoc/base/services/executor_spec.rb
+++ b/spec/nanoc/base/services/executor_spec.rb
@@ -293,7 +293,7 @@ describe Nanoc::Int::Executor do
       let(:layout_content) { 'head <%= @layout[:bug] %> foot' }
 
       it 'exposes @layout as view' do
-        allow(dependency_tracker).to receive(:enter).with(layout)
+        allow(dependency_tracker).to receive(:enter).with(layout, raw_content: false, attributes: false, compiled_content: false, path: false)
         allow(dependency_tracker).to receive(:exit)
         subject
         expect(rep.snapshot_contents[:last].string).to eq('head Gum Emperor foot')

--- a/spec/nanoc/base/services/executor_spec.rb
+++ b/spec/nanoc/base/services/executor_spec.rb
@@ -293,9 +293,14 @@ describe Nanoc::Int::Executor do
       let(:layout_content) { 'head <%= @layout[:bug] %> foot' }
 
       it 'exposes @layout as view' do
-        allow(dependency_tracker).to receive(:enter).with(layout, raw_content: false, attributes: false, compiled_content: false, path: false)
+        allow(dependency_tracker).to receive(:enter)
+          .with(layout, raw_content: true, attributes: false, compiled_content: false, path: false)
+        allow(dependency_tracker).to receive(:enter)
+          .with(layout, raw_content: false, attributes: true, compiled_content: false, path: false)
         allow(dependency_tracker).to receive(:exit)
+
         subject
+
         expect(rep.snapshot_contents[:last].string).to eq('head Gum Emperor foot')
       end
     end

--- a/spec/nanoc/helpers/capturing_spec.rb
+++ b/spec/nanoc/helpers/capturing_spec.rb
@@ -100,7 +100,8 @@ describe Nanoc::Helpers::Capturing, helper: true do
 
         context 'other item is not yet compiled' do
           it 'raises an unmet dependency error' do
-            expect(ctx.dependency_tracker).to receive(:bounce).with(item.unwrap)
+            expect(ctx.dependency_tracker).to receive(:bounce)
+              .with(item.unwrap, raw_content: true, attributes: true, compiled_content: true, path: true)
             expect { subject }.to raise_error(FiberError)
           end
         end
@@ -112,7 +113,8 @@ describe Nanoc::Helpers::Capturing, helper: true do
           end
 
           it 'returns the captured content' do
-            expect(ctx.dependency_tracker).to receive(:bounce).with(item.unwrap)
+            expect(ctx.dependency_tracker).to receive(:bounce)
+              .with(item.unwrap, raw_content: true, attributes: true, compiled_content: true, path: true)
             expect(subject).to eql('other captured foo')
           end
         end

--- a/spec/nanoc/helpers/rendering_spec.rb
+++ b/spec/nanoc/helpers/rendering_spec.rb
@@ -30,7 +30,8 @@ describe Nanoc::Helpers::Rendering, helper: true do
           it { is_expected.to eql('blah') }
 
           it 'tracks proper dependencies' do
-            expect(ctx.dependency_tracker).to receive(:enter).with(layout, raw_content: false, attributes: false, compiled_content: false, path: false)
+            expect(ctx.dependency_tracker).to receive(:enter)
+              .with(layout, raw_content: true, attributes: true, compiled_content: true, path: true)
             subject
           end
         end

--- a/spec/nanoc/helpers/rendering_spec.rb
+++ b/spec/nanoc/helpers/rendering_spec.rb
@@ -30,7 +30,7 @@ describe Nanoc::Helpers::Rendering, helper: true do
           it { is_expected.to eql('blah') }
 
           it 'tracks proper dependencies' do
-            expect(ctx.dependency_tracker).to receive(:enter).with(layout)
+            expect(ctx.dependency_tracker).to receive(:enter).with(layout, raw_content: false, attributes: false, compiled_content: false, path: false)
             subject
           end
         end

--- a/test/base/test_checksum_store.rb
+++ b/test/base/test_checksum_store.rb
@@ -7,7 +7,7 @@ class Nanoc::Int::ChecksumStoreTest < Nanoc::TestCase
     pstore = PStore.new('tmp/checksums')
     pstore.transaction do
       pstore[:data] = { [:item, '/moo/'] => 'zomg' }
-      pstore[:version] = 1
+      pstore[:version] = 2
     end
 
     # Check

--- a/test/base/test_directed_graph.rb
+++ b/test/base/test_directed_graph.rb
@@ -44,7 +44,7 @@ class Nanoc::Int::DirectedGraphTest < Nanoc::TestCase
     graph.add_edge(1, 2)
     graph.add_edge(2, 3)
 
-    assert_equal [[0, 1], [1, 2]], graph.edges.sort
+    assert_equal [[0, 1, nil], [1, 2, nil]], graph.edges.sort
   end
 
   def test_edges_with_new_vertices
@@ -55,7 +55,15 @@ class Nanoc::Int::DirectedGraphTest < Nanoc::TestCase
     graph.add_edge(3, 2)
     assert_equal [1, 2, 3], graph.vertices
 
-    assert_equal [[0, 1], [2, 1]], graph.edges.sort
+    assert_equal [[0, 1, nil], [2, 1, nil]], graph.edges.sort
+  end
+
+  def test_edge_with_props
+    graph = Nanoc::Int::DirectedGraph.new([1, 2, 3])
+    graph.add_edge(1, 2, props: { donkey: 14 })
+    graph.add_edge(2, 3, props: { giraffe: 3 })
+
+    assert_equal [[0, 1, { donkey: 14 }], [1, 2, { giraffe: 3 }]], graph.edges.sort
   end
 
   def test_add_edge


### PR DESCRIPTION
⚠️ **EXPERIMENTAL** ⚠️

Check outdatedness and record dependencies based on four types of data:

* raw content
* attributes
* compiled content
* path

### Detailed description

* [x] Let outdatedness checker return details on what property is outdated.

* [x] Let outdatedness checker use the dependency properties to determine whether the dependency is causing outdatedness or not.

* [ ] Let dependency tracker/store handle these more granular dependencies.

### To do

Many things. Will fill up this section as I progress.