### PR TITLE
Remove compiler stack

### DIFF
--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -208,11 +208,17 @@ module Nanoc::Int
       selector = Nanoc::Int::ItemRepSelector.new(outdated_reps)
       selector.each do |rep|
         @stack = []
-        compile_rep(rep)
+        handle_errors_while(rep) { compile_rep(rep) }
       end
     ensure
       Nanoc::Int::NotificationCenter.remove(:processing_started, self)
       Nanoc::Int::NotificationCenter.remove(:processing_ended,   self)
+    end
+
+    def handle_errors_while(item_rep)
+      yield
+    rescue => e
+      raise Nanoc::Int::Errors::WithItemRepError.new(e, item_rep)
     end
 
     # Compiles the given item representation.

--- a/lib/nanoc/base/compilation/compiler.rb
+++ b/lib/nanoc/base/compilation/compiler.rb
@@ -192,7 +192,7 @@ module Nanoc::Int
     def handle_errors_while(item_rep)
       yield
     rescue => e
-      raise Nanoc::Int::Errors::WithItemRepError.new(e, item_rep)
+      raise Nanoc::Int::Errors::CompilationError.new(e, item_rep)
     end
 
     # Compiles the given item representation.

--- a/lib/nanoc/base/errors.rb
+++ b/lib/nanoc/base/errors.rb
@@ -10,9 +10,9 @@ module Nanoc::Int
     class GenericTrivial < Generic
     end
 
-    # TODO: document
-    # TODO: Rename to ItemRepCompilationError
-    class WithItemRepError < Generic
+    # Error that is raised when compilation of an item rep fails. The
+    # underlying error is available by calling `#unwrap`.
+    class CompilationError < Generic
       attr_reader :item_rep
 
       def initialize(wrapped, item_rep)

--- a/lib/nanoc/base/errors.rb
+++ b/lib/nanoc/base/errors.rb
@@ -10,6 +10,21 @@ module Nanoc::Int
     class GenericTrivial < Generic
     end
 
+    # TODO: document
+    # TODO: Rename to ItemRepCompilationError
+    class WithItemRepError < Generic
+      attr_reader :item_rep
+
+      def initialize(wrapped, item_rep)
+        @wrapped = wrapped
+        @item_rep = item_rep
+      end
+
+      def unwrap
+        @wrapped
+      end
+    end
+
     # Error that is raised when a site is loaded that uses a data source with
     # an unknown identifier.
     class UnknownDataSource < Generic

--- a/lib/nanoc/base/services/executor.rb
+++ b/lib/nanoc/base/services/executor.rb
@@ -70,9 +70,7 @@ module Nanoc
         @dependency_tracker.bounce(layout, raw_content: true)
 
         begin
-          # Notify start
-          Nanoc::Int::NotificationCenter.post(:processing_started, layout)
-          Nanoc::Int::NotificationCenter.post(:filtering_started,  rep, filter_name)
+          Nanoc::Int::NotificationCenter.post(:filtering_started, rep, filter_name)
 
           # Layout
           content = layout.content
@@ -83,9 +81,7 @@ module Nanoc
           # Create "post" snapshot
           snapshot(rep, :post, final: false)
         ensure
-          # Notify end
-          Nanoc::Int::NotificationCenter.post(:filtering_ended,  rep, filter_name)
-          Nanoc::Int::NotificationCenter.post(:processing_ended, layout)
+          Nanoc::Int::NotificationCenter.post(:filtering_ended, rep, filter_name)
         end
       end
 

--- a/lib/nanoc/base/services/item_rep_selector.rb
+++ b/lib/nanoc/base/services/item_rep_selector.rb
@@ -31,7 +31,7 @@ module Nanoc::Int
 
     def handle_error(e, rep, graph)
       case e
-      when Nanoc::Int::Errors::WithItemRepError
+      when Nanoc::Int::Errors::CompilationError
         handle_error(e.unwrap, rep, graph)
       when Nanoc::Int::Errors::UnmetDependency
         handle_dependency_error(e, rep, graph)

--- a/lib/nanoc/base/services/item_rep_selector.rb
+++ b/lib/nanoc/base/services/item_rep_selector.rb
@@ -18,8 +18,7 @@ module Nanoc::Int
           yield(rep)
           graph.delete_vertex(rep)
         rescue => e
-          is_success = handle_error(e, rep, graph)
-          raise(e) unless is_success
+          handle_error(e, rep, graph)
         end
       end
 
@@ -30,14 +29,17 @@ module Nanoc::Int
     end
 
     def handle_error(e, rep, graph)
-      case e
-      when Nanoc::Int::Errors::CompilationError
-        handle_error(e.unwrap, rep, graph)
-      when Nanoc::Int::Errors::UnmetDependency
-        handle_dependency_error(e, rep, graph)
-        true
+      actual_error =
+        if e.is_a?(Nanoc::Int::Errors::CompilationError)
+          e.unwrap
+        else
+          e
+        end
+
+      if actual_error.is_a?(Nanoc::Int::Errors::UnmetDependency)
+        handle_dependency_error(actual_error, rep, graph)
       else
-        false
+        raise(e)
       end
     end
 

--- a/lib/nanoc/cli/command_runner.rb
+++ b/lib/nanoc/cli/command_runner.rb
@@ -65,12 +65,5 @@ module Nanoc::CLI
     def debug?
       Nanoc::CLI.debug?
     end
-
-    protected
-
-    # @return [Array] The compilation stack.
-    def stack
-      (site && site.compiler.stack) || []
-    end
   end
 end

--- a/lib/nanoc/cli/error_handler.rb
+++ b/lib/nanoc/cli/error_handler.rb
@@ -262,7 +262,7 @@ module Nanoc::CLI
     end
 
     def write_item_rep(stream, error, verbose: false)
-      return unless error.respond_to?(:item_rep)
+      return unless error.is_a?(Nanoc::Int::Errors::CompilationError)
 
       write_section_header(stream, 'Item being compiled', verbose: verbose)
 
@@ -327,8 +327,9 @@ module Nanoc::CLI
     end
 
     def unwrap_error(e)
-      if e.respond_to?(:unwrap)
-        unwrap_error(e.unwrap)
+      case e
+      when Nanoc::Int::Errors::CompilationError
+        e.unwrap
       else
         e
       end

--- a/lib/nanoc/cli/error_handler.rb
+++ b/lib/nanoc/cli/error_handler.rb
@@ -161,11 +161,6 @@ module Nanoc::CLI
       site && site.compiler
     end
 
-    # @return [Array] The current compilation stack
-    def stack
-      (compiler && compiler.stack) || []
-    end
-
     # @return [Hash<String, Array>] A hash containing the gem names as keys and gem versions as value
     def gems_and_versions
       gems = {}

--- a/lib/nanoc/helpers/rendering.rb
+++ b/lib/nanoc/helpers/rendering.rb
@@ -47,28 +47,20 @@ module Nanoc::Helpers
       # Create filter
       filter = filter_class.new(assigns)
 
-      begin
-        # Notify start
-        Nanoc::Int::NotificationCenter.post(:processing_started, layout)
+      # Layout
+      content = layout.content
+      arg = content.binary? ? content.filename : content.string
+      result = filter.setup_and_run(arg, filter_args)
 
-        # Layout
-        content = layout.content
-        arg = content.binary? ? content.filename : content.string
-        result = filter.setup_and_run(arg, filter_args)
-
-        # Append to erbout if we have a block
-        if block_given?
-          # Append result and return nothing
-          erbout = eval('_erbout', block.binding)
-          erbout << result
-          ''
-        else
-          # Return result
-          result
-        end
-      ensure
-        # Notify end
-        Nanoc::Int::NotificationCenter.post(:processing_ended, layout)
+      # Append to erbout if we have a block
+      if block_given?
+        # Append result and return nothing
+        erbout = eval('_erbout', block.binding)
+        erbout << result
+        ''
+      else
+        # Return result
+        result
       end
     end
   end

--- a/spec/nanoc/base/compiler_spec.rb
+++ b/spec/nanoc/base/compiler_spec.rb
@@ -66,64 +66,6 @@ describe Nanoc::Int::Compiler do
     allow(action_provider).to receive(:memory_for).with(other_rep).and_return(memory)
   end
 
-  describe '#compile_reps' do
-    subject { compiler.send(:compile_reps) }
-
-    before do
-      allow(action_provider).to receive(:snapshots_defs_for).with(rep).and_return(snapshot_defs_for_rep)
-      allow(action_provider).to receive(:snapshots_defs_for).with(other_rep).and_return(snapshot_defs_for_rep)
-    end
-
-    let(:snapshot_defs_for_rep) do
-      [Nanoc::Int::SnapshotDef.new(:last, true)]
-    end
-
-    let(:snapshot_defs_for_other_rep) do
-      [Nanoc::Int::SnapshotDef.new(:last, true)]
-    end
-
-    it 'keeps the compilation stack in a good state' do
-      expect(compiler.stack).to be_empty
-      subject
-      expect(compiler.stack).to be_empty
-    end
-
-    context 'exception' do
-      let(:item) { Nanoc::Int::Item.new('<%= raise "lol" %>', {}, '/hi.md') }
-
-      it 'keeps the compilation stack in a good state' do
-        expect(compiler.stack).to be_empty
-        expect { subject }.to raise_error(Nanoc::Int::Errors::WithItemRepError)
-        expect(compiler.stack).to eql([rep])
-      end
-    end
-
-    context 'interrupted compilation' do
-      let(:item) { Nanoc::Int::Item.new('other=<%= @items["/other.*"].compiled_content %>', {}, '/hi.md') }
-
-      before do
-        expect(outdatedness_checker).to receive(:outdated?).with(other_rep).and_return(true)
-        expect(action_provider).to receive(:memory_for).with(other_rep).and_return(memory)
-      end
-
-      it 'keeps the compilation stack in a good state' do
-        expect(compiler.stack).to be_empty
-        subject
-        expect(compiler.stack).to be_empty
-      end
-
-      context 'exception' do
-        let(:item) { Nanoc::Int::Item.new('other=<%= @items["/other.*"].compiled_content %><% raise "lol" %>', {}, '/hi.md') }
-
-        it 'keeps the compilation stack in a good state' do
-          expect(compiler.stack).to be_empty
-          expect { subject }.to raise_error(Nanoc::Int::Errors::WithItemRepError)
-          expect(compiler.stack).to eql([rep])
-        end
-      end
-    end
-  end
-
   describe '#compile_rep' do
     subject { compiler.send(:compile_rep, rep) }
 
@@ -134,12 +76,10 @@ describe Nanoc::Int::Compiler do
     end
 
     it 'generates notifications in the proper order' do
-      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:processing_started, rep).ordered
       expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:compilation_started, rep).ordered
       expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:filtering_started, rep, :erb).ordered
       expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:filtering_ended, rep, :erb).ordered
       expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:compilation_ended, rep).ordered
-      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:processing_ended, rep).ordered
 
       subject
     end
@@ -162,42 +102,23 @@ describe Nanoc::Int::Compiler do
         expect(rep.snapshot_contents[:last].string).to eql('other=other content')
       end
 
-      it 'keeps the compilation stack in a good state' do
-        expect(compiler.stack).to be_empty
-
-        expect { compiler.send(:compile_rep, rep) }.to raise_error(Nanoc::Int::Errors::UnmetDependency)
-        expect(compiler.stack).to be_empty
-
-        compiler.send(:compile_rep, other_rep)
-        expect(compiler.stack).to be_empty
-
-        compiler.send(:compile_rep, rep)
-        expect(compiler.stack).to be_empty
-      end
-
       it 'generates notifications in the proper order' do
         # rep 1
-        expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:processing_started, rep).ordered
         expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:compilation_started, rep).ordered
         expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:filtering_started, rep, :erb).ordered
         expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:dependency_created, item, other_item).ordered
         expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:compilation_suspended, rep, anything).ordered
-        expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:processing_ended, rep).ordered
 
         # rep 2
-        expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:processing_started, other_rep).ordered
         expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:compilation_started, other_rep).ordered
         expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:filtering_started, other_rep, :erb).ordered
         expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:filtering_ended, other_rep, :erb).ordered
         expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:compilation_ended, other_rep).ordered
-        expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:processing_ended, other_rep).ordered
 
         # rep 1 (again)
-        expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:processing_started, rep).ordered
         expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:compilation_started, rep).ordered
         expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:filtering_ended, rep, :erb).ordered
         expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:compilation_ended, rep).ordered
-        expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:processing_ended, rep).ordered
 
         expect { compiler.send(:compile_rep, rep) }.to raise_error(Nanoc::Int::Errors::UnmetDependency)
         compiler.send(:compile_rep, other_rep)

--- a/spec/nanoc/base/compiler_spec.rb
+++ b/spec/nanoc/base/compiler_spec.rb
@@ -93,7 +93,7 @@ describe Nanoc::Int::Compiler do
 
       it 'keeps the compilation stack in a good state' do
         expect(compiler.stack).to be_empty
-        expect { subject }.to raise_error(RuntimeError)
+        expect { subject }.to raise_error(Nanoc::Int::Errors::WithItemRepError)
         expect(compiler.stack).to eql([rep])
       end
     end
@@ -117,7 +117,7 @@ describe Nanoc::Int::Compiler do
 
         it 'keeps the compilation stack in a good state' do
           expect(compiler.stack).to be_empty
-          expect { subject }.to raise_error(RuntimeError)
+          expect { subject }.to raise_error(Nanoc::Int::Errors::WithItemRepError)
           expect(compiler.stack).to eql([rep])
         end
       end

--- a/spec/nanoc/base/services/executor_spec.rb
+++ b/spec/nanoc/base/services/executor_spec.rb
@@ -322,10 +322,8 @@ describe Nanoc::Int::Executor do
       end
 
       it 'sends notifications' do
-        expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:processing_started, layout).ordered
         expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:filtering_started, rep, :erb).ordered
         expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:filtering_ended, rep, :erb).ordered
-        expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:processing_ended, layout).ordered
 
         subject
       end

--- a/test/cli/test_error_handler.rb
+++ b/test/cli/test_error_handler.rb
@@ -49,7 +49,7 @@ class Nanoc::CLI::ErrorHandlerTest < Nanoc::TestCase
   def test_write_error_message_wrapped
     stream = StringIO.new
     @handler.send(:write_error_message, stream, new_wrapped_error(new_error), verbose: true)
-    refute_match(/WithItemRepError/, stream.string)
+    refute_match(/CompilationError/, stream.string)
   end
 
   def test_write_stack_trace_wrapped
@@ -76,7 +76,7 @@ class Nanoc::CLI::ErrorHandlerTest < Nanoc::TestCase
   def new_wrapped_error(wrapped)
     item = Nanoc::Int::Item.new('asdf', {}, '/about.md')
     item_rep = Nanoc::Int::ItemRep.new(item, :latex)
-    raise Nanoc::Int::Errors::WithItemRepError.new(wrapped, item_rep)
+    raise Nanoc::Int::Errors::CompilationError.new(wrapped, item_rep)
   rescue => e
     return e
   end

--- a/test/cli/test_error_handler.rb
+++ b/test/cli/test_error_handler.rb
@@ -46,7 +46,42 @@ class Nanoc::CLI::ErrorHandlerTest < Nanoc::TestCase
     refute_match(/See full crash log for details./, stream.string)
   end
 
-  def new_error(amount_factor)
+  def test_write_error_message_wrapped
+    stream = StringIO.new
+    @handler.send(:write_error_message, stream, new_wrapped_error(new_error), verbose: true)
+    refute_match(/WithItemRepError/, stream.string)
+  end
+
+  def test_write_stack_trace_wrapped
+    stream = StringIO.new
+    @handler.send(:write_stack_trace, stream, new_wrapped_error(new_error), verbose: false)
+    assert_match(/new_error/, stream.string)
+  end
+
+  def test_write_item_rep
+    stream = StringIO.new
+    @handler.send(:write_item_rep, stream, new_wrapped_error(new_error), verbose: false)
+    assert_match(/^Item identifier: \/about\.md$/, stream.string)
+    assert_match(/^Item rep name:   :latex$/, stream.string)
+  end
+
+  def test_resolution_for_wrapped
+    def @handler.using_bundler?
+      true
+    end
+    error = new_wrapped_error(LoadError.new('no such file to load -- kramdown'))
+    assert_match(/^Make sure the gem is added to Gemfile/, @handler.send(:resolution_for, error))
+  end
+
+  def new_wrapped_error(wrapped)
+    item = Nanoc::Int::Item.new('asdf', {}, '/about.md')
+    item_rep = Nanoc::Int::ItemRep.new(item, :latex)
+    raise Nanoc::Int::Errors::WithItemRepError.new(wrapped, item_rep)
+  rescue => e
+    return e
+  end
+
+  def new_error(amount_factor = 1)
     backtrace_generator = lambda do |af|
       if af.zero?
         raise 'finally!'


### PR DESCRIPTION
Remove the compiler stack and print the details of the current in-compilation item rep.

### Detailed description

This is done in two steps:

1. Wrap every error raised during compilation in an error decorator that will contain the current item rep that is being compiled, and ensure that item rep is printed in the error handler.

2. Remove the now unused compiler stack.

Before:

![before](https://cloud.githubusercontent.com/assets/6269/20578883/c1cbd5e8-b1c9-11e6-9baf-71b3892c897f.png)

After:

![after](https://cloud.githubusercontent.com/assets/6269/20578885/c62d563e-b1c9-11e6-9c45-e85430d261eb.png)

### To do

* [x] Tests
* [x] Cleanup
  * [x] Rename `WithItemRepError` to `CompilerError`
  * [x] Unwrap consistently; don’t check `respond_to?`