### PR TITLE
Allow setting content_for directly

### DIFF
--- a/lib/nanoc/helpers/capturing.rb
+++ b/lib/nanoc/helpers/capturing.rb
@@ -66,7 +66,7 @@ module Nanoc::Helpers
 
           unless rep.compiled?
             Fiber.yield(Nanoc::Int::Errors::UnmetDependency.new(rep))
-            return content_for(*args, &block)
+            return run
           end
         end
 

--- a/lib/nanoc/helpers/capturing.rb
+++ b/lib/nanoc/helpers/capturing.rb
@@ -128,7 +128,7 @@ module Nanoc::Helpers
               "of the capture, optionally params, and the content) but got #{args.size} instead"
           end
 
-        _erbout = ''
+        _erbout = '' # rubocop:disable Lint/UnderscorePrefixedVariableName
         SetContent.new(name, params, @item).run { _erbout << content }
       else # Get content
         if args.size != 2

--- a/lib/nanoc/helpers/capturing.rb
+++ b/lib/nanoc/helpers/capturing.rb
@@ -114,7 +114,7 @@ module Nanoc::Helpers
           end
 
         SetContent.new(name, params, @item).run(&block)
-      elsif args.size > 1 && args.first.is_a?(Symbol) # Set content
+      elsif args.size > 1 && (args.first.is_a?(Symbol) || args.first.is_a?(String)) # Set content
         name = args[0]
         content = args.last
         params =

--- a/lib/nanoc/helpers/capturing.rb
+++ b/lib/nanoc/helpers/capturing.rb
@@ -76,8 +76,23 @@ module Nanoc::Helpers
       end
     end
 
-    # @overload content_for(name, params = {}, &block)
+    # @overload content_for(name, &block)
     #   @param [Symbol, String] name
+    #   @return [void]
+    #
+    # @overload content_for(name, params, &block)
+    #   @param [Symbol, String] name
+    #   @option params [Symbol] existing
+    #   @return [void]
+    #
+    # @overload content_for(name, content)
+    #   @param [Symbol, String] name
+    #   @param [String] content
+    #   @return [void]
+    #
+    # @overload content_for(name, params, content)
+    #   @param [Symbol, String] name
+    #   @param [String] content
     #   @option params [Symbol] existing
     #   @return [void]
     #
@@ -99,6 +114,22 @@ module Nanoc::Helpers
           end
 
         SetContent.new(name, params, @item).run(&block)
+      elsif args.size > 1 && args.first.is_a?(Symbol) # Set content
+        name = args[0]
+        content = args.last
+        params =
+          case args.size
+          when 2
+            {}
+          when 3
+            args[1]
+          else
+            raise ArgumentError, 'expected 2 or 3 arguments (the name ' \
+              "of the capture, optionally params, and the content) but got #{args.size} instead"
+          end
+
+        _erbout = ''
+        SetContent.new(name, params, @item).run { _erbout << content }
       else # Get content
         if args.size != 2
           raise ArgumentError, 'expected 2 arguments (the item ' \

--- a/spec/nanoc/helpers/capturing_spec.rb
+++ b/spec/nanoc/helpers/capturing_spec.rb
@@ -10,9 +10,7 @@ describe Nanoc::Helpers::Capturing, helper: true do
 
       let(:params) { raise 'overwrite me' }
 
-      let(:contents) { %w( foo bar ) }
-
-      let(:contents_enumerator) { contents.to_enum }
+      let(:contents_enumerator) { %w(foo bar).to_enum }
 
       shared_examples 'setting content' do
         context 'only name given' do


### PR DESCRIPTION
Implements #1066.

In addition to what is currently possible,

```ruby
content_for(:head) { _erbout << 'stuff' }
```

it is now possible to pass a string, rather than a block that changes `_erbout`, to `#content_for`:

```ruby
content_for(:head, 'stuff')
```

Note that

```ruby
content_for(:head) { 'stuff' }
```

will (still) not have any effect.

* [x] Add tests
* [x] Allow passing string as first arg
* [x] Refactor

Documentation will be updated afterwards.