### PR TITLE
remove require 'parallel' in external links checks

### DIFF
--- a/lib/nanoc/checking/checks/external_links.rb
+++ b/lib/nanoc/checking/checks/external_links.rb
@@ -12,8 +12,6 @@ module ::Nanoc::Checking::Checks
     identifiers :external_links, :elinks
 
     def run
-      require 'parallel'
-
       # Find all broken external hrefs
       # TODO: de-duplicate this (duplicated in internal links check)
       filenames = output_filenames.select { |f| File.extname(f) == '.html' && !excluded_file?(f) }


### PR DESCRIPTION
remove require 'parallel' in external links checks

### Detailed description

This change proposes to remove the require statement on parallel as it seems it is not used here anymore, and is dropped from the Gemfile.
