### PR TITLE
Add fine-grained path dependencies

### DIFF
--- a/lib/nanoc/base/compilation/outdatedness_checker.rb
+++ b/lib/nanoc/base/compilation/outdatedness_checker.rb
@@ -82,6 +82,7 @@ module Nanoc::Int
     RULES_FOR_ITEM_REP =
       [
         Rules::RulesModified,
+        Rules::PathsModified,
         Rules::NotEnoughData,
         Rules::ContentModified,
         Rules::AttributesModified,
@@ -199,6 +200,21 @@ module Nanoc::Int
       !rule_memory_store[obj].eql?(@action_provider.memory_for(obj).serialize)
     end
     memoize :rule_memory_differs_for
+
+    contract Nanoc::Int::ItemRep => C::Bool
+    def paths_differ_for(obj)
+      # FIXME: Prefer to not work on serialised version
+
+      mem_then = rule_memory_store[obj]
+      mem_now = @action_provider.memory_for(obj).serialize
+      return true if mem_then.nil?
+
+      paths_then = mem_then.select { |pa| pa[0] == :snapshot }
+      paths_now = mem_now.select { |pa| pa[0] == :snapshot }
+
+      paths_then != paths_now
+    end
+    memoize :paths_differ_for
 
     contract C::Any => String
     # @param obj The object to create a checksum for

--- a/lib/nanoc/base/compilation/outdatedness_reasons.rb
+++ b/lib/nanoc/base/compilation/outdatedness_reasons.rb
@@ -58,5 +58,10 @@ module Nanoc::Int
       'The attributes of this item have been modified since the last time the site was compiled.',
       Props.new(attributes: true, compiled_content: true, path: true),
     )
+
+    PathsModified = Generic.new(
+      'One or more output paths of this item have been modified since the last time the site was compiled.',
+      Props.new(path: true),
+    )
   end
 end

--- a/lib/nanoc/base/compilation/outdatedness_reasons.rb
+++ b/lib/nanoc/base/compilation/outdatedness_reasons.rb
@@ -51,12 +51,12 @@ module Nanoc::Int
 
     ContentModified = Generic.new(
       'The content of this item has been modified since the last time the site was compiled.',
-      Props.new(raw_content: true, compiled_content: true, path: true),
+      Props.new(raw_content: true, compiled_content: true),
     )
 
     AttributesModified = Generic.new(
       'The attributes of this item have been modified since the last time the site was compiled.',
-      Props.new(attributes: true, compiled_content: true, path: true),
+      Props.new(attributes: true, compiled_content: true),
     )
 
     PathsModified = Generic.new(

--- a/lib/nanoc/base/entities/rule_memory.rb
+++ b/lib/nanoc/base/entities/rule_memory.rb
@@ -47,6 +47,13 @@ module Nanoc::Int
       @actions.any? { |a| a.is_a?(Nanoc::Int::ProcessingActions::Layout) }
     end
 
+    contract C::None => Hash
+    def paths
+      snapshot_actions.each_with_object({}) do |action, paths|
+        paths[action.snapshot_name] = action.path
+      end
+    end
+
     # TODO: Add contract
     def serialize
       map(&:serialize)

--- a/lib/nanoc/base/services/action_provider.rb
+++ b/lib/nanoc/base/services/action_provider.rb
@@ -19,8 +19,8 @@ module Nanoc::Int
       raise NotImplementedError
     end
 
-    def paths_for(_rep)
-      raise NotImplementedError
+    def paths_for(rep)
+      memory_for(rep).paths
     end
   end
 end

--- a/lib/nanoc/base/services/outdatedness_rules.rb
+++ b/lib/nanoc/base/services/outdatedness_rules.rb
@@ -94,5 +94,15 @@ module Nanoc::Int
         outdatedness_checker.rule_memory_differs_for(obj)
       end
     end
+
+    class PathsModified < OutdatednessRule
+      def reason
+        Nanoc::Int::OutdatednessReasons::PathsModified
+      end
+
+      def apply(obj, outdatedness_checker)
+        outdatedness_checker.paths_differ_for(obj)
+      end
+    end
   end
 end

--- a/lib/nanoc/rule_dsl/action_provider.rb
+++ b/lib/nanoc/rule_dsl/action_provider.rb
@@ -40,10 +40,6 @@ module Nanoc::RuleDSL
       @rule_memory_calculator.snapshots_defs_for(rep)
     end
 
-    def paths_for(rep)
-      @rule_memory_calculator.paths_for_rep(rep)
-    end
-
     def preprocess(site)
       ctx = new_preprocessor_context(site)
 

--- a/lib/nanoc/rule_dsl/rule_memory_calculator.rb
+++ b/lib/nanoc/rule_dsl/rule_memory_calculator.rb
@@ -47,7 +47,6 @@ module Nanoc::RuleDSL
         raise UnsupportedObjectTypeException.new(obj)
       end
     end
-    memoize :[]
 
     # @param [Nanoc::Int::ItemRep] rep The item representation for which to fetch
     #   the list of snapshots
@@ -87,17 +86,6 @@ module Nanoc::RuleDSL
       end
 
       executor.rule_memory
-    end
-
-    # @param [Nanoc::Int::ItemRep] rep The item representation to get the rule
-    #   memory for
-    #
-    # @return [Hash<Symbol, String>] Pairs of snapshot name and path
-    def paths_for_rep(rep)
-      snapshot_actions = new_rule_memory_for_rep(rep).snapshot_actions
-      snapshot_actions.each_with_object({}) do |action, paths|
-        paths[action.snapshot_name] = action.path
-      end
     end
 
     # @param [Nanoc::Int::Layout] layout

--- a/spec/nanoc/base/entities/outdatedness_status_spec.rb
+++ b/spec/nanoc/base/entities/outdatedness_status_spec.rb
@@ -106,7 +106,7 @@ describe Nanoc::Int::OutdatednessStatus do
       let(:status) { described_class.new(props: Nanoc::Int::Props.new(attributes: true)) }
 
       it 'updates props' do
-        expect(subject.props.active).to eql(Set.new([:raw_content, :attributes, :compiled_content, :path]))
+        expect(subject.props.active).to eql(Set.new([:raw_content, :attributes, :compiled_content]))
       end
     end
   end

--- a/spec/nanoc/base/services/outdatedness_checker_spec.rb
+++ b/spec/nanoc/base/services/outdatedness_checker_spec.rb
@@ -274,7 +274,7 @@ describe Nanoc::Int::OutdatednessChecker do
 
       context 'raw content changed' do
         before { other_item.content = Nanoc::Int::TextualContent.new('omg new content') }
-        it { is_expected.to be }
+        it { is_expected.not_to be }
       end
     end
 
@@ -285,12 +285,12 @@ describe Nanoc::Int::OutdatednessChecker do
 
       context 'attribute changed' do
         before { other_item.attributes[:title] = 'omg new title' }
-        it { is_expected.to be }
+        it { is_expected.not_to be }
       end
 
       context 'raw content changed' do
         before { other_item.content = Nanoc::Int::TextualContent.new('omg new content') }
-        it { is_expected.to be }
+        it { is_expected.not_to be }
       end
     end
   end

--- a/spec/nanoc/base/services/outdatedness_checker_spec.rb
+++ b/spec/nanoc/base/services/outdatedness_checker_spec.rb
@@ -156,6 +156,17 @@ describe Nanoc::Int::OutdatednessChecker do
         before { other_item.content = Nanoc::Int::TextualContent.new('omg new content') }
         it { is_expected.to be }
       end
+
+      context 'path changed' do
+        let(:new_memory_for_other_item_rep) do
+          Nanoc::Int::RuleMemory.new(other_item_rep).tap do |mem|
+            mem.add_filter(:erb, {})
+            mem.add_snapshot(:donkey, true, '/giraffe.txt')
+          end
+        end
+
+        it { is_expected.not_to be }
+      end
     end
 
     context 'only raw content dependency' do
@@ -177,6 +188,44 @@ describe Nanoc::Int::OutdatednessChecker do
         before { other_item.attributes[:title] = 'omg new title' }
         before { other_item.content = Nanoc::Int::TextualContent.new('omg new content') }
         it { is_expected.to be }
+      end
+
+      context 'path changed' do
+        let(:new_memory_for_other_item_rep) do
+          Nanoc::Int::RuleMemory.new(other_item_rep).tap do |mem|
+            mem.add_filter(:erb, {})
+            mem.add_snapshot(:donkey, true, '/giraffe.txt')
+          end
+        end
+
+        it { is_expected.not_to be }
+      end
+    end
+
+    context 'only path dependency' do
+      before do
+        dependency_store.record_dependency(item, other_item, raw_content: true)
+      end
+
+      context 'attribute changed' do
+        before { other_item.attributes[:title] = 'omg new title' }
+        it { is_expected.not_to be }
+      end
+
+      context 'raw content changed' do
+        before { other_item.content = Nanoc::Int::TextualContent.new('omg new content') }
+        it { is_expected.to be }
+      end
+
+      context 'path changed' do
+        let(:new_memory_for_other_item_rep) do
+          Nanoc::Int::RuleMemory.new(other_item_rep).tap do |mem|
+            mem.add_filter(:erb, {})
+            mem.add_snapshot(:donkey, true, '/giraffe.txt')
+          end
+        end
+
+        it { is_expected.not_to be }
       end
     end
 

--- a/spec/nanoc/base/services/outdatedness_rules_spec.rb
+++ b/spec/nanoc/base/services/outdatedness_rules_spec.rb
@@ -283,5 +283,45 @@ describe Nanoc::Int::OutdatednessRules do
         it { is_expected.to be }
       end
     end
+
+    context 'PathsModified' do
+      let(:rule_class) { Nanoc::Int::OutdatednessRules::PathsModified }
+
+      let(:old_mem) do
+        Nanoc::Int::RuleMemory.new(item_rep).tap do |mem|
+          mem.add_filter(:erb, {})
+          mem.add_snapshot(:donkey, true, '/foo.md')
+        end
+      end
+
+      before do
+        rule_memory_store[item_rep] = old_mem.serialize
+        allow(action_provider).to receive(:memory_for).with(item_rep).and_return(new_mem)
+      end
+
+      context 'paths in memory are the same' do
+        let(:new_mem) do
+          Nanoc::Int::RuleMemory.new(item_rep).tap do |mem|
+            mem.add_snapshot(:donkey, true, '/foo.md')
+            mem.add_filter(:asdf, {})
+          end
+        end
+
+        it { is_expected.not_to be }
+      end
+
+      context 'paths in memory are different' do
+        let(:new_mem) do
+          Nanoc::Int::RuleMemory.new(item_rep).tap do |mem|
+            mem.add_filter(:erb, {})
+            mem.add_snapshot(:donkey, true, '/foo.md')
+            mem.add_filter(:donkey, {})
+            mem.add_snapshot(:giraffe, true, '/bar.md')
+          end
+        end
+
+        it { is_expected.to be }
+      end
+    end
   end
 end


### PR DESCRIPTION
This makes path dependencies not unconditionally cause outdatedness.