### PR TITLE
Use most recent timestamp for <updated> in Atom feed

### DIFF
--- a/lib/nanoc/helpers/blogging.rb
+++ b/lib/nanoc/helpers/blogging.rb
@@ -72,6 +72,11 @@ module Nanoc::Helpers
         sorted_relevant_articles.first
       end
 
+      def updated
+        # FIXME: if updated_at exists, prefer that
+        relevant_articles.map { |a| attribute_to_time(a[:created_at]) }.max
+      end
+
       def validate_config
         if @config[:base_url].nil?
           raise Nanoc::Int::Errors::GenericTrivial.new('Cannot build Atom feed: site configuration has no base_url')
@@ -109,7 +114,7 @@ module Nanoc::Helpers
           xml.title title
 
           # Add date
-          xml.updated(attribute_to_time(last_article[:created_at]).__nanoc_to_iso8601_time)
+          xml.updated(updated.__nanoc_to_iso8601_time)
 
           # Add links
           xml.link(rel: 'alternate', href: root_url)

--- a/lib/nanoc/helpers/blogging.rb
+++ b/lib/nanoc/helpers/blogging.rb
@@ -73,8 +73,7 @@ module Nanoc::Helpers
       end
 
       def updated
-        # FIXME: if updated_at exists, prefer that
-        relevant_articles.map { |a| attribute_to_time(a[:created_at]) }.max
+        relevant_articles.map { |a| attribute_to_time(a[:updated_at] || a[:created_at]) }.max
       end
 
       def validate_config

--- a/test/helpers/test_blogging.rb
+++ b/test/helpers/test_blogging.rb
@@ -93,6 +93,35 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     end
   end
 
+  def test_atom_feed_updated_is_most_recent
+    if_have 'builder' do
+      # Create items
+      @items = [mock_item, mock_article, mock_article]
+
+      # Create item 1
+      @items[1].stubs(:[]).with(:created_at).returns(Time.parse('2016-12-01 17:20:00 +00:00'))
+      @items[1].expects(:compiled_content).returns('item 1 content')
+
+      # Create item 2
+      @items[2].stubs(:[]).with(:created_at).returns(Time.parse('2016-12-01 18:40:00 +00:00'))
+      @items[2].expects(:compiled_content).returns('item 2 content')
+
+      # Mock site
+      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+
+      # Create feed item
+      @item = mock
+      @item.stubs(:[]).with(:title).returns('My Cool Blog')
+      @item.stubs(:[]).with(:author_name).returns('Denis Defreyne')
+      @item.stubs(:[]).with(:author_uri).returns('http://stoneship.org/')
+      @item.stubs(:[]).with(:feed_url).returns(nil)
+      @item.stubs(:path).returns('/journal/feed/')
+
+      # Check
+      assert_match(%r{<title>My Cool Blog</title>\n  <updated>2016-12-01T18:40:00Z</updated>}, atom_feed)
+    end
+  end
+
   def test_atom_feed_without_articles
     if_have 'builder' do
       # Mock items

--- a/test/helpers/test_blogging.rb
+++ b/test/helpers/test_blogging.rb
@@ -99,10 +99,12 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items = [mock_item, mock_article, mock_article]
 
       # Create item 1
+      @items[1].stubs(:[]).with(:updated_at).returns(nil)
       @items[1].stubs(:[]).with(:created_at).returns(Time.parse('2016-12-01 17:20:00 +00:00'))
       @items[1].expects(:compiled_content).returns('item 1 content')
 
       # Create item 2
+      @items[2].stubs(:[]).with(:updated_at).returns(nil)
       @items[2].stubs(:[]).with(:created_at).returns(Time.parse('2016-12-01 18:40:00 +00:00'))
       @items[2].expects(:compiled_content).returns('item 2 content')
 
@@ -119,6 +121,37 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
 
       # Check
       assert_match(%r{<title>My Cool Blog</title>\n  <updated>2016-12-01T18:40:00Z</updated>}, atom_feed)
+    end
+  end
+
+  def test_atom_feed_updated_is_most_recent_updated_at
+    if_have 'builder' do
+      # Create items
+      @items = [mock_item, mock_article, mock_article]
+
+      # Create item 1
+      @items[1].stubs(:[]).with(:updated_at).returns(Time.parse('2016-12-01 19:20:00 +00:00'))
+      @items[1].stubs(:[]).with(:created_at).returns(Time.parse('2016-12-01 17:20:00 +00:00'))
+      @items[1].expects(:compiled_content).returns('item 1 content')
+
+      # Create item 2
+      @items[2].stubs(:[]).with(:updated_at).returns(Time.parse('2016-12-01 20:40:00 +00:00'))
+      @items[2].stubs(:[]).with(:created_at).returns(Time.parse('2016-12-01 18:40:00 +00:00'))
+      @items[2].expects(:compiled_content).returns('item 2 content')
+
+      # Mock site
+      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+
+      # Create feed item
+      @item = mock
+      @item.stubs(:[]).with(:title).returns('My Cool Blog')
+      @item.stubs(:[]).with(:author_name).returns('Denis Defreyne')
+      @item.stubs(:[]).with(:author_uri).returns('http://stoneship.org/')
+      @item.stubs(:[]).with(:feed_url).returns(nil)
+      @item.stubs(:path).returns('/journal/feed/')
+
+      # Check
+      assert_match(%r{<title>My Cool Blog</title>\n  <updated>2016-12-01T20:40:00Z</updated>}, atom_feed)
     end
   end
 


### PR DESCRIPTION
This constructs the Atom feed’s `<updated>` from the most recent `updated_at` or `created_at`, rather than the last article’s `created_at`.

Fix for #1007. In addition, `updated_at` is now preferred to `created_at`, if available.