### PR TITLE
Make DocumentViewMixin#raw_content generate dependency

### DIFF
--- a/lib/nanoc/base/views/mixins/document_view_mixin.rb
+++ b/lib/nanoc/base/views/mixins/document_view_mixin.rb
@@ -74,6 +74,7 @@ module Nanoc
 
     # @api private
     def raw_content
+      @context.dependency_tracker.bounce(unwrap)
       unwrap.content.string
     end
 

--- a/spec/nanoc/base/views/document_view_spec.rb
+++ b/spec/nanoc/base/views/document_view_spec.rb
@@ -218,4 +218,16 @@ shared_examples 'a document view' do
 
     it { should == described_class.hash ^ '/foo/'.hash }
   end
+
+  describe '#raw_content' do
+    let(:document) { entity_class.new('stuff', { animal: 'donkey' }, '/foo/') }
+
+    subject { view.raw_content }
+
+    it { is_expected.to eql('stuff') }
+
+    it 'creates a dependency' do
+      expect { subject }.to change { dependency_store.objects_causing_outdatedness_of(base_item) }.from([]).to([document])
+    end
+  end
 end

--- a/spec/nanoc/base/views/item_view_spec.rb
+++ b/spec/nanoc/base/views/item_view_spec.rb
@@ -16,15 +16,6 @@ describe Nanoc::ItemWithRepsView do
     dependency_tracker.enter(base_item)
   end
 
-  describe '#raw_content' do
-    let(:item) { Nanoc::Int::Item.new('content', {}, '/asdf/') }
-    let(:view) { described_class.new(item, nil) }
-
-    subject { view.raw_content }
-
-    it { should eq('content') }
-  end
-
   describe '#parent' do
     let(:item) do
       Nanoc::Int::Item.new('me', {}, identifier)


### PR DESCRIPTION
~Fixes #924.~

This fixes an issue with the XSL filter not generating a correct dependency on the layout.