### PR TITLE
Optimise recording deps on new items

### DIFF
--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -58,27 +58,6 @@ module Nanoc::Int
       end
     end
 
-    # Returns the direct inverse dependencies for the given object.
-    #
-    # The direct inverse dependencies of the given object include the objects
-    # that will be marked as outdated when the given object is outdated.
-    # Indirect dependencies will not be returned (e.g. if A depends on B which
-    # depends on C, then the direct inverse dependencies of C do not include
-    # A).
-    #
-    # @param [Nanoc::Int::Item, Nanoc::Int::Layout] object The object for which to
-    #   fetch the direct successors
-    #
-    # @return [Array<Nanoc::Int::Item, Nanoc::Int::Layout>] The direct successors of
-    #   the given object
-    def objects_outdated_due_to(object)
-      if @new_objects.include?(object)
-        @objects
-      else
-        @graph.direct_successors_of(object).compact
-      end
-    end
-
     contract C::Maybe[C::Or[Nanoc::Int::Item, Nanoc::Int::Layout]], C::Maybe[C::Or[Nanoc::Int::Item, Nanoc::Int::Layout]], C::KeywordArgs[raw_content: C::Optional[C::Bool], attributes: C::Optional[C::Bool], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]] => C::Any
     # Records a dependency from `src` to `dst` in the dependency graph. When
     # `dst` is oudated, `src` will also become outdated.

--- a/spec/nanoc/base/repos/dependency_store_spec.rb
+++ b/spec/nanoc/base/repos/dependency_store_spec.rb
@@ -165,11 +165,8 @@ describe Nanoc::Int::DependencyStore do
         expect(store.objects_causing_outdatedness_of(obj_c)).to eq([obj_d])
       end
 
-      it 'has the right target dependencies' do
-        expect(store.objects_outdated_due_to(obj_a)).to be_empty
-        expect(store.objects_outdated_due_to(obj_b)).to eq([obj_a])
-        expect(store.objects_outdated_due_to(obj_c)).to be_empty
-        expect(store.objects_outdated_due_to(obj_d)).to eq(objects_after)
+      it 'marks new items as outdated' do
+        expect(store.objects_causing_outdatedness_of(obj_d)).to eq([obj_d])
       end
     end
 
@@ -188,12 +185,10 @@ describe Nanoc::Int::DependencyStore do
         expect(store.objects_causing_outdatedness_of(obj_c)).to eq([obj_d]).or eq([obj_e])
       end
 
-      it 'has the right target dependencies' do
-        expect(store.objects_outdated_due_to(obj_a)).to be_empty
-        expect(store.objects_outdated_due_to(obj_b)).to eq([obj_a])
-        expect(store.objects_outdated_due_to(obj_c)).to be_empty
-        expect(store.objects_outdated_due_to(obj_d)).to eq(objects_after)
-        expect(store.objects_outdated_due_to(obj_e)).to eq(objects_after)
+      it 'marks new items as outdated' do
+        # Only one of obj D or E needed!
+        expect(store.objects_causing_outdatedness_of(obj_d)).to eq([obj_d]).or eq([obj_e])
+        expect(store.objects_causing_outdatedness_of(obj_e)).to eq([obj_d]).or eq([obj_e])
       end
     end
   end

--- a/spec/nanoc/base/services/dependency_tracker_spec.rb
+++ b/spec/nanoc/base/services/dependency_tracker_spec.rb
@@ -23,18 +23,6 @@ describe Nanoc::Int::DependencyTracker do
     end
 
     example do
-      expect { subject }.not_to change { store.objects_outdated_due_to(item_a) }
-    end
-
-    example do
-      expect { subject }.not_to change { store.objects_outdated_due_to(item_b) }
-    end
-
-    example do
-      expect { subject }.not_to change { store.objects_outdated_due_to(item_c) }
-    end
-
-    example do
       expect { subject }.not_to change { store.dependencies_causing_outdatedness_of(item_a) }
     end
 
@@ -66,18 +54,6 @@ describe Nanoc::Int::DependencyTracker do
       example do
         expect { subject }.not_to change { store.objects_causing_outdatedness_of(item_c) }
       end
-
-      example do
-        expect { subject }.not_to change { store.objects_outdated_due_to(item_a) }
-      end
-
-      example do
-        expect { subject }.not_to change { store.objects_outdated_due_to(item_b) }
-      end
-
-      example do
-        expect { subject }.not_to change { store.objects_outdated_due_to(item_c) }
-      end
     end
 
     context 'enter + enter' do
@@ -93,25 +69,12 @@ describe Nanoc::Int::DependencyTracker do
           .from([]).to([item_b])
       end
 
-      it 'changes successors of item B' do
-        expect { subject }.to change { store.objects_outdated_due_to(item_b) }
-          .from([]).to([item_a])
-      end
-
       example do
         expect { subject }.not_to change { store.objects_causing_outdatedness_of(item_b) }
       end
 
       example do
         expect { subject }.not_to change { store.objects_causing_outdatedness_of(item_c) }
-      end
-
-      example do
-        expect { subject }.not_to change { store.objects_outdated_due_to(item_a) }
-      end
-
-      example do
-        expect { subject }.not_to change { store.objects_outdated_due_to(item_c) }
       end
     end
 
@@ -126,11 +89,6 @@ describe Nanoc::Int::DependencyTracker do
       it 'changes predecessors of item A' do
         expect { subject }.to change { store.objects_causing_outdatedness_of(item_a) }
           .from([]).to([item_b])
-      end
-
-      it 'changes successors of item B' do
-        expect { subject }.to change { store.objects_outdated_due_to(item_b) }
-          .from([]).to([item_a])
       end
 
       it 'changes dependencies causing outdatedness of item A' do
@@ -166,14 +124,6 @@ describe Nanoc::Int::DependencyTracker do
       end
 
       example do
-        expect { subject }.not_to change { store.objects_outdated_due_to(item_a) }
-      end
-
-      example do
-        expect { subject }.not_to change { store.objects_outdated_due_to(item_c) }
-      end
-
-      example do
         expect { subject }.not_to change { store.dependencies_causing_outdatedness_of(item_b) }
       end
 
@@ -195,11 +145,6 @@ describe Nanoc::Int::DependencyTracker do
       it 'changes predecessors of item A' do
         expect { subject }.to change { store.objects_causing_outdatedness_of(item_a) }
           .from([]).to([item_b])
-      end
-
-      it 'changes successors of item B' do
-        expect { subject }.to change { store.objects_outdated_due_to(item_b) }
-          .from([]).to([item_a])
       end
 
       it 'changes dependencies causing outdatedness of item A' do
@@ -235,14 +180,6 @@ describe Nanoc::Int::DependencyTracker do
       end
 
       example do
-        expect { subject }.not_to change { store.objects_outdated_due_to(item_a) }
-      end
-
-      example do
-        expect { subject }.not_to change { store.objects_outdated_due_to(item_c) }
-      end
-
-      example do
         expect { subject }.not_to change { store.dependencies_causing_outdatedness_of(item_b) }
       end
 
@@ -266,26 +203,12 @@ describe Nanoc::Int::DependencyTracker do
           .from([]).to([item_b, item_c])
       end
 
-      it 'changes successors of item B' do
-        expect { subject }.to change { store.objects_outdated_due_to(item_b) }
-          .from([]).to([item_a])
-      end
-
-      it 'changes successors of item C' do
-        expect { subject }.to change { store.objects_outdated_due_to(item_c) }
-          .from([]).to([item_a])
-      end
-
       example do
         expect { subject }.not_to change { store.objects_causing_outdatedness_of(item_b) }
       end
 
       example do
         expect { subject }.not_to change { store.objects_causing_outdatedness_of(item_c) }
-      end
-
-      example do
-        expect { subject }.not_to change { store.objects_outdated_due_to(item_a) }
       end
     end
 
@@ -303,26 +226,12 @@ describe Nanoc::Int::DependencyTracker do
           .from([]).to([item_b, item_c])
       end
 
-      it 'changes successors of item B' do
-        expect { subject }.to change { store.objects_outdated_due_to(item_b) }
-          .from([]).to([item_a])
-      end
-
-      it 'changes successors of item C' do
-        expect { subject }.to change { store.objects_outdated_due_to(item_c) }
-          .from([]).to([item_a])
-      end
-
       example do
         expect { subject }.not_to change { store.objects_causing_outdatedness_of(item_b) }
       end
 
       example do
         expect { subject }.not_to change { store.objects_causing_outdatedness_of(item_c) }
-      end
-
-      example do
-        expect { subject }.not_to change { store.objects_outdated_due_to(item_a) }
       end
     end
   end

--- a/test/base/test_dependency_tracker.rb
+++ b/test/base/test_dependency_tracker.rb
@@ -87,25 +87,6 @@ class Nanoc::Int::DependencyTrackerTest < Nanoc::TestCase
     assert_contains_exactly [items[1]], store.objects_causing_outdatedness_of(items[0])
   end
 
-  def test_objects_outdated_due_to
-    # Mock items
-    items = [
-      Nanoc::Int::Item.new('a', {}, '/a.md'),
-      Nanoc::Int::Item.new('b', {}, '/b.md'),
-      Nanoc::Int::Item.new('c', {}, '/c.md'),
-    ]
-
-    # Create
-    store = Nanoc::Int::DependencyStore.new(items)
-
-    # Record some dependencies
-    store.record_dependency(items[0], items[1])
-    store.record_dependency(items[1], items[2])
-
-    # Verify dependencies
-    assert_contains_exactly [items[0]], store.objects_outdated_due_to(items[1])
-  end
-
   def test_store_graph_and_load_graph_simple
     # Mock items
     items = [


### PR DESCRIPTION
When an item is added, Nanoc generates a dependency of all items onto this new item. This is done because Nanoc can‘t accurately infer whether a newly added item will cause an existing item to need recompilation. This approach is crude and definitely something I’d like to improve, but at the same time it is also *correct*, which for me is the most important bit.

Unfortunately, radically changing the directory structure of a site means that dependency generation blows up. While Nanoc is apparently doing nothing (right after Compiling…), it is generating all these dependencies, which takes minutes. On top of that, all these artificially new dependencies make memory usage increase up to the point where my laptop cannot handle it anymore.

This fix: Mark new items as “new”, and when looking up all objects that can cause the outdatedness of a given item, return a single new item (because that’s enough to trigger outdatedness). Do not generate any artificial dependencies.

A longer-term solution would be to introduce a mechanism for determining more reliably whether or not the addition of an item might cause an given item to become outdated.