### PR TITLE
Work around lack of composite outdatedness reasons

### DIFF
--- a/lib/nanoc/base/compilation/outdatedness_checker.rb
+++ b/lib/nanoc/base/compilation/outdatedness_checker.rb
@@ -185,8 +185,13 @@ module Nanoc::Int
     contract Nanoc::Int::DependencyStore::Dependency => Set
     def valid_reasons_for_dep_outdatedness(dep)
       Set.new.tap do |s|
-        s << Nanoc::Int::OutdatednessReasons::AttributesModified if dep.attributes?
-        s << Nanoc::Int::OutdatednessReasons::ContentModified if dep.raw_content?
+        if dep.attributes? || dep.raw_content?
+          # FIXME: We can’t go more fine-grained here, because outdatedness reasons are limited
+          # to a single reason; we’d need composite reasons to go finer-grained.
+          s << Nanoc::Int::OutdatednessReasons::AttributesModified
+          s << Nanoc::Int::OutdatednessReasons::ContentModified
+        end
+
         s << :all if dep.compiled_content?
         s << :all if dep.path?
       end

--- a/spec/nanoc/base/services/outdatedness_checker_spec.rb
+++ b/spec/nanoc/base/services/outdatedness_checker_spec.rb
@@ -135,7 +135,14 @@ describe Nanoc::Int::OutdatednessChecker do
 
       context 'raw content changed' do
         before { other_item.content = Nanoc::Int::TextualContent.new('omg new content') }
-        it { is_expected.not_to be }
+        # FIXME: This should become false when we have finer-grained dependencies
+        it { is_expected.to be }
+      end
+
+      context 'attribute + raw content changed' do
+        before { other_item.attributes[:title] = 'omg new title' }
+        before { other_item.content = Nanoc::Int::TextualContent.new('omg new content') }
+        it { is_expected.to be }
       end
     end
 
@@ -146,10 +153,17 @@ describe Nanoc::Int::OutdatednessChecker do
 
       context 'attribute changed' do
         before { other_item.attributes[:title] = 'omg new title' }
-        it { is_expected.not_to be }
+        # FIXME: This should become false when we have finer-grained dependencies
+        it { is_expected.to be }
       end
 
       context 'raw content changed' do
+        before { other_item.content = Nanoc::Int::TextualContent.new('omg new content') }
+        it { is_expected.to be }
+      end
+
+      context 'attribute + raw content changed' do
+        before { other_item.attributes[:title] = 'omg new title' }
         before { other_item.content = Nanoc::Int::TextualContent.new('omg new content') }
         it { is_expected.to be }
       end

--- a/spec/nanoc/integration/outdatedness_integration_spec.rb
+++ b/spec/nanoc/integration/outdatedness_integration_spec.rb
@@ -38,14 +38,15 @@ EOS
       )
     end
 
-    it 'shows file and dependencies as not outdated after content modification' do
+    # FIXME: This should become *not* outdated when we have finer-grained dependencies
+    it 'shows file and dependencies as outdated after content modification' do
       File.write('content/foo.md', "---\ntitle: hello\n---\n\nfoooOoooOOoooOooo")
 
       expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
         output(/^item \/foo\.md, rep default:\n  is outdated: /).to_stdout,
       )
       expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
-        output(/^item \/bar\.md, rep default:\n  is not outdated/).to_stdout,
+        output(/^item \/bar\.md, rep default:\n  is outdated: /).to_stdout,
       )
     end
 
@@ -111,14 +112,15 @@ EOS
       )
     end
 
-    it 'shows file and dependencies as not outdated after title modification' do
+    # FIXME: This should become *not* outdated when we have finer-grained dependencies
+    it 'shows file and dependencies as outdated after title modification' do
       File.write('content/foo.md', "---\ntitle: bye\n---\n\nfoo")
 
       expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
         output(/^item \/foo\.md, rep default:\n  is outdated: /).to_stdout,
       )
       expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
-        output(/^item \/bar\.md, rep default:\n  is not outdated/).to_stdout,
+        output(/^item \/bar\.md, rep default:\n  is outdated: /).to_stdout,
       )
     end
   end


### PR DESCRIPTION
Nanoc’s outdatedness checking system is currently not able to handle composite outdatedness reasons, and is therefore not able to express outdatedness such as “raw content *and* attributes modified”.

This is problematic for the current finer-grained dependency/outdatedness implementation; changing both raw content *and* attributes will cause the attribute change to be ignored, and items that have an attribute dependency will therefore not be considered as outdated.

**This workaround:** For both attribute and raw content dependencies, consider both raw content and attributes to be modified. This approach is not incorrect, but also not optimal.

**The fix:** Eventually, allow multiple outdatedness reasons to be returned.