### PR TITLE
Prioritise in-progress reps

### DIFF
--- a/lib/nanoc/base/services/item_rep_selector.rb
+++ b/lib/nanoc/base/services/item_rep_selector.rb
@@ -12,16 +12,17 @@ module Nanoc::Int
     def each
       graph = Nanoc::Int::DirectedGraph.new(@reps)
 
-      prioritised_dependent = Set.new
+      prio_dependent = Set.new
+      prio_in_progress = Set.new
       loop do
-        rep = find(graph, prioritised_dependent)
+        rep = find(graph, prio_dependent, prio_in_progress)
         break if NONE.equal?(rep)
 
         begin
           yield(rep)
           graph.delete_vertex(rep)
         rescue => e
-          handle_error(e, rep, graph, prioritised_dependent)
+          handle_error(e, rep, graph, prio_dependent, prio_in_progress)
         end
       end
 
@@ -31,26 +32,26 @@ module Nanoc::Int
       end
     end
 
-    def find(graph, prioritised_dependent)
+    def find(graph, prio_dependent, prio_in_progress)
       if graph.roots.empty?
         NONE
-      elsif prioritised_dependent.any?
-        until prioritised_dependent.empty?
-          rep = prioritised_dependent.each { |e| break e }
+      elsif prio_dependent.any?
+        until prio_dependent.empty?
+          rep = prio_dependent.each { |e| break e }
           if graph.roots.include?(rep)
             return rep
           else
-            prioritised_dependent.delete(rep)
+            prio_dependent.delete(rep)
           end
         end
 
-        find(graph, prioritised_dependent)
+        find(graph, prio_dependent, prio_in_progress)
       else
         graph.roots.each { |e| break e }
       end
     end
 
-    def handle_error(e, rep, graph, prioritised_dependent)
+    def handle_error(e, rep, graph, prio_dependent, prio_in_progress)
       actual_error =
         if e.is_a?(Nanoc::Int::Errors::CompilationError)
           e.unwrap
@@ -59,15 +60,15 @@ module Nanoc::Int
         end
 
       if actual_error.is_a?(Nanoc::Int::Errors::UnmetDependency)
-        handle_dependency_error(actual_error, rep, graph, prioritised_dependent)
+        handle_dependency_error(actual_error, rep, graph, prio_dependent, prio_in_progress)
       else
         raise(e)
       end
     end
 
-    def handle_dependency_error(e, rep, graph, prioritised_dependent)
+    def handle_dependency_error(e, rep, graph, prio_dependent, _prio_in_progress)
       other_rep = e.rep
-      prioritised_dependent << other_rep
+      prio_dependent << other_rep
       graph.add_edge(other_rep, rep)
       unless graph.vertices.include?(other_rep)
         graph.add_vertex(other_rep)

--- a/lib/nanoc/base/services/item_rep_selector.rb
+++ b/lib/nanoc/base/services/item_rep_selector.rb
@@ -36,19 +36,23 @@ module Nanoc::Int
       if graph.roots.empty?
         NONE
       elsif prio_dependent.any?
-        until prio_dependent.empty?
-          rep = prio_dependent.each { |e| break e }
-          if graph.roots.include?(rep)
-            return rep
-          else
-            prio_dependent.delete(rep)
-          end
-        end
-
-        find(graph, prio_dependent, prio_in_progress)
+        find_prio(graph, prio_dependent, prio_dependent, prio_in_progress)
       else
         graph.roots.each { |e| break e }
       end
+    end
+
+    def find_prio(graph, prio, prio_dependent, prio_in_progress)
+      until prio.empty?
+        rep = prio.each { |e| break e }
+        if graph.roots.include?(rep)
+          return rep
+        else
+          prio.delete(rep)
+        end
+      end
+
+      find(graph, prio_dependent, prio_in_progress)
     end
 
     def handle_error(e, rep, graph, prio_dependent, prio_in_progress)

--- a/lib/nanoc/base/services/item_rep_selector.rb
+++ b/lib/nanoc/base/services/item_rep_selector.rb
@@ -19,10 +19,12 @@ module Nanoc::Int
         break if NONE.equal?(rep)
 
         begin
+          prio_in_progress << rep
           yield(rep)
+          prio_in_progress.delete(rep)
           graph.delete_vertex(rep)
         rescue => e
-          handle_error(e, rep, graph, prio_dependent, prio_in_progress)
+          handle_error(e, rep, graph, prio_dependent)
         end
       end
 
@@ -37,6 +39,8 @@ module Nanoc::Int
         NONE
       elsif prio_dependent.any?
         find_prio(graph, prio_dependent, prio_dependent, prio_in_progress)
+      elsif prio_in_progress.any?
+        find_prio(graph, prio_in_progress, prio_dependent, prio_in_progress)
       else
         graph.roots.each { |e| break e }
       end
@@ -55,7 +59,7 @@ module Nanoc::Int
       find(graph, prio_dependent, prio_in_progress)
     end
 
-    def handle_error(e, rep, graph, prio_dependent, prio_in_progress)
+    def handle_error(e, rep, graph, prio_dependent)
       actual_error =
         if e.is_a?(Nanoc::Int::Errors::CompilationError)
           e.unwrap
@@ -64,13 +68,13 @@ module Nanoc::Int
         end
 
       if actual_error.is_a?(Nanoc::Int::Errors::UnmetDependency)
-        handle_dependency_error(actual_error, rep, graph, prio_dependent, prio_in_progress)
+        handle_dependency_error(actual_error, rep, graph, prio_dependent)
       else
         raise(e)
       end
     end
 
-    def handle_dependency_error(e, rep, graph, prio_dependent, _prio_in_progress)
+    def handle_dependency_error(e, rep, graph, prio_dependent)
       other_rep = e.rep
       prio_dependent << other_rep
       graph.add_edge(other_rep, rep)

--- a/spec/nanoc/base/services/item_rep_selector_spec.rb
+++ b/spec/nanoc/base/services/item_rep_selector_spec.rb
@@ -147,7 +147,7 @@ describe Nanoc::Int::ItemRepSelector do
 
       example do
         expect(successfully_yielded).to eq [:b, :c, :d, :e, :a]
-        expect(tentatively_yielded).to eq [:a, :b, :c, :d, :e, :a]
+        expect(tentatively_yielded).to eq [:a, :b, :a, :c, :a, :d, :a, :e, :a]
       end
     end
 
@@ -176,8 +176,8 @@ describe Nanoc::Int::ItemRepSelector do
       end
 
       it 'picks prioritised roots' do
-        expect(successfully_yielded).to eq [:d, :e, :c, :a, :b]
-        expect(tentatively_yielded).to eq [:a, :d, :b, :e, :c, :a, :b]
+        expect(successfully_yielded).to eq [:d, :a, :e, :b, :c]
+        expect(tentatively_yielded).to eq [:a, :d, :a, :b, :e, :b, :c]
       end
     end
   end


### PR DESCRIPTION
This change gives (secondary) priority to in-progress reps, in order to reduce in-flight (suspended) compilations, and thus work towards finishing off work before starting new work.

This change reduces memory usage slightly.