### PR TITLE
Store compact checksums

### DIFF
--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -164,7 +164,7 @@ module Nanoc::DataSources
             content,
             attributes,
             identifier,
-            content_checksum_data: proto_doc.content_checksum_data,
+            content_checksum_data: content_checksum_data_for(proto_doc),
             attributes_checksum_data: attributes_checksum_data_for(proto_doc, content_filename, meta_filename),
           )
         end
@@ -173,10 +173,18 @@ module Nanoc::DataSources
       res
     end
 
+    def content_checksum_data_for(proto_doc)
+      Digest::SHA1.digest(
+        proto_doc.content_checksum_data || '',
+      )
+    end
+
     def attributes_checksum_data_for(proto_doc, content_filename, meta_filename)
-      YAML.dump(
-        attributes: proto_doc.attributes_checksum_data,
-        extra_attributes: extra_attributes_for(content_filename, meta_filename),
+      Digest::SHA1.digest(
+        YAML.dump(
+          attributes: proto_doc.attributes_checksum_data,
+          extra_attributes: extra_attributes_for(content_filename, meta_filename),
+        ),
       )
     end
 

--- a/spec/nanoc/data_sources/filesystem_spec.rb
+++ b/spec/nanoc/data_sources/filesystem_spec.rb
@@ -47,20 +47,32 @@ describe Nanoc::DataSources::Filesystem do
           expect(subject[0].attributes).to eq(expected_attributes)
           expect(subject[0].identifier).to eq(Nanoc::Identifier.new('/bar/'))
           expect(subject[0].checksum_data).to be_nil
-          expect(subject[0].content_checksum_data).to eq('test 1')
+          expect(subject[0].attributes_checksum_data).to be_a(String)
+          expect(subject[0].attributes_checksum_data.size).to eq(20)
+          expect(subject[0].content_checksum_data).to be_a(String)
+          expect(subject[0].content_checksum_data.size).to eq(20)
         end
 
-        it 'has the right attributes checksum data' do
-          cs = YAML.load(subject[0].attributes_checksum_data)
+        context 'split files' do
+          let(:block) do
+            lambda do
+              FileUtils.mkdir_p('foo')
 
-          expect(cs[:attributes]).to eq("num: 1\n")
-          expect(cs[:extra_attributes]).to eq(
-            filename: 'foo/bar.html',
-            content_filename: 'foo/bar.html',
-            meta_filename: nil,
-            extension: 'html',
-            mtime: now,
-          )
+              File.write('foo/bar.html', 'test 1')
+              FileUtils.touch('foo/bar.html', mtime: now)
+
+              File.write('foo/bar.yaml', "---\nnum: 1\n")
+              FileUtils.touch('foo/bar.yaml', mtime: now)
+            end
+          end
+
+          it 'has a different attributes checksum' do
+            expect(block).to change { data_source.send(:load_objects, 'foo', klass)[0].attributes_checksum_data }
+          end
+
+          it 'has the same content checksum' do
+            expect(block).not_to change { data_source.send(:load_objects, 'foo', klass)[0].content_checksum_data }
+          end
         end
       end
     end


### PR DESCRIPTION
The filesystem data source stores the entire content and dumped attributes as the checksum. This PR turns the checksum into SHA1 hashes, which speeds up checksum comparisons and reduces memory usage.