### PR TITLE
Include extra attributes in filesystem checksum

### DIFF
--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -163,12 +163,19 @@ module Nanoc::DataSources
             attributes,
             identifier,
             content_checksum_data: proto_doc.content_checksum_data,
-            attributes_checksum_data: proto_doc.attributes_checksum_data,
+            attributes_checksum_data: attributes_checksum_data_for(proto_doc, content_filename, meta_filename),
           )
         end
       end
 
       res
+    end
+
+    def attributes_checksum_data_for(proto_doc, content_filename, meta_filename)
+      YAML.dump(
+        attributes: proto_doc.attributes_checksum_data,
+        extra_attributes: extra_attributes_for(content_filename, meta_filename),
+      )
     end
 
     def extra_attributes_for(content_filename, meta_filename)

--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -171,16 +171,18 @@ module Nanoc::DataSources
       res
     end
 
-    def attributes_for(proto_doc, content_filename, meta_filename)
-      extra_attributes = {
+    def extra_attributes_for(content_filename, meta_filename)
+      {
         filename: content_filename,
         content_filename: content_filename,
         meta_filename: meta_filename,
         extension: content_filename ? ext_of(content_filename)[1..-1] : nil,
         mtime: mtime_of(content_filename, meta_filename),
       }
+    end
 
-      extra_attributes.merge(proto_doc.attributes)
+    def attributes_for(proto_doc, content_filename, meta_filename)
+      extra_attributes_for(content_filename, meta_filename).merge(proto_doc.attributes)
     end
 
     def identifier_for(content_filename, meta_filename, dir_name)

--- a/spec/nanoc/data_sources/filesystem_spec.rb
+++ b/spec/nanoc/data_sources/filesystem_spec.rb
@@ -48,7 +48,19 @@ describe Nanoc::DataSources::Filesystem do
           expect(subject[0].identifier).to eq(Nanoc::Identifier.new('/bar/'))
           expect(subject[0].checksum_data).to be_nil
           expect(subject[0].content_checksum_data).to eq('test 1')
-          expect(subject[0].attributes_checksum_data).to eq("num: 1\n")
+        end
+
+        it 'has the right attributes checksum data' do
+          cs = YAML.load(subject[0].attributes_checksum_data)
+
+          expect(cs[:attributes]).to eq("num: 1\n")
+          expect(cs[:extra_attributes]).to eq(
+            filename: 'foo/bar.html',
+            content_filename: 'foo/bar.html',
+            meta_filename: nil,
+            extension: 'html',
+            mtime: now,
+          )
         end
       end
     end

--- a/spec/nanoc/integration/outdatedness_integration_spec.rb
+++ b/spec/nanoc/integration/outdatedness_integration_spec.rb
@@ -1,8 +1,13 @@
 describe 'Outdatedness integration', site: true, stdio: true do
   context 'only attribute dependency' do
+    let(:time) { Time.now }
+
     before do
       File.write('content/foo.md', "---\ntitle: hello\n---\n\nfoo")
       File.write('content/bar.md', '<%= @items["/foo.*"][:title] %>')
+
+      FileUtils.touch('content/foo.md', mtime: time)
+      FileUtils.touch('content/bar.md', mtime: time)
 
       File.write('Rules', <<EOS)
 compile '/foo.*' do
@@ -29,6 +34,7 @@ EOS
 
     it 'shows file as outdated after modification' do
       File.write('content/bar.md', 'JUST BAR!')
+      FileUtils.touch('content/bar.md', mtime: time)
 
       expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
         output(/^item \/foo\.md, rep default:\n  is not outdated/).to_stdout,
@@ -40,6 +46,7 @@ EOS
 
     it 'shows file and dependencies as not outdated after content modification' do
       File.write('content/foo.md', "---\ntitle: hello\n---\n\nfoooOoooOOoooOooo")
+      FileUtils.touch('content/foo.md', mtime: time)
 
       expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
         output(/^item \/foo\.md, rep default:\n  is outdated: /).to_stdout,
@@ -51,6 +58,7 @@ EOS
 
     it 'shows file and dependencies as outdated after title modification' do
       File.write('content/foo.md', "---\ntitle: bye\n---\n\nfoo")
+      FileUtils.touch('content/foo.md', mtime: time)
 
       expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
         output(/^item \/foo\.md, rep default:\n  is outdated: /).to_stdout,

--- a/spec/nanoc/regressions/gh_1045_spec.rb
+++ b/spec/nanoc/regressions/gh_1045_spec.rb
@@ -1,0 +1,48 @@
+describe 'GH-1045', site: true, stdio: true do
+  before do
+    File.write('content/foo.txt', 'foo')
+    FileUtils.touch('content/foo.txt', mtime: Time.parse('2015-03-02 10:00:00Z'))
+
+    File.write('content/sitemap.erb', '<%= xml_sitemap(items: items.select { |i| i.path.end_with?(\'/\') }) %>')
+
+    File.write('nanoc.yaml', <<EOS)
+base_url: 'http://example.com'
+EOS
+
+    File.write('lib/default.rb', <<EOS)
+include Nanoc::Helpers::XMLSitemap
+EOS
+
+    File.write('Rules', <<EOS)
+compile '/*.txt' do
+  write item.identifier.without_ext + '/index.html'
+end
+
+compile '/sitemap.erb' do
+  filter :erb
+  write item.identifier.without_ext + '.xml'
+end
+EOS
+  end
+
+  it 'creates the sitemap' do
+    Nanoc::CLI.run(%w(compile))
+
+    expect(File.file?('output/sitemap.xml')).to be
+    contents = File.read('output/sitemap.xml')
+    expect(contents).to match(%r{<loc>http://example.com/foo/</loc>})
+    expect(contents).to match(%r{<lastmod>2015-03-02</lastmod>})
+  end
+
+  it 'updates the sitemap' do
+    Nanoc::CLI.run(%w(compile))
+    File.write('content/foo.txt', 'foo 2')
+    FileUtils.touch('content/foo.txt', mtime: Time.parse('2016-04-03 10:00:00Z'))
+    Nanoc::CLI.run(%w(compile))
+
+    expect(File.file?('output/sitemap.xml')).to be
+    contents = File.read('output/sitemap.xml')
+    expect(contents).to match(%r{<loc>http://example.com/foo/</loc>})
+    expect(contents).to match(%r{<lastmod>2016-04-03</lastmod>})
+  end
+end


### PR DESCRIPTION
Fixes #1045.

The checksum data provided by the filesystem data source did not include extra attributes (most specifically `mtime`).