### PR TITLE
Prioritise recompiling dependent reps

### DIFF
--- a/lib/nanoc/base/services/item_rep_selector.rb
+++ b/lib/nanoc/base/services/item_rep_selector.rb
@@ -10,6 +10,7 @@ module Nanoc::Int
     def each
       graph = Nanoc::Int::DirectedGraph.new(@reps)
 
+      prioritised = Set.new
       loop do
         break if graph.roots.empty?
         rep = graph.roots.each { |e| break e }
@@ -18,7 +19,7 @@ module Nanoc::Int
           yield(rep)
           graph.delete_vertex(rep)
         rescue => e
-          handle_error(e, rep, graph)
+          handle_error(e, rep, graph, prioritised)
         end
       end
 
@@ -28,7 +29,7 @@ module Nanoc::Int
       end
     end
 
-    def handle_error(e, rep, graph)
+    def handle_error(e, rep, graph, prioritised)
       actual_error =
         if e.is_a?(Nanoc::Int::Errors::CompilationError)
           e.unwrap
@@ -37,14 +38,15 @@ module Nanoc::Int
         end
 
       if actual_error.is_a?(Nanoc::Int::Errors::UnmetDependency)
-        handle_dependency_error(actual_error, rep, graph)
+        handle_dependency_error(actual_error, rep, graph, prioritised)
       else
         raise(e)
       end
     end
 
-    def handle_dependency_error(e, rep, graph)
+    def handle_dependency_error(e, rep, graph, prioritised)
       other_rep = e.rep
+      prioritised << other_rep
       graph.add_edge(other_rep, rep)
       unless graph.vertices.include?(other_rep)
         graph.add_vertex(other_rep)

--- a/lib/nanoc/base/services/item_rep_selector.rb
+++ b/lib/nanoc/base/services/item_rep_selector.rb
@@ -7,13 +7,15 @@ module Nanoc::Int
       @reps = reps
     end
 
+    NONE = Object.new
+
     def each
       graph = Nanoc::Int::DirectedGraph.new(@reps)
 
       prioritised = Set.new
       loop do
-        break if graph.roots.empty?
-        rep = graph.roots.each { |e| break e }
+        rep = next(graph, prioritised)
+        break if NONE.equal?(rep)
 
         begin
           yield(rep)
@@ -26,6 +28,14 @@ module Nanoc::Int
       # Check whether everything was compiled
       unless graph.vertices.empty?
         raise Nanoc::Int::Errors::RecursiveCompilation.new(graph.vertices)
+      end
+    end
+
+    def next(graph, _prioritised)
+      if graph.roots.empty?
+        NONE
+      else
+        graph.roots.each { |e| break e }
       end
     end
 

--- a/lib/nanoc/base/services/item_rep_selector.rb
+++ b/lib/nanoc/base/services/item_rep_selector.rb
@@ -14,7 +14,7 @@ module Nanoc::Int
 
       prioritised = Set.new
       loop do
-        rep = next(graph, prioritised)
+        rep = find(graph, prioritised)
         break if NONE.equal?(rep)
 
         begin
@@ -31,9 +31,20 @@ module Nanoc::Int
       end
     end
 
-    def next(graph, _prioritised)
+    def find(graph, prioritised)
       if graph.roots.empty?
         NONE
+      elsif prioritised.any?
+        until prioritised.empty?
+          rep = prioritised.each { |e| break e }
+          if graph.roots.include?(rep)
+            return rep
+          else
+            prioritised.delete(rep)
+          end
+        end
+
+        find(graph, prioritised)
       else
         graph.roots.each { |e| break e }
       end

--- a/spec/nanoc/base/services/item_rep_selector_spec.rb
+++ b/spec/nanoc/base/services/item_rep_selector_spec.rb
@@ -165,5 +165,20 @@ describe Nanoc::Int::ItemRepSelector do
         expect(tentatively_yielded).to eq [:a, :b, :a, :c, :a, :d, :a, :e, :a]
       end
     end
+
+    context 'unrelated roots' do
+      let(:dependencies) do
+        {
+          a: [:d],
+          b: [:e],
+          c: [],
+        }
+      end
+
+      it 'picks prioritised roots' do
+        expect(successfully_yielded).to eq [:d, :e, :c, :a, :b]
+        expect(tentatively_yielded).to eq [:a, :d, :b, :e, :c, :a, :b]
+      end
+    end
   end
 end


### PR DESCRIPTION
The item rep selector now prioritises recompiling item reps that are a hard dependency of another item rep.

This keeps the number of suspended item rep compilations down, and can lead to significant reductions in memory usage (memory usage went down by 40% on nanoc.ws, from ±100 MB peak to ±60 MB peak).