### PR TITLE
On-disk compiled content cache

### DIFF
--- a/lib/nanoc/base/repos.rb
+++ b/lib/nanoc/base/repos.rb
@@ -1,4 +1,5 @@
 require_relative 'repos/store'
+require_relative 'repos/dddb'
 
 require_relative 'repos/checksum_store'
 require_relative 'repos/compiled_content_cache'

--- a/lib/nanoc/base/repos/compiled_content_cache.rb
+++ b/lib/nanoc/base/repos/compiled_content_cache.rb
@@ -3,54 +3,49 @@ module Nanoc::Int
   # to prevent it from being needlessly recompiled.
   #
   # @api private
-  class CompiledContentCache < ::Nanoc::Int::Store
+  class CompiledContentCache
     include Nanoc::Int::ContractsSupport
 
     contract C::KeywordArgs[site: C::Maybe[Nanoc::Int::Site], items: C::IterOf[Nanoc::Int::Item]] => C::Any
     def initialize(site: nil, items:)
-      super(Nanoc::Int::Store.tmp_path_for(site: site, store_name: 'compiled_content'), 2)
-
       @items = items
-      @cache = {}
+
+      filename = Nanoc::Int::Store.tmp_path_for(site: site, store_name: 'cococa')
+      FileUtils.mkdir_p(File.dirname(filename))
+      @db = Nanoc::Int::DDDB.new(filename)
+      @db.open
+    end
+
+    def load
+      item_identifier_strings = Set.new(@items.map { |i| i.identifier.to_s })
+
+      @db.keys.each do |key|
+        identifier_string, _name = *Marshal.load(key)
+        unless item_identifier_strings.include?(identifier_string)
+          @db.delete(key)
+        end
+      end
+
+      @db.compact
+    end
+
+    def store
+      # TODO: compact
+      @db.flush
     end
 
     contract Nanoc::Int::ItemRep => C::Maybe[C::HashOf[Symbol => Nanoc::Int::Content]]
-    # Returns the cached compiled content for the given item representation.
-    #
-    # This cached compiled content is a hash where the keys are the snapshot
-    # names. and the values the compiled content at the given snapshot.
     def [](rep)
-      item_cache = @cache[rep.item.identifier] || {}
-      item_cache[rep.name]
+      key = Marshal.dump([rep.item.identifier.to_s, rep.name])
+      raw_data = @db[key]
+      raw_data && Marshal.load(raw_data)
     end
 
     contract Nanoc::Int::ItemRep, C::HashOf[Symbol => Nanoc::Int::Content] => self
-    # Sets the compiled content for the given representation.
-    #
-    # This cached compiled content is a hash where the keys are the snapshot
-    # names. and the values the compiled content at the given snapshot.
     def []=(rep, content)
-      @cache[rep.item.identifier] ||= {}
-      @cache[rep.item.identifier][rep.name] = content
+      key = Marshal.dump([rep.item.identifier.to_s, rep.name])
+      @db[key] = Marshal.dump(content)
       self
-    end
-
-    protected
-
-    def data
-      @cache
-    end
-
-    def data=(new_data)
-      @cache = {}
-
-      item_identifiers = Set.new(@items.map(&:identifier))
-
-      new_data.each_pair do |item_identifier, content_per_rep|
-        if item_identifiers.include?(item_identifier)
-          @cache[item_identifier] ||= content_per_rep
-        end
-      end
     end
   end
 end

--- a/lib/nanoc/base/repos/compiled_content_cache.rb
+++ b/lib/nanoc/base/repos/compiled_content_cache.rb
@@ -10,7 +10,11 @@ module Nanoc::Int
     def initialize(site: nil, items:)
       @items = items
 
-      filename = Nanoc::Int::Store.tmp_path_for(site: site, store_name: 'cococa')
+      filename = Nanoc::Int::Store.tmp_path_for(site: site, store_name: 'compiled_content')
+      if File.file?(filename)
+        # old
+        FileUtils.rm_f(filename)
+      end
       FileUtils.mkdir_p(File.dirname(filename))
       @db = Nanoc::Int::DDDB.new(filename)
       @db.open

--- a/lib/nanoc/base/repos/dddb.rb
+++ b/lib/nanoc/base/repos/dddb.rb
@@ -1,0 +1,177 @@
+require 'set'
+require 'fileutils'
+
+module Nanoc::Int
+  module DDDB
+    def self.new(filename)
+      DB.new(filename)
+    end
+
+    class DataFile
+      def initialize(filename)
+        @filename = filename
+      end
+
+      def open
+        @io = File.open(@filename, File::RDWR | File::CREAT | File::BINARY, 0o644)
+        @size = File.size(@filename)
+      end
+
+      def reopen
+        close if @io
+        open
+      end
+
+      def flush
+        @io.flush if @io
+      end
+
+      def close
+        @io.close
+        @io = nil
+      end
+
+      def compact(index)
+        flush
+
+        offsets = index.invert
+
+        new_index = {}
+        File.open(tmp_filename, File::RDWR | File::CREAT | File::BINARY, 0o644) do |new_io|
+          @io.seek(0)
+          loop do
+            break if @io.eof?
+
+            offset_old = @io.pos
+            offset_new = new_io.pos
+
+            entry_size = read_int
+
+            if offsets.key?(offset_old)
+              # write to new db
+              write_int(entry_size, new_io)
+              IO.copy_stream(@io, new_io, entry_size)
+
+              # update idx
+              new_index[offsets[offset_old]] = offset_new
+            else
+              # skip
+              @io.seek(entry_size, IO::SEEK_CUR)
+            end
+          end
+        end
+
+        close
+        FileUtils.mv(tmp_filename, @filename)
+        reopen
+
+        new_index
+      end
+
+      def add(data)
+        offset = @size
+
+        @io.seek(@size)
+        write_int(data.size)
+        @io.write(data)
+
+        @size += 4 + data.size
+
+        offset
+      end
+
+      def read_data(offset)
+        @io.seek(offset)
+        size = read_int
+        @io.read(size)
+      end
+
+      private
+
+      def read_int
+        @io.read(4).unpack('N').first
+      end
+
+      def write_int(int, io = @io)
+        if int >= 2**32
+          raise ArgumentError, 'cannot write ints ≥ 2^32'
+        end
+
+        io.write([int].pack('N'))
+      end
+
+      def tmp_filename
+        @filename + '.tmp'
+      end
+    end
+
+    class DB
+      def initialize(filename)
+        @filename = filename
+
+        @data_file = DataFile.new(db_filename)
+
+        @index = {}
+      end
+
+      def open
+        @index =
+          if File.file?(index_filename)
+            Marshal.load(File.read(index_filename))
+          else
+            {}
+          end
+
+        @data_file.open
+      end
+
+      def close
+        flush
+        @data_file.close
+      end
+
+      def flush
+        @data_file.flush
+        File.write(index_filename, Marshal.dump(@index))
+      end
+
+      def compact
+        @index = @data_file.compact(@index)
+      end
+
+      def delete(key)
+        @index.delete(key)
+      end
+
+      def key?(key)
+        @index.key?(key)
+      end
+
+      def keys
+        @index.keys
+      end
+
+      def [](key)
+        offset = @index[key]
+        if offset
+          @data_file.read_data(offset)
+        end
+      end
+
+      def []=(key, value)
+        offset = @data_file.add(value)
+        @index[key] = offset
+      end
+
+      private
+
+      def db_filename
+        @filename + '.db'
+      end
+
+      def index_filename
+        @filename + '.idx'
+      end
+    end
+  end
+end

--- a/spec/nanoc/base/repos/dddb_spec.rb
+++ b/spec/nanoc/base/repos/dddb_spec.rb
@@ -1,0 +1,118 @@
+require 'tmpdir'
+
+describe Nanoc::Int::DDDB do
+  it 'has no data by default' do
+    db = described_class.new('donkey')
+    db.open
+
+    expect(db['a']).to be_nil
+    expect(db['b']).to be_nil
+  end
+
+  it 'can insert data' do
+    db = described_class.new('donkey')
+    db.open
+    db['a'] = 'value for a'
+
+    expect(db['a']).to eq('value for a')
+    expect(db['b']).to be_nil
+  end
+
+  it 'persists data' do
+    db = described_class.new('donkey')
+    db.open
+    db['a'] = 'value for a'
+    db.close
+
+    db = described_class.new('donkey')
+    db.open
+
+    expect(db['a']).to eq('value for a')
+    expect(db['b']).to be_nil
+  end
+
+  describe '#key? and #eys' do
+    context 'key exists' do
+      it 'is true' do
+        db = described_class.new('donkey')
+        db.open
+        db['a'] = 'value for a'
+        expect(db.key?('a')).to be
+        expect(db.keys).to eq(['a'])
+      end
+    end
+
+    context 'key does not exist' do
+      it 'is false' do
+        db = described_class.new('donkey')
+        db.open
+        expect(db.key?('a')).not_to be
+        expect(db.keys).to be_empty
+      end
+    end
+  end
+
+  describe '#delete' do
+    context 'key exists' do
+      example do
+        db = described_class.new('donkey')
+        db.open
+        db['a'] = 'value for a'
+        expect(db.key?('a')).to be
+        db.delete('a')
+        expect(db.key?('a')).not_to be
+      end
+    end
+
+    context 'key does not exist' do
+      example do
+        db = described_class.new('donkey')
+        db.open
+        expect(db.key?('a')).not_to be
+        db.delete('a')
+        expect(db.key?('a')).not_to be
+      end
+    end
+  end
+
+  describe '#compact' do
+    it 'does not change existing values' do
+      db = described_class.new('donkey')
+      db.open
+
+      db['a'] = 'value for a'
+      db['b'] = 'value for b'
+
+      expect(db['a']).to eq('value for a')
+      expect(db['b']).to eq('value for b')
+
+      db.delete('a')
+
+      expect(db['a']).to be_nil
+      expect(db['b']).to eq('value for b')
+
+      expect { db.compact }
+        .to change { File.read('donkey.db') }
+        .from("\u0000\u0000\u0000\vvalue for a\u0000\u0000\u0000\vvalue for b")
+        .to("\u0000\u0000\u0000\vvalue for b")
+
+      expect(db['a']).to be_nil
+      expect(db['b']).to eq('value for b')
+    end
+
+    it 'supports adding/fetching afterwards' do
+      db = described_class.new('donkey')
+      db.open
+      db['a'] = 'value for a'
+      db['b'] = 'value for b'
+      db.delete('a')
+
+      db.compact
+
+      db['c'] = 'value for c'
+      expect(db['a']).to be_nil
+      expect(db['b']).to eq('value for b')
+      expect(db['c']).to eq('value for c')
+    end
+  end
+end

--- a/spec/nanoc/base/repos/dddb_spec.rb
+++ b/spec/nanoc/base/repos/dddb_spec.rb
@@ -92,9 +92,9 @@ describe Nanoc::Int::DDDB do
       expect(db['b']).to eq('value for b')
 
       expect { db.compact }
-        .to change { File.read('donkey.db') }
-        .from("\u0000\u0000\u0000\vvalue for a\u0000\u0000\u0000\vvalue for b")
-        .to("\u0000\u0000\u0000\vvalue for b")
+        .to change { File.read('donkey.db', encoding: 'ASCII-8BIT') }
+        .from("\u0000\u0000\u0000\u0013" + Zlib::Deflate.deflate('value for a') + "\u0000\u0000\u0000\u0013" + Zlib::Deflate.deflate('value for b'))
+        .to("\u0000\u0000\u0000\u0013" + Zlib::Deflate.deflate('value for b'))
 
       expect(db['a']).to be_nil
       expect(db['b']).to eq('value for b')

--- a/spec/nanoc/base/services/compiler/phases/cache_spec.rb
+++ b/spec/nanoc/base/services/compiler/phases/cache_spec.rb
@@ -99,7 +99,7 @@ describe Nanoc::Int::Compiler::Phases::Cache do
         it 'does not change compiled content cache' do
           expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:cached_content_used, rep)
           expect { subject }
-            .not_to change { compiled_content_cache[rep] }
+            .not_to change { compiled_content_cache[rep][:last].string }
         end
       end
 


### PR DESCRIPTION
Do not load eagerly load compiled content cache data into memory.

### Detailed description

The compiled content cache uses a database called `Nanoc::Int::DDDB`, which is intended for situations where large amounts of data need to be kept out of memory in order to prevent swapping.

The database consists of a data file (with extension `.db`) and an index file (with extension `.idx`):

* The data file consists of a series of records. Each record has a header and a body. The body contains the data of the record, while the header contains the length of the body.

* The index file is a hash table mapping keys to offsets in the data file. It is a Ruby hash that is serialised using Ruby’s marshaling functionality.

The data file is append-only. New entries will be appended to the end, and deleted entries will not be removed from the data file. A database can be compacted, which will replace the data file with a new data file that only contains entries for keys that are also in the index.

Limitations:

* The database can have at most one reader and at most one writer. The database is not thread-safe.