### PR TITLE
Refactor: Move item rep writing out of executor

### DIFF
--- a/lib/nanoc/base/services/executor.rb
+++ b/lib/nanoc/base/services/executor.rb
@@ -91,10 +91,7 @@ module Nanoc
         rep.snapshot_contents[snapshot_name] = rep.snapshot_contents[:last]
 
         if final
-          raw_path = rep.raw_path(snapshot: snapshot_name)
-          if raw_path
-            ItemRepWriter.new.write(rep, raw_path)
-          end
+          ItemRepWriter.new.write(rep, snapshot_name)
         end
       end
 

--- a/lib/nanoc/base/services/executor.rb
+++ b/lib/nanoc/base/services/executor.rb
@@ -86,13 +86,7 @@ module Nanoc
       end
 
       def snapshot(rep, snapshot_name, final: true, path: nil) # rubocop:disable Lint/UnusedMethodArgument
-        # NOTE: :path is irrelevant
-
         rep.snapshot_contents[snapshot_name] = rep.snapshot_contents[:last]
-
-        if final
-          ItemRepWriter.new.write(rep, snapshot_name)
-        end
       end
 
       def assigns_for(rep)

--- a/lib/nanoc/base/services/executor.rb
+++ b/lib/nanoc/base/services/executor.rb
@@ -88,9 +88,7 @@ module Nanoc
       def snapshot(rep, snapshot_name, final: true, path: nil) # rubocop:disable Lint/UnusedMethodArgument
         # NOTE: :path is irrelevant
 
-        unless rep.binary?
-          rep.snapshot_contents[snapshot_name] = rep.snapshot_contents[:last]
-        end
+        rep.snapshot_contents[snapshot_name] = rep.snapshot_contents[:last]
 
         if final
           raw_path = rep.raw_path(snapshot: snapshot_name)

--- a/lib/nanoc/base/services/item_rep_writer.rb
+++ b/lib/nanoc/base/services/item_rep_writer.rb
@@ -3,7 +3,10 @@ module Nanoc::Int
   class ItemRepWriter
     TMP_TEXT_ITEMS_DIR = 'text_items'.freeze
 
-    def write(item_rep, raw_path)
+    def write(item_rep, snapshot_name)
+      raw_path = item_rep.raw_path(snapshot: snapshot_name)
+      return unless raw_path
+
       # Create parent directory
       FileUtils.mkdir_p(File.dirname(raw_path))
 

--- a/lib/nanoc/base/services/item_rep_writer.rb
+++ b/lib/nanoc/base/services/item_rep_writer.rb
@@ -18,7 +18,7 @@ module Nanoc::Int
         :will_write_rep, item_rep, raw_path
       )
 
-      content = item_rep.snapshot_contents[:last]
+      content = item_rep.snapshot_contents[snapshot_name]
       if content.binary?
         temp_path = content.filename
       else

--- a/spec/nanoc/base/item_rep_writer_spec.rb
+++ b/spec/nanoc/base/item_rep_writer_spec.rb
@@ -14,6 +14,7 @@ describe Nanoc::Int::ItemRepWriter do
     let(:snapshot_contents) do
       {
         last: Nanoc::Int::TextualContent.new('last content'),
+        donkey: Nanoc::Int::TextualContent.new('donkey content'),
       }
     end
 
@@ -34,13 +35,17 @@ describe Nanoc::Int::ItemRepWriter do
 
       let(:snapshot_contents) do
         {
-          last: Nanoc::Int::BinaryContent.new(File.expand_path('input.dat')),
+          last: Nanoc::Int::BinaryContent.new(File.expand_path('input-last.dat')),
+          donkey: Nanoc::Int::BinaryContent.new(File.expand_path('input-donkey.dat')),
         }
       end
 
-      it 'copies' do
-        File.write(snapshot_contents[:last].filename, 'binary stuff')
+      before do
+        File.write(snapshot_contents[:last].filename, 'binary last stuff')
+        File.write(snapshot_contents[:donkey].filename, 'binary donkey stuff')
+      end
 
+      it 'copies' do
         expect(Nanoc::Int::NotificationCenter).to receive(:post)
           .with(:will_write_rep, item_rep, 'output/blah.dat')
         expect(Nanoc::Int::NotificationCenter).to receive(:post)
@@ -48,22 +53,20 @@ describe Nanoc::Int::ItemRepWriter do
 
         subject
 
-        expect(File.read('output/blah.dat')).to eql('binary stuff')
+        expect(File.read('output/blah.dat')).to eql('binary donkey stuff')
       end
 
       context 'output file already exists' do
         let(:old_mtime) { Time.at((Time.now - 600).to_i) }
 
         before do
-          File.write(snapshot_contents[:last].filename, 'binary stuff')
-
           FileUtils.mkdir_p('output')
           File.write('output/blah.dat', old_content)
           FileUtils.touch('output/blah.dat', mtime: old_mtime)
         end
 
         context 'file is identical' do
-          let(:old_content) { 'binary stuff' }
+          let(:old_content) { 'binary donkey stuff' }
 
           it 'keeps mtime' do
             subject
@@ -72,7 +75,7 @@ describe Nanoc::Int::ItemRepWriter do
         end
 
         context 'file is not identical' do
-          let(:old_content) { 'other binary stuff' }
+          let(:old_content) { 'other binary donkey stuff' }
 
           it 'updates mtime' do
             subject
@@ -93,7 +96,7 @@ describe Nanoc::Int::ItemRepWriter do
 
         subject
 
-        expect(File.read('output/blah.dat')).to eql('last content')
+        expect(File.read('output/blah.dat')).to eql('donkey content')
       end
 
       context 'output file already exists' do
@@ -106,7 +109,7 @@ describe Nanoc::Int::ItemRepWriter do
         end
 
         context 'file is identical' do
-          let(:old_content) { 'last content' }
+          let(:old_content) { 'donkey content' }
 
           it 'keeps mtime' do
             subject
@@ -115,7 +118,7 @@ describe Nanoc::Int::ItemRepWriter do
         end
 
         context 'file is not identical' do
-          let(:old_content) { 'other last content' }
+          let(:old_content) { 'other donkey content' }
 
           it 'updates mtime' do
             subject

--- a/spec/nanoc/base/item_rep_writer_spec.rb
+++ b/spec/nanoc/base/item_rep_writer_spec.rb
@@ -7,6 +7,7 @@ describe Nanoc::Int::ItemRepWriter do
     let(:item_rep) do
       Nanoc::Int::ItemRep.new(item, :default).tap do |ir|
         ir.snapshot_contents = snapshot_contents
+        ir.raw_paths = raw_paths
       end
     end
 
@@ -16,7 +17,13 @@ describe Nanoc::Int::ItemRepWriter do
       }
     end
 
-    subject { described_class.new.write(item_rep, raw_path) }
+    let(:snapshot_name) { :donkey }
+
+    let(:raw_paths) do
+      { snapshot_name => raw_path }
+    end
+
+    subject { described_class.new.write(item_rep, snapshot_name) }
 
     before do
       expect(File.directory?('output')).to be_falsy

--- a/spec/nanoc/base/services/executor_spec.rb
+++ b/spec/nanoc/base/services/executor_spec.rb
@@ -412,10 +412,10 @@ describe Nanoc::Int::Executor do
     context 'binary content' do
       let(:content) { Nanoc::Int::BinaryContent.new(File.expand_path('donkey.dat')) }
 
-      it 'does not create snapshots' do
+      it 'creates snapshots' do
         executor.snapshot(rep, :something)
 
-        expect(rep.snapshot_contents[:something]).to be_nil
+        expect(rep.snapshot_contents[:something]).not_to be_nil
       end
     end
 

--- a/spec/nanoc/base/services/executor_spec.rb
+++ b/spec/nanoc/base/services/executor_spec.rb
@@ -437,10 +437,10 @@ describe Nanoc::Int::Executor do
           rep.raw_paths = { something: 'output/donkey.md' }
         end
 
-        it 'writes' do
+        it 'does not write' do
           executor.snapshot(rep, :something)
 
-          expect(File.read('output/donkey.md')).to eq('Donkey Power')
+          expect(File.file?('output/donkey.md')).not_to be
         end
       end
 


### PR DESCRIPTION
This will bring the `Executor` class closer to something stateless. All that remains is not updating `snapshot_contents`.