### PR TITLE
Prune old data from compiled content cache

### DIFF
--- a/lib/nanoc/base/repos/compiled_content_cache.rb
+++ b/lib/nanoc/base/repos/compiled_content_cache.rb
@@ -46,7 +46,15 @@ module Nanoc::Int
     end
 
     def data=(new_data)
-      @cache = new_data
+      @cache = {}
+
+      item_identifiers = Set.new(@items.map(&:identifier))
+
+      new_data.each_pair do |item_identifier, content_per_rep|
+        if item_identifiers.include?(item_identifier)
+          @cache[item_identifier] ||= content_per_rep
+        end
+      end
     end
   end
 end

--- a/lib/nanoc/base/repos/compiled_content_cache.rb
+++ b/lib/nanoc/base/repos/compiled_content_cache.rb
@@ -4,9 +4,10 @@ module Nanoc::Int
   #
   # @api private
   class CompiledContentCache < ::Nanoc::Int::Store
-    def initialize(env_name: nil)
+    def initialize(env_name: nil, items:)
       super(Nanoc::Int::Store.tmp_path_for(env_name: env_name, store_name: 'compiled_content'), 2)
 
+      @items = items
       @cache = {}
     end
 

--- a/lib/nanoc/base/services/compiler_loader.rb
+++ b/lib/nanoc/base/services/compiler_loader.rb
@@ -24,8 +24,14 @@ module Nanoc::Int
           reps: item_rep_repo,
         )
 
+      compiled_content_cache =
+        Nanoc::Int::CompiledContentCache.new(
+          env_name: site.config.env_name,
+          items: site.items,
+        )
+
       params = {
-        compiled_content_cache: Nanoc::Int::CompiledContentCache.new(env_name: site.config.env_name),
+        compiled_content_cache: compiled_content_cache,
         checksum_store: checksum_store,
         rule_memory_store: rule_memory_store,
         dependency_store: dependency_store,

--- a/spec/nanoc/base/compiler_spec.rb
+++ b/spec/nanoc/base/compiler_spec.rb
@@ -21,7 +21,7 @@ describe Nanoc::Int::Compiler do
   let(:outdatedness_checker) { double(:outdatedness_checker) }
   let(:action_provider) { double(:action_provider) }
 
-  let(:compiled_content_cache) { Nanoc::Int::CompiledContentCache.new }
+  let(:compiled_content_cache) { Nanoc::Int::CompiledContentCache.new(items: items) }
 
   let(:rep) { Nanoc::Int::ItemRep.new(item, :default) }
   let(:item) { Nanoc::Int::Item.new('<%= 1 + 2 %>', {}, '/hi.md') }

--- a/spec/nanoc/base/repos/compiled_content_cache_spec.rb
+++ b/spec/nanoc/base/repos/compiled_content_cache_spec.rb
@@ -1,0 +1,53 @@
+describe Nanoc::Int::CompiledContentCache do
+  let(:cache) { described_class.new(items: items) }
+
+  let(:items) { [item] }
+
+  let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo.md') }
+  let(:item_rep) { Nanoc::Int::ItemRep.new(item, :default) }
+
+  let(:other_item) { Nanoc::Int::Item.new('asdf', {}, '/sneaky.md') }
+  let(:other_item_rep) { Nanoc::Int::ItemRep.new(other_item, :default) }
+
+  it 'has no content by default' do
+    expect(cache[item_rep]).to be_nil
+  end
+
+  context 'setting content on known item' do
+    before { cache[item_rep] = 'omg' }
+
+    it 'has content' do
+      expect(cache[item_rep]).to eql('omg')
+    end
+
+    context 'after storing and loading' do
+      before do
+        cache.store
+        cache.load
+      end
+
+      it 'has content' do
+        expect(cache[item_rep]).to eql('omg')
+      end
+    end
+  end
+
+  context 'setting content on unknown item' do
+    before { cache[other_item_rep] = 'omg' }
+
+    it 'has content' do
+      expect(cache[other_item_rep]).to eql('omg')
+    end
+
+    context 'after storing and loading' do
+      before do
+        cache.store
+        cache.load
+      end
+
+      it 'has no content' do
+        expect(cache[other_item_rep]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/nanoc/base/views/post_compile_item_rep_view_spec.rb
+++ b/spec/nanoc/base/views/post_compile_item_rep_view_spec.rb
@@ -26,7 +26,7 @@ describe Nanoc::PostCompileItemRepView do
   end
 
   let(:compiled_content_cache) do
-    Nanoc::Int::CompiledContentCache.new.tap do |ccc|
+    Nanoc::Int::CompiledContentCache.new(items: items).tap do |ccc|
       ccc[item_rep] = snapshot_contents
     end
   end

--- a/test/base/test_compiler.rb
+++ b/test/base/test_compiler.rb
@@ -12,7 +12,7 @@ class Nanoc::Int::CompilerTest < Nanoc::TestCase
     action_provider = Nanoc::Int::ActionProvider.named(:rule_dsl).for(site)
 
     params = {
-      compiled_content_cache: Nanoc::Int::CompiledContentCache.new,
+      compiled_content_cache: Nanoc::Int::CompiledContentCache.new(items: site.items),
       checksum_store: Nanoc::Int::ChecksumStore.new(site: site),
       rule_memory_store: Nanoc::Int::RuleMemoryStore.new,
       dependency_store: Nanoc::Int::DependencyStore.new(


### PR DESCRIPTION
This ensures that no cached compiled content is loaded for items that do not exist. This will prevent the compiled content cache from ever growing.

A partial fix for #1004.