### PR TITLE
Refactor: Split up compiler

### DIFF
--- a/lib/nanoc/base/services/compiler.rb
+++ b/lib/nanoc/base/services/compiler.rb
@@ -22,10 +22,12 @@ module Nanoc::Int
     class Single
       include Nanoc::Int::ContractsSupport
 
-      def initialize(dependency_store:, compiled_content_cache:, action_provider:, compiler:)
+      def initialize(dependency_store:, compiled_content_cache:, action_provider:, site:, reps:, compiler:)
         @dependency_store = dependency_store
         @compiled_content_cache = compiled_content_cache
         @action_provider = action_provider
+        @site = site
+        @reps = reps
         @compiler = compiler # TODO: remove me
       end
 
@@ -84,6 +86,11 @@ module Nanoc::Int
       contract Nanoc::Int::ItemRep, C::Named['Nanoc::Int::DependencyTracker'] => C::Any
       def recalculate_content_for_rep(rep, dependency_tracker)
         executor = Nanoc::Int::Executor.new(@compiler, dependency_tracker)
+
+        # @compiler.filter_name_and_args_for_layout(layout)
+        # @compiler.create_view_context(@dependency_tracker)
+        # @compiler.assigns_for(rep, @dependency_tracker)
+        # @compiler.site.layouts
 
         @action_provider.memory_for(rep).each do |action|
           case action
@@ -296,6 +303,8 @@ module Nanoc::Int
         dependency_store: @dependency_store,
         compiled_content_cache: compiled_content_cache,
         action_provider: action_provider,
+        site: @site,
+        reps: @reps,
         compiler: self,
       )
     end

--- a/lib/nanoc/base/services/compiler.rb
+++ b/lib/nanoc/base/services/compiler.rb
@@ -263,10 +263,6 @@ module Nanoc::Int
       builder.run
     end
 
-    def assigns_for(rep, dependency_tracker)
-      compilation_context.assigns_for(rep, dependency_tracker)
-    end
-
     # @api private
     def filter_name_and_args_for_layout(layout)
       compilation_context.filter_name_and_args_for_layout(layout)

--- a/lib/nanoc/base/services/compiler.rb
+++ b/lib/nanoc/base/services/compiler.rb
@@ -106,13 +106,10 @@ module Nanoc::Int
     class ItemRepCompiler
       include Nanoc::Int::ContractsSupport
 
-      def initialize(dependency_store:, compiled_content_cache:, action_provider:, compilation_context:)
+      def initialize(dependency_store:, compiled_content_cache:, recalculator:)
         @dependency_store = dependency_store
         @compiled_content_cache = compiled_content_cache
-        @recalculator = ItemRepRecalculator.new(
-          action_provider: action_provider,
-          compilation_context: compilation_context,
-        )
+        @recalculator = recalculator
       end
 
       contract Nanoc::Int::ItemRep, C::KeywordArgs[is_outdated: C::Bool] => C::Any
@@ -336,6 +333,12 @@ module Nanoc::Int
       @_item_rep_compiler ||= ItemRepCompiler.new(
         dependency_store: @dependency_store,
         compiled_content_cache: compiled_content_cache,
+        recalculator: item_rep_recalculator,
+      )
+    end
+
+    def item_rep_recalculator
+      @_item_rep_recalculator ||= ItemRepRecalculator.new(
         action_provider: action_provider,
         compilation_context: compilation_context,
       )

--- a/lib/nanoc/base/services/compiler.rb
+++ b/lib/nanoc/base/services/compiler.rb
@@ -22,11 +22,10 @@ module Nanoc::Int
     class Single
       include Nanoc::Int::ContractsSupport
 
-      # TODO: The reference to compiler should go away.
-
-      def initialize(dependency_store:, compiled_content_cache:, compiler:)
+      def initialize(dependency_store:, compiled_content_cache:, action_provider:, compiler:)
         @dependency_store = dependency_store
         @compiled_content_cache = compiled_content_cache
+        @action_provider = action_provider
         @compiler = compiler # TODO: remove me
       end
 
@@ -86,7 +85,7 @@ module Nanoc::Int
       def recalculate_content_for_rep(rep, dependency_tracker)
         executor = Nanoc::Int::Executor.new(@compiler, dependency_tracker)
 
-        @compiler.action_provider.memory_for(rep).each do |action|
+        @action_provider.memory_for(rep).each do |action|
           case action
           when Nanoc::Int::ProcessingActions::Filter
             executor.filter(rep, action.filter_name, action.params)
@@ -296,6 +295,7 @@ module Nanoc::Int
       @_single ||= Single.new(
         dependency_store: @dependency_store,
         compiled_content_cache: compiled_content_cache,
+        action_provider: action_provider,
         compiler: self,
       )
     end

--- a/lib/nanoc/base/services/compiler.rb
+++ b/lib/nanoc/base/services/compiler.rb
@@ -112,8 +112,7 @@ module Nanoc::Int
     class ItemRepCompiler
       include Nanoc::Int::ContractsSupport
 
-      def initialize(dependency_store:, compiled_content_cache:, recalculator:)
-        @dependency_store = dependency_store
+      def initialize(compiled_content_cache:, recalculator:)
         @compiled_content_cache = compiled_content_cache
         @recalculator = recalculator
       end
@@ -330,7 +329,6 @@ module Nanoc::Int
 
     def item_rep_compiler
       @_item_rep_compiler ||= ItemRepCompiler.new(
-        dependency_store: @dependency_store,
         compiled_content_cache: compiled_content_cache,
         recalculator: item_rep_recalculator,
       )

--- a/lib/nanoc/base/services/compiler.rb
+++ b/lib/nanoc/base/services/compiler.rb
@@ -18,14 +18,17 @@ module Nanoc::Int
   #
   # @api private
   class Compiler
+    # Provides common functionality for accesing “context” of an item that is being compiled.
     class ExecutorDelegate
-      def initialize(compiler:, site:)
+      def initialize(compiler:, action_provider:, reps:, site:)
         @compiler = compiler # TODO: remove
+        @action_provider = action_provider
+        @reps = reps
         @site = site
       end
 
       def filter_name_and_args_for_layout(layout)
-        mem = @compiler.action_provider.memory_for(layout)
+        mem = @action_provider.memory_for(layout)
         if mem.nil? || mem.size != 1 || !mem[0].is_a?(Nanoc::Int::ProcessingActions::Filter)
           raise Nanoc::Int::Errors::UndefinedFilterForLayout.new(layout)
         end
@@ -34,7 +37,7 @@ module Nanoc::Int
 
       def create_view_context(dependency_tracker)
         Nanoc::ViewContext.new(
-          reps: @compiler.reps,
+          reps: @reps,
           items: @site.items,
           dependency_tracker: dependency_tracker,
           compiler: @compiler,
@@ -317,7 +320,12 @@ module Nanoc::Int
     end
 
     def executor_delegate
-      @_executor_delegate ||= ExecutorDelegate.new(compiler: self, site: @site)
+      @_executor_delegate ||= ExecutorDelegate.new(
+        compiler: self,
+        action_provider: action_provider,
+        reps: @reps,
+        site: @site,
+      )
     end
 
     # Returns all stores that can load/store data that can be used for

--- a/lib/nanoc/base/services/compiler.rb
+++ b/lib/nanoc/base/services/compiler.rb
@@ -74,7 +74,7 @@ module Nanoc::Int
     end
 
     # Coordinates the compilation of a single item rep.
-    class Single
+    class ItemRepCompiler
       include Nanoc::Int::ContractsSupport
 
       def initialize(dependency_store:, compiled_content_cache:, action_provider:, compilation_context:)
@@ -316,11 +316,11 @@ module Nanoc::Int
     end
 
     def compile_rep(rep, is_outdated:)
-      single.compile(rep, is_outdated: is_outdated)
+      item_rep_compiler.compile(rep, is_outdated: is_outdated)
     end
 
-    def single
-      @_single ||= Single.new(
+    def item_rep_compiler
+      @_item_rep_compiler ||= ItemRepCompiler.new(
         dependency_store: @dependency_store,
         compiled_content_cache: compiled_content_cache,
         action_provider: action_provider,

--- a/lib/nanoc/base/services/compiler.rb
+++ b/lib/nanoc/base/services/compiler.rb
@@ -85,7 +85,7 @@ module Nanoc::Int
       end
 
       contract Nanoc::Int::ItemRep => C::Any
-      def recalculate_content_for_rep(rep)
+      def run(rep)
         dependency_tracker = Nanoc::Int::DependencyTracker.new(@dependency_store)
         dependency_tracker.enter(rep.item)
 
@@ -150,7 +150,7 @@ module Nanoc::Int
               Nanoc::Int::NotificationCenter.post(:cached_content_used, rep)
               rep.snapshot_contents = @compiled_content_cache[rep]
             else
-              @recalculator.recalculate_content_for_rep(rep)
+              @recalculator.run(rep)
             end
 
             rep.compiled = true

--- a/lib/nanoc/base/services/compiler.rb
+++ b/lib/nanoc/base/services/compiler.rb
@@ -259,13 +259,18 @@ module Nanoc::Int
       compilation_context.assigns_for(rep, dependency_tracker)
     end
 
-    def create_view_context(dependency_tracker)
-      compilation_context.create_view_context(dependency_tracker)
-    end
-
     # @api private
     def filter_name_and_args_for_layout(layout)
       compilation_context.filter_name_and_args_for_layout(layout)
+    end
+
+    def compilation_context
+      @_compilation_context ||= CompilationContext.new(
+        action_provider: action_provider,
+        reps: @reps,
+        site: @site,
+        compiled_content_cache: compiled_content_cache,
+      )
     end
 
     private
@@ -320,15 +325,6 @@ module Nanoc::Int
         compiled_content_cache: compiled_content_cache,
         action_provider: action_provider,
         compilation_context: compilation_context,
-      )
-    end
-
-    def compilation_context
-      @_compilation_context ||= CompilationContext.new(
-        action_provider: action_provider,
-        reps: @reps,
-        site: @site,
-        compiled_content_cache: compiled_content_cache,
       )
     end
 

--- a/lib/nanoc/base/services/compiler.rb
+++ b/lib/nanoc/base/services/compiler.rb
@@ -288,17 +288,7 @@ module Nanoc::Int
       raise Nanoc::Int::Errors::CompilationError.new(e, item_rep)
     end
 
-    # Compiles the given item representation.
-    #
-    # This method should not be called directly; please use
-    # {Nanoc::Int::Compiler#run} instead, and pass this item representation's item
-    # as its first argument.
-    #
-    # @param [Nanoc::Int::ItemRep] rep The rep that is to be compiled
-    #
-    # @return [void]
-    def compile_rep(rep, is_outdated: true)
-      # TODO: remove is_outdated arg fallback
+    def compile_rep(rep, is_outdated:)
       single.compile(rep, is_outdated: is_outdated)
     end
 

--- a/lib/nanoc/base/services/compiler.rb
+++ b/lib/nanoc/base/services/compiler.rb
@@ -19,9 +19,10 @@ module Nanoc::Int
   # @api private
   class Compiler
     # Provides common functionality for accesing “context” of an item that is being compiled.
+    #
+    # TODO: Rename to CompilationContext
     class ExecutorDelegate
-      def initialize(compiler:, action_provider:, reps:, site:, compiled_content_cache:)
-        @compiler = compiler # TODO: remove
+      def initialize(action_provider:, reps:, site:, compiled_content_cache:)
         @action_provider = action_provider
         @reps = reps
         @site = site
@@ -41,7 +42,7 @@ module Nanoc::Int
           reps: @reps,
           items: @site.items,
           dependency_tracker: dependency_tracker,
-          compiler: @compiler,
+          compiler: self,
         )
       end
 
@@ -326,7 +327,6 @@ module Nanoc::Int
 
     def executor_delegate
       @_executor_delegate ||= ExecutorDelegate.new(
-        compiler: self,
         action_provider: action_provider,
         reps: @reps,
         site: @site,

--- a/lib/nanoc/base/services/compiler.rb
+++ b/lib/nanoc/base/services/compiler.rb
@@ -20,11 +20,12 @@ module Nanoc::Int
   class Compiler
     # Provides common functionality for accesing “context” of an item that is being compiled.
     class ExecutorDelegate
-      def initialize(compiler:, action_provider:, reps:, site:)
+      def initialize(compiler:, action_provider:, reps:, site:, compiled_content_cache:)
         @compiler = compiler # TODO: remove
         @action_provider = action_provider
         @reps = reps
         @site = site
+        @compiled_content_cache = compiled_content_cache
       end
 
       def filter_name_and_args_for_layout(layout)
@@ -66,6 +67,10 @@ module Nanoc::Int
 
       def site
         @site
+      end
+
+      def compiled_content_cache
+        @compiled_content_cache
       end
     end
 
@@ -325,6 +330,7 @@ module Nanoc::Int
         action_provider: action_provider,
         reps: @reps,
         site: @site,
+        compiled_content_cache: compiled_content_cache,
       )
     end
 

--- a/lib/nanoc/base/services/compiler.rb
+++ b/lib/nanoc/base/services/compiler.rb
@@ -40,7 +40,7 @@ module Nanoc::Int
           reps: @reps,
           items: @site.items,
           dependency_tracker: dependency_tracker,
-          compiler: self,
+          compilation_context: self,
         )
       end
 

--- a/lib/nanoc/base/services/compiler.rb
+++ b/lib/nanoc/base/services/compiler.rb
@@ -263,11 +263,6 @@ module Nanoc::Int
       builder.run
     end
 
-    # @api private
-    def filter_name_and_args_for_layout(layout)
-      compilation_context.filter_name_and_args_for_layout(layout)
-    end
-
     def compilation_context
       @_compilation_context ||= CompilationContext.new(
         action_provider: action_provider,

--- a/lib/nanoc/base/services/compiler.rb
+++ b/lib/nanoc/base/services/compiler.rb
@@ -45,13 +45,11 @@ module Nanoc::Int
     class Single
       include Nanoc::Int::ContractsSupport
 
-      def initialize(dependency_store:, compiled_content_cache:, action_provider:, site:, reps:, compiler:)
+      def initialize(dependency_store:, compiled_content_cache:, action_provider:, executor_delegate:)
         @dependency_store = dependency_store
         @compiled_content_cache = compiled_content_cache
         @action_provider = action_provider
-        @site = site
-        @reps = reps
-        @executor_delegate = ExecutorDelegate.new(compiler: compiler, site: @site)
+        @executor_delegate = executor_delegate
       end
 
       contract Nanoc::Int::ItemRep, C::KeywordArgs[is_outdated: C::Bool] => C::Any
@@ -321,9 +319,7 @@ module Nanoc::Int
         dependency_store: @dependency_store,
         compiled_content_cache: compiled_content_cache,
         action_provider: action_provider,
-        site: @site,
-        reps: @reps,
-        compiler: self,
+        executor_delegate: ExecutorDelegate.new(compiler: self, site: @site),
       )
     end
 

--- a/lib/nanoc/base/services/compiler.rb
+++ b/lib/nanoc/base/services/compiler.rb
@@ -63,7 +63,7 @@ module Nanoc::Int
               dependency_tracker = Nanoc::Int::DependencyTracker.new(@dependency_store)
               dependency_tracker.enter(rep.item)
 
-              if can_reuse_content_for_rep?(rep)
+              if can_reuse_content_for_rep?(rep, is_outdated: is_outdated)
                 Nanoc::Int::NotificationCenter.post(:cached_content_used, rep)
                 rep.snapshot_contents = @compiled_content_cache[rep]
               else
@@ -100,9 +100,9 @@ module Nanoc::Int
         end
       end
 
-      contract Nanoc::Int::ItemRep => C::Bool
-      def can_reuse_content_for_rep?(rep)
-        !@compiler.outdatedness_checker.outdated?(rep) && !@compiled_content_cache[rep].nil?
+      contract Nanoc::Int::ItemRep, C::KeywordArgs[is_outdated: C::Bool] => C::Bool
+      def can_reuse_content_for_rep?(rep, is_outdated:)
+        !is_outdated && !@compiled_content_cache[rep].nil?
       end
     end
 

--- a/lib/nanoc/base/services/compiler.rb
+++ b/lib/nanoc/base/services/compiler.rb
@@ -63,7 +63,7 @@ module Nanoc::Int
               dependency_tracker = Nanoc::Int::DependencyTracker.new(@dependency_store)
               dependency_tracker.enter(rep.item)
 
-              if @compiler.send(:can_reuse_content_for_rep?, rep)
+              if can_reuse_content_for_rep?(rep)
                 Nanoc::Int::NotificationCenter.post(:cached_content_used, rep)
                 rep.snapshot_contents = @compiled_content_cache[rep]
               else
@@ -98,6 +98,11 @@ module Nanoc::Int
             raise Nanoc::Int::Errors::InternalInconsistency, "unknown action #{action.inspect}"
           end
         end
+      end
+
+      contract Nanoc::Int::ItemRep => C::Bool
+      def can_reuse_content_for_rep?(rep)
+        !@compiler.outdatedness_checker.outdated?(rep) && !@compiled_content_cache[rep].nil?
       end
     end
 
@@ -303,11 +308,6 @@ module Nanoc::Int
         compiled_content_cache: compiled_content_cache,
         compiler: self,
       )
-    end
-
-    # @return [Boolean]
-    def can_reuse_content_for_rep?(rep)
-      !outdatedness_checker.outdated?(rep) && compiled_content_cache[rep]
     end
 
     # Returns all stores that can load/store data that can be used for

--- a/lib/nanoc/base/services/executor.rb
+++ b/lib/nanoc/base/services/executor.rb
@@ -7,8 +7,8 @@ module Nanoc
         end
       end
 
-      def initialize(compiler, dependency_tracker)
-        @compiler = compiler
+      def initialize(compilation_context, dependency_tracker)
+        @compilation_context = compilation_context
         @dependency_tracker = dependency_tracker
       end
 
@@ -44,7 +44,7 @@ module Nanoc
 
       def layout(rep, layout_identifier, extra_filter_args = nil)
         layout = find_layout(layout_identifier)
-        filter_name, filter_args = *@compiler.filter_name_and_args_for_layout(layout)
+        filter_name, filter_args = *@compilation_context.filter_name_and_args_for_layout(layout)
         if filter_name.nil?
           raise Nanoc::Int::Errors::Generic, "Cannot find rule for layout matching #{layout_identifier}"
         end
@@ -62,7 +62,7 @@ module Nanoc
         # Create filter
         klass = Nanoc::Filter.named(filter_name)
         raise Nanoc::Int::Errors::UnknownFilter.new(filter_name) if klass.nil?
-        view_context = @compiler.create_view_context(@dependency_tracker)
+        view_context = @compilation_context.create_view_context(@dependency_tracker)
         layout_view = Nanoc::LayoutView.new(layout, view_context)
         filter = klass.new(assigns_for(rep).merge({ layout: layout_view }))
 
@@ -105,11 +105,11 @@ module Nanoc
       end
 
       def assigns_for(rep)
-        @compiler.assigns_for(rep, @dependency_tracker)
+        @compilation_context.assigns_for(rep, @dependency_tracker)
       end
 
       def layouts
-        @compiler.site.layouts
+        @compilation_context.site.layouts
       end
 
       def find_layout(arg)
@@ -140,7 +140,7 @@ module Nanoc
       end
 
       def use_globs?
-        @compiler.site.config[:string_pattern_type] == 'glob'
+        @compilation_context.site.config[:string_pattern_type] == 'glob'
       end
     end
   end

--- a/lib/nanoc/base/views/post_compile_item_rep_view.rb
+++ b/lib/nanoc/base/views/post_compile_item_rep_view.rb
@@ -5,7 +5,7 @@ module Nanoc
         raise Nanoc::Int::Errors::CannotGetCompiledContentOfBinaryItem.new(unwrap)
       end
 
-      snapshot_contents = @context.compiler.compiled_content_cache[unwrap]
+      snapshot_contents = @context.compilation_context.compiled_content_cache[unwrap]
       snapshot_name = snapshot || (snapshot_contents[:pre] ? :pre : :last)
 
       if snapshot_contents[snapshot_name]

--- a/lib/nanoc/base/views/view_context.rb
+++ b/lib/nanoc/base/views/view_context.rb
@@ -4,13 +4,13 @@ module Nanoc
     attr_reader :reps
     attr_reader :items
     attr_reader :dependency_tracker
-    attr_reader :compiler
+    attr_reader :compilation_context
 
-    def initialize(reps:, items:, dependency_tracker:, compiler:)
+    def initialize(reps:, items:, dependency_tracker:, compilation_context:)
       @reps = reps
       @items = items
       @dependency_tracker = dependency_tracker
-      @compiler = compiler
+      @compilation_context = compilation_context
     end
   end
 end

--- a/lib/nanoc/checking/check.rb
+++ b/lib/nanoc/checking/check.rb
@@ -20,7 +20,7 @@ module Nanoc::Checking
       output_filenames = Dir[output_dir + '/**/*'].select { |f| File.file?(f) }
 
       # FIXME: ugly
-      view_context = site.compiler.create_view_context(Nanoc::Int::DependencyTracker::Null.new)
+      view_context = site.compiler.compilation_context.create_view_context(Nanoc::Int::DependencyTracker::Null.new)
 
       context = {
         items: Nanoc::ItemCollectionWithRepsView.new(site.items, view_context),

--- a/lib/nanoc/cli/commands/shell.rb
+++ b/lib/nanoc/cli/commands/shell.rb
@@ -34,7 +34,7 @@ module Nanoc::CLI::Commands
         reps: reps_for(site),
         items: site.items,
         dependency_tracker: Nanoc::Int::DependencyTracker::Null.new,
-        compiler: nil,
+        compilation_context: nil,
       )
     end
 

--- a/lib/nanoc/helpers/rendering.rb
+++ b/lib/nanoc/helpers/rendering.rb
@@ -37,7 +37,7 @@ module Nanoc::Helpers
       }.merge(other_assigns)
 
       # Get filter name
-      filter_name, filter_args = *@config._context.compiler.filter_name_and_args_for_layout(layout)
+      filter_name, filter_args = *@config._context.compilation_context.filter_name_and_args_for_layout(layout)
       raise Nanoc::Int::Errors::CannotDetermineFilter.new(layout.identifier) if filter_name.nil?
 
       # Get filter class

--- a/lib/nanoc/rule_dsl/action_provider.rb
+++ b/lib/nanoc/rule_dsl/action_provider.rb
@@ -55,7 +55,7 @@ module Nanoc::RuleDSL
           reps: reps,
           items: site.items,
           dependency_tracker: dependency_tracker,
-          compiler: site.compiler,
+          compilation_context: site.compiler.compilation_context,
         )
       ctx = new_postprocessor_context(site, view_context)
 
@@ -72,7 +72,7 @@ module Nanoc::RuleDSL
           reps: nil,
           items: nil,
           dependency_tracker: dependency_tracker,
-          compiler: nil,
+          compilation_context: nil,
         )
 
       Nanoc::Int::Context.new(

--- a/lib/nanoc/rule_dsl/recording_executor.rb
+++ b/lib/nanoc/rule_dsl/recording_executor.rb
@@ -50,7 +50,7 @@ module Nanoc
         return nil if routing_rule.nil?
 
         dependency_tracker = Nanoc::Int::DependencyTracker::Null.new
-        view_context = Nanoc::ViewContext.new(reps: nil, items: nil, dependency_tracker: dependency_tracker, compiler: nil)
+        view_context = Nanoc::ViewContext.new(reps: nil, items: nil, dependency_tracker: dependency_tracker, compilation_context: nil)
         basic_path = routing_rule.apply_to(rep, executor: nil, site: @site, view_context: view_context)
         if basic_path && !basic_path.start_with?('/')
           raise PathWithoutInitialSlashError.new(rep, basic_path)

--- a/lib/nanoc/rule_dsl/rule_memory_calculator.rb
+++ b/lib/nanoc/rule_dsl/rule_memory_calculator.rb
@@ -66,7 +66,7 @@ module Nanoc::RuleDSL
     # @return [Nanoc::Int::RuleMemory]
     def new_rule_memory_for_rep(rep)
       dependency_tracker = Nanoc::Int::DependencyTracker::Null.new
-      view_context = @site.compiler.create_view_context(dependency_tracker)
+      view_context = @site.compiler.compilation_context.create_view_context(dependency_tracker)
 
       executor = Nanoc::RuleDSL::RecordingExecutor.new(rep, @rules_collection, @site)
       rule = @rules_collection.compilation_rule_for(rep)

--- a/lib/nanoc/spec.rb
+++ b/lib/nanoc/spec.rb
@@ -118,7 +118,7 @@ module Nanoc
           reps: @reps,
           items: @items,
           dependency_tracker: @dependency_tracker,
-          compiler: new_site.compiler,
+          compilation_context: new_site.compiler.compilation_context,
         )
       end
 

--- a/spec/nanoc/base/compiler_spec.rb
+++ b/spec/nanoc/base/compiler_spec.rb
@@ -111,7 +111,9 @@ describe Nanoc::Int::Compiler do
   end
 
   describe '#compile_rep' do
-    subject { compiler.send(:compile_rep, rep) }
+    subject { compiler.send(:compile_rep, rep, is_outdated: is_outdated) }
+
+    let(:is_outdated) { true }
 
     it 'generates expected output' do
       expect(rep.snapshot_contents[:last].string).to eql(item.content.string)
@@ -132,7 +134,6 @@ describe Nanoc::Int::Compiler do
       let(:item) { Nanoc::Int::Item.new('other=<%= @items["/other.*"].compiled_content %>', {}, '/hi.md') }
 
       before do
-        expect(outdatedness_checker).to receive(:outdated?).with(other_rep).and_return(true)
         expect(action_provider).to receive(:memory_for).with(other_rep).and_return(memory)
       end
 

--- a/spec/nanoc/base/compiler_spec.rb
+++ b/spec/nanoc/base/compiler_spec.rb
@@ -140,9 +140,10 @@ describe Nanoc::Int::Compiler do
       it 'generates expected output' do
         expect(rep.snapshot_contents[:last].string).to eql(item.content.string)
 
-        expect { compiler.send(:compile_rep, rep) }.to raise_error(Nanoc::Int::Errors::UnmetDependency)
-        compiler.send(:compile_rep, other_rep)
-        compiler.send(:compile_rep, rep)
+        expect { compiler.send(:compile_rep, rep, is_outdated: true) }
+          .to raise_error(Nanoc::Int::Errors::UnmetDependency)
+        compiler.send(:compile_rep, other_rep, is_outdated: true)
+        compiler.send(:compile_rep, rep, is_outdated: true)
 
         expect(rep.snapshot_contents[:last].string).to eql('other=other content')
       end
@@ -165,9 +166,10 @@ describe Nanoc::Int::Compiler do
         expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:filtering_ended, rep, :erb).ordered
         expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:compilation_ended, rep).ordered
 
-        expect { compiler.send(:compile_rep, rep) }.to raise_error(Nanoc::Int::Errors::UnmetDependency)
-        compiler.send(:compile_rep, other_rep)
-        compiler.send(:compile_rep, rep)
+        expect { compiler.send(:compile_rep, rep, is_outdated: true) }
+          .to raise_error(Nanoc::Int::Errors::UnmetDependency)
+        compiler.send(:compile_rep, other_rep, is_outdated: true)
+        compiler.send(:compile_rep, rep, is_outdated: true)
       end
     end
   end

--- a/spec/nanoc/base/filter_spec.rb
+++ b/spec/nanoc/base/filter_spec.rb
@@ -52,7 +52,7 @@ describe Nanoc::Filter do
         reps: reps,
         items: double(:items),
         dependency_tracker: dependency_tracker,
-        compiler: double(:compiler),
+        compilation_context: double(:compilation_context),
       )
     end
 

--- a/spec/nanoc/base/services/executor_spec.rb
+++ b/spec/nanoc/base/services/executor_spec.rb
@@ -1,7 +1,20 @@
 describe Nanoc::Int::Executor do
   let(:executor) { described_class.new(compilation_context, dependency_tracker) }
 
-  let(:compilation_context) { Nanoc::Int::Compiler.allocate }
+  let(:compilation_context) do
+    Nanoc::Int::Compiler::CompilationContext.new(
+      action_provider: action_provider,
+      reps: reps,
+      site: site,
+      compiled_content_cache: compiled_content_cache,
+    )
+  end
+
+  let(:action_provider) { double(:action_provider) }
+  let(:reps) { double(:reps) }
+  let(:site) { double(:site) }
+  let(:compiled_content_cache) { double(:compiled_content_cache) }
+
   let(:dependency_tracker) { Nanoc::Int::DependencyTracker.new(double(:dependency_store)) }
 
   describe '#filter' do
@@ -275,13 +288,11 @@ describe Nanoc::Int::Executor do
       end
     end
 
-    let(:action_provider) { double(:action_provider) }
-
     before do
       allow(compilation_context).to receive(:site) { site }
-      allow(compilation_context).to receive(:action_provider) { action_provider }
       allow(compilation_context).to receive(:assigns_for).with(rep, dependency_tracker) { assigns }
       allow(compilation_context).to receive(:create_view_context).with(dependency_tracker).and_return(view_context)
+
       allow(action_provider).to receive(:memory_for).with(layout).and_return(rule_memory)
     end
 

--- a/spec/nanoc/base/services/executor_spec.rb
+++ b/spec/nanoc/base/services/executor_spec.rb
@@ -1,7 +1,7 @@
 describe Nanoc::Int::Executor do
-  let(:executor) { described_class.new(compiler, dependency_tracker) }
+  let(:executor) { described_class.new(compilation_context, dependency_tracker) }
 
-  let(:compiler) { Nanoc::Int::Compiler.allocate }
+  let(:compilation_context) { Nanoc::Int::Compiler.allocate }
   let(:dependency_tracker) { Nanoc::Int::DependencyTracker.new(double(:dependency_store)) }
 
   describe '#filter' do
@@ -14,7 +14,7 @@ describe Nanoc::Int::Executor do
     let(:rep) { Nanoc::Int::ItemRep.new(item, :donkey) }
 
     before do
-      allow(compiler).to receive(:assigns_for) { assigns }
+      allow(compilation_context).to receive(:assigns_for) { assigns }
     end
 
     context 'normal flow with textual rep' do
@@ -265,7 +265,7 @@ describe Nanoc::Int::Executor do
         reps: double(:reps),
         items: double(:items),
         dependency_tracker: dependency_tracker,
-        compiler: double(:compiler),
+        compilation_context: double(:compilation_context),
       )
     end
 
@@ -278,10 +278,10 @@ describe Nanoc::Int::Executor do
     let(:action_provider) { double(:action_provider) }
 
     before do
-      allow(compiler).to receive(:site) { site }
-      allow(compiler).to receive(:action_provider) { action_provider }
-      allow(compiler).to receive(:assigns_for).with(rep, dependency_tracker) { assigns }
-      allow(compiler).to receive(:create_view_context).with(dependency_tracker).and_return(view_context)
+      allow(compilation_context).to receive(:site) { site }
+      allow(compilation_context).to receive(:action_provider) { action_provider }
+      allow(compilation_context).to receive(:assigns_for).with(rep, dependency_tracker) { assigns }
+      allow(compilation_context).to receive(:create_view_context).with(dependency_tracker).and_return(view_context)
       allow(action_provider).to receive(:memory_for).with(layout).and_return(rule_memory)
     end
 
@@ -457,7 +457,7 @@ describe Nanoc::Int::Executor do
     let(:config) { {} }
 
     before do
-      allow(compiler).to receive(:site) { site }
+      allow(compilation_context).to receive(:site) { site }
     end
 
     subject { executor.find_layout(arg) }

--- a/spec/nanoc/base/views/document_view_spec.rb
+++ b/spec/nanoc/base/views/document_view_spec.rb
@@ -6,7 +6,7 @@ shared_examples 'a document view' do
       reps: double(:reps),
       items: double(:items),
       dependency_tracker: dependency_tracker,
-      compiler: double(:compiler),
+      compilation_context: double(:compilation_context),
     )
   end
 

--- a/spec/nanoc/base/views/item_rep_view_spec.rb
+++ b/spec/nanoc/base/views/item_rep_view_spec.rb
@@ -1,9 +1,9 @@
 describe Nanoc::ItemRepView do
-  let(:view_context) { Nanoc::ViewContext.new(reps: reps, items: items, dependency_tracker: dependency_tracker, compiler: compiler) }
+  let(:view_context) { Nanoc::ViewContext.new(reps: reps, items: items, dependency_tracker: dependency_tracker, compilation_context: compilation_context) }
 
   let(:reps) { double(:reps) }
   let(:items) { double(:items) }
-  let(:compiler) { double(:compiler) }
+  let(:compilation_context) { double(:compilation_context) }
 
   let(:dependency_tracker) { Nanoc::Int::DependencyTracker.new(dependency_store) }
   let(:dependency_store) { Nanoc::Int::DependencyStore.new([]) }

--- a/spec/nanoc/base/views/item_view_spec.rb
+++ b/spec/nanoc/base/views/item_view_spec.rb
@@ -3,12 +3,12 @@ describe Nanoc::ItemWithRepsView do
   let(:other_view_class) { Nanoc::LayoutView }
   it_behaves_like 'a document view'
 
-  let(:view_context) { Nanoc::ViewContext.new(reps: reps, items: items, dependency_tracker: dependency_tracker, compiler: compiler) }
+  let(:view_context) { Nanoc::ViewContext.new(reps: reps, items: items, dependency_tracker: dependency_tracker, compilation_context: compilation_context) }
   let(:reps) { [] }
   let(:items) { [] }
   let(:dependency_tracker) { Nanoc::Int::DependencyTracker.new(dependency_store) }
   let(:dependency_store) { Nanoc::Int::DependencyStore.new([]) }
-  let(:compiler) { double(:compiler) }
+  let(:compilation_context) { double(:compilation_context) }
 
   let(:base_item) { Nanoc::Int::Item.new('base', {}, '/base.md') }
 

--- a/spec/nanoc/base/views/mutable_document_view_spec.rb
+++ b/spec/nanoc/base/views/mutable_document_view_spec.rb
@@ -6,7 +6,7 @@ shared_examples 'a mutable document view' do
       reps: double(:reps),
       items: double(:items),
       dependency_tracker: dependency_tracker,
-      compiler: double(:compiler),
+      compilation_context: double(:compilation_context),
     )
   end
 

--- a/spec/nanoc/base/views/post_compile_item_rep_view_spec.rb
+++ b/spec/nanoc/base/views/post_compile_item_rep_view_spec.rb
@@ -8,7 +8,7 @@ describe Nanoc::PostCompileItemRepView do
       reps: reps,
       items: items,
       dependency_tracker: dependency_tracker,
-      compiler: compiler,
+      compilation_context: compilation_context,
     )
   end
 
@@ -16,7 +16,7 @@ describe Nanoc::PostCompileItemRepView do
   let(:items) { Nanoc::Int::IdentifiableCollection.new(config) }
   let(:config) { Nanoc::Int::Configuration.new }
   let(:dependency_tracker) { Nanoc::Int::DependencyTracker.new(double(:dependency_store)) }
-  let(:compiler) { double(:compiler, compiled_content_cache: compiled_content_cache) }
+  let(:compilation_context) { double(:compilation_context, compiled_content_cache: compiled_content_cache) }
 
   let(:snapshot_contents) do
     {

--- a/spec/nanoc/rule_dsl/rule_context_spec.rb
+++ b/spec/nanoc/rule_dsl/rule_context_spec.rb
@@ -13,8 +13,8 @@ describe(Nanoc::RuleDSL::RuleContext) do
   let(:site) { double(:site, items: items, layouts: layouts, config: config) }
   let(:executor) { double(:executor) }
   let(:reps) { double(:reps) }
-  let(:compiler) { double(:compiler) }
-  let(:view_context) { Nanoc::ViewContext.new(reps: reps, items: items, dependency_tracker: dependency_tracker, compiler: compiler) }
+  let(:compilation_context) { double(:compilation_context) }
+  let(:view_context) { Nanoc::ViewContext.new(reps: reps, items: items, dependency_tracker: dependency_tracker, compilation_context: compilation_context) }
   let(:dependency_tracker) { double(:dependency_tracker) }
 
   describe '#initialize' do

--- a/spec/nanoc/rule_dsl/rule_memory_calculator_spec.rb
+++ b/spec/nanoc/rule_dsl/rule_memory_calculator_spec.rb
@@ -17,11 +17,12 @@ describe(Nanoc::RuleDSL::RuleMemoryCalculator) do
       let(:items) { Nanoc::Int::IdentifiableCollection.new(config) }
       let(:layouts) { Nanoc::Int::IdentifiableCollection.new(config) }
       let(:site) { double(:site, items: items, layouts: layouts, config: config, compiler: compiler) }
-      let(:compiler) { double(:compiler) }
+      let(:compiler) { double(:compiler, compilation_context: compilation_context) }
+      let(:compilation_context) { double(:compilation_context) }
       let(:view_context) { double(:view_context) }
 
       before do
-        expect(compiler).to receive(:create_view_context).and_return(view_context)
+        expect(compilation_context).to receive(:create_view_context).and_return(view_context)
       end
 
       context 'no rules exist' do
@@ -132,7 +133,8 @@ describe(Nanoc::RuleDSL::RuleMemoryCalculator) do
     let(:items) { Nanoc::Int::IdentifiableCollection.new(config) }
     let(:layouts) { Nanoc::Int::IdentifiableCollection.new(config) }
     let(:site) { double(:site, items: items, layouts: layouts, config: config, compiler: compiler) }
-    let(:compiler) { double(:compiler) }
+    let(:compiler) { double(:compiler, compilation_context: compilation_context) }
+    let(:compilation_context) { double(:compilation_context) }
     let(:view_context) { double(:view_context) }
 
     before do
@@ -144,7 +146,7 @@ describe(Nanoc::RuleDSL::RuleMemoryCalculator) do
       rule = Nanoc::RuleDSL::Rule.new(Nanoc::Int::Pattern.from('/list.*'), :csv, rules_proc)
       rules_collection.add_item_compilation_rule(rule)
 
-      expect(compiler).to receive(:create_view_context).and_return(view_context)
+      expect(compilation_context).to receive(:create_view_context).and_return(view_context)
     end
 
     example do

--- a/test/filters/test_xsl.rb
+++ b/test/filters/test_xsl.rb
@@ -97,7 +97,7 @@ EOS
       reps: :__irrelevat_reps,
       items: :__irrelevat_items,
       dependency_tracker: @dependency_tracker,
-      compiler: :__irrelevat_compiler,
+      compilation_context: :__irrelevat_compiler,
     )
   end
 

--- a/test/helpers/test_capturing.rb
+++ b/test/helpers/test_capturing.rb
@@ -12,7 +12,7 @@ class Nanoc::Helpers::CapturingTest < Nanoc::TestCase
       reps: item_rep_repo_for(item),
       items: :__irrelevant__,
       dependency_tracker: :__irrelevant__,
-      compiler: :__irrelevant__,
+      compilation_context: :__irrelevant__,
     )
   end
 

--- a/test/helpers/test_xml_sitemap.rb
+++ b/test/helpers/test_xml_sitemap.rb
@@ -6,7 +6,7 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
 
     @reps = Nanoc::Int::ItemRepRepo.new
     dependency_tracker = Nanoc::Int::DependencyTracker.new(nil)
-    @view_context = Nanoc::ViewContext.new(reps: @reps, items: nil, dependency_tracker: dependency_tracker, compiler: :__irrelevant__)
+    @view_context = Nanoc::ViewContext.new(reps: @reps, items: nil, dependency_tracker: dependency_tracker, compilation_context: :__irrelevant__)
 
     @items = nil
     @item = nil


### PR DESCRIPTION
This creates

* `CompilationContext`

* Three `ItemRepCompiler` classes:

  * `ResumingItemRepCompiler` — Handles fiber management to support suspending and resuming item rep compilation. Always calls the next compiler (`CachingItemRepCompiler`). Also handles notifications.

  * `CachingItemRepCompiler` — If the given item rep is not outdated and cached compiled content is available, reuses said content. Otherwise, calls the next compiler (`RecalculatingItemRepCompiler`).

  * `RecalculatingItemRepCompiler` — (Re)calculate the compiled content of a given item rep. Also sets up dependency tracking.