### PR TITLE
Use Integer instead of Fixnum

### DIFF
--- a/lib/nanoc/base/views/item_rep_collection_view.rb
+++ b/lib/nanoc/base/views/item_rep_collection_view.rb
@@ -57,7 +57,7 @@ module Nanoc
       when Symbol
         res = @item_reps.find { |ir| ir.name == rep_name }
         res && view_class.new(res, @context)
-      when Fixnum
+      when Integer
         raise ArgumentError, "expected ItemRepCollectionView#[] to be called with a symbol (you likely want `.reps[:default]` rather than `.reps[#{rep_name}]`)"
       else
         raise ArgumentError, 'expected ItemRepCollectionView#[] to be called with a symbol'

--- a/lib/nanoc/extra/parallel_collection.rb
+++ b/lib/nanoc/extra/parallel_collection.rb
@@ -7,7 +7,7 @@ module Nanoc::Extra
 
     include Nanoc::Int::ContractsSupport
 
-    contract C::RespondTo[:each], C::KeywordArgs[parallelism: Fixnum] => C::Any
+    contract C::RespondTo[:each], C::KeywordArgs[parallelism: Integer] => C::Any
     def initialize(enum, parallelism: 2)
       @enum = enum
       @parallelism = parallelism


### PR DESCRIPTION
Fixes #1061.

Integer exists on Ruby 2.3 (and before) too, so `Fixnum` can be safely replace with `Integer`.