### PR TITLE
Propagate outdatedness only across compiled-content deps

### DIFF
--- a/lib/nanoc/base/compilation/outdatedness_checker.rb
+++ b/lib/nanoc/base/compilation/outdatedness_checker.rb
@@ -158,7 +158,9 @@ module Nanoc::Int
 
       # Calculate
       is_outdated = dependency_store.dependencies_causing_outdatedness_of(obj).any? do |dep|
-        dependency_causes_outdatedness?(dep) || outdated_due_to_dependencies?(dep.from, processed.merge([obj]))
+        dependency_causes_outdatedness?(dep) ||
+          (dep.props.compiled_content? &&
+            outdated_due_to_dependencies?(dep.from, processed.merge([obj])))
       end
 
       # Cache


### PR DESCRIPTION
This prevents transitive dependencies from needlessly generating outdatedness. Transitive dependencies should only be considered if they apply to compiled content.

### Scenario 1

Given:

* Item A has an **attribute dependency** on item B
* Item B has an attribute dependency on item C

When:

* Item C’s attributes change

Then:

* Item B is outdated
* Item A **is not** outdated

### Scenario 2

Given:

* Item A has a **compiled content dependency** on item B
* Item B has an attribute dependency on item C

When:

* Item C’s attributes change

Then:

* Item B is outdated
* Item A **is** outdated
