### PR TITLE
Support full identifiers in breadcrumbs

### DIFF
--- a/lib/nanoc/helpers/breadcrumbs.rb
+++ b/lib/nanoc/helpers/breadcrumbs.rb
@@ -1,24 +1,26 @@
 module Nanoc::Helpers
   # @see http://nanoc.ws/doc/reference/helpers/#breadcrumbs
   module Breadcrumbs
-    class CannotGetBreadcrumbsForNonLegacyItem < Nanoc::Int::Errors::Generic
-      def initialize(identifier)
-        super("You cannot build a breadcrumbs trail for an item that has a “full” identifier (#{identifier}). Doing so is only possible for items that have a legacy identifier.")
-      end
-    end
-
     # @return [Array]
     def breadcrumbs_trail
-      unless @item.identifier.legacy?
-        raise CannotGetBreadcrumbsForNonLegacyItem.new(@item.identifier)
-      end
-
       # e.g. ['', '/foo', '/foo/bar']
       prefixes =
         item.identifier.components
         .inject(['']) { |acc, elem| acc + [acc.last + '/' + elem] }
 
-      prefixes.map { |pr| @items[Nanoc::Identifier.new('/' + pr, type: :legacy)] }
+      if @item.identifier.legacy?
+        prefixes.map { |pr| @items[Nanoc::Identifier.new('/' + pr, type: :legacy)] }
+      else
+        prefixes
+          .reject { |pr| pr =~ /^\/index\./ }
+          .map do |pr|
+            if pr == ''
+              @items['/index.*']
+            else
+              @items[Nanoc::Identifier.new(pr).without_ext + '.*']
+            end
+          end
+      end
     end
   end
 end

--- a/lib/nanoc/helpers/breadcrumbs.rb
+++ b/lib/nanoc/helpers/breadcrumbs.rb
@@ -13,19 +13,12 @@ module Nanoc::Helpers
         raise CannotGetBreadcrumbsForNonLegacyItem.new(@item.identifier)
       end
 
-      trail      = []
-      idx_start  = 0
+      # e.g. ['', '/foo', '/foo/bar']
+      prefixes =
+        item.identifier.components
+        .inject(['']) { |acc, elem| acc + [acc.last + '/' + elem] }
 
-      loop do
-        idx = @item.identifier.to_s.index('/', idx_start)
-        break if idx.nil?
-
-        idx_start = idx + 1
-        identifier = @item.identifier.to_s[0..idx]
-        trail << @items[identifier]
-      end
-
-      trail
+      prefixes.map { |pr| @items[Nanoc::Identifier.new('/' + pr, type: :legacy)] }
     end
   end
 end

--- a/lib/nanoc/helpers/breadcrumbs.rb
+++ b/lib/nanoc/helpers/breadcrumbs.rb
@@ -4,9 +4,8 @@ module Nanoc::Helpers
     # @return [Array]
     def breadcrumbs_trail
       # e.g. ['', '/foo', '/foo/bar']
-      prefixes =
-        item.identifier.components
-        .inject(['']) { |acc, elem| acc + [acc.last + '/' + elem] }
+      components = item.identifier.components
+      prefixes = components.inject(['']) { |acc, elem| acc + [acc.last + '/' + elem] }
 
       if @item.identifier.legacy?
         prefixes.map { |pr| @items[Nanoc::Identifier.new('/' + pr, type: :legacy)] }

--- a/spec/nanoc/helpers/breadcrumbs_spec.rb
+++ b/spec/nanoc/helpers/breadcrumbs_spec.rb
@@ -62,14 +62,71 @@ describe Nanoc::Helpers::Breadcrumbs, helper: true do
     end
 
     context 'non-legacy identifiers' do
-      before do
-        ctx.create_item('root', {}, '/index.md')
+      context 'root' do
+        before do
+          ctx.create_item('root', {}, Nanoc::Identifier.new('/index.md'))
 
-        ctx.item = ctx.items['/index.md']
+          ctx.item = ctx.items['/index.md']
+        end
+
+        it 'returns an array with the item' do
+          expect(subject).to eql([ctx.items['/index.md']])
+        end
       end
 
-      it 'raises' do
-        expect { subject }.to raise_error(Nanoc::Helpers::Breadcrumbs::CannotGetBreadcrumbsForNonLegacyItem)
+      context 'root and direct child' do
+        before do
+          ctx.create_item('child', {}, Nanoc::Identifier.new('/foo.md'))
+          ctx.create_item('root', {}, Nanoc::Identifier.new('/index.md'))
+
+          ctx.item = ctx.items['/foo.md']
+        end
+
+        it 'returns an array with the items' do
+          expect(subject).to eql([ctx.items['/index.md'], ctx.items['/foo.md']])
+        end
+      end
+
+      context 'root, child and grandchild' do
+        before do
+          ctx.create_item('grandchild', {}, Nanoc::Identifier.new('/foo/bar.md'))
+          ctx.create_item('child', {}, Nanoc::Identifier.new('/foo.md'))
+          ctx.create_item('root', {}, Nanoc::Identifier.new('/index.md'))
+
+          ctx.item = ctx.items['/foo/bar.md']
+        end
+
+        it 'returns an array with the items' do
+          expect(subject).to eql([ctx.items['/index.md'], ctx.items['/foo.md'], ctx.items['/foo/bar.md']])
+        end
+      end
+
+      context 'root, missing child and grandchild' do
+        before do
+          ctx.create_item('grandchild', {}, Nanoc::Identifier.new('/foo/bar.md'))
+          ctx.create_item('root', {}, Nanoc::Identifier.new('/index.md'))
+
+          ctx.item = ctx.items['/foo/bar.md']
+        end
+
+        it 'returns an array with the items' do
+          expect(subject).to eql([ctx.items['/index.md'], nil, ctx.items['/foo/bar.md']])
+        end
+      end
+
+      context 'index.md child' do
+        # No special handling of non-root index.* files.
+
+        before do
+          ctx.create_item('grandchild', {}, Nanoc::Identifier.new('/foo/index.md'))
+          ctx.create_item('root', {}, Nanoc::Identifier.new('/index.md'))
+
+          ctx.item = ctx.items['/foo/index.md']
+        end
+
+        it 'returns an array with the items' do
+          expect(subject).to eql([ctx.items['/index.md'], nil, ctx.items['/foo/index.md']])
+        end
       end
     end
   end

--- a/spec/nanoc/helpers/breadcrumbs_spec.rb
+++ b/spec/nanoc/helpers/breadcrumbs_spec.rb
@@ -7,55 +7,57 @@ describe Nanoc::Helpers::Breadcrumbs, helper: true do
   describe '#breadcrumbs_trail' do
     subject { helper.breadcrumbs_trail }
 
-    context 'root' do
-      before do
-        ctx.create_item('root', {}, Nanoc::Identifier.new('/', type: :legacy))
+    context 'legacy identifiers' do
+      context 'root' do
+        before do
+          ctx.create_item('root', {}, Nanoc::Identifier.new('/', type: :legacy))
 
-        ctx.item = ctx.items['/']
+          ctx.item = ctx.items['/']
+        end
+
+        it 'returns an array with the item' do
+          expect(subject).to eql([ctx.items['/']])
+        end
       end
 
-      it 'returns an array with the item' do
-        expect(subject).to eql([ctx.items['/']])
-      end
-    end
+      context 'root and direct child' do
+        before do
+          ctx.create_item('child', {}, Nanoc::Identifier.new('/foo/', type: :legacy))
+          ctx.create_item('root', {}, Nanoc::Identifier.new('/', type: :legacy))
 
-    context 'root and direct child' do
-      before do
-        ctx.create_item('child', {}, Nanoc::Identifier.new('/foo/', type: :legacy))
-        ctx.create_item('root', {}, Nanoc::Identifier.new('/', type: :legacy))
+          ctx.item = ctx.items['/foo/']
+        end
 
-        ctx.item = ctx.items['/foo/']
-      end
-
-      it 'returns an array with the items' do
-        expect(subject).to eql([ctx.items['/'], ctx.items['/foo/']])
-      end
-    end
-
-    context 'root, child and grandchild' do
-      before do
-        ctx.create_item('grandchild', {}, Nanoc::Identifier.new('/foo/bar/', type: :legacy))
-        ctx.create_item('child', {}, Nanoc::Identifier.new('/foo/', type: :legacy))
-        ctx.create_item('root', {}, Nanoc::Identifier.new('/', type: :legacy))
-
-        ctx.item = ctx.items['/foo/bar/']
+        it 'returns an array with the items' do
+          expect(subject).to eql([ctx.items['/'], ctx.items['/foo/']])
+        end
       end
 
-      it 'returns an array with the items' do
-        expect(subject).to eql([ctx.items['/'], ctx.items['/foo/'], ctx.items['/foo/bar/']])
+      context 'root, child and grandchild' do
+        before do
+          ctx.create_item('grandchild', {}, Nanoc::Identifier.new('/foo/bar/', type: :legacy))
+          ctx.create_item('child', {}, Nanoc::Identifier.new('/foo/', type: :legacy))
+          ctx.create_item('root', {}, Nanoc::Identifier.new('/', type: :legacy))
+
+          ctx.item = ctx.items['/foo/bar/']
+        end
+
+        it 'returns an array with the items' do
+          expect(subject).to eql([ctx.items['/'], ctx.items['/foo/'], ctx.items['/foo/bar/']])
+        end
       end
-    end
 
-    context 'root, missing child and grandchild' do
-      before do
-        ctx.create_item('grandchild', {}, Nanoc::Identifier.new('/foo/bar/', type: :legacy))
-        ctx.create_item('root', {}, Nanoc::Identifier.new('/', type: :legacy))
+      context 'root, missing child and grandchild' do
+        before do
+          ctx.create_item('grandchild', {}, Nanoc::Identifier.new('/foo/bar/', type: :legacy))
+          ctx.create_item('root', {}, Nanoc::Identifier.new('/', type: :legacy))
 
-        ctx.item = ctx.items['/foo/bar/']
-      end
+          ctx.item = ctx.items['/foo/bar/']
+        end
 
-      it 'returns an array with the items' do
-        expect(subject).to eql([ctx.items['/'], nil, ctx.items['/foo/bar/']])
+        it 'returns an array with the items' do
+          expect(subject).to eql([ctx.items['/'], nil, ctx.items['/foo/bar/']])
+        end
       end
     end
 


### PR DESCRIPTION
This adds support for full identifiers (e.g. `/projects/nanoc.md`) to `#breadcrumbs_trail`. Currently, only legacy identifiers (e.g. `/projects/nanoc/`) are supported.

Fix for #1010.

### Detailed description

This change first of all refactors the existing code to construct a prefix array for a given item identifier. For example, `/projects/nanoc/` is turned into `['', '/projects', '/projects/nanoc']`. This in turn is used to construct the array of item identifiers which will be the breadcrumbs trail.

For full identifiers, the procedure is the same, with the main difference that the item matching `/index.*` is treated specially. This item is considered the root item and has the same role as the `/` item when using legacy identifiers.

### Related issues

* #1010
