### PR TITLE
Enable environments feature

### DIFF
--- a/lib/nanoc/base/feature.rb
+++ b/lib/nanoc/base/feature.rb
@@ -90,4 +90,3 @@ module Nanoc
 end
 
 Nanoc::Feature.define('profiler', version: '4.3')
-Nanoc::Feature.define('environments', version: '4.3')

--- a/lib/nanoc/base/repos/config_loader.rb
+++ b/lib/nanoc/base/repos/config_loader.rb
@@ -44,11 +44,7 @@ module Nanoc::Int
         ).with_defaults
 
       # Load environment
-      if Nanoc::Feature.enabled?(Nanoc::Feature::ENVIRONMENTS)
-        config.with_environment
-      else
-        config
-      end
+      config.with_environment
     end
 
     # @api private

--- a/lib/nanoc/cli/commands/nanoc.rb
+++ b/lib/nanoc/cli/commands/nanoc.rb
@@ -10,10 +10,8 @@ opt :d, :debug, 'enable debugging' do
   Nanoc::CLI.debug = true
 end
 
-if Nanoc::Feature.enabled?(Nanoc::Feature::ENVIRONMENTS)
-  opt :e, :env, 'set environment', argument: :required do |value|
-    ENV.store('NANOC_ENV', value)
-  end
+opt :e, :env, 'set environment', argument: :required do |value|
+  ENV.store('NANOC_ENV', value)
 end
 
 opt :h, :help, 'show the help message and quit' do |_value, cmd|

--- a/spec/nanoc/base/repos/config_loader_spec.rb
+++ b/spec/nanoc/base/repos/config_loader_spec.rb
@@ -71,58 +71,28 @@ describe Nanoc::Int::ConfigLoader do
         File.write('nanoc.yaml', YAML.dump(config))
       end
 
-      context 'environments feature enabled' do
-        around(:each) do |example|
-          Nanoc::Feature.enable(Nanoc::Feature::ENVIRONMENTS) do
-            example.run
-          end
-        end
+      before do
+        expect(ENV).to receive(:fetch).with('NANOC_ENV', 'default').and_return(active_env_name)
+      end
 
-        before do
-          expect(ENV).to receive(:fetch).with('NANOC_ENV', 'default').and_return(active_env_name)
-        end
+      it 'returns the configuration' do
+        expect(subject).to be_a(Nanoc::Int::Configuration)
+      end
 
-        it 'returns the configuration' do
-          expect(subject).to be_a(Nanoc::Int::Configuration)
-        end
+      it 'has option defined not within environments' do
+        expect(subject[:tofoo]).to eq('bar')
+      end
 
-        it 'has option defined not within environments' do
-          expect(subject[:tofoo]).to eq('bar')
-        end
+      context 'current env is test' do
+        let(:active_env_name) { 'test' }
 
-        context 'current env is test' do
-          let(:active_env_name) { 'test' }
-
-          it 'has the test environment custom option' do
-            expect(subject[:foo]).to eq('test-bar')
-          end
-        end
-
-        it 'has the default environment custom option' do
-          expect(subject[:foo]).to eq('default-bar')
+        it 'has the test environment custom option' do
+          expect(subject[:foo]).to eq('test-bar')
         end
       end
 
-      context 'environments feature disabled' do
-        it 'returns the configuration' do
-          expect(subject).to be_a(Nanoc::Int::Configuration)
-        end
-
-        it 'has option defined not within environments' do
-          expect(subject[:tofoo]).to eq('bar')
-        end
-
-        context 'current env is test' do
-          let(:active_env_name) { 'test' }
-
-          it 'has the test environment custom option' do
-            expect(subject[:foo]).to eq('bar')
-          end
-        end
-
-        it 'has the default environment custom option' do
-          expect(subject[:foo]).to eq('bar')
-        end
+      it 'has the default environment custom option' do
+        expect(subject[:foo]).to eq('default-bar')
       end
     end
   end

--- a/spec/nanoc/base/repos/site_loader_spec.rb
+++ b/spec/nanoc/base/repos/site_loader_spec.rb
@@ -168,25 +168,12 @@ describe Nanoc::Int::SiteLoader do
         EOS
       end
 
-      context 'environments feature disabled' do
-        before do
-          expect(Nanoc::Feature).to receive(:enabled?).with('environments').and_return(false)
-        end
-
-        it 'does not load environment' do
-          expect(subject.config[:animal]).to eq('donkey')
-        end
+      before do
+        expect(ENV).to receive(:fetch).with('NANOC_ENV', 'default').and_return('staging')
       end
 
-      context 'environments feature enabled' do
-        before do
-          expect(Nanoc::Feature).to receive(:enabled?).with('environments').and_return(true)
-          expect(ENV).to receive(:fetch).with('NANOC_ENV', 'default').and_return('staging')
-        end
-
-        it 'does not load environment' do
-          expect(subject.config[:animal]).to eq('giraffe')
-        end
+      it 'does not load environment' do
+        expect(subject.config[:animal]).to eq('giraffe')
       end
     end
 

--- a/spec/nanoc/regressions/gh_937_spec.rb
+++ b/spec/nanoc/regressions/gh_937_spec.rb
@@ -16,12 +16,10 @@ EOS
   end
 
   it 'does not use cache when switching environments' do
-    Nanoc::Feature.enable(Nanoc::Feature::ENVIRONMENTS) do
-      Nanoc::CLI.run(%w(compile))
-      expect(File.read('output/style.css')).to eq(".test { color: red; }\n")
+    Nanoc::CLI.run(%w(compile))
+    expect(File.read('output/style.css')).to eq(".test { color: red; }\n")
 
-      Nanoc::CLI.run(%w(compile --env=staging))
-      expect(File.read('output/style.css')).to eq(".test {\n  color: red;\n}\n")
-    end
+    Nanoc::CLI.run(%w(compile --env=staging))
+    expect(File.read('output/style.css')).to eq(".test {\n  color: red;\n}\n")
   end
 end


### PR DESCRIPTION
This removes the feature flag around the environments feature and makes it officially supported. Best viewed with [?w=1](https://github.com/nanoc/nanoc/pull/993/files?w=1).

This requires a 4.4 release.