### PR TITLE
Add ParallelCollection

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,12 @@ Style/TrailingCommaInArguments:
 Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma
 
+# `rescue nil` is useful in specs where the exception is not important, but
+# the size effects are.
+Style/RescueModifier:
+  Exclude:
+    - 'spec/**/*.rb'
+
 Style/IndentArray:
   EnforcedStyle: consistent
 

--- a/lib/nanoc/checking/checks/external_links.rb
+++ b/lib/nanoc/checking/checks/external_links.rb
@@ -43,7 +43,8 @@ module ::Nanoc::Checking::Checks
     end
 
     def select_invalid(hrefs)
-      Parallel.map(hrefs, in_threads: 10) { |href| validate(href) }.compact
+      col = Nanoc::Extra::ParallelCollection.new(hrefs, parallelism: 10)
+      col.map { |href| validate(href) }.compact
     end
 
     def validate(href)

--- a/lib/nanoc/extra.rb
+++ b/lib/nanoc/extra.rb
@@ -18,3 +18,4 @@ module Nanoc::Extra
 end
 
 require 'nanoc/extra/core_ext'
+require 'nanoc/extra/parallel_collection'

--- a/lib/nanoc/extra/parallel_collection.rb
+++ b/lib/nanoc/extra/parallel_collection.rb
@@ -1,0 +1,57 @@
+require 'thread'
+
+module Nanoc::Extra
+  # @api private
+  class ParallelCollection
+    STOP = Object.new
+
+    include Nanoc::Int::ContractsSupport
+
+    contract C::RespondTo[:each], C::KeywordArgs[parallelism: Fixnum] => C::Any
+    def initialize(enum, parallelism: 2)
+      @enum = enum
+      @parallelism = parallelism
+    end
+
+    contract C::Func[C::Any => C::Any] => self
+    def each
+      queue = SizedQueue.new(2 * @parallelism)
+      error = nil
+
+      threads = (1..@parallelism).map do
+        Thread.new do
+          loop do
+            begin
+              elem = queue.pop
+              break if error
+              break if STOP.equal?(elem)
+              yield elem
+            rescue => err
+              error = err
+              break
+            end
+          end
+        end
+      end
+
+      @enum.each { |e| queue << e }
+      @parallelism.times { queue << STOP }
+
+      threads.each(&:join)
+
+      raise error if error
+      self
+    end
+
+    contract C::Func[C::Any => C::Any] => C::RespondTo[:each]
+    def map
+      [].tap do |all|
+        mutex = Mutex.new
+        each do |e|
+          res = yield(e)
+          mutex.synchronize { all << res }
+        end
+      end
+    end
+  end
+end

--- a/nanoc.gemspec
+++ b/nanoc.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('cri', '~> 2.3')
   s.add_runtime_dependency('hamster', '~> 3.0')
   s.add_runtime_dependency('ref', '~> 2.0')
-  s.add_runtime_dependency('parallel', '~> 1.9')
 
   s.add_development_dependency('bundler', '>= 1.7.10', '< 2.0')
   s.add_development_dependency('appraisal', '~> 2.1')

--- a/spec/nanoc/cli/commands/deploy_spec.rb
+++ b/spec/nanoc/cli/commands/deploy_spec.rb
@@ -11,9 +11,7 @@ describe Nanoc::CLI::Commands::Shell, site: true, stdio: true do
 
     shared_examples 'no effective deploy' do
       it 'does not write any files' do
-        # rubocop:disable Style/RescueModifier
         expect { run rescue nil }.not_to change { Dir['remote/*'] }
-        # rubocop:enable Style/RescueModifier
         expect(Dir['remote/*']).to be_empty
       end
     end

--- a/spec/nanoc/extra/parallel_collection_spec.rb
+++ b/spec/nanoc/extra/parallel_collection_spec.rb
@@ -1,0 +1,108 @@
+describe Nanoc::Extra::ParallelCollection do
+  subject(:col) { described_class.new(wrapped, parallelism: parallelism) }
+  let(:wrapped) { [1, 2, 3, 4, 5] }
+  let(:parallelism) { 5 }
+
+  describe '#each' do
+    subject do
+      col.each do |e|
+        sleep 0.1
+        out << e
+      end
+    end
+    let!(:out) { [] }
+
+    it 'is fast' do
+      expect { subject }.to finish_in_under(0.2).seconds
+    end
+
+    it 'is correct' do
+      expect { subject }.to change { out.sort }.from([]).to([1, 2, 3, 4, 5])
+    end
+
+    it 'does not leave threads lingering' do
+      expect { subject }.not_to change { Thread.list.size }
+    end
+
+    context 'errors' do
+      subject do
+        col.each do |e|
+          if e == 1
+            sleep 0.02
+            raise 'ugh'
+          else
+            sleep 0.1
+            out << e
+          end
+        end
+      end
+
+      let(:parallelism) { 3 }
+
+      it 'raises' do
+        expect { subject }.to raise_error(RuntimeError, 'ugh')
+      end
+
+      it 'aborts early' do
+        expect { subject rescue nil }.to change { out.sort }.from([]).to([2, 3])
+      end
+    end
+
+    context 'low parallelism' do
+      let(:parallelism) { 1 }
+
+      it 'is not fast' do
+        expect { subject }.not_to finish_in_under(0.5).seconds
+      end
+    end
+  end
+
+  describe '#map' do
+    subject do
+      col.map do |e|
+        sleep 0.1
+        e * 10
+      end
+    end
+
+    it 'is fast' do
+      expect { subject }.to finish_in_under(0.2).seconds
+    end
+
+    it 'does not leave threads lingering' do
+      expect { subject }.not_to change { Thread.list.size }
+    end
+
+    it 'is correct' do
+      expect(subject.sort).to eq([10, 20, 30, 40, 50])
+    end
+
+    context 'errors' do
+      subject do
+        col.each do |e|
+          if e == 1
+            sleep 0.02
+            raise 'ugh'
+          else
+            sleep 0.1
+            e * 10
+          end
+        end
+      end
+
+      let(:parallelism) { 3 }
+
+      it 'raises' do
+        expect { subject }.to raise_error(RuntimeError, 'ugh')
+      end
+    end
+
+    context 'low parallelism' do
+      let(:parallelism) { 1 }
+
+      it 'is not fast' do
+        expect { subject }.not_to finish_in_under(0.5).seconds
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -126,6 +126,29 @@ RSpec::Matchers.define :be_humanly_sorted do
   end
 end
 
+RSpec::Matchers.define :finish_in_under do |expected|
+  supports_block_expectations
+
+  match do |actual|
+    before = Time.now
+    actual.call
+    after = Time.now
+    @actual_duration = after - before
+    @actual_duration < expected
+  end
+
+  chain :seconds do
+  end
+
+  failure_message do |_actual|
+    "expected that proc would finish in under #{expected}s, but took #{format '%0.1fs', @actual_duration}"
+  end
+
+  failure_message_when_negated do |_actual|
+    "expected that proc would not finish in under #{expected}s, but took #{format '%0.1fs', @actual_duration}"
+  end
+end
+
 RSpec::Matchers.define :yield_from_fiber do |expected|
   supports_block_expectations
 


### PR DESCRIPTION
This replaces the `parallel` dependency with a `ParallelCollection` that looks like this:

```ruby
ints = [1, 2, 3, 4, 5]
col = Nanoc::Extra::ParallelCollection.new(ints, parallelism: 10)
p(col.map { |e| sleep rand; e * 10 })
```

This runs in ≤1s (roughly) and prints the array `[10, 20, 30, 40, 50]` *in any order*.