### PR TITLE
Record finer grained dependencies

### DIFF
--- a/lib/nanoc/base/entities/directed_graph.rb
+++ b/lib/nanoc/base/entities/directed_graph.rb
@@ -41,6 +41,8 @@ module Nanoc::Int
       @from_graph = {}
       @to_graph   = {}
 
+      @edge_props = {}
+
       @roots = Set.new(@vertices.keys)
 
       invalidate_caches
@@ -55,7 +57,7 @@ module Nanoc::Int
     # @param to   Vertex where the edge should end
     #
     # @return [void]
-    def add_edge(from, to)
+    def add_edge(from, to, props: nil)
       add_vertex(from)
       add_vertex(to)
 
@@ -64,6 +66,10 @@ module Nanoc::Int
 
       @to_graph[to] ||= Set.new
       @to_graph[to] << from
+
+      if props
+        @edge_props[[from, to]] = props
+      end
 
       @roots.delete(to)
 
@@ -86,6 +92,8 @@ module Nanoc::Int
 
       @to_graph[to] ||= Set.new
       @to_graph[to].delete(from)
+
+      @edge_props.delete([from, to])
 
       @roots.add(to) if @to_graph[to].empty?
 
@@ -119,6 +127,7 @@ module Nanoc::Int
 
       @from_graph[from].each do |to|
         @to_graph[to].delete(from)
+        @edge_props.delete([from, to])
         @roots.add(to) if @to_graph[to].empty?
       end
       @from_graph.delete(from)
@@ -134,6 +143,7 @@ module Nanoc::Int
 
       @to_graph[to].each do |from|
         @from_graph[from].delete(to)
+        @edge_props.delete([from, to])
       end
       @to_graph.delete(to)
       @roots.add(to)
@@ -196,6 +206,10 @@ module Nanoc::Int
       @successors[from] ||= recursively_find_vertices(from, :direct_successors_of)
     end
 
+    def props_for(from, to)
+      @edge_props[[from, to]]
+    end
+
     # @return [Array] The list of all vertices in this graph.
     def vertices
       @vertices.keys.sort_by { |v| @vertices[v] }
@@ -208,8 +222,8 @@ module Nanoc::Int
     def edges
       result = []
       @vertices.each_pair do |v1, i1|
-        direct_successors_of(v1).map { |v2| @vertices[v2] }.each do |i2|
-          result << [i1, i2]
+        direct_successors_of(v1).map { |v2| [@vertices[v2], v2] }.each do |i2, v2|
+          result << [i1, i2, @edge_props[[v1, v2]]]
         end
       end
       result

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -64,8 +64,10 @@ module Nanoc::Int
     #   outdated if the destination is outdated
     #
     # @return [void]
-    def record_dependency(src, dst, raw_content: false, attributes: false, compiled_content: false, path: false) # rubocop:disable Lint/UnusedMethodArgument
-      props = { donkey: 14 }
+    def record_dependency(src, dst, raw_content: false, attributes: false, compiled_content: false, path: false)
+      existing_props = @graph.props_for(dst, src) || {}
+      new_props = { raw_content: raw_content, attributes: attributes, compiled_content: compiled_content, path: path }
+      props = merge_props(existing_props, new_props)
 
       # Warning! dst and src are *reversed* here!
       @graph.add_edge(dst, src, props: props) unless src == dst
@@ -85,6 +87,13 @@ module Nanoc::Int
     end
 
     protected
+
+    def merge_props(p1, p2)
+      keys = (p1.keys + p2.keys).uniq
+      keys.each_with_object({}) do |key, memo|
+        memo[key] = p1.fetch(key, false) || p2.fetch(key, false)
+      end
+    end
 
     def data
       {

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -1,6 +1,8 @@
 module Nanoc::Int
   # @api private
   class DependencyStore < ::Nanoc::Int::Store
+    include Nanoc::Int::ContractsSupport
+
     # @return [Array<Nanoc::Int::Item, Nanoc::Int::Layout>]
     attr_accessor :objects
 
@@ -50,6 +52,7 @@ module Nanoc::Int
       @graph.direct_successors_of(object).compact
     end
 
+    contract C::Maybe[C::Or[Nanoc::Int::Item, Nanoc::Int::Layout]], C::Maybe[C::Or[Nanoc::Int::Item, Nanoc::Int::Layout]], C::KeywordArgs[raw_content: C::Optional[C::Bool], attributes: C::Optional[C::Bool], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]] => C::Any
     # Records a dependency from `src` to `dst` in the dependency graph. When
     # `dst` is oudated, `src` will also become outdated.
     #
@@ -61,7 +64,7 @@ module Nanoc::Int
     #   outdated if the destination is outdated
     #
     # @return [void]
-    def record_dependency(src, dst)
+    def record_dependency(src, dst, raw_content: false, attributes: false, compiled_content: false, path: false) # rubocop:disable Lint/UnusedMethodArgument
       # Warning! dst and src are *reversed* here!
       @graph.add_edge(dst, src) unless src == dst
     end

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -65,8 +65,10 @@ module Nanoc::Int
     #
     # @return [void]
     def record_dependency(src, dst, raw_content: false, attributes: false, compiled_content: false, path: false) # rubocop:disable Lint/UnusedMethodArgument
+      props = { donkey: 14 }
+
       # Warning! dst and src are *reversed* here!
-      @graph.add_edge(dst, src) unless src == dst
+      @graph.add_edge(dst, src, props: props) unless src == dst
     end
 
     # Empties the list of dependencies for the given object. This is necessary
@@ -102,7 +104,7 @@ module Nanoc::Int
 
       # Load edges
       new_data[:edges].each do |edge|
-        from_index, to_index = *edge
+        from_index, to_index, _props = *edge
         from = from_index && previous_objects[from_index]
         to   = to_index && previous_objects[to_index]
         @graph.add_edge(from, to)

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -171,10 +171,10 @@ module Nanoc::Int
 
       # Load edges
       new_data[:edges].each do |edge|
-        from_index, to_index, _props = *edge
+        from_index, to_index, props = *edge
         from = from_index && previous_objects[from_index]
         to   = to_index && previous_objects[to_index]
-        @graph.add_edge(from, to)
+        @graph.add_edge(from, to, props: props)
       end
 
       # Record dependency from all items on new items

--- a/lib/nanoc/base/services/dependency_tracker.rb
+++ b/lib/nanoc/base/services/dependency_tracker.rb
@@ -28,8 +28,14 @@ module Nanoc::Int
     def enter(obj, raw_content: false, attributes: false, compiled_content: false, path: false)
       unless @stack.empty?
         Nanoc::Int::NotificationCenter.post(:dependency_created, @stack.last, obj)
-        # TODO: use props
-        @dependency_store.record_dependency(@stack.last, obj)
+        @dependency_store.record_dependency(
+          @stack.last,
+          obj,
+          raw_content: raw_content,
+          attributes: attributes,
+          compiled_content: compiled_content,
+          path: path,
+        )
       end
 
       @stack.push(obj)

--- a/lib/nanoc/base/services/dependency_tracker.rb
+++ b/lib/nanoc/base/services/dependency_tracker.rb
@@ -4,16 +4,16 @@ module Nanoc::Int
     class Null
       include Nanoc::Int::ContractsSupport
 
-      contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout] => C::Any
-      def enter(_obj)
+      contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout], C::KeywordArgs[raw_content: C::Optional[C::Bool], attributes: C::Optional[C::Bool], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]] => C::Any
+      def enter(_obj, raw_content: false, attributes: false, compiled_content: false, path: false)
       end
 
       contract C::None => C::Any
       def exit
       end
 
-      contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout] => C::Any
-      def bounce(_obj)
+      contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout], C::KeywordArgs[raw_content: C::Optional[C::Bool], attributes: C::Optional[C::Bool], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]] => C::Any
+      def bounce(_obj, raw_content: false, attributes: false, compiled_content: false, path: false)
       end
     end
 
@@ -24,10 +24,11 @@ module Nanoc::Int
       @stack = []
     end
 
-    contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout] => C::Any
-    def enter(obj)
+    contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout], C::KeywordArgs[raw_content: C::Optional[C::Bool], attributes: C::Optional[C::Bool], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]] => C::Any
+    def enter(obj, raw_content: false, attributes: false, compiled_content: false, path: false)
       unless @stack.empty?
         Nanoc::Int::NotificationCenter.post(:dependency_created, @stack.last, obj)
+        # TODO: use props
         @dependency_store.record_dependency(@stack.last, obj)
       end
 
@@ -39,9 +40,9 @@ module Nanoc::Int
       @stack.pop
     end
 
-    contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout] => C::Any
-    def bounce(obj)
-      enter(obj)
+    contract C::Or[Nanoc::Int::Item, Nanoc::Int::Layout], C::KeywordArgs[raw_content: C::Optional[C::Bool], attributes: C::Optional[C::Bool], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]] => C::Any
+    def bounce(obj, raw_content: false, attributes: false, compiled_content: false, path: false)
+      enter(obj, raw_content: raw_content, attributes: attributes, compiled_content: compiled_content, path: path)
       exit
     end
   end

--- a/lib/nanoc/base/services/executor.rb
+++ b/lib/nanoc/base/services/executor.rb
@@ -67,7 +67,7 @@ module Nanoc
         filter = klass.new(assigns_for(rep).merge({ layout: layout_view }))
 
         # Visit
-        @dependency_tracker.bounce(layout)
+        @dependency_tracker.bounce(layout, raw_content: true)
 
         begin
           # Notify start

--- a/lib/nanoc/base/services/filter.rb
+++ b/lib/nanoc/base/services/filter.rb
@@ -195,7 +195,7 @@ module Nanoc
 
       # Notify
       dependency_tracker = @assigns[:item]._context.dependency_tracker
-      items.each { |item| dependency_tracker.bounce(item) }
+      items.each { |item| dependency_tracker.bounce(item, compiled_content: true) }
 
       # Raise unmet dependency error if necessary
       items.each do |item|

--- a/lib/nanoc/base/views/item_rep_view.rb
+++ b/lib/nanoc/base/views/item_rep_view.rb
@@ -42,7 +42,7 @@ module Nanoc
     #
     # @return [String] The content at the given snapshot.
     def compiled_content(snapshot: nil)
-      @context.dependency_tracker.bounce(unwrap.item)
+      @context.dependency_tracker.bounce(unwrap.item, compiled_content: true)
       @item_rep.compiled_content(snapshot: snapshot)
     end
 

--- a/lib/nanoc/base/views/item_rep_view.rb
+++ b/lib/nanoc/base/views/item_rep_view.rb
@@ -56,7 +56,7 @@ module Nanoc
     #
     # @return [String] The item rep’s path.
     def path(snapshot: :last)
-      @context.dependency_tracker.bounce(unwrap.item)
+      @context.dependency_tracker.bounce(unwrap.item, path: true)
       @item_rep.path(snapshot: snapshot)
     end
 

--- a/lib/nanoc/base/views/item_rep_view.rb
+++ b/lib/nanoc/base/views/item_rep_view.rb
@@ -69,7 +69,7 @@ module Nanoc
 
     # @api private
     def raw_path(snapshot: :last)
-      @context.dependency_tracker.bounce(unwrap.item)
+      @context.dependency_tracker.bounce(unwrap.item, path: true)
       @item_rep.raw_path(snapshot: snapshot)
     end
 

--- a/lib/nanoc/base/views/mixins/document_view_mixin.rb
+++ b/lib/nanoc/base/views/mixins/document_view_mixin.rb
@@ -74,7 +74,7 @@ module Nanoc
 
     # @api private
     def raw_content
-      @context.dependency_tracker.bounce(unwrap)
+      @context.dependency_tracker.bounce(unwrap, raw_content: true)
       unwrap.content.string
     end
 

--- a/lib/nanoc/base/views/mixins/document_view_mixin.rb
+++ b/lib/nanoc/base/views/mixins/document_view_mixin.rb
@@ -48,7 +48,7 @@ module Nanoc
 
     # @see Hash#fetch
     def fetch(key, fallback = NONE, &_block)
-      @context.dependency_tracker.bounce(unwrap)
+      @context.dependency_tracker.bounce(unwrap, attributes: true)
 
       if unwrap.attributes.key?(key)
         unwrap.attributes[key]

--- a/lib/nanoc/base/views/mixins/document_view_mixin.rb
+++ b/lib/nanoc/base/views/mixins/document_view_mixin.rb
@@ -42,7 +42,7 @@ module Nanoc
 
     # @return [Hash]
     def attributes
-      @context.dependency_tracker.bounce(unwrap)
+      @context.dependency_tracker.bounce(unwrap, attributes: true)
       unwrap.attributes
     end
 

--- a/lib/nanoc/base/views/mixins/document_view_mixin.rb
+++ b/lib/nanoc/base/views/mixins/document_view_mixin.rb
@@ -36,7 +36,7 @@ module Nanoc
 
     # @see Hash#[]
     def [](key)
-      @context.dependency_tracker.bounce(unwrap)
+      @context.dependency_tracker.bounce(unwrap, attributes: true)
       unwrap.attributes[key]
     end
 

--- a/lib/nanoc/base/views/mixins/document_view_mixin.rb
+++ b/lib/nanoc/base/views/mixins/document_view_mixin.rb
@@ -63,7 +63,7 @@ module Nanoc
 
     # @see Hash#key?
     def key?(key)
-      @context.dependency_tracker.bounce(unwrap)
+      @context.dependency_tracker.bounce(unwrap, attributes: true)
       unwrap.attributes.key?(key)
     end
 

--- a/lib/nanoc/cli/commands/show-data.rb
+++ b/lib/nanoc/cli/commands/show-data.rb
@@ -65,8 +65,13 @@ module Nanoc::CLI::Commands
       sorted_with_prev(items) do |item, prev|
         puts if prev
         puts "item #{item.identifier} depends on:"
-        predecessors = dependency_store.objects_causing_outdatedness_of(item).sort_by { |i| i ? i.identifier : '' }
-        predecessors.each do |pred|
+        dependencies =
+          dependency_store
+          .dependencies_causing_outdatedness_of(item)
+          .sort_by { |dep| dep.from ? dep.from.identifier : '' }
+        dependencies.each do |dep|
+          pred = dep.from
+
           type =
             case pred
             when Nanoc::Int::Layout
@@ -77,13 +82,21 @@ module Nanoc::CLI::Commands
               'item'
             end
 
+          # TODO: print property legend
+
+          props = ''
+          props << (dep.raw_content? ? 'r' : '_')
+          props << (dep.attributes? ? 'a' : '_')
+          props << (dep.compiled_content? ? 'c' : '_')
+          props << (dep.path? ? 'p' : '_')
+
           if pred
-            puts "  [ #{format '%6s', type} ] #{pred.identifier}"
+            puts "  [ #{format '%6s', type} ] (#{props}) #{pred.identifier}"
           else
             puts '  ( removed item )'
           end
         end
-        puts '  (nothing)' if predecessors.empty?
+        puts '  (nothing)' if dependencies.empty?
       end
     end
 

--- a/lib/nanoc/cli/commands/show-data.rb
+++ b/lib/nanoc/cli/commands/show-data.rb
@@ -62,6 +62,13 @@ module Nanoc::CLI::Commands
     def print_item_dependencies(items, dependency_store)
       print_header('Item dependencies')
 
+      puts 'Legend:'
+      puts '  r = dependency on raw content'
+      puts '  a = dependency on attributes'
+      puts '  c = dependency on compiled content'
+      puts '  p = dependency on the path'
+      puts
+
       sorted_with_prev(items) do |item, prev|
         puts if prev
         puts "item #{item.identifier} depends on:"
@@ -81,8 +88,6 @@ module Nanoc::CLI::Commands
             when Nanoc::Int::Item
               'item'
             end
-
-          # TODO: print property legend
 
           props = ''
           props << (dep.raw_content? ? 'r' : '_')

--- a/lib/nanoc/helpers/capturing.rb
+++ b/lib/nanoc/helpers/capturing.rb
@@ -64,7 +64,7 @@ module Nanoc::Helpers
         # Create dependency
         if @item.nil? || item != @item.unwrap
           dependency_tracker = @config._context.dependency_tracker
-          dependency_tracker.bounce(item.unwrap)
+          dependency_tracker.bounce(item.unwrap, compiled_content: true)
 
           unless rep.compiled?
             Fiber.yield(Nanoc::Int::Errors::UnmetDependency.new(rep))

--- a/lib/nanoc/helpers/rendering.rb
+++ b/lib/nanoc/helpers/rendering.rb
@@ -20,7 +20,7 @@ module Nanoc::Helpers
 
       # Visit
       dependency_tracker = @config._context.dependency_tracker
-      dependency_tracker.bounce(layout)
+      dependency_tracker.bounce(layout, raw_content: true)
 
       # Capture content, if any
       captured_content = block_given? ? capture(&block) : nil

--- a/spec/nanoc/base/filter_spec.rb
+++ b/spec/nanoc/base/filter_spec.rb
@@ -69,7 +69,7 @@ describe Nanoc::Filter do
     before do
       reps << rep
 
-      expect(dependency_tracker).to receive(:bounce).with(item)
+      expect(dependency_tracker).to receive(:bounce).with(item, compiled_content: true)
     end
 
     context 'rep is compiled' do

--- a/spec/nanoc/base/repos/dependency_store_spec.rb
+++ b/spec/nanoc/base/repos/dependency_store_spec.rb
@@ -114,4 +114,37 @@ describe Nanoc::Int::DependencyStore do
       end
     end
   end
+
+  describe 'reloading' do
+    before do
+      store.record_dependency(obj_a, obj_b, compiled_content: true)
+      store.record_dependency(obj_a, obj_b, attributes: true)
+
+      store.store
+      store.load
+    end
+
+    it 'has the right dependencies for item A' do
+      deps = store.dependencies_causing_outdatedness_of(obj_a)
+      expect(deps.size).to eql(1)
+
+      expect(deps[0].from).to eql(obj_b)
+      expect(deps[0].to).to eql(obj_a)
+
+      expect(deps[0].raw_content?).to eq(false)
+      expect(deps[0].attributes?).to eq(true)
+      expect(deps[0].compiled_content?).to eq(true)
+      expect(deps[0].path?).to eq(false)
+    end
+
+    it 'has the right dependencies for item B' do
+      deps = store.dependencies_causing_outdatedness_of(obj_b)
+      expect(deps).to be_empty
+    end
+
+    it 'has the right dependencies for item C' do
+      deps = store.dependencies_causing_outdatedness_of(obj_c)
+      expect(deps).to be_empty
+    end
+  end
 end

--- a/spec/nanoc/base/repos/dependency_store_spec.rb
+++ b/spec/nanoc/base/repos/dependency_store_spec.rb
@@ -1,0 +1,117 @@
+describe Nanoc::Int::DependencyStore do
+  let(:store) { described_class.new(objects) }
+
+  let(:objects) do
+    [obj_a, obj_b, obj_c]
+  end
+
+  let(:obj_a) { Nanoc::Int::Item.new('a', {}, '/a.md') }
+  let(:obj_b) { Nanoc::Int::Item.new('b', {}, '/b.md') }
+  let(:obj_c) { Nanoc::Int::Item.new('c', {}, '/c.md') }
+
+  describe '#dependencies_causing_outdatedness_of' do
+    context 'no dependencies' do
+      it 'returns nothing for each' do
+        expect(store.dependencies_causing_outdatedness_of(obj_a)).to be_empty
+        expect(store.dependencies_causing_outdatedness_of(obj_b)).to be_empty
+        expect(store.dependencies_causing_outdatedness_of(obj_c)).to be_empty
+      end
+    end
+
+    context 'one dependency' do
+      context 'no props' do
+        before do
+          # FIXME: weird argument order (obj_b depends on obj_a, not th other way around)
+          store.record_dependency(obj_a, obj_b)
+        end
+
+        it 'returns one dependency' do
+          deps = store.dependencies_causing_outdatedness_of(obj_a)
+          expect(deps.size).to eql(1)
+        end
+
+        it 'returns dependency from b to a' do
+          deps = store.dependencies_causing_outdatedness_of(obj_a)
+          expect(deps[0].from).to eql(obj_b)
+          expect(deps[0].to).to eql(obj_a)
+        end
+
+        it 'returns false for all props by default' do
+          deps = store.dependencies_causing_outdatedness_of(obj_a)
+          expect(deps[0].raw_content?).to eq(false)
+          expect(deps[0].attributes?).to eq(false)
+          expect(deps[0].compiled_content?).to eq(false)
+          expect(deps[0].path?).to eq(false)
+        end
+
+        it 'returns nothing for the others' do
+          expect(store.dependencies_causing_outdatedness_of(obj_b)).to be_empty
+          expect(store.dependencies_causing_outdatedness_of(obj_c)).to be_empty
+        end
+      end
+
+      context 'one prop' do
+        before do
+          # FIXME: weird argument order (obj_b depends on obj_a, not th other way around)
+          store.record_dependency(obj_a, obj_b, compiled_content: true)
+        end
+
+        it 'returns false for all unspecified props' do
+          deps = store.dependencies_causing_outdatedness_of(obj_a)
+          expect(deps[0].raw_content?).to eq(false)
+          expect(deps[0].attributes?).to eq(false)
+          expect(deps[0].path?).to eq(false)
+        end
+
+        it 'returns the specified props' do
+          deps = store.dependencies_causing_outdatedness_of(obj_a)
+          expect(deps[0].compiled_content?).to eq(true)
+        end
+      end
+
+      context 'two props' do
+        before do
+          # FIXME: weird argument order (obj_b depends on obj_a, not th other way around)
+          store.record_dependency(obj_a, obj_b, compiled_content: true)
+          store.record_dependency(obj_a, obj_b, attributes: true)
+        end
+
+        it 'returns false for all unspecified props' do
+          deps = store.dependencies_causing_outdatedness_of(obj_a)
+          expect(deps[0].raw_content?).to eq(false)
+          expect(deps[0].path?).to eq(false)
+        end
+
+        it 'returns the specified props' do
+          deps = store.dependencies_causing_outdatedness_of(obj_a)
+          expect(deps[0].attributes?).to eq(true)
+          expect(deps[0].compiled_content?).to eq(true)
+        end
+      end
+    end
+
+    context 'two dependency in a chain' do
+      before do
+        # FIXME: weird argument order (obj_b depends on obj_a, not th other way around)
+        store.record_dependency(obj_a, obj_b)
+        store.record_dependency(obj_b, obj_c)
+      end
+
+      it 'returns one dependency for object A' do
+        deps = store.dependencies_causing_outdatedness_of(obj_a)
+        expect(deps.size).to eql(1)
+        expect(deps[0].from).to eql(obj_b)
+      end
+
+      it 'returns one dependency for object B' do
+        deps = store.dependencies_causing_outdatedness_of(obj_b)
+        expect(deps.size).to eql(1)
+        expect(deps[0].from).to eql(obj_c)
+      end
+
+      it 'returns nothing for the others' do
+        expect(store.dependencies_causing_outdatedness_of(obj_c)).to be_empty
+      end
+    end
+  end
+end

--- a/spec/nanoc/base/services/dependency_tracker_spec.rb
+++ b/spec/nanoc/base/services/dependency_tracker_spec.rb
@@ -33,9 +33,21 @@ describe Nanoc::Int::DependencyTracker do
     example do
       expect { subject }.not_to change { store.objects_outdated_due_to(item_c) }
     end
+
+    example do
+      expect { subject }.not_to change { store.dependencies_causing_outdatedness_of(item_a) }
+    end
+
+    example do
+      expect { subject }.not_to change { store.dependencies_causing_outdatedness_of(item_b) }
+    end
+
+    example do
+      expect { subject }.not_to change { store.dependencies_causing_outdatedness_of(item_c) }
+    end
   end
 
-  describe '#enter and exit' do
+  describe '#enter and #exit' do
     context 'enter' do
       subject do
         tracker.enter(item_a)
@@ -100,6 +112,142 @@ describe Nanoc::Int::DependencyTracker do
 
       example do
         expect { subject }.not_to change { store.objects_outdated_due_to(item_c) }
+      end
+    end
+
+    context 'enter + enter with props' do
+      subject do
+        tracker.enter(item_a)
+        tracker.enter(item_b, compiled_content: true)
+      end
+
+      it_behaves_like 'a null dependency tracker'
+
+      it 'changes predecessors of item A' do
+        expect { subject }.to change { store.objects_causing_outdatedness_of(item_a) }
+          .from([]).to([item_b])
+      end
+
+      it 'changes successors of item B' do
+        expect { subject }.to change { store.objects_outdated_due_to(item_b) }
+          .from([]).to([item_a])
+      end
+
+      it 'changes dependencies causing outdatedness of item A' do
+        expect { subject }.to change { store.dependencies_causing_outdatedness_of(item_a).size }
+          .from(0).to(1)
+      end
+
+      it 'creates correct new dependency causing outdatedness of item A' do
+        subject
+        dep = store.dependencies_causing_outdatedness_of(item_a)[0]
+
+        expect(dep.from).to eql(item_b)
+        expect(dep.to).to eql(item_a)
+      end
+
+      it 'creates dependency with correct props causing outdatedness of item A' do
+        subject
+        dep = store.dependencies_causing_outdatedness_of(item_a)[0]
+
+        expect(dep.compiled_content?).to eq(true)
+
+        expect(dep.raw_content?).to eq(false)
+        expect(dep.attributes?).to eq(false)
+        expect(dep.path?).to eq(false)
+      end
+
+      example do
+        expect { subject }.not_to change { store.objects_causing_outdatedness_of(item_b) }
+      end
+
+      example do
+        expect { subject }.not_to change { store.objects_causing_outdatedness_of(item_c) }
+      end
+
+      example do
+        expect { subject }.not_to change { store.objects_outdated_due_to(item_a) }
+      end
+
+      example do
+        expect { subject }.not_to change { store.objects_outdated_due_to(item_c) }
+      end
+
+      example do
+        expect { subject }.not_to change { store.dependencies_causing_outdatedness_of(item_b) }
+      end
+
+      example do
+        expect { subject }.not_to change { store.dependencies_causing_outdatedness_of(item_c) }
+      end
+    end
+
+    context 'enter + enter with prop + exit + enter with prop' do
+      subject do
+        tracker.enter(item_a)
+        tracker.enter(item_b, compiled_content: true)
+        tracker.exit
+        tracker.enter(item_b, attributes: true)
+      end
+
+      it_behaves_like 'a null dependency tracker'
+
+      it 'changes predecessors of item A' do
+        expect { subject }.to change { store.objects_causing_outdatedness_of(item_a) }
+          .from([]).to([item_b])
+      end
+
+      it 'changes successors of item B' do
+        expect { subject }.to change { store.objects_outdated_due_to(item_b) }
+          .from([]).to([item_a])
+      end
+
+      it 'changes dependencies causing outdatedness of item A' do
+        expect { subject }.to change { store.dependencies_causing_outdatedness_of(item_a).size }
+          .from(0).to(1)
+      end
+
+      it 'creates correct new dependency causing outdatedness of item A' do
+        subject
+        dep = store.dependencies_causing_outdatedness_of(item_a)[0]
+
+        expect(dep.from).to eql(item_b)
+        expect(dep.to).to eql(item_a)
+      end
+
+      it 'creates dependency with correct props causing outdatedness of item A' do
+        subject
+        dep = store.dependencies_causing_outdatedness_of(item_a)[0]
+
+        expect(dep.compiled_content?).to eq(true)
+        expect(dep.attributes?).to eq(true)
+
+        expect(dep.raw_content?).to eq(false)
+        expect(dep.path?).to eq(false)
+      end
+
+      example do
+        expect { subject }.not_to change { store.objects_causing_outdatedness_of(item_b) }
+      end
+
+      example do
+        expect { subject }.not_to change { store.objects_causing_outdatedness_of(item_c) }
+      end
+
+      example do
+        expect { subject }.not_to change { store.objects_outdated_due_to(item_a) }
+      end
+
+      example do
+        expect { subject }.not_to change { store.objects_outdated_due_to(item_c) }
+      end
+
+      example do
+        expect { subject }.not_to change { store.dependencies_causing_outdatedness_of(item_b) }
+      end
+
+      example do
+        expect { subject }.not_to change { store.dependencies_causing_outdatedness_of(item_c) }
       end
     end
 

--- a/spec/nanoc/base/services/executor_spec.rb
+++ b/spec/nanoc/base/services/executor_spec.rb
@@ -294,7 +294,7 @@ describe Nanoc::Int::Executor do
 
       it 'exposes @layout as view' do
         allow(dependency_tracker).to receive(:enter)
-          .with(layout, raw_content: false, attributes: false, compiled_content: false, path: false)
+          .with(layout, raw_content: true, attributes: false, compiled_content: false, path: false)
         allow(dependency_tracker).to receive(:enter)
           .with(layout, raw_content: false, attributes: true, compiled_content: false, path: false)
         allow(dependency_tracker).to receive(:exit)

--- a/spec/nanoc/base/services/executor_spec.rb
+++ b/spec/nanoc/base/services/executor_spec.rb
@@ -293,7 +293,8 @@ describe Nanoc::Int::Executor do
       let(:layout_content) { 'head <%= @layout[:bug] %> foot' }
 
       it 'exposes @layout as view' do
-        allow(dependency_tracker).to receive(:enter).with(layout)
+        allow(dependency_tracker).to receive(:enter)
+          .with(layout, raw_content: false, attributes: false, compiled_content: false, path: false)
         allow(dependency_tracker).to receive(:exit)
         subject
         expect(rep.snapshot_contents[:last].string).to eq('head Gum Emperor foot')

--- a/spec/nanoc/base/services/executor_spec.rb
+++ b/spec/nanoc/base/services/executor_spec.rb
@@ -295,6 +295,8 @@ describe Nanoc::Int::Executor do
       it 'exposes @layout as view' do
         allow(dependency_tracker).to receive(:enter)
           .with(layout, raw_content: false, attributes: false, compiled_content: false, path: false)
+        allow(dependency_tracker).to receive(:enter)
+          .with(layout, raw_content: false, attributes: true, compiled_content: false, path: false)
         allow(dependency_tracker).to receive(:exit)
         subject
         expect(rep.snapshot_contents[:last].string).to eq('head Gum Emperor foot')

--- a/spec/nanoc/base/views/document_view_spec.rb
+++ b/spec/nanoc/base/views/document_view_spec.rb
@@ -264,6 +264,17 @@ shared_examples 'a document view' do
       it 'creates a dependency' do
         expect { subject }.to change { dependency_store.objects_causing_outdatedness_of(base_item) }.from([]).to([document])
       end
+
+      it 'creates a dependency with the right props' do
+        subject
+        dep = dependency_store.dependencies_causing_outdatedness_of(base_item)[0]
+
+        expect(dep.attributes?).to eq(true)
+
+        expect(dep.raw_content?).to eq(false)
+        expect(dep.compiled_content?).to eq(false)
+        expect(dep.path?).to eq(false)
+      end
     end
 
     context 'with non-existant key' do
@@ -273,6 +284,17 @@ shared_examples 'a document view' do
 
       it 'creates a dependency' do
         expect { subject }.to change { dependency_store.objects_causing_outdatedness_of(base_item) }.from([]).to([document])
+      end
+
+      it 'creates a dependency with the right props' do
+        subject
+        dep = dependency_store.dependencies_causing_outdatedness_of(base_item)[0]
+
+        expect(dep.attributes?).to eq(true)
+
+        expect(dep.raw_content?).to eq(false)
+        expect(dep.compiled_content?).to eq(false)
+        expect(dep.path?).to eq(false)
       end
     end
   end

--- a/spec/nanoc/base/views/document_view_spec.rb
+++ b/spec/nanoc/base/views/document_view_spec.rb
@@ -154,6 +154,17 @@ shared_examples 'a document view' do
       expect { subject }.to change { dependency_store.objects_causing_outdatedness_of(base_item) }.from([]).to([document])
     end
 
+    it 'creates a dependency with the right props' do
+      subject
+      dep = dependency_store.dependencies_causing_outdatedness_of(base_item)[0]
+
+      expect(dep.attributes?).to eq(true)
+
+      expect(dep.raw_content?).to eq(false)
+      expect(dep.compiled_content?).to eq(false)
+      expect(dep.path?).to eq(false)
+    end
+
     it 'returns attributes' do
       expect(subject).to eql(animal: 'donkey')
     end

--- a/spec/nanoc/base/views/document_view_spec.rb
+++ b/spec/nanoc/base/views/document_view_spec.rb
@@ -110,6 +110,17 @@ shared_examples 'a document view' do
       it 'creates a dependency' do
         expect { subject }.to change { dependency_store.objects_causing_outdatedness_of(base_item) }.from([]).to([document])
       end
+
+      it 'creates a dependency with the right props' do
+        subject
+        dep = dependency_store.dependencies_causing_outdatedness_of(base_item)[0]
+
+        expect(dep.attributes?).to eq(true)
+
+        expect(dep.raw_content?).to eq(false)
+        expect(dep.compiled_content?).to eq(false)
+        expect(dep.path?).to eq(false)
+      end
     end
 
     context 'with non-existant key' do
@@ -119,6 +130,17 @@ shared_examples 'a document view' do
 
       it 'creates a dependency' do
         expect { subject }.to change { dependency_store.objects_causing_outdatedness_of(base_item) }.from([]).to([document])
+      end
+
+      it 'creates a dependency with the right props' do
+        subject
+        dep = dependency_store.dependencies_causing_outdatedness_of(base_item)[0]
+
+        expect(dep.attributes?).to eq(true)
+
+        expect(dep.raw_content?).to eq(false)
+        expect(dep.compiled_content?).to eq(false)
+        expect(dep.path?).to eq(false)
       end
     end
   end

--- a/spec/nanoc/base/views/document_view_spec.rb
+++ b/spec/nanoc/base/views/document_view_spec.rb
@@ -317,5 +317,16 @@ shared_examples 'a document view' do
     it 'creates a dependency' do
       expect { subject }.to change { dependency_store.objects_causing_outdatedness_of(base_item) }.from([]).to([document])
     end
+
+    it 'creates a dependency with the right props' do
+      subject
+      dep = dependency_store.dependencies_causing_outdatedness_of(base_item)[0]
+
+      expect(dep.raw_content?).to eq(true)
+
+      expect(dep.attributes?).to eq(false)
+      expect(dep.compiled_content?).to eq(false)
+      expect(dep.path?).to eq(false)
+    end
   end
 end

--- a/spec/nanoc/base/views/document_view_spec.rb
+++ b/spec/nanoc/base/views/document_view_spec.rb
@@ -183,6 +183,17 @@ shared_examples 'a document view' do
       it 'creates a dependency' do
         expect { subject }.to change { dependency_store.objects_causing_outdatedness_of(base_item) }.from([]).to([document])
       end
+
+      it 'creates a dependency with the right props' do
+        subject
+        dep = dependency_store.dependencies_causing_outdatedness_of(base_item)[0]
+
+        expect(dep.attributes?).to eq(true)
+
+        expect(dep.raw_content?).to eq(false)
+        expect(dep.compiled_content?).to eq(false)
+        expect(dep.path?).to eq(false)
+      end
     end
 
     context 'with non-existant key' do
@@ -196,6 +207,17 @@ shared_examples 'a document view' do
         it 'creates a dependency' do
           expect { subject }.to change { dependency_store.objects_causing_outdatedness_of(base_item) }.from([]).to([document])
         end
+
+        it 'creates a dependency with the right props' do
+          subject
+          dep = dependency_store.dependencies_causing_outdatedness_of(base_item)[0]
+
+          expect(dep.attributes?).to eq(true)
+
+          expect(dep.raw_content?).to eq(false)
+          expect(dep.compiled_content?).to eq(false)
+          expect(dep.path?).to eq(false)
+        end
       end
 
       context 'with block' do
@@ -205,6 +227,17 @@ shared_examples 'a document view' do
 
         it 'creates a dependency' do
           expect { subject }.to change { dependency_store.objects_causing_outdatedness_of(base_item) }.from([]).to([document])
+        end
+
+        it 'creates a dependency with the right props' do
+          subject
+          dep = dependency_store.dependencies_causing_outdatedness_of(base_item)[0]
+
+          expect(dep.attributes?).to eq(true)
+
+          expect(dep.raw_content?).to eq(false)
+          expect(dep.compiled_content?).to eq(false)
+          expect(dep.path?).to eq(false)
         end
       end
 

--- a/spec/nanoc/base/views/item_rep_view_spec.rb
+++ b/spec/nanoc/base/views/item_rep_view_spec.rb
@@ -150,6 +150,17 @@ describe Nanoc::ItemRepView do
       expect { subject }.to change { dependency_store.objects_causing_outdatedness_of(base_item) }.from([]).to([item])
     end
 
+    it 'creates a dependency with the right props' do
+      subject
+      dep = dependency_store.dependencies_causing_outdatedness_of(base_item)[0]
+
+      expect(dep.compiled_content?).to eq(true)
+
+      expect(dep.raw_content?).to eq(false)
+      expect(dep.attributes?).to eq(false)
+      expect(dep.path?).to eq(false)
+    end
+
     it { should eq('Hallo') }
   end
 

--- a/spec/nanoc/base/views/item_rep_view_spec.rb
+++ b/spec/nanoc/base/views/item_rep_view_spec.rb
@@ -220,6 +220,17 @@ describe Nanoc::ItemRepView do
       expect { subject }.to change { dependency_store.objects_causing_outdatedness_of(base_item) }.from([]).to([item])
     end
 
+    it 'creates a dependency with the right props' do
+      subject
+      dep = dependency_store.dependencies_causing_outdatedness_of(base_item)[0]
+
+      expect(dep.path?).to eq(true)
+
+      expect(dep.raw_content?).to eq(false)
+      expect(dep.attributes?).to eq(false)
+      expect(dep.compiled_content?).to eq(false)
+    end
+
     it { should eq('output/about/index.html') }
   end
 

--- a/spec/nanoc/base/views/item_rep_view_spec.rb
+++ b/spec/nanoc/base/views/item_rep_view_spec.rb
@@ -185,6 +185,17 @@ describe Nanoc::ItemRepView do
       expect { subject }.to change { dependency_store.objects_causing_outdatedness_of(base_item) }.from([]).to([item])
     end
 
+    it 'creates a dependency with the right props' do
+      subject
+      dep = dependency_store.dependencies_causing_outdatedness_of(base_item)[0]
+
+      expect(dep.path?).to eq(true)
+
+      expect(dep.raw_content?).to eq(false)
+      expect(dep.attributes?).to eq(false)
+      expect(dep.compiled_content?).to eq(false)
+    end
+
     it { should eq('/about/') }
   end
 

--- a/spec/nanoc/cli/commands/show_data_spec.rb
+++ b/spec/nanoc/cli/commands/show_data_spec.rb
@@ -37,6 +37,10 @@ describe Nanoc::CLI::Commands::ShowData, stdio: true do
       end
     end
 
+    it 'prints a legend' do
+      expect { subject }.to output(%r{Item dependencies =+\n\nLegend:}).to_stdout
+    end
+
     context 'no dependencies' do
       it 'outputs no dependencies for /about.md' do
         expect { subject }.to output(%r{^item /about.md depends on:\n  \(nothing\)$}m).to_stdout

--- a/spec/nanoc/cli/commands/show_data_spec.rb
+++ b/spec/nanoc/cli/commands/show_data_spec.rb
@@ -1,0 +1,122 @@
+describe Nanoc::CLI::Commands::ShowData, stdio: true do
+  describe '#print_item_dependencies' do
+    subject { runner.send(:print_item_dependencies, items, dependency_store) }
+
+    let(:runner) do
+      described_class.new(options, arguments, command)
+    end
+
+    let(:options) { {} }
+    let(:arguments) { [] }
+    let(:command) { double(:command) }
+
+    let(:items) do
+      Nanoc::Int::IdentifiableCollection.new(config).tap do |ic|
+        ic << item_about
+        ic << item_dog
+        ic << item_other
+      end
+    end
+
+    let(:item_about) { Nanoc::Int::Item.new('About Me', {}, '/about.md') }
+    let(:item_dog)   { Nanoc::Int::Item.new('About My Dog', {}, '/dog.md') }
+    let(:item_other) { Nanoc::Int::Item.new('Raw Data', {}, '/other.dat') }
+
+    let(:config) { Nanoc::Int::Configuration.new }
+
+    let(:dependency_store) do
+      Nanoc::Int::DependencyStore.new(objects)
+    end
+
+    let(:objects) do
+      items.to_a + layouts.to_a
+    end
+
+    let(:layouts) do
+      Nanoc::Int::IdentifiableCollection.new(config).tap do |ic|
+      end
+    end
+
+    context 'no dependencies' do
+      it 'outputs no dependencies for /about.md' do
+        expect { subject }.to output(%r{^item /about.md depends on:\n  \(nothing\)$}m).to_stdout
+      end
+
+      it 'outputs no dependencies for /dog.md' do
+        expect { subject }.to output(%r{^item /dog.md depends on:\n  \(nothing\)$}m).to_stdout
+      end
+
+      it 'outputs no dependencies for /other.dat' do
+        expect { subject }.to output(%r{^item /other.dat depends on:\n  \(nothing\)$}m).to_stdout
+      end
+    end
+
+    context 'dependency (without props) from about to dog' do
+      before do
+        dependency_store.record_dependency(item_dog, item_about)
+      end
+
+      it 'outputs no dependencies for /about.md' do
+        expect { subject }.to output(%r{^item /about.md depends on:\n  \(nothing\)$}m).to_stdout
+      end
+
+      it 'outputs dependencies for /dog.md' do
+        expect { subject }.to output(%r{^item /dog.md depends on:\n  \[   item \] \(____\) /about.md$}m).to_stdout
+      end
+
+      it 'outputs no dependencies for /other.dat' do
+        expect { subject }.to output(%r{^item /other.dat depends on:\n  \(nothing\)$}m).to_stdout
+      end
+    end
+
+    context 'dependency (with raw_content prop) from about to dog' do
+      before do
+        dependency_store.record_dependency(item_dog, item_about, raw_content: true)
+      end
+
+      it 'outputs dependencies for /dog.md' do
+        expect { subject }.to output(%r{^item /dog.md depends on:\n  \[   item \] \(r___\) /about.md$}m).to_stdout
+      end
+    end
+
+    context 'dependency (with attributes prop) from about to dog' do
+      before do
+        dependency_store.record_dependency(item_dog, item_about, attributes: true)
+      end
+
+      it 'outputs dependencies for /dog.md' do
+        expect { subject }.to output(%r{^item /dog.md depends on:\n  \[   item \] \(_a__\) /about.md$}m).to_stdout
+      end
+    end
+
+    context 'dependency (with compiled_content prop) from about to dog' do
+      before do
+        dependency_store.record_dependency(item_dog, item_about, compiled_content: true)
+      end
+
+      it 'outputs dependencies for /dog.md' do
+        expect { subject }.to output(%r{^item /dog.md depends on:\n  \[   item \] \(__c_\) /about.md$}m).to_stdout
+      end
+    end
+
+    context 'dependency (with path prop) from about to dog' do
+      before do
+        dependency_store.record_dependency(item_dog, item_about, path: true)
+      end
+
+      it 'outputs dependencies for /dog.md' do
+        expect { subject }.to output(%r{^item /dog.md depends on:\n  \[   item \] \(___p\) /about.md$}m).to_stdout
+      end
+    end
+
+    context 'dependency (with multiple props) from about to dog' do
+      before do
+        dependency_store.record_dependency(item_dog, item_about, attributes: true, raw_content: true)
+      end
+
+      it 'outputs dependencies for /dog.md' do
+        expect { subject }.to output(%r{^item /dog.md depends on:\n  \[   item \] \(ra__\) /about.md$}m).to_stdout
+      end
+    end
+  end
+end

--- a/spec/nanoc/helpers/capturing_spec.rb
+++ b/spec/nanoc/helpers/capturing_spec.rb
@@ -100,7 +100,7 @@ describe Nanoc::Helpers::Capturing, helper: true do
 
         context 'other item is not yet compiled' do
           it 'raises an unmet dependency error' do
-            expect(ctx.dependency_tracker).to receive(:bounce).with(item.unwrap)
+            expect(ctx.dependency_tracker).to receive(:bounce).with(item.unwrap, compiled_content: true)
             expect { subject }.to raise_error(FiberError)
           end
         end
@@ -112,7 +112,7 @@ describe Nanoc::Helpers::Capturing, helper: true do
           end
 
           it 'returns the captured content' do
-            expect(ctx.dependency_tracker).to receive(:bounce).with(item.unwrap)
+            expect(ctx.dependency_tracker).to receive(:bounce).with(item.unwrap, compiled_content: true)
             expect(subject).to eql('other captured foo')
           end
         end

--- a/spec/nanoc/helpers/rendering_spec.rb
+++ b/spec/nanoc/helpers/rendering_spec.rb
@@ -30,7 +30,8 @@ describe Nanoc::Helpers::Rendering, helper: true do
           it { is_expected.to eql('blah') }
 
           it 'tracks proper dependencies' do
-            expect(ctx.dependency_tracker).to receive(:enter).with(layout)
+            expect(ctx.dependency_tracker).to receive(:enter)
+              .with(layout, raw_content: false, attributes: false, compiled_content: false, path: false)
             subject
           end
         end

--- a/spec/nanoc/helpers/rendering_spec.rb
+++ b/spec/nanoc/helpers/rendering_spec.rb
@@ -31,7 +31,7 @@ describe Nanoc::Helpers::Rendering, helper: true do
 
           it 'tracks proper dependencies' do
             expect(ctx.dependency_tracker).to receive(:enter)
-              .with(layout, raw_content: false, attributes: false, compiled_content: false, path: false)
+              .with(layout, raw_content: true, attributes: false, compiled_content: false, path: false)
             subject
           end
         end

--- a/test/base/test_directed_graph.rb
+++ b/test/base/test_directed_graph.rb
@@ -44,7 +44,7 @@ class Nanoc::Int::DirectedGraphTest < Nanoc::TestCase
     graph.add_edge(1, 2)
     graph.add_edge(2, 3)
 
-    assert_equal [[0, 1], [1, 2]], graph.edges.sort
+    assert_equal [[0, 1, nil], [1, 2, nil]], graph.edges.sort
   end
 
   def test_edges_with_new_vertices
@@ -55,7 +55,50 @@ class Nanoc::Int::DirectedGraphTest < Nanoc::TestCase
     graph.add_edge(3, 2)
     assert_equal [1, 2, 3], graph.vertices
 
-    assert_equal [[0, 1], [2, 1]], graph.edges.sort
+    assert_equal [[0, 1, nil], [2, 1, nil]], graph.edges.sort
+  end
+
+  def test_edge_with_props
+    graph = Nanoc::Int::DirectedGraph.new([1, 2, 3])
+    graph.add_edge(1, 2, props: { donkey: 14 })
+    graph.add_edge(2, 3, props: { giraffe: 3 })
+
+    assert_equal [[0, 1, { donkey: 14 }], [1, 2, { giraffe: 3 }]], graph.edges.sort
+  end
+
+  def test_props_for
+    graph = Nanoc::Int::DirectedGraph.new([1, 2, 3, 4])
+    graph.add_edge(1, 2, props: { donkey: 14 })
+    graph.add_edge(2, 3, props: { giraffe: 3 })
+    graph.add_edge(3, 4)
+
+    assert_equal({ donkey: 14 }, graph.props_for(1, 2))
+    assert_equal({ giraffe: 3 }, graph.props_for(2, 3))
+    assert_equal(nil, graph.props_for(3, 4))
+  end
+
+  def test_props_for_with_deleted_edge
+    graph = Nanoc::Int::DirectedGraph.new([1, 2])
+    graph.add_edge(1, 2, props: { donkey: 14 })
+    graph.delete_edge(1, 2)
+
+    assert_equal(nil, graph.props_for(1, 2))
+  end
+
+  def test_props_for_with_deleted_edges_from
+    graph = Nanoc::Int::DirectedGraph.new([1, 2])
+    graph.add_edge(1, 2, props: { donkey: 14 })
+    graph.delete_edges_from(1)
+
+    assert_equal(nil, graph.props_for(1, 2))
+  end
+
+  def test_props_for_with_deleted_edges_to
+    graph = Nanoc::Int::DirectedGraph.new([1, 2])
+    graph.add_edge(1, 2, props: { donkey: 14 })
+    graph.delete_edges_to(2)
+
+    assert_equal(nil, graph.props_for(1, 2))
   end
 
   def test_add_edge

--- a/test/filters/test_xsl.rb
+++ b/test/filters/test_xsl.rb
@@ -122,8 +122,8 @@ EOS
       assert_match SAMPLE_XML_OUT, result
 
       # Verify dependencies
-      obj = @dependency_store.objects_causing_outdatedness_of(@base_item)[0]
-      refute_nil obj
+      dep = @dependency_store.dependencies_causing_outdatedness_of(@base_item)[0]
+      refute_nil dep
     end
   end
 
@@ -148,8 +148,8 @@ EOS
       assert_match SAMPLE_XML_OUT_WITH_PARAMS, result
 
       # Verify dependencies
-      obj = @dependency_store.objects_causing_outdatedness_of(@base_item)[0]
-      refute_nil obj
+      dep = @dependency_store.dependencies_causing_outdatedness_of(@base_item)[0]
+      refute_nil dep
     end
   end
 
@@ -174,8 +174,8 @@ EOS
       assert_match SAMPLE_XML_OUT_WITH_OMIT_XML_DECL, result
 
       # Verify dependencies
-      obj = @dependency_store.objects_causing_outdatedness_of(@base_item)[0]
-      refute_nil obj
+      dep = @dependency_store.dependencies_causing_outdatedness_of(@base_item)[0]
+      refute_nil dep
     end
   end
 end


### PR DESCRIPTION
This is part of what #991 wants to achieve, without making changes to the outdatedness checker yet.

* [x] Let dependency tracker take props
* [x] Store props in dependency store
* [x] Make show-data show finer-grained dependencies
* [x] Make each call to `#enter` and `#bounce` pass the correct props