### PR TITLE
Split content and attributes checksums

### DIFF
--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -118,9 +118,7 @@ module Nanoc::Int
       # Calculate checksums
       objects_to_checksum =
         site.items.to_a + site.layouts.to_a + site.code_snippets + [site.config]
-      objects_to_checksum.each do |obj|
-        checksum_store[obj] = Nanoc::Int::Checksummer.calc(obj)
-      end
+      objects_to_checksum.each { |obj| checksum_store.add(obj) }
 
       # Store
       stores.each(&:store)

--- a/lib/nanoc/base/compilation/outdatedness_checker.rb
+++ b/lib/nanoc/base/compilation/outdatedness_checker.rb
@@ -213,15 +213,13 @@ module Nanoc::Int
 
     contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout] => C::Bool
     def content_checksums_identical?(obj)
-      checksum_store.content_checksum_for(obj) ==
-        (obj.content_checksum_data || Nanoc::Int::Checksummer.calc(obj.content))
+      checksum_store.content_checksum_for(obj) == Nanoc::Int::Checksummer.calc_for_content_of(obj)
     end
     memoize :content_checksums_identical?
 
     contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout] => C::Bool
     def attributes_checksums_identical?(obj)
-      checksum_store.attributes_checksum_for(obj) ==
-        (obj.attributes_checksum_data || Nanoc::Int::Checksummer.calc(obj.attributes))
+      checksum_store.attributes_checksum_for(obj) == Nanoc::Int::Checksummer.calc_for_attributes_of(obj)
     end
     memoize :attributes_checksums_identical?
 

--- a/lib/nanoc/base/compilation/outdatedness_checker.rb
+++ b/lib/nanoc/base/compilation/outdatedness_checker.rb
@@ -97,7 +97,8 @@ module Nanoc::Int
 
         # Outdated if checksums are missing or different
         return Reasons::NotEnoughData unless checksums_available?(obj.item)
-        return Reasons::SourceModified unless checksums_identical?(obj.item)
+        return Reasons::SourceModified unless content_checksums_identical?(obj.item)
+        return Reasons::SourceModified unless attributes_checksums_identical?(obj.item)
 
         # Outdated if compiled file doesn't exist (yet)
         return Reasons::NotWritten if obj.raw_path && !File.file?(obj.raw_path)
@@ -121,7 +122,8 @@ module Nanoc::Int
 
         # Outdated if checksums are missing or different
         return Reasons::NotEnoughData unless checksums_available?(obj)
-        return Reasons::SourceModified unless checksums_identical?(obj)
+        return Reasons::SourceModified unless content_checksums_identical?(obj)
+        return Reasons::SourceModified unless attributes_checksums_identical?(obj)
 
         # Not outdated
         nil
@@ -180,7 +182,7 @@ module Nanoc::Int
     end
     memoize :rule_memory_differs_for
 
-    contract C::Or[Nanoc::Int::Item, Nanoc::Int::ItemRep, Nanoc::Int::Layout, Nanoc::Int::Configuration, Nanoc::Int::CodeSnippet] => String
+    contract C::Any => String
     # @param obj The object to create a checksum for
     #
     # @return [String] The digest
@@ -189,7 +191,7 @@ module Nanoc::Int
     end
     memoize :calc_checksum
 
-    contract C::Or[Nanoc::Int::Item, Nanoc::Int::ItemRep, Nanoc::Int::Layout, Nanoc::Int::Configuration, Nanoc::Int::CodeSnippet] => C::Bool
+    contract C::Any => C::Bool
     # @param obj
     #
     # @return [Boolean] false if either the new or the old checksum for the
@@ -199,7 +201,7 @@ module Nanoc::Int
     end
     memoize :checksums_available?
 
-    contract C::Or[Nanoc::Int::Item, Nanoc::Int::ItemRep, Nanoc::Int::Layout, Nanoc::Int::Configuration, Nanoc::Int::CodeSnippet] => C::Bool
+    contract C::Any => C::Bool
     # @param obj
     #
     # @return [Boolean] false if the old and new checksums for the given
@@ -209,7 +211,19 @@ module Nanoc::Int
     end
     memoize :checksums_identical?
 
-    contract C::Or[Nanoc::Int::Item, Nanoc::Int::ItemRep, Nanoc::Int::Layout, Nanoc::Int::Configuration, Nanoc::Int::CodeSnippet] => C::Bool
+    contract C::Any => C::Bool
+    def content_checksums_identical?(obj)
+      checksum_store.content_checksum_for(obj) == calc_checksum(obj.content)
+    end
+    memoize :content_checksums_identical?
+
+    contract C::Any => C::Bool
+    def attributes_checksums_identical?(obj)
+      checksum_store.attributes_checksum_for(obj) == calc_checksum(obj.attributes)
+    end
+    memoize :attributes_checksums_identical?
+
+    contract C::Any => C::Bool
     # @param obj
     #
     # @return [Boolean] true if the old and new checksums for the given object

--- a/lib/nanoc/base/compilation/outdatedness_checker.rb
+++ b/lib/nanoc/base/compilation/outdatedness_checker.rb
@@ -211,13 +211,13 @@ module Nanoc::Int
     end
     memoize :checksums_identical?
 
-    contract C::Any => C::Bool
+    contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout] => C::Bool
     def content_checksums_identical?(obj)
       checksum_store.content_checksum_for(obj) == calc_checksum(obj.content)
     end
     memoize :content_checksums_identical?
 
-    contract C::Any => C::Bool
+    contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout] => C::Bool
     def attributes_checksums_identical?(obj)
       checksum_store.attributes_checksum_for(obj) == calc_checksum(obj.attributes)
     end

--- a/lib/nanoc/base/compilation/outdatedness_checker.rb
+++ b/lib/nanoc/base/compilation/outdatedness_checker.rb
@@ -213,13 +213,15 @@ module Nanoc::Int
 
     contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout] => C::Bool
     def content_checksums_identical?(obj)
-      checksum_store.content_checksum_for(obj) == calc_checksum(obj.content)
+      checksum_store.content_checksum_for(obj) ==
+        (obj.content_checksum_data || Nanoc::Int::Checksummer.calc(obj.content))
     end
     memoize :content_checksums_identical?
 
     contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout] => C::Bool
     def attributes_checksums_identical?(obj)
-      checksum_store.attributes_checksum_for(obj) == calc_checksum(obj.attributes)
+      checksum_store.attributes_checksum_for(obj) ==
+        (obj.attributes_checksum_data || Nanoc::Int::Checksummer.calc(obj.attributes))
     end
     memoize :attributes_checksums_identical?
 

--- a/lib/nanoc/base/compilation/outdatedness_checker.rb
+++ b/lib/nanoc/base/compilation/outdatedness_checker.rb
@@ -97,8 +97,8 @@ module Nanoc::Int
 
         # Outdated if checksums are missing or different
         return Reasons::NotEnoughData unless checksums_available?(obj.item)
-        return Reasons::SourceModified unless content_checksums_identical?(obj.item)
-        return Reasons::SourceModified unless attributes_checksums_identical?(obj.item)
+        return Reasons::ContentModified unless content_checksums_identical?(obj.item)
+        return Reasons::AttributesModified unless attributes_checksums_identical?(obj.item)
 
         # Outdated if compiled file doesn't exist (yet)
         return Reasons::NotWritten if obj.raw_path && !File.file?(obj.raw_path)
@@ -122,8 +122,8 @@ module Nanoc::Int
 
         # Outdated if checksums are missing or different
         return Reasons::NotEnoughData unless checksums_available?(obj)
-        return Reasons::SourceModified unless content_checksums_identical?(obj)
-        return Reasons::SourceModified unless attributes_checksums_identical?(obj)
+        return Reasons::ContentModified unless content_checksums_identical?(obj)
+        return Reasons::AttributesModified unless attributes_checksums_identical?(obj)
 
         # Not outdated
         nil

--- a/lib/nanoc/base/compilation/outdatedness_reasons.rb
+++ b/lib/nanoc/base/compilation/outdatedness_reasons.rb
@@ -45,7 +45,7 @@ module Nanoc::Int
     )
 
     AttributesModified = Generic.new(
-      'The atributes of this item have been modified since the last time the site was compiled.',
+      'The attributes of this item have been modified since the last time the site was compiled.',
     )
   end
 end

--- a/lib/nanoc/base/compilation/outdatedness_reasons.rb
+++ b/lib/nanoc/base/compilation/outdatedness_reasons.rb
@@ -40,8 +40,12 @@ module Nanoc::Int
       'The rules file has been modified since the last time the site was compiled.',
     )
 
-    SourceModified = Generic.new(
-      'The source file of this item has been modified since the last time the site was compiled.',
+    ContentModified = Generic.new(
+      'The content of this item has been modified since the last time the site was compiled.',
+    )
+
+    AttributesModified = Generic.new(
+      'The atributes of this item have been modified since the last time the site was compiled.',
     )
   end
 end

--- a/lib/nanoc/base/entities/document.rb
+++ b/lib/nanoc/base/entities/document.rb
@@ -18,24 +18,41 @@ module Nanoc
       # @return [String, nil]
       attr_accessor :checksum_data
 
+      # @return [String, nil]
+      attr_accessor :content_checksum_data
+
+      # @return [String, nil]
+      attr_accessor :attributes_checksum_data
+
       c_content = C::Or[String, Nanoc::Int::Content]
       c_attributes = C::Or[Hash, Proc]
       c_identifier = C::Or[String, Nanoc::Identifier]
-      c_checksum_data = C::Optional[C::Maybe[String]]
+      c_checksum_data = C::KeywordArgs[
+        checksum_data: C::Optional[C::Maybe[String]],
+        content_checksum_data: C::Optional[C::Maybe[String]],
+        attributes_checksum_data: C::Optional[C::Maybe[String]],
+      ]
 
-      contract c_content, c_attributes, c_identifier, C::KeywordArgs[checksum_data: c_checksum_data] => C::Any
+      contract c_content, c_attributes, c_identifier, c_checksum_data => C::Any
       # @param [String, Nanoc::Int::Content] content
       #
       # @param [Hash, Proc] attributes
       #
       # @param [String, Nanoc::Identifier] identifier
       #
-      # @param [String, nil] checksum_data Used to determine whether the document has changed
-      def initialize(content, attributes, identifier, checksum_data: nil)
+      # @param [String, nil] checksum_data
+      #
+      # @param [String, nil] content_checksum_data
+      #
+      # @param [String, nil] attributes_checksum_data
+      def initialize(content, attributes, identifier, checksum_data: nil, content_checksum_data: nil, attributes_checksum_data: nil)
         @content = Nanoc::Int::Content.create(content)
         @attributes = Nanoc::Int::LazyValue.new(attributes).map(&:__nanoc_symbolize_keys_recursively)
         @identifier = Nanoc::Identifier.from(identifier)
+
         @checksum_data = checksum_data
+        @content_checksum_data = content_checksum_data
+        @attributes_checksum_data = attributes_checksum_data
       end
 
       contract C::None => self

--- a/lib/nanoc/base/repos/checksum_store.rb
+++ b/lib/nanoc/base/repos/checksum_store.rb
@@ -23,13 +23,22 @@ module Nanoc::Int
       @checksums[obj.reference]
     end
 
-    # Sets the checksum for the given object.
-    #
-    # @param [#reference] obj The object for which to set the checksum
-    #
-    # @param [String] checksum The checksum
-    def []=(obj, checksum)
-      @checksums[obj.reference] = checksum
+    # Calculates and stores the checksum for the given object.
+    def add(obj)
+      if obj.is_a?(Document)
+        @checksums[[obj.reference, :content]] = Nanoc::Int::Checksummer.calc(obj.content)
+        @checksums[[obj.reference, :attributes]] = Nanoc::Int::Checksummer.calc(obj.attributes)
+      end
+
+      @checksums[obj.reference] = Nanoc::Int::Checksummer.calc(obj)
+    end
+
+    def content_checksum_for(obj)
+      @checksums[[obj.reference, :content]]
+    end
+
+    def attributes_checksum_for(obj)
+      @checksums[[obj.reference, :attributes]]
     end
 
     protected

--- a/lib/nanoc/base/repos/checksum_store.rb
+++ b/lib/nanoc/base/repos/checksum_store.rb
@@ -4,6 +4,8 @@ module Nanoc::Int
   #
   # @api private
   class ChecksumStore < ::Nanoc::Int::Store
+    include Nanoc::Int::ContractsSupport
+
     # @param [Nanoc::Int::Site] site
     def initialize(site: nil)
       super(Nanoc::Int::Store.tmp_path_for(env_name: (site.config.env_name if site), store_name: 'checksums'), 1)
@@ -13,6 +15,7 @@ module Nanoc::Int
       @checksums = {}
     end
 
+    contract C::Any => C::Maybe[String]
     # Returns the old checksum for the given object. This makes sense for
     # items, layouts and code snippets.
     #
@@ -33,10 +36,12 @@ module Nanoc::Int
       @checksums[obj.reference] = Nanoc::Int::Checksummer.calc(obj)
     end
 
+    contract C::Any => C::Maybe[String]
     def content_checksum_for(obj)
       @checksums[[obj.reference, :content]]
     end
 
+    contract C::Any => C::Maybe[String]
     def attributes_checksum_for(obj)
       @checksums[[obj.reference, :attributes]]
     end

--- a/lib/nanoc/base/repos/checksum_store.rb
+++ b/lib/nanoc/base/repos/checksum_store.rb
@@ -29,10 +29,8 @@ module Nanoc::Int
     # Calculates and stores the checksum for the given object.
     def add(obj)
       if obj.is_a?(Nanoc::Int::Document)
-        @checksums[[obj.reference, :content]] =
-          obj.content_checksum_data || Nanoc::Int::Checksummer.calc(obj.content)
-        @checksums[[obj.reference, :attributes]] =
-          obj.attributes_checksum_data || Nanoc::Int::Checksummer.calc(obj.attributes)
+        @checksums[[obj.reference, :content]] = Nanoc::Int::Checksummer.calc_for_content_of(obj)
+        @checksums[[obj.reference, :attributes]] = Nanoc::Int::Checksummer.calc_for_attributes_of(obj)
       end
 
       @checksums[obj.reference] = Nanoc::Int::Checksummer.calc(obj)

--- a/lib/nanoc/base/repos/checksum_store.rb
+++ b/lib/nanoc/base/repos/checksum_store.rb
@@ -28,9 +28,11 @@ module Nanoc::Int
 
     # Calculates and stores the checksum for the given object.
     def add(obj)
-      if obj.is_a?(Document)
-        @checksums[[obj.reference, :content]] = Nanoc::Int::Checksummer.calc(obj.content)
-        @checksums[[obj.reference, :attributes]] = Nanoc::Int::Checksummer.calc(obj.attributes)
+      if obj.is_a?(Nanoc::Int::Document)
+        @checksums[[obj.reference, :content]] =
+          obj.content_checksum_data || Nanoc::Int::Checksummer.calc(obj.content)
+        @checksums[[obj.reference, :attributes]] =
+          obj.attributes_checksum_data || Nanoc::Int::Checksummer.calc(obj.attributes)
       end
 
       @checksums[obj.reference] = Nanoc::Int::Checksummer.calc(obj)

--- a/lib/nanoc/base/repos/data_source.rb
+++ b/lib/nanoc/base/repos/data_source.rb
@@ -140,10 +140,14 @@ module Nanoc
     #
     # @param [Boolean] binary Whether or not this item is binary
     #
-    # @param [String, nil] checksum_data Used to determine whether the item has changed
-    def new_item(content, attributes, identifier, binary: false, checksum_data: nil)
+    # @param [String, nil] checksum_data
+    #
+    # @param [String, nil] content_checksum_data
+    #
+    # @param [String, nil] attributes_checksum_data
+    def new_item(content, attributes, identifier, binary: false, checksum_data: nil, content_checksum_data: nil, attributes_checksum_data: nil)
       content = Nanoc::Int::Content.create(content, binary: binary)
-      Nanoc::Int::Item.new(content, attributes, identifier, checksum_data: checksum_data)
+      Nanoc::Int::Item.new(content, attributes, identifier, checksum_data: checksum_data, content_checksum_data: content_checksum_data, attributes_checksum_data: attributes_checksum_data)
     end
 
     # Creates a new in-memory layout instance. This is intended for use within
@@ -155,9 +159,13 @@ module Nanoc
     #
     # @param [String] identifier This layout's identifier.
     #
-    # @param [String, nil] checksum_data Used to determine whether the layout has changed
-    def new_layout(raw_content, attributes, identifier, checksum_data: nil)
-      Nanoc::Int::Layout.new(raw_content, attributes, identifier, checksum_data: checksum_data)
+    # @param [String, nil] checksum_data
+    #
+    # @param [String, nil] content_checksum_data
+    #
+    # @param [String, nil] attributes_checksum_data
+    def new_layout(raw_content, attributes, identifier, checksum_data: nil, content_checksum_data: nil, attributes_checksum_data: nil)
+      Nanoc::Int::Layout.new(raw_content, attributes, identifier, checksum_data: checksum_data, content_checksum_data: content_checksum_data, attributes_checksum_data: attributes_checksum_data)
     end
   end
 end

--- a/lib/nanoc/base/services/checksummer.rb
+++ b/lib/nanoc/base/services/checksummer.rb
@@ -181,11 +181,19 @@ module Nanoc::Int
         if obj.checksum_data
           digest.update('checksum_data=' + obj.checksum_data)
         else
-          digest.update('content=')
-          yield(obj.content)
+          if obj.content_checksum_data
+            digest.update('content_checksum_data=' + obj.content_checksum_data)
+          else
+            digest.update('content=')
+            yield(obj.content)
+          end
 
-          digest.update(',attributes=')
-          yield(obj.attributes)
+          if obj.attributes_checksum_data
+            digest.update(',attributes_checksum_data=' + obj.attributes_checksum_data)
+          else
+            digest.update(',attributes=')
+            yield(obj.attributes)
+          end
 
           digest.update(',identifier=')
           yield(obj.identifier)

--- a/lib/nanoc/base/services/checksummer.rb
+++ b/lib/nanoc/base/services/checksummer.rb
@@ -44,6 +44,14 @@ module Nanoc::Int
         digest.to_s
       end
 
+      def calc_for_content_of(obj)
+        obj.content_checksum_data || Nanoc::Int::Checksummer.calc(obj.content)
+      end
+
+      def calc_for_attributes_of(obj)
+        obj.attributes_checksum_data || Nanoc::Int::Checksummer.calc(obj.attributes)
+      end
+
       private
 
       def update(obj, digest, visited = Hamster::Set.new)

--- a/lib/nanoc/base/services/checksummer.rb
+++ b/lib/nanoc/base/services/checksummer.rb
@@ -45,11 +45,11 @@ module Nanoc::Int
       end
 
       def calc_for_content_of(obj)
-        obj.content_checksum_data || Nanoc::Int::Checksummer.calc(obj.content)
+        obj.content_checksum_data || obj.checksum_data || Nanoc::Int::Checksummer.calc(obj.content)
       end
 
       def calc_for_attributes_of(obj)
-        obj.attributes_checksum_data || Nanoc::Int::Checksummer.calc(obj.attributes)
+        obj.attributes_checksum_data || obj.checksum_data || Nanoc::Int::Checksummer.calc(obj.attributes)
       end
 
       private

--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -76,11 +76,12 @@ module Nanoc::DataSources
 
     class ProtoDocument
       attr_reader :attributes
-      attr_reader :checksum_data
+      attr_reader :content_checksum_data
+      attr_reader :attributes_checksum_data
       attr_reader :is_binary
       alias binary? is_binary
 
-      def initialize(is_binary:, content: nil, filename: nil, attributes:, checksum_data: nil)
+      def initialize(is_binary:, content: nil, filename: nil, attributes:, content_checksum_data: nil, attributes_checksum_data: nil)
         if content.nil? && filename.nil?
           raise ArgumentError, '#initialize needs at least content or filename'
         end
@@ -89,7 +90,8 @@ module Nanoc::DataSources
         @content = content
         @filename = filename
         @attributes = attributes
-        @checksum_data = checksum_data
+        @content_checksum_data = content_checksum_data
+        @attributes_checksum_data = attributes_checksum_data
       end
 
       def content
@@ -125,7 +127,8 @@ module Nanoc::DataSources
           is_binary: false,
           content: parse_result.content,
           attributes: parse_result.attributes,
-          checksum_data: "content=#{parse_result.content},meta=#{parse_result.attributes_data}",
+          content_checksum_data: parse_result.content,
+          attributes_checksum_data: parse_result.attributes_data,
         )
       end
     end
@@ -157,7 +160,13 @@ module Nanoc::DataSources
           attributes = attributes_for(proto_doc, content_filename, meta_filename)
           identifier = identifier_for(content_filename, meta_filename, dir_name)
 
-          res << klass.new(content, attributes, identifier, checksum_data: proto_doc.checksum_data)
+          res << klass.new(
+            content,
+            attributes,
+            identifier,
+            content_checksum_data: proto_doc.content_checksum_data,
+            attributes_checksum_data: proto_doc.attributes_checksum_data,
+          )
         end
       end
 

--- a/spec/nanoc/base/checksummer_spec.rb
+++ b/spec/nanoc/base/checksummer_spec.rb
@@ -196,6 +196,18 @@ describe Nanoc::Int::Checksummer do
 
       it { is_expected.to eql('Nanoc::Int::Item<checksum_data=abcdef>') }
     end
+
+    context 'with content checksum' do
+      let(:obj) { Nanoc::Int::Item.new('asdf', { 'foo' => 'bar' }, '/foo.md', content_checksum_data: 'con-cs') }
+
+      it { is_expected.to eql('Nanoc::Int::Item<content_checksum_data=con-cs,attributes=Hash<Symbol<foo>=String<bar>,>,identifier=Nanoc::Identifier<String</foo.md>>>') }
+    end
+
+    context 'with attributes checksum' do
+      let(:obj) { Nanoc::Int::Item.new('asdf', { 'foo' => 'bar' }, '/foo.md', attributes_checksum_data: 'attr-cs') }
+
+      it { is_expected.to eql('Nanoc::Int::Item<content=Nanoc::Int::TextualContent<String<asdf>>,attributes_checksum_data=attr-cs,identifier=Nanoc::Identifier<String</foo.md>>>') }
+    end
   end
 
   context 'Nanoc::Int::Layout' do

--- a/spec/nanoc/base/entities/document_spec.rb
+++ b/spec/nanoc/base/entities/document_spec.rb
@@ -4,8 +4,19 @@ shared_examples 'a document' do
     let(:attributes_arg) { { 'title' => 'Home' } }
     let(:identifier_arg) { '/home.md' }
     let(:checksum_data_arg) { 'abcdef' }
+    let(:content_checksum_data_arg) { 'con-cs' }
+    let(:attributes_checksum_data_arg) { 'attr-cs' }
 
-    subject { described_class.new(content_arg, attributes_arg, identifier_arg, checksum_data: checksum_data_arg) }
+    subject do
+      described_class.new(
+        content_arg,
+        attributes_arg,
+        identifier_arg,
+        checksum_data: checksum_data_arg,
+        content_checksum_data: content_checksum_data_arg,
+        attributes_checksum_data: attributes_checksum_data_arg,
+      )
+    end
 
     describe 'content arg' do
       context 'string' do
@@ -80,6 +91,18 @@ shared_examples 'a document' do
     describe 'checksum_data arg' do
       it 'reuses checksum_data' do
         expect(subject.checksum_data).to eql(checksum_data_arg)
+      end
+    end
+
+    describe 'content_checksum_data arg' do
+      it 'reuses content_checksum_data' do
+        expect(subject.content_checksum_data).to eql(content_checksum_data_arg)
+      end
+    end
+
+    describe 'attributes_checksum_data arg' do
+      it 'reuses attributes_checksum_data' do
+        expect(subject.attributes_checksum_data).to eql(attributes_checksum_data_arg)
       end
     end
   end

--- a/spec/nanoc/base/services/outdatedness_checker_spec.rb
+++ b/spec/nanoc/base/services/outdatedness_checker_spec.rb
@@ -102,27 +102,95 @@ describe Nanoc::Int::OutdatednessChecker do
 
     shared_examples 'a document' do
       let(:stored_obj) { klass.new('a', {}, '/foo.md') }
-      let(:new_obj)    { klass.new('a', {}, '/foo.md') }
+      let(:new_obj)    { stored_obj }
 
-      context 'not stored' do
-        it { is_expected.to eql([false, false]) }
+      context 'no checksum data' do
+        context 'not stored' do
+          it { is_expected.to eql([false, false]) }
+        end
+
+        context 'stored' do
+          before { checksum_store.add(stored_obj) }
+
+          context 'but content changed afterwards' do
+            let(:new_obj) { klass.new('aaaaaaaa', {}, '/foo.md') }
+            it { is_expected.to eql([false, true]) }
+          end
+
+          context 'but attributes changed afterwards' do
+            let(:new_obj) { klass.new('a', { animal: 'donkey' }, '/foo.md') }
+            it { is_expected.to eql([true, false]) }
+          end
+
+          context 'and unchanged' do
+            it { is_expected.to eql([true, true]) }
+          end
+        end
       end
 
-      context 'stored' do
-        before { checksum_store.add(stored_obj) }
+      context 'checksum_data' do
+        let(:stored_obj) { klass.new('a', {}, '/foo.md', checksum_data: 'cs-data') }
+        let(:new_obj)    { stored_obj }
 
-        context 'but content changed afterwards' do
-          let(:new_obj) { klass.new('aaaaaaaa', {}, '/foo.md') }
-          it { is_expected.to eql([false, true]) }
+        context 'not stored' do
+          it { is_expected.to eql([false, false]) }
         end
 
-        context 'but attributes changed afterwards' do
-          let(:new_obj) { klass.new('a', { animal: 'donkey' }, '/foo.md') }
-          it { is_expected.to eql([true, false]) }
+        context 'stored' do
+          before { checksum_store.add(stored_obj) }
+
+          context 'but checksum data afterwards' do
+            let(:new_obj) { klass.new('a', {}, '/foo.md', checksum_data: 'cs-data-new') }
+            it { is_expected.to eql([false, false]) }
+          end
+
+          context 'and unchanged' do
+            it { is_expected.to eql([true, true]) }
+          end
+        end
+      end
+
+      context 'content_checksum_data' do
+        let(:stored_obj) { klass.new('a', {}, '/foo.md', content_checksum_data: 'cs-data') }
+        let(:new_obj)    { stored_obj }
+
+        context 'not stored' do
+          it { is_expected.to eql([false, false]) }
         end
 
-        context 'and unchanged' do
-          it { is_expected.to eql([true, true]) }
+        context 'stored' do
+          before { checksum_store.add(stored_obj) }
+
+          context 'but checksum data afterwards' do
+            let(:new_obj) { klass.new('a', {}, '/foo.md', content_checksum_data: 'cs-data-new') }
+            it { is_expected.to eql([false, true]) }
+          end
+
+          context 'and unchanged' do
+            it { is_expected.to eql([true, true]) }
+          end
+        end
+      end
+
+      context 'attributes_checksum_data' do
+        let(:stored_obj) { klass.new('a', {}, '/foo.md', attributes_checksum_data: 'cs-data') }
+        let(:new_obj)    { stored_obj }
+
+        context 'not stored' do
+          it { is_expected.to eql([false, false]) }
+        end
+
+        context 'stored' do
+          before { checksum_store.add(stored_obj) }
+
+          context 'but checksum data afterwards' do
+            let(:new_obj) { klass.new('a', {}, '/foo.md', attributes_checksum_data: 'cs-data-new') }
+            it { is_expected.to eql([true, false]) }
+          end
+
+          context 'and unchanged' do
+            it { is_expected.to eql([true, true]) }
+          end
         end
       end
     end

--- a/spec/nanoc/data_sources/filesystem_spec.rb
+++ b/spec/nanoc/data_sources/filesystem_spec.rb
@@ -1,0 +1,56 @@
+describe Nanoc::DataSources::Filesystem do
+  let(:data_source) { Nanoc::DataSources::Filesystem.new(site.config, nil, nil, params) }
+  let(:params) { {} }
+  let(:site) { Nanoc::Int::SiteLoader.new.new_empty }
+
+  before { Timecop.freeze(now) }
+  after { Timecop.return }
+
+  let(:now) { Time.local(2008, 1, 2, 14, 5, 0) }
+
+  describe '#load_objects' do
+    subject { data_source.send(:load_objects, 'foo', klass) }
+
+    let(:klass) { raise 'override me' }
+
+    context 'items' do
+      let(:klass) { Nanoc::Int::Item }
+
+      context 'no files' do
+        it 'loads nothing' do
+          expect(subject).to be_empty
+        end
+      end
+
+      context 'one regular file' do
+        before do
+          FileUtils.mkdir_p('foo')
+          File.write('foo/bar.html', "---\nnum: 1\n---\ntest 1")
+          FileUtils.touch('foo/bar.html', mtime: now)
+        end
+
+        let(:expected_attributes) do
+          {
+            content_filename: "foo/bar.html",
+            extension: "html",
+            filename: "foo/bar.html",
+            meta_filename: nil,
+            mtime: now,
+            num: 1,
+          }
+        end
+
+        it 'loads that file' do
+          expect(subject.size).to eq(1)
+
+          expect(subject[0].content.string).to eq("test 1")
+          expect(subject[0].attributes).to eq(expected_attributes)
+          expect(subject[0].identifier).to eq(Nanoc::Identifier.new('/bar/'))
+          expect(subject[0].checksum_data).to be_nil
+          expect(subject[0].content_checksum_data).to eq('test 1')
+          expect(subject[0].attributes_checksum_data).to eq("num: 1\n")
+        end
+      end
+    end
+  end
+end

--- a/spec/nanoc/data_sources/filesystem_spec.rb
+++ b/spec/nanoc/data_sources/filesystem_spec.rb
@@ -31,9 +31,9 @@ describe Nanoc::DataSources::Filesystem do
 
         let(:expected_attributes) do
           {
-            content_filename: "foo/bar.html",
-            extension: "html",
-            filename: "foo/bar.html",
+            content_filename: 'foo/bar.html',
+            extension: 'html',
+            filename: 'foo/bar.html',
             meta_filename: nil,
             mtime: now,
             num: 1,
@@ -43,7 +43,7 @@ describe Nanoc::DataSources::Filesystem do
         it 'loads that file' do
           expect(subject.size).to eq(1)
 
-          expect(subject[0].content.string).to eq("test 1")
+          expect(subject[0].content.string).to eq('test 1')
           expect(subject[0].attributes).to eq(expected_attributes)
           expect(subject[0].identifier).to eq(Nanoc::Identifier.new('/bar/'))
           expect(subject[0].checksum_data).to be_nil

--- a/test/base/test_data_source.rb
+++ b/test/base/test_data_source.rb
@@ -40,6 +40,17 @@ class Nanoc::DataSourceTest < Nanoc::TestCase
     assert_equal 'abcdef', item.checksum_data
   end
 
+  def test_new_item_with_checksums
+    data_source = Nanoc::DataSource.new(nil, nil, nil, nil)
+
+    item = data_source.new_item('stuff', { title: 'Stuff!' }, '/asdf/', content_checksum_data: 'con-cs', attributes_checksum_data: 'attr-cs')
+    assert_equal 'stuff', item.content.string
+    assert_equal 'Stuff!', item.attributes[:title]
+    assert_equal Nanoc::Identifier.new('/asdf/'), item.identifier
+    assert_equal 'con-cs', item.content_checksum_data
+    assert_equal 'attr-cs', item.attributes_checksum_data
+  end
+
   def test_new_layout
     data_source = Nanoc::DataSource.new(nil, nil, nil, nil)
 
@@ -48,5 +59,16 @@ class Nanoc::DataSourceTest < Nanoc::TestCase
     assert_equal 'Stuff!', layout.attributes[:title]
     assert_equal Nanoc::Identifier.new('/asdf/'), layout.identifier
     assert_equal 'abcdef', layout.checksum_data
+  end
+
+  def test_new_layout_with_checksums
+    data_source = Nanoc::DataSource.new(nil, nil, nil, nil)
+
+    layout = data_source.new_layout('stuff', { title: 'Stuff!' }, '/asdf/', content_checksum_data: 'con-cs', attributes_checksum_data: 'attr-cs')
+    assert_equal 'stuff', layout.content.string
+    assert_equal 'Stuff!', layout.attributes[:title]
+    assert_equal Nanoc::Identifier.new('/asdf/'), layout.identifier
+    assert_equal 'con-cs', layout.content_checksum_data
+    assert_equal 'attr-cs', layout.attributes_checksum_data
   end
 end


### PR DESCRIPTION
Record separate checksums for item content and attributes, so that later on, dependencies can be more granular.

This change requires updating the documentation to mention the existence of `content_checksum_data` and `attributes_checksum_data`. (Not urgent; `checksum_data` remains functional.)

* [x] Tests
* [ ] Documentation