### PR TITLE
Fix CannotLayoutBinaryItem error (missing # before {})

### DIFF
--- a/lib/nanoc/base/errors.rb
+++ b/lib/nanoc/base/errors.rb
@@ -125,7 +125,7 @@ module Nanoc::Int
       # @param [Nanoc::Int::ItemRep] rep The item representation that was attempted
       #   to be laid out
       def initialize(rep)
-        super("The “{rep.item.identifier}” item (rep “#{rep.name}”) cannot be laid out because it is a binary item. If you are getting this error for an item that should be textual instead of binary, make sure that its extension is included in the text_extensions array in the site configuration.")
+        super("The “#{rep.item.identifier}” item (rep “#{rep.name}”) cannot be laid out because it is a binary item. If you are getting this error for an item that should be textual instead of binary, make sure that its extension is included in the text_extensions array in the site configuration.")
       end
     end
 

--- a/spec/nanoc/base/services/executor_spec.rb
+++ b/spec/nanoc/base/services/executor_spec.rb
@@ -383,7 +383,10 @@ describe Nanoc::Int::Executor do
       let(:content) { Nanoc::Int::BinaryContent.new(File.expand_path('donkey.md')) }
 
       it 'raises' do
-        expect { subject }.to raise_error(Nanoc::Int::Errors::CannotLayoutBinaryItem)
+        expect { subject }.to raise_error(
+          Nanoc::Int::Errors::CannotLayoutBinaryItem,
+          'The “/index.md” item (rep “donkey”) cannot be laid out because it is a binary item. If you are getting this error for an item that should be textual instead of binary, make sure that its extension is included in the text_extensions array in the site configuration.',
+        )
       end
     end
 


### PR DESCRIPTION
The “cannot layout binary item” error would not properly print the item identifier.