### PR TITLE
Allow calling #write with ext: param

### DIFF
--- a/lib/nanoc/rule_dsl/rule_context.rb
+++ b/lib/nanoc/rule_dsl/rule_context.rb
@@ -73,11 +73,25 @@ module Nanoc::RuleDSL
     # @param [String] path
     #
     # @return [void]
-    def write(path)
+    def write(arg)
       @_write_snapshot_counter ||= 0
       snapshot_name = "_#{@_write_snapshot_counter}".to_sym
       @_write_snapshot_counter += 1
-      snapshot(snapshot_name, path: path)
+
+      case arg
+      when String, Nanoc::Identifier
+        snapshot(snapshot_name, path: arg)
+      when Hash
+        if arg.key?(:ext)
+          ext = arg[:ext].sub(/\A\./, '')
+          path = @item.identifier.without_exts + '.' + ext
+          snapshot(snapshot_name, path: path)
+        else
+          raise ArgumentError, 'Cannot call #write this way (need path or :ext)'
+        end
+      else
+        raise ArgumentError, 'Cannot call #write this way (need path or :ext)'
+      end
     end
   end
 end

--- a/spec/nanoc/rule_dsl/rule_context_spec.rb
+++ b/spec/nanoc/rule_dsl/rule_context_spec.rb
@@ -162,25 +162,75 @@ describe(Nanoc::RuleDSL::RuleContext) do
   end
 
   describe '#write' do
-    context 'calling once' do
-      subject { rule_context.write('/foo.html') }
+    context 'with path' do
+      context 'calling once' do
+        subject { rule_context.write('/foo.html') }
 
-      it 'makes a request to the executor' do
-        expect(executor).to receive(:snapshot).with(:_0, path: '/foo.html')
-        subject
+        it 'makes a request to the executor' do
+          expect(executor).to receive(:snapshot).with(:_0, path: '/foo.html')
+          subject
+        end
+      end
+
+      context 'calling twice' do
+        subject do
+          rule_context.write('/foo.html')
+          rule_context.write('/bar.html')
+        end
+
+        it 'makes two requests to the executor with unique snapshot names' do
+          expect(executor).to receive(:snapshot).with(:_0, path: '/foo.html')
+          expect(executor).to receive(:snapshot).with(:_1, path: '/bar.html')
+          subject
+        end
       end
     end
 
-    context 'calling twice' do
-      subject do
-        rule_context.write('/foo.html')
-        rule_context.write('/bar.html')
+    context 'with :ext, without period' do
+      context 'calling once' do
+        subject { rule_context.write(ext: 'html') }
+
+        it 'makes a request to the executor' do
+          expect(executor).to receive(:snapshot).with(:_0, path: '/foo.html')
+          subject
+        end
       end
 
-      it 'makes two requests to the executor with unique snapshot names' do
-        expect(executor).to receive(:snapshot).with(:_0, path: '/foo.html')
-        expect(executor).to receive(:snapshot).with(:_1, path: '/bar.html')
-        subject
+      context 'calling twice' do
+        subject do
+          rule_context.write(ext: 'html')
+          rule_context.write(ext: 'htm')
+        end
+
+        it 'makes a request to the executor' do
+          expect(executor).to receive(:snapshot).with(:_0, path: '/foo.html')
+          expect(executor).to receive(:snapshot).with(:_1, path: '/foo.htm')
+          subject
+        end
+      end
+    end
+
+    context 'with :ext, without period' do
+      context 'calling once' do
+        subject { rule_context.write(ext: '.html') }
+
+        it 'makes a request to the executor' do
+          expect(executor).to receive(:snapshot).with(:_0, path: '/foo.html')
+          subject
+        end
+      end
+
+      context 'calling twice' do
+        subject do
+          rule_context.write(ext: '.html')
+          rule_context.write(ext: '.htm')
+        end
+
+        it 'makes a request to the executor' do
+          expect(executor).to receive(:snapshot).with(:_0, path: '/foo.html')
+          expect(executor).to receive(:snapshot).with(:_1, path: '/foo.htm')
+          subject
+        end
       end
     end
   end


### PR DESCRIPTION
This adds

```ruby
write ext: 'html'
```

as an alternative to

```ruby
write item.identifier.without_exts + '.html'
```

* [x] Handle both `'html'` and `'.html'`
* [x] Use `ext`, not `extension`