### PR TITLE
Fix Less filter dependencies

### DIFF
--- a/lib/nanoc/filters/less.rb
+++ b/lib/nanoc/filters/less.rb
@@ -10,28 +10,9 @@ module Nanoc::Filters
     #
     # @return [String] The filtered content
     def run(content, params = {})
-      imported_filenames = imported_filenames_from(content)
-
-      item_dir_path = Pathname.new(@item[:content_filename]).dirname.realpath
-      cwd = Pathname.pwd # FIXME: ugly (get site dir instead)
-
-      # Convert to items
-      imported_items = imported_filenames.map do |filename|
-        full_paths = Set.new
-
-        imported_pathname = Pathname.new(filename)
-        full_paths << find_file(imported_pathname, item_dir_path)
-        full_paths << find_file(imported_pathname, cwd)
-
-        # Find matching item
-        @items.find do |i|
-          next if i[:content_filename].nil?
-          item_path = Pathname.new(i[:content_filename]).realpath
-          full_paths.any? { |fp| fp == item_path }
-        end
-      end.compact
-
       # Create dependencies
+      imported_filenames = imported_filenames_from(content)
+      imported_items = imported_filenames_to_items(imported_filenames)
       depend_on(imported_items)
 
       # Add filename to load path
@@ -50,6 +31,26 @@ module Nanoc::Filters
       imported_filenames = imports.map do |i|
         i[1] =~ /\.(less|css)$/ ? i[1] : i[1] + '.less'
       end
+    end
+
+    def imported_filenames_to_items(imported_filenames)
+      item_dir_path = Pathname.new(@item[:content_filename]).dirname.realpath
+      cwd = Pathname.pwd # FIXME: ugly (get site dir instead)
+
+      imported_items = imported_filenames.map do |filename|
+        full_paths = Set.new
+
+        imported_pathname = Pathname.new(filename)
+        full_paths << find_file(imported_pathname, item_dir_path)
+        full_paths << find_file(imported_pathname, cwd)
+
+        # Find matching item
+        @items.find do |i|
+          next if i[:content_filename].nil?
+          item_path = Pathname.new(i[:content_filename]).realpath
+          full_paths.any? { |fp| fp == item_path }
+        end
+      end.compact
     end
 
     # @param [Pathname] pathname Pathname of the file to find. Can be relative or absolute.

--- a/lib/nanoc/filters/less.rb
+++ b/lib/nanoc/filters/less.rb
@@ -10,13 +10,7 @@ module Nanoc::Filters
     #
     # @return [String] The filtered content
     def run(content, params = {})
-      # Find imports (hacky)
-      imports = []
-      imports.concat(content.scan(/^@import\s+(["'])([^\1]+?)\1;/))
-      imports.concat(content.scan(/^@import\s+url\((["']?)([^)]+?)\1\);/))
-      imported_filenames = imports.map do |i|
-        i[1] =~ /\.(less|css)$/ ? i[1] : i[1] + '.less'
-      end
+      imported_filenames = imported_filenames_from(content)
 
       item_dir_path = Pathname.new(@item[:content_filename]).dirname.realpath
       cwd = Pathname.pwd # FIXME: ugly (get site dir instead)
@@ -45,6 +39,16 @@ module Nanoc::Filters
       on_main_fiber do
         parser = ::Less::Parser.new(paths: paths)
         parser.parse(content).to_css(params)
+      end
+    end
+
+    def imported_filenames_from(content)
+      imports = []
+      imports.concat(content.scan(/^@import\s+(["'])([^\1]+?)\1;/))
+      imports.concat(content.scan(/^@import\s+url\((["']?)([^)]+?)\1\);/))
+
+      imported_filenames = imports.map do |i|
+        i[1] =~ /\.(less|css)$/ ? i[1] : i[1] + '.less'
       end
     end
 

--- a/lib/nanoc/filters/less.rb
+++ b/lib/nanoc/filters/less.rb
@@ -28,16 +28,14 @@ module Nanoc::Filters
       imports.concat(content.scan(/^@import\s+(["'])([^\1]+?)\1;/))
       imports.concat(content.scan(/^@import\s+url\((["']?)([^)]+?)\1\);/))
 
-      imported_filenames = imports.map do |i|
-        i[1] =~ /\.(less|css)$/ ? i[1] : i[1] + '.less'
-      end
+      imports.map { |i| i[1] =~ /\.(less|css)$/ ? i[1] : i[1] + '.less' }
     end
 
     def imported_filenames_to_items(imported_filenames)
       item_dir_path = Pathname.new(@item[:content_filename]).dirname.realpath
       cwd = Pathname.pwd # FIXME: ugly (get site dir instead)
 
-      imported_items = imported_filenames.map do |filename|
+      imported_filenames.map do |filename|
         full_paths = Set.new
 
         imported_pathname = Pathname.new(filename)

--- a/spec/nanoc/filters/less_spec.rb
+++ b/spec/nanoc/filters/less_spec.rb
@@ -82,7 +82,14 @@ describe Nanoc::Filters::Less, site: true, stdio: true do
       expect(File.read('output/a.css')).to match(/^p\s*\{\s*color:\s*red;?\s*\}/)
     end
 
-    it 'recompiles a.less if b.less has changed'
+    it 'recompiles a.less if b.less has changed' do
+      Nanoc::CLI.run(%w(compile))
+
+      File.write('content/foo/bar/imported_file.less', 'p { color: blue; }')
+
+      Nanoc::CLI.run(%w(compile))
+      expect(File.read('output/a.css')).to match(/^p\s*\{\s*color:\s*blue;?\s*\}/)
+    end
   end
 
   context 'paths relative to current file' do
@@ -101,6 +108,13 @@ describe Nanoc::Filters::Less, site: true, stdio: true do
       expect(File.read('output/foo/a.css')).to match(/^p\s*\{\s*color:\s*red;?\s*\}/)
     end
 
-    it 'recompiles a.less if b.less has changed'
+    it 'recompiles a.less if b.less has changed' do
+      Nanoc::CLI.run(%w(compile))
+
+      File.write('content/foo/bar/imported_file.less', 'p { color: blue; }')
+
+      Nanoc::CLI.run(%w(compile))
+      expect(File.read('output/foo/a.css')).to match(/^p\s*\{\s*color:\s*blue;?\s*\}/)
+    end
   end
 end


### PR DESCRIPTION
In Less, `@import`s relative to the site directory would not generate the proper dependencies. This fixes that.

This also refactors the source for the `:less` filter (in separate commits).