### PR TITLE
Allow calling #write more than once

### DIFF
--- a/lib/nanoc/base/entities/rule_memory.rb
+++ b/lib/nanoc/base/entities/rule_memory.rb
@@ -65,6 +65,21 @@ module Nanoc::Int
       self
     end
 
+    # Attempts to merge anonymous snapshots with named ones around it
+    def canonicalize
+      return if @actions.size < 2
+
+      last_two = @actions.last(2)
+      last_two_mergeable =
+        last_two.all? { |pa| pa.is_a?(Nanoc::Int::ProcessingActions::Snapshot) } &&
+        last_two.last.snapshot_name == :last &&
+        last_two.first.snapshot_name.to_s =~ /\A_\d+\z/
+
+      if last_two_mergeable
+        @actions[-2, 2] = [Nanoc::Int::ProcessingActions::Snapshot.new(:last, true, last_two.first.path)]
+      end
+    end
+
     private
 
     def will_add_snapshot(name)

--- a/lib/nanoc/rule_dsl/rule_context.rb
+++ b/lib/nanoc/rule_dsl/rule_context.rb
@@ -12,6 +12,8 @@ module Nanoc::RuleDSL
     def initialize(rep:, site:, executor:, view_context:)
       @_executor = executor
 
+      @_write_snapshot_counter = 0
+
       super({
         item: Nanoc::ItemWithoutRepsView.new(rep.item, view_context),
         rep: Nanoc::ItemRepView.new(rep, view_context),
@@ -65,7 +67,7 @@ module Nanoc::RuleDSL
       @_executor.snapshot(snapshot_name, path: path)
     end
 
-    # Creates a snapshot named :last the current compiled item content, with
+    # Creates an unnamed snapshot of the current compiled item content, with
     # the given path. This is a convenience method for {#snapshot}.
     #
     # @see #snapshot
@@ -74,7 +76,9 @@ module Nanoc::RuleDSL
     #
     # @return [void]
     def write(path)
-      snapshot(:last, path: path)
+      snapshot_name = "_#{@_write_snapshot_counter}".to_sym
+      @_write_snapshot_counter += 1
+      snapshot(snapshot_name, path: path)
     end
   end
 end

--- a/lib/nanoc/rule_dsl/rule_memory_calculator.rb
+++ b/lib/nanoc/rule_dsl/rule_memory_calculator.rb
@@ -85,7 +85,9 @@ module Nanoc::RuleDSL
         executor.snapshot(:last)
       end
 
-      executor.rule_memory
+      mem = executor.rule_memory
+      mem.canonicalize
+      mem
     end
 
     # @param [Nanoc::Int::Layout] layout

--- a/spec/nanoc/regressions/gh_1037_spec.rb
+++ b/spec/nanoc/regressions/gh_1037_spec.rb
@@ -1,0 +1,29 @@
+describe 'GH-1037', site: true, stdio: true do
+  before do
+    File.write('content/giraffe.md', 'I am a giraffe!')
+    File.write('content/donkey.erb', '[<%= @items["/giraffe.*"].compiled_content(snapshot: :last) %>]')
+
+    File.write('Rules', <<EOS)
+  compile '/donkey.erb' do
+    filter :erb
+    write '/donkey.txt'
+  end
+
+  compile '/giraffe.*' do
+    write '/giraffe.txt'
+    write '/giraffe.md'
+  end
+EOS
+  end
+
+  it 'writes two files' do
+    Nanoc::CLI.run(%w(compile))
+    expect(File.read('output/giraffe.txt')).to eql('I am a giraffe!')
+    expect(File.read('output/giraffe.md')).to eql('I am a giraffe!')
+  end
+
+  it 'has the right :last snapshot' do
+    Nanoc::CLI.run(%w(compile))
+    expect(File.read('output/donkey.txt')).to eql('[I am a giraffe!]')
+  end
+end

--- a/spec/nanoc/rule_dsl/rule_context_spec.rb
+++ b/spec/nanoc/rule_dsl/rule_context_spec.rb
@@ -165,13 +165,26 @@ describe(Nanoc::RuleDSL::RuleContext) do
   end
 
   describe '#write' do
-    subject { rule_context.write(path) }
+    context 'calling once' do
+      subject { rule_context.write('/foo.html') }
 
-    let(:path) { '/foo.html' }
+      it 'makes a request to the executor' do
+        expect(executor).to receive(:snapshot).with(:_0, path: '/foo.html')
+        subject
+      end
+    end
 
-    it 'makes a request to the executor' do
-      expect(executor).to receive(:snapshot).with(:last, path: '/foo.html')
-      subject
+    context 'calling twice' do
+      subject do
+        rule_context.write('/foo.html')
+        rule_context.write('/bar.html')
+      end
+
+      it 'makes two requests to the executor with unique snapshot names' do
+        expect(executor).to receive(:snapshot).with(:_0, path: '/foo.html')
+        expect(executor).to receive(:snapshot).with(:_1, path: '/bar.html')
+        subject
+      end
     end
   end
 end

--- a/spec/nanoc/rule_dsl/rule_memory_calculator_spec.rb
+++ b/spec/nanoc/rule_dsl/rule_memory_calculator_spec.rb
@@ -33,7 +33,7 @@ describe(Nanoc::RuleDSL::RuleMemoryCalculator) do
       end
 
       context 'rules exist' do
-        before do
+        example do
           rules_proc = proc do
             filter :erb, speed: :over_9000
             layout '/default.*'
@@ -41,9 +41,7 @@ describe(Nanoc::RuleDSL::RuleMemoryCalculator) do
           end
           rule = Nanoc::RuleDSL::Rule.new(Nanoc::Int::Pattern.from('/list.*'), :csv, rules_proc)
           rules_collection.add_item_compilation_rule(rule)
-        end
 
-        example do
           subject
 
           expect(subject.size).to eql(8)
@@ -84,6 +82,37 @@ describe(Nanoc::RuleDSL::RuleMemoryCalculator) do
           expect(subject[7].snapshot_name).to eql(:last)
           expect(subject[7]).to be_final
           expect(subject[7].path).to be_nil
+        end
+
+        context 'anonymous snapshot followed by :last snapshot' do
+          before do
+            rules_proc = proc do
+              write '/hello.txt'
+            end
+            rule = Nanoc::RuleDSL::Rule.new(Nanoc::Int::Pattern.from('/list.*'), :csv, rules_proc)
+            rules_collection.add_item_compilation_rule(rule)
+          end
+
+          it 'merges the two snapshots' do
+            subject
+
+            expect(subject.size).to eql(3)
+
+            expect(subject[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+            expect(subject[0].snapshot_name).to eql(:raw)
+            expect(subject[0]).to be_final
+            expect(subject[0].path).to be_nil
+
+            expect(subject[1]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+            expect(subject[1].snapshot_name).to eql(:pre)
+            expect(subject[1]).not_to be_final
+            expect(subject[1].path).to be_nil
+
+            expect(subject[2]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+            expect(subject[2].snapshot_name).to eql(:last)
+            expect(subject[2]).to be_final
+            expect(subject[2].path).to eq('/hello.txt')
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes #1037.

* * *

The way snapshots are handled is currently less than ideal. I’d like them to be decoupled, so that

```ruby
write '/something.txt'
snapshot :something
```

or

```ruby
snapshot :something
write '/something.txt'
```

would both create a snapshot named `:something`, pointing to the file `/something.txt`.

Perhaps even

```ruby
snapshot :something
write '/something.txt'
write '/same.txt'
```

which would create a snapshot pointing to two files, or

```ruby
snapshot :something
write '/something.txt'
snapshot :same
```

which would be two snapshots pointing to the same file.

None of this currently works, and I’m hesitant to call it a bug (it’s not documented behavior!) but it would still be nice to have, because it makes sense. Out of scope for this PR, though.