### PR TITLE
Refactor: Move path calculation into RuleMemCalculator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :devel do
   gem 'pry'
   gem 'rake'
   gem 'rdoc', '~> 5.0'
+  gem 'rspec-its', '~> 1.2'
   gem 'rspec-mocks'
   gem 'rspec'
   gem 'rubocop'

--- a/lib/nanoc/base/entities/processing_actions/snapshot.rb
+++ b/lib/nanoc/base/entities/processing_actions/snapshot.rb
@@ -19,6 +19,12 @@ module Nanoc::Int::ProcessingActions
       [:snapshot, @snapshot_name, @final, @path]
     end
 
+    NONE = Object.new
+
+    def copy(path: NONE)
+      self.class.new(@snapshot_name, @final, path.equal?(NONE) ? @path : path)
+    end
+
     def to_s
       "snapshot #{@snapshot_name.inspect}, final: #{@final.inspect}, path: #{@path.inspect}"
     end

--- a/lib/nanoc/base/entities/rule_memory.rb
+++ b/lib/nanoc/base/entities/rule_memory.rb
@@ -3,9 +3,9 @@ module Nanoc::Int
     include Nanoc::Int::ContractsSupport
     include Enumerable
 
-    def initialize(item_rep)
+    def initialize(item_rep, actions: [])
       @item_rep = item_rep
-      @actions = []
+      @actions = actions
     end
 
     contract C::None => Numeric
@@ -56,13 +56,21 @@ module Nanoc::Int
 
     # TODO: Add contract
     def serialize
-      map(&:serialize)
+      to_a.map(&:serialize)
     end
 
     contract C::Func[Nanoc::Int::ProcessingAction => C::Any] => self
     def each
       @actions.each { |a| yield(a) }
       self
+    end
+
+    contract C::Func[Nanoc::Int::ProcessingAction => C::Any] => self
+    def map
+      self.class.new(
+        @item_rep,
+        actions: @actions.map { |a| yield(a) },
+      )
     end
 
     private

--- a/lib/nanoc/rule_dsl/recording_executor.rb
+++ b/lib/nanoc/rule_dsl/recording_executor.rb
@@ -3,20 +3,8 @@ module Nanoc
     class RecordingExecutor
       include Nanoc::Int::ContractsSupport
 
-      class PathWithoutInitialSlashError < ::Nanoc::Error
-        def initialize(rep, basic_path)
-          super("The path returned for the #{rep.inspect} item representation, “#{basic_path}”, does not start with a slash. Please ensure that all routing rules return a path that starts with a slash.")
-        end
-      end
-
-      attr_reader :rule_memory
-
-      def initialize(item_rep, rules_collection, site)
-        @item_rep = item_rep
-        @rules_collection = rules_collection
-        @site = site
-
-        @rule_memory = Nanoc::Int::RuleMemory.new(item_rep)
+      def initialize(rule_memory)
+        @rule_memory = rule_memory
       end
 
       def filter(filter_name, filter_args = {})
@@ -38,24 +26,8 @@ module Nanoc
       Pathlike = C::Maybe[C::Or[String, Nanoc::Identifier]]
       contract Symbol, C::KeywordArgs[path: C::Optional[Pathlike], final: C::Optional[C::Bool]] => nil
       def snapshot(snapshot_name, final: true, path: nil)
-        pathlike = final ? (path || basic_path_from_rules_for(@item_rep, snapshot_name)) : nil
-        actual_path = pathlike && pathlike.to_s
-        @rule_memory.add_snapshot(snapshot_name, final, actual_path)
+        @rule_memory.add_snapshot(snapshot_name, final, path && final ? path.to_s : nil)
         nil
-      end
-
-      def basic_path_from_rules_for(rep, snapshot_name)
-        routing_rules = @rules_collection.routing_rules_for(rep)
-        routing_rule = routing_rules[snapshot_name]
-        return nil if routing_rule.nil?
-
-        dependency_tracker = Nanoc::Int::DependencyTracker::Null.new
-        view_context = Nanoc::ViewContext.new(reps: nil, items: nil, dependency_tracker: dependency_tracker, compilation_context: nil)
-        basic_path = routing_rule.apply_to(rep, executor: nil, site: @site, view_context: view_context)
-        if basic_path && !basic_path.start_with?('/')
-          raise PathWithoutInitialSlashError.new(rep, basic_path)
-        end
-        basic_path
       end
     end
   end

--- a/spec/nanoc/base/entities/processing_actions/snapshot_spec.rb
+++ b/spec/nanoc/base/entities/processing_actions/snapshot_spec.rb
@@ -15,4 +15,20 @@ describe Nanoc::Int::ProcessingActions::Snapshot do
     subject { action.inspect }
     it { is_expected.to eql('<Nanoc::Int::ProcessingActions::Snapshot :before_layout, true, "/foo.md">') }
   end
+
+  describe '#copy' do
+    context 'without path' do
+      subject { action.copy }
+      its(:snapshot_name) { is_expected.to eql(:before_layout) }
+      its(:final) { is_expected.to be }
+      its(:path) { is_expected.to eql('/foo.md') }
+    end
+
+    context 'with path' do
+      subject { action.copy(path: '/donkey.md') }
+      its(:snapshot_name) { is_expected.to eql(:before_layout) }
+      its(:final) { is_expected.to be }
+      its(:path) { is_expected.to eql('/donkey.md') }
+    end
+  end
 end

--- a/spec/nanoc/base/entities/rule_memory_spec.rb
+++ b/spec/nanoc/base/entities/rule_memory_spec.rb
@@ -92,6 +92,34 @@ describe Nanoc::Int::RuleMemory do
     end
   end
 
+  describe '#each' do
+    before do
+      rule_memory.add_filter(:erb, { awesomeness: 'high' })
+      rule_memory.add_snapshot(:bar, true, '/foo.md')
+      rule_memory.add_layout('/default.erb', { somelayoutparam: 'yes' })
+    end
+
+    example do
+      actions = []
+      rule_memory.each { |a| actions << a }
+      expect(actions.size).to eq(3)
+    end
+  end
+
+  describe '#map' do
+    before do
+      rule_memory.add_filter(:erb, { awesomeness: 'high' })
+      rule_memory.add_snapshot(:bar, true, '/foo.md')
+      rule_memory.add_layout('/default.erb', { somelayoutparam: 'yes' })
+    end
+
+    example do
+      res = rule_memory.map { Nanoc::Int::ProcessingActions::Filter.new(:donkey, {}) }
+      expect(res.to_a.size).to eq(3)
+      expect(res.to_a).to all(be_a(Nanoc::Int::ProcessingActions::Filter))
+    end
+  end
+
   describe '#serialize' do
     subject { rule_memory.serialize }
 

--- a/spec/nanoc/rule_dsl/recording_executor_spec.rb
+++ b/spec/nanoc/rule_dsl/recording_executor_spec.rb
@@ -1,27 +1,26 @@
 describe Nanoc::RuleDSL::RecordingExecutor do
-  let(:executor) { described_class.new(rep, rules_collection, site) }
+  let(:executor) { described_class.new(rule_memory) }
 
+  let(:rule_memory) { Nanoc::Int::RuleMemory.new(rep) }
   let(:rep) { double(:rep) }
-  let(:rules_collection) { double(:rules_collection) }
-  let(:site) { double(:site) }
 
   describe '#filter' do
     it 'records filter call without arguments' do
       executor.filter(:erb)
 
-      expect(executor.rule_memory.size).to eql(1)
-      expect(executor.rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Filter)
-      expect(executor.rule_memory[0].filter_name).to eql(:erb)
-      expect(executor.rule_memory[0].params).to eql({})
+      expect(rule_memory.size).to eql(1)
+      expect(rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Filter)
+      expect(rule_memory[0].filter_name).to eql(:erb)
+      expect(rule_memory[0].params).to eql({})
     end
 
     it 'records filter call with arguments' do
       executor.filter(:erb, x: 123)
 
-      expect(executor.rule_memory.size).to eql(1)
-      expect(executor.rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Filter)
-      expect(executor.rule_memory[0].filter_name).to eql(:erb)
-      expect(executor.rule_memory[0].params).to eql({ x: 123 })
+      expect(rule_memory.size).to eql(1)
+      expect(rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Filter)
+      expect(rule_memory[0].filter_name).to eql(:erb)
+      expect(rule_memory[0].params).to eql({ x: 123 })
     end
   end
 
@@ -29,31 +28,31 @@ describe Nanoc::RuleDSL::RecordingExecutor do
     it 'records layout call without arguments' do
       executor.layout('/default.*')
 
-      expect(executor.rule_memory.size).to eql(2)
+      expect(rule_memory.size).to eql(2)
 
-      expect(executor.rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
-      expect(executor.rule_memory[0].snapshot_name).to eql(:pre)
-      expect(executor.rule_memory[0]).to be_final
-      expect(executor.rule_memory[0].path).to be_nil
+      expect(rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+      expect(rule_memory[0].snapshot_name).to eql(:pre)
+      expect(rule_memory[0]).to be_final
+      expect(rule_memory[0].path).to be_nil
 
-      expect(executor.rule_memory[1]).to be_a(Nanoc::Int::ProcessingActions::Layout)
-      expect(executor.rule_memory[1].layout_identifier).to eql('/default.*')
-      expect(executor.rule_memory[1].params).to eql({})
+      expect(rule_memory[1]).to be_a(Nanoc::Int::ProcessingActions::Layout)
+      expect(rule_memory[1].layout_identifier).to eql('/default.*')
+      expect(rule_memory[1].params).to eql({})
     end
 
     it 'records layout call with arguments' do
       executor.layout('/default.*', final: false)
 
-      expect(executor.rule_memory.size).to eql(2)
+      expect(rule_memory.size).to eql(2)
 
-      expect(executor.rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
-      expect(executor.rule_memory[0].snapshot_name).to eql(:pre)
-      expect(executor.rule_memory[0]).to be_final
-      expect(executor.rule_memory[0].path).to be_nil
+      expect(rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+      expect(rule_memory[0].snapshot_name).to eql(:pre)
+      expect(rule_memory[0]).to be_final
+      expect(rule_memory[0].path).to be_nil
 
-      expect(executor.rule_memory[1]).to be_a(Nanoc::Int::ProcessingActions::Layout)
-      expect(executor.rule_memory[1].layout_identifier).to eql('/default.*')
-      expect(executor.rule_memory[1].params).to eql({ final: false })
+      expect(rule_memory[1]).to be_a(Nanoc::Int::ProcessingActions::Layout)
+      expect(rule_memory[1].layout_identifier).to eql('/default.*')
+      expect(rule_memory[1].params).to eql({ final: false })
     end
 
     it 'fails when passed a symbol' do
@@ -62,10 +61,6 @@ describe Nanoc::RuleDSL::RecordingExecutor do
   end
 
   describe '#snapshot' do
-    let(:rules_collection) do
-      Nanoc::RuleDSL::RulesCollection.new
-    end
-
     context 'snapshot already exists' do
       before do
         executor.snapshot(:foo)
@@ -82,11 +77,11 @@ describe Nanoc::RuleDSL::RecordingExecutor do
 
       it 'records' do
         subject
-        expect(executor.rule_memory.size).to eql(1)
-        expect(executor.rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
-        expect(executor.rule_memory[0].snapshot_name).to eql(:foo)
-        expect(executor.rule_memory[0].path).to be_nil
-        expect(executor.rule_memory[0]).to be_final
+        expect(rule_memory.size).to eql(1)
+        expect(rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+        expect(rule_memory[0].snapshot_name).to eql(:foo)
+        expect(rule_memory[0].path).to be_nil
+        expect(rule_memory[0]).to be_final
       end
     end
 
@@ -101,11 +96,11 @@ describe Nanoc::RuleDSL::RecordingExecutor do
           context 'no explicit path given' do
             it 'records' do
               subject
-              expect(executor.rule_memory.size).to eql(1)
-              expect(executor.rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
-              expect(executor.rule_memory[0].snapshot_name).to eql(:foo)
-              expect(executor.rule_memory[0].path).to be_nil
-              expect(executor.rule_memory[0]).to be_final
+              expect(rule_memory.size).to eql(1)
+              expect(rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+              expect(rule_memory[0].snapshot_name).to eql(:foo)
+              expect(rule_memory[0].path).to be_nil
+              expect(rule_memory[0]).to be_final
             end
           end
 
@@ -114,11 +109,11 @@ describe Nanoc::RuleDSL::RecordingExecutor do
 
             it 'records' do
               subject
-              expect(executor.rule_memory.size).to eql(1)
-              expect(executor.rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
-              expect(executor.rule_memory[0].snapshot_name).to eql(:foo)
-              expect(executor.rule_memory[0].path).to eql('/routed-foo.html')
-              expect(executor.rule_memory[0]).to be_final
+              expect(rule_memory.size).to eql(1)
+              expect(rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+              expect(rule_memory[0].snapshot_name).to eql(:foo)
+              expect(rule_memory[0].path).to eql('/routed-foo.html')
+              expect(rule_memory[0]).to be_final
             end
           end
 
@@ -127,65 +122,11 @@ describe Nanoc::RuleDSL::RecordingExecutor do
 
             it 'records' do
               subject
-              expect(executor.rule_memory.size).to eql(1)
-              expect(executor.rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
-              expect(executor.rule_memory[0].snapshot_name).to eql(:foo)
-              expect(executor.rule_memory[0].path).to eql('/routed-foo.html')
-              expect(executor.rule_memory[0]).to be_final
-            end
-          end
-        end
-
-        context 'routing rule exists' do
-          let(:item) { Nanoc::Int::Item.new('', {}, '/foo.md') }
-          let(:route_proc) { proc { '/routed-foo.html' } }
-
-          before do
-            rules_collection.add_item_routing_rule(
-              Nanoc::RuleDSL::Rule.new(
-                Nanoc::Int::Pattern.from('/foo.*'),
-                :default,
-                route_proc,
-                snapshot_name: :foo,
-              ),
-            )
-
-            allow(rep).to receive(:item).and_return(item)
-            allow(rep).to receive(:name).and_return(:default)
-            allow(site).to receive(:items).and_return(double(:items))
-            allow(site).to receive(:layouts).and_return(double(:layouts))
-            allow(site).to receive(:config).and_return(double(:config))
-          end
-
-          context 'no explicit path given' do
-            context 'routing rule returns path not starting with a slash' do
-              let(:route_proc) { proc { 'routed-foo.html' } }
-
-              it 'errors' do
-                expect { subject }.to raise_error(Nanoc::RuleDSL::RecordingExecutor::PathWithoutInitialSlashError)
-              end
-            end
-
-            it 'records' do
-              subject
-              expect(executor.rule_memory.size).to eql(1)
-              expect(executor.rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
-              expect(executor.rule_memory[0].snapshot_name).to eql(:foo)
-              expect(executor.rule_memory[0].path).to eql('/routed-foo.html')
-              expect(executor.rule_memory[0]).to be_final
-            end
-          end
-
-          context 'explicit path given' do
-            let(:path) { '/routed-foo-from-path.html' }
-
-            it 'uses the explicit path' do
-              subject
-              expect(executor.rule_memory.size).to eql(1)
-              expect(executor.rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
-              expect(executor.rule_memory[0].snapshot_name).to eql(:foo)
-              expect(executor.rule_memory[0].path).to eql('/routed-foo-from-path.html')
-              expect(executor.rule_memory[0]).to be_final
+              expect(rule_memory.size).to eql(1)
+              expect(rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+              expect(rule_memory[0].snapshot_name).to eql(:foo)
+              expect(rule_memory[0].path).to eql('/routed-foo.html')
+              expect(rule_memory[0]).to be_final
             end
           end
         end
@@ -197,11 +138,11 @@ describe Nanoc::RuleDSL::RecordingExecutor do
         it 'records' do
           subject
 
-          expect(executor.rule_memory.size).to eql(1)
-          expect(executor.rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
-          expect(executor.rule_memory[0].snapshot_name).to eql(:foo)
-          expect(executor.rule_memory[0].path).to be_nil
-          expect(executor.rule_memory[0]).not_to be_final
+          expect(rule_memory.size).to eql(1)
+          expect(rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+          expect(rule_memory[0].snapshot_name).to eql(:foo)
+          expect(rule_memory[0].path).to be_nil
+          expect(rule_memory[0]).not_to be_final
         end
 
         context 'explicit path given' do
@@ -210,42 +151,11 @@ describe Nanoc::RuleDSL::RecordingExecutor do
           it 'records without path' do
             subject
 
-            expect(executor.rule_memory.size).to eql(1)
-            expect(executor.rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
-            expect(executor.rule_memory[0].snapshot_name).to eql(:foo)
-            expect(executor.rule_memory[0].path).to be_nil
-            expect(executor.rule_memory[0]).not_to be_final
-          end
-        end
-
-        context 'routing rule exists' do
-          let(:item) { Nanoc::Int::Item.new('', {}, '/foo.md') }
-
-          before do
-            rules_collection.add_item_routing_rule(
-              Nanoc::RuleDSL::Rule.new(
-                Nanoc::Int::Pattern.from('/foo.*'),
-                :default,
-                proc { '/routed-foo.html' },
-                snapshot_name: :foo,
-              ),
-            )
-
-            allow(rep).to receive(:item).and_return(item)
-            allow(rep).to receive(:name).and_return(:default)
-            allow(site).to receive(:items).and_return(double(:items))
-            allow(site).to receive(:layouts).and_return(double(:layouts))
-            allow(site).to receive(:config).and_return(double(:config))
-          end
-
-          it 'records without path' do
-            subject
-
-            expect(executor.rule_memory.size).to eql(1)
-            expect(executor.rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
-            expect(executor.rule_memory[0].snapshot_name).to eql(:foo)
-            expect(executor.rule_memory[0].path).to be_nil
-            expect(executor.rule_memory[0]).not_to be_final
+            expect(rule_memory.size).to eql(1)
+            expect(rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+            expect(rule_memory[0].snapshot_name).to eql(:foo)
+            expect(rule_memory[0].path).to be_nil
+            expect(rule_memory[0]).not_to be_final
           end
         end
       end
@@ -254,10 +164,10 @@ describe Nanoc::RuleDSL::RecordingExecutor do
     it 'records snapshot call with final argument' do
       executor.snapshot(:foo, final: false)
 
-      expect(executor.rule_memory.size).to eql(1)
-      expect(executor.rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
-      expect(executor.rule_memory[0].snapshot_name).to eql(:foo)
-      expect(executor.rule_memory[0]).not_to be_final
+      expect(rule_memory.size).to eql(1)
+      expect(rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+      expect(rule_memory[0].snapshot_name).to eql(:foo)
+      expect(rule_memory[0]).not_to be_final
     end
 
     it 'raises when given unknown arguments' do
@@ -269,13 +179,13 @@ describe Nanoc::RuleDSL::RecordingExecutor do
       executor.snapshot(:foo)
       executor.snapshot(:bar)
 
-      expect(executor.rule_memory.size).to eql(2)
-      expect(executor.rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
-      expect(executor.rule_memory[0].snapshot_name).to eql(:foo)
-      expect(executor.rule_memory[0]).to be_final
-      expect(executor.rule_memory[1]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
-      expect(executor.rule_memory[1].snapshot_name).to eql(:bar)
-      expect(executor.rule_memory[1]).to be_final
+      expect(rule_memory.size).to eql(2)
+      expect(rule_memory[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+      expect(rule_memory[0].snapshot_name).to eql(:foo)
+      expect(rule_memory[0]).to be_final
+      expect(rule_memory[1]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+      expect(rule_memory[1].snapshot_name).to eql(:bar)
+      expect(rule_memory[1]).to be_final
     end
   end
 end

--- a/spec/nanoc/rule_dsl/rule_memory_calculator_spec.rb
+++ b/spec/nanoc/rule_dsl/rule_memory_calculator_spec.rb
@@ -86,6 +86,134 @@ describe(Nanoc::RuleDSL::RuleMemoryCalculator) do
           expect(subject[7].path).to be_nil
         end
       end
+
+      context 'no routing rule exists' do
+        before do
+          # Add compilation rule
+          compilation_rule = Nanoc::RuleDSL::Rule.new(Nanoc::Int::Pattern.from('/list.*'), :csv, proc {})
+          rules_collection.add_item_compilation_rule(compilation_rule)
+        end
+
+        example do
+          subject
+
+          expect(subject[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+          expect(subject[0].snapshot_name).to eql(:raw)
+          expect(subject[0]).to be_final
+          expect(subject[0].path).to be_nil
+
+          expect(subject[1]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+          expect(subject[1].snapshot_name).to eql(:pre)
+          expect(subject[1]).not_to be_final
+          expect(subject[1].path).to be_nil
+
+          expect(subject[2]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+          expect(subject[2].snapshot_name).to eql(:last)
+          expect(subject[2]).to be_final
+          expect(subject[2].path).to be_nil
+
+          expect(subject.size).to eql(3)
+        end
+      end
+
+      context 'routing rule exists' do
+        before do
+          # Add compilation rule
+          compilation_rule = Nanoc::RuleDSL::Rule.new(Nanoc::Int::Pattern.from('/list.*'), :csv, proc {})
+          rules_collection.add_item_compilation_rule(compilation_rule)
+
+          # Add routing rule
+          routing_rule = Nanoc::RuleDSL::Rule.new(Nanoc::Int::Pattern.from('/list.*'), :csv, proc { '/foo.md' }, snapshot_name: :last)
+          rules_collection.add_item_routing_rule(routing_rule)
+        end
+
+        example do
+          subject
+
+          expect(subject[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+          expect(subject[0].snapshot_name).to eql(:raw)
+          expect(subject[0]).to be_final
+          expect(subject[0].path).to be_nil
+
+          expect(subject[1]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+          expect(subject[1].snapshot_name).to eql(:pre)
+          expect(subject[1]).not_to be_final
+          expect(subject[1].path).to be_nil
+
+          expect(subject[2]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+          expect(subject[2].snapshot_name).to eql(:last)
+          expect(subject[2]).to be_final
+          expect(subject[2].path).to eq('/foo.md')
+
+          expect(subject.size).to eql(3)
+        end
+      end
+
+      context 'routing rule exists for non-final snapshot' do
+        before do
+          # Add compilation rule
+          compilation_rule = Nanoc::RuleDSL::Rule.new(Nanoc::Int::Pattern.from('/list.*'), :csv, proc {})
+          rules_collection.add_item_compilation_rule(compilation_rule)
+
+          # Add routing rule
+          routing_rule = Nanoc::RuleDSL::Rule.new(Nanoc::Int::Pattern.from('/list.*'), :csv, proc { '/foo.md' }, snapshot_name: :pre)
+          rules_collection.add_item_routing_rule(routing_rule)
+        end
+
+        example do
+          subject
+
+          expect(subject[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+          expect(subject[0].snapshot_name).to eql(:raw)
+          expect(subject[0]).to be_final
+          expect(subject[0].path).to be_nil
+
+          expect(subject[1]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+          expect(subject[1].snapshot_name).to eql(:pre)
+          expect(subject[1]).not_to be_final
+          expect(subject[1].path).to be_nil
+
+          expect(subject[2]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+          expect(subject[2].snapshot_name).to eql(:last)
+          expect(subject[2]).to be_final
+          expect(subject[2].path).to be_nil
+
+          expect(subject.size).to eql(3)
+        end
+      end
+
+      context 'routing rule for other rep exists' do
+        before do
+          # Add compilation rule
+          compilation_rule = Nanoc::RuleDSL::Rule.new(Nanoc::Int::Pattern.from('/list.*'), :csv, proc {})
+          rules_collection.add_item_compilation_rule(compilation_rule)
+
+          # Add routing rule
+          routing_rule = Nanoc::RuleDSL::Rule.new(Nanoc::Int::Pattern.from('/list.*'), :abc, proc { '/foo.md' }, snapshot_name: :last)
+          rules_collection.add_item_routing_rule(routing_rule)
+        end
+
+        example do
+          subject
+
+          expect(subject[0]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+          expect(subject[0].snapshot_name).to eql(:raw)
+          expect(subject[0]).to be_final
+          expect(subject[0].path).to be_nil
+
+          expect(subject[1]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+          expect(subject[1].snapshot_name).to eql(:pre)
+          expect(subject[1]).not_to be_final
+          expect(subject[1].path).to be_nil
+
+          expect(subject[2]).to be_a(Nanoc::Int::ProcessingActions::Snapshot)
+          expect(subject[2].snapshot_name).to eql(:last)
+          expect(subject[2]).to be_final
+          expect(subject[2].path).to be_nil
+
+          expect(subject.size).to eql(3)
+        end
+      end
     end
 
     context 'with layout' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'nanoc/cli'
 require 'nanoc/spec'
 
 require 'timecop'
+require 'rspec/its'
 
 Nanoc::CLI.setup
 


### PR DESCRIPTION
This turns `RecordingExecutor` into a dumb service that does nothing more than record actions.

The logic what was in `RecordingExecutor` for dealing with paths defined in routing rules is now in `RuleMemoryCalculator`, where it’s a transformation using the new `RuleMemory#map`. This new `#map` function will make it easy to make changes to the rule memory in the future.