### PR TITLE
Treat deps without props as deps with all props

### DIFF
--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -70,7 +70,7 @@ module Nanoc::Int
     contract C::Or[Nanoc::Int::Item, Nanoc::Int::ItemRep, Nanoc::Int::Layout] => C::ArrayOf[Dependency]
     def dependencies_causing_outdatedness_of(object)
       objects_causing_outdatedness_of(object).map do |other_object|
-        props = @graph.props_for(other_object, object) || {}
+        props = props_for(other_object, object)
 
         Dependency.new(
           other_object,
@@ -156,6 +156,16 @@ module Nanoc::Int
     end
 
     protected
+
+    def props_for(a, b)
+      props = @graph.props_for(a, b) || {}
+
+      if props.values.any? { |v| v }
+        props
+      else
+        { raw_content: true, attributes: true, compiled_content: true, path: true }
+      end
+    end
 
     def merge_props(p1, p2)
       keys = (p1.keys + p2.keys).uniq

--- a/spec/nanoc/base/repos/dependency_store_spec.rb
+++ b/spec/nanoc/base/repos/dependency_store_spec.rb
@@ -36,12 +36,12 @@ describe Nanoc::Int::DependencyStore do
           expect(deps[0].to).to eql(obj_a)
         end
 
-        it 'returns false for all props by default' do
+        it 'returns true for all props by default' do
           deps = store.dependencies_causing_outdatedness_of(obj_a)
-          expect(deps[0].raw_content?).to eq(false)
-          expect(deps[0].attributes?).to eq(false)
-          expect(deps[0].compiled_content?).to eq(false)
-          expect(deps[0].path?).to eq(false)
+          expect(deps[0].raw_content?).to eq(true)
+          expect(deps[0].attributes?).to eq(true)
+          expect(deps[0].compiled_content?).to eq(true)
+          expect(deps[0].path?).to eq(true)
         end
 
         it 'returns nothing for the others' do

--- a/spec/nanoc/cli/commands/show_data_spec.rb
+++ b/spec/nanoc/cli/commands/show_data_spec.rb
@@ -65,7 +65,7 @@ describe Nanoc::CLI::Commands::ShowData, stdio: true do
       end
 
       it 'outputs dependencies for /dog.md' do
-        expect { subject }.to output(%r{^item /dog.md depends on:\n  \[   item \] \(____\) /about.md$}m).to_stdout
+        expect { subject }.to output(%r{^item /dog.md depends on:\n  \[   item \] \(racp\) /about.md$}m).to_stdout
       end
 
       it 'outputs no dependencies for /other.dat' do


### PR DESCRIPTION
Until recently, dependencies in Nanoc were unqualified: a dependency of one item onto another object (item or layout) had no information about what property the item had a dependency on. This changed in Nanoc 4.4.1, which records dependency properties.

The dependencies store (in `tmp/`) might still have old dependencies with no prop information. Additionally, even in the most recent release (4.4.3), Nanoc would generate dependencies without props for new items (see eb801a6e7028755f0a630412e283a28e8aa35fc3 for a fix).

Prop-less dependencies should be considered as dependencies with all props. This matches the historic behavior of how Nanoc treats dependencies before the upcoming Nanoc 4.4.4 release (which will make use of fine-grained dependencies to reduce outdatedness).