### PR TITLE
Record snapshot definition binary-ness

### DIFF
--- a/lib/nanoc/base/entities/snapshot_def.rb
+++ b/lib/nanoc/base/entities/snapshot_def.rb
@@ -7,9 +7,7 @@ module Nanoc
       attr_reader :binary
 
       contract Symbol, C::KeywordArgs[binary: C::Optional[C::Bool]] => C::Any
-      def initialize(name, binary: false)
-        # TODO: make binary required
-
+      def initialize(name, binary:)
         @name = name
         @binary = binary
       end

--- a/lib/nanoc/base/entities/snapshot_def.rb
+++ b/lib/nanoc/base/entities/snapshot_def.rb
@@ -4,10 +4,18 @@ module Nanoc
       include Nanoc::Int::ContractsSupport
 
       attr_reader :name
+      attr_reader :binary
 
-      contract Symbol => C::Any
-      def initialize(name)
+      contract Symbol, C::KeywordArgs[binary: C::Optional[C::Bool]] => C::Any
+      def initialize(name, binary: false)
+        # TODO: make binary required
+
         @name = name
+        @binary = binary
+      end
+
+      def binary?
+        @binary
       end
     end
   end

--- a/lib/nanoc/base/views/item_rep_view.rb
+++ b/lib/nanoc/base/views/item_rep_view.rb
@@ -80,7 +80,9 @@ module Nanoc
 
     # @api private
     def binary?
-      @context.snapshot_repo.raw_compiled_content(rep: unwrap, snapshot: :last).binary?
+      snapshot_def = unwrap.snapshot_defs.find { |sd| sd.name == :last }
+      raise Nanoc::Int::Errors::NoSuchSnapshot.new(unwrap, :last) if snapshot_def.nil?
+      snapshot_def.binary?
     end
 
     def inspect

--- a/lib/nanoc/rule_dsl/rule_memory_calculator.rb
+++ b/lib/nanoc/rule_dsl/rule_memory_calculator.rb
@@ -55,9 +55,19 @@ module Nanoc::RuleDSL
     end
 
     def snapshots_defs_for(rep)
-      self[rep].snapshot_actions.map do |a|
-        Nanoc::Int::SnapshotDef.new(a.snapshot_name)
+      is_binary = rep.item.content.binary?
+      snapshot_defs = []
+
+      self[rep].each do |action|
+        case action
+        when Nanoc::Int::ProcessingActions::Snapshot
+          snapshot_defs << Nanoc::Int::SnapshotDef.new(action.snapshot_name, binary: is_binary)
+        when Nanoc::Int::ProcessingActions::Filter
+          is_binary = Nanoc::Filter.named!(action.filter_name).to_binary?
+        end
       end
+
+      snapshot_defs
     end
 
     # @param [Nanoc::Int::ItemRep] rep The item representation to get the rule

--- a/lib/nanoc/spec.rb
+++ b/lib/nanoc/spec.rb
@@ -146,7 +146,7 @@ module Nanoc
           end
 
           def snapshots_defs_for(_rep)
-            [Nanoc::Int::SnapshotDef.new(:last)]
+            [Nanoc::Int::SnapshotDef.new(:last, binary: false)]
           end
         end.new(self)
       end

--- a/spec/nanoc/base/compiler_spec.rb
+++ b/spec/nanoc/base/compiler_spec.rb
@@ -62,7 +62,7 @@ describe Nanoc::Int::Compiler do
     reps << other_rep
 
     reps.each do |rep|
-      rep.snapshot_defs << Nanoc::Int::SnapshotDef.new(:last)
+      rep.snapshot_defs << Nanoc::Int::SnapshotDef.new(:last, binary: false)
     end
 
     allow(outdatedness_checker).to receive(:outdated?).with(rep).and_return(true)

--- a/spec/nanoc/base/entities/item_rep_spec.rb
+++ b/spec/nanoc/base/entities/item_rep_spec.rb
@@ -8,7 +8,7 @@ describe Nanoc::Int::ItemRep do
     let(:snapshot_name) { raise 'override me' }
 
     before do
-      rep.snapshot_defs = [Nanoc::Int::SnapshotDef.new(:donkey)]
+      rep.snapshot_defs = [Nanoc::Int::SnapshotDef.new(:donkey, binary: false)]
     end
 
     context 'snapshot does not exist' do

--- a/spec/nanoc/base/repos/snapshot_repo_spec.rb
+++ b/spec/nanoc/base/repos/snapshot_repo_spec.rb
@@ -103,7 +103,7 @@ describe Nanoc::Int::SnapshotRepo do
 
       context 'snapshot def exists' do
         before do
-          rep.snapshot_defs = [Nanoc::Int::SnapshotDef.new(snapshot_name)]
+          rep.snapshot_defs = [Nanoc::Int::SnapshotDef.new(snapshot_name, binary: false)]
           repo.set_all(rep, snapshot_name => content)
         end
 
@@ -128,7 +128,7 @@ describe Nanoc::Int::SnapshotRepo do
 
       context 'snapshot def exists, but not content' do
         before do
-          rep.snapshot_defs = [Nanoc::Int::SnapshotDef.new(snapshot_name)]
+          rep.snapshot_defs = [Nanoc::Int::SnapshotDef.new(snapshot_name, binary: false)]
           repo.set_all(rep, {})
         end
 
@@ -148,7 +148,7 @@ describe Nanoc::Int::SnapshotRepo do
       context 'snapshot exists' do
         context 'snapshot is not final' do
           before do
-            rep.snapshot_defs = [Nanoc::Int::SnapshotDef.new(snapshot_name)]
+            rep.snapshot_defs = [Nanoc::Int::SnapshotDef.new(snapshot_name, binary: false)]
           end
 
           context 'snapshot content does not exist' do
@@ -209,7 +209,7 @@ describe Nanoc::Int::SnapshotRepo do
 
         context 'snapshot is final' do
           before do
-            rep.snapshot_defs = [Nanoc::Int::SnapshotDef.new(snapshot_name)]
+            rep.snapshot_defs = [Nanoc::Int::SnapshotDef.new(snapshot_name, binary: false)]
           end
 
           context 'snapshot content does not exist' do

--- a/spec/nanoc/base/services/compiler/stages/compile_reps_spec.rb
+++ b/spec/nanoc/base/services/compiler/stages/compile_reps_spec.rb
@@ -67,7 +67,7 @@ describe Nanoc::Int::Compiler::Stages::CompileReps do
     reps << other_rep
 
     reps.each do |rep|
-      rep.snapshot_defs << Nanoc::Int::SnapshotDef.new(:last)
+      rep.snapshot_defs << Nanoc::Int::SnapshotDef.new(:last, binary: false)
     end
 
     allow(action_provider).to receive(:memory_for).with(rep).and_return(memory)
@@ -83,11 +83,11 @@ describe Nanoc::Int::Compiler::Stages::CompileReps do
     end
 
     let(:snapshot_defs_for_rep) do
-      [Nanoc::Int::SnapshotDef.new(:last)]
+      [Nanoc::Int::SnapshotDef.new(:last, binary: false)]
     end
 
     let(:snapshot_defs_for_other_rep) do
-      [Nanoc::Int::SnapshotDef.new(:last)]
+      [Nanoc::Int::SnapshotDef.new(:last, binary: false)]
     end
 
     context 'rep not in outdatedness store' do

--- a/spec/nanoc/base/services/executor_spec.rb
+++ b/spec/nanoc/base/services/executor_spec.rb
@@ -414,7 +414,7 @@ describe Nanoc::Int::Executor do
     end
 
     before do
-      rep.snapshot_defs = [Nanoc::Int::SnapshotDef.new(:pre)]
+      rep.snapshot_defs = [Nanoc::Int::SnapshotDef.new(:pre, binary: false)]
 
       snapshot_repo.set(rep, :last, content)
 

--- a/spec/nanoc/base/views/item_rep_view_spec.rb
+++ b/spec/nanoc/base/views/item_rep_view_spec.rb
@@ -146,7 +146,7 @@ describe Nanoc::ItemRepView do
       Nanoc::Int::ItemRep.new(item, :default).tap do |ir|
         ir.compiled = true
         ir.snapshot_defs = [
-          Nanoc::Int::SnapshotDef.new(:last),
+          Nanoc::Int::SnapshotDef.new(:last, binary: false),
         ]
       end
     end
@@ -213,7 +213,7 @@ describe Nanoc::ItemRepView do
       Nanoc::Int::ItemRep.new(item, :default).tap do |ir|
         ir.compiled = true
         ir.snapshot_defs = [
-          Nanoc::Int::SnapshotDef.new(:last),
+          Nanoc::Int::SnapshotDef.new(:last, binary: false),
         ]
       end
     end

--- a/spec/nanoc/base/views/item_rep_view_spec.rb
+++ b/spec/nanoc/base/views/item_rep_view_spec.rb
@@ -317,6 +317,40 @@ describe Nanoc::ItemRepView do
     it { should eq('output/about/index.html') }
   end
 
+  describe '#binary?' do
+    let(:item_rep) { Nanoc::Int::ItemRep.new(item, :jacques) }
+    let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo/') }
+    let(:view) { described_class.new(item_rep, view_context) }
+
+    subject { view.binary? }
+
+    context 'no :last snapshot' do
+      before do
+        item_rep.snapshot_defs = []
+      end
+
+      it 'raises' do
+        expect { subject }.to raise_error(Nanoc::Int::Errors::NoSuchSnapshot)
+      end
+    end
+
+    context ':last snapshot is textual' do
+      before do
+        item_rep.snapshot_defs = [Nanoc::Int::SnapshotDef.new(:last, binary: false)]
+      end
+
+      it { is_expected.not_to be }
+    end
+
+    context ':last snapshot is binary' do
+      before do
+        item_rep.snapshot_defs = [Nanoc::Int::SnapshotDef.new(:last, binary: true)]
+      end
+
+      it { is_expected.to be }
+    end
+  end
+
   describe '#item' do
     let(:item_rep) { Nanoc::Int::ItemRep.new(item, :jacques) }
     let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo/') }

--- a/spec/nanoc/base/views/item_view_spec.rb
+++ b/spec/nanoc/base/views/item_view_spec.rb
@@ -214,10 +214,10 @@ describe Nanoc::ItemWithRepsView do
       Nanoc::Int::ItemRep.new(item, :default).tap do |ir|
         ir.compiled = true
         ir.snapshot_defs = [
-          Nanoc::Int::SnapshotDef.new(:last),
-          Nanoc::Int::SnapshotDef.new(:pre),
-          Nanoc::Int::SnapshotDef.new(:post),
-          Nanoc::Int::SnapshotDef.new(:specific),
+          Nanoc::Int::SnapshotDef.new(:last, binary: false),
+          Nanoc::Int::SnapshotDef.new(:pre, binary: false),
+          Nanoc::Int::SnapshotDef.new(:post, binary: false),
+          Nanoc::Int::SnapshotDef.new(:specific, binary: false),
         ]
       end
     end

--- a/spec/nanoc/regressions/gh_1082c_spec.rb
+++ b/spec/nanoc/regressions/gh_1082c_spec.rb
@@ -1,0 +1,19 @@
+describe 'GH-1082', site: true, stdio: true do
+  before do
+    File.write('content/a.erb', '<%= @items["/b.*"].reps[:default].binary? %>')
+    File.write('content/b.erb', '<%= @items["/a.*"].reps[:default].binary? %>')
+
+    File.write('Rules', <<EOS)
+  compile '/*' do
+    filter :erb
+    write item.identifier.without_ext + '.txt'
+  end
+EOS
+  end
+
+  it 'does not require any items to be compiled' do
+    Nanoc::CLI.run(%w(compile))
+    expect(File.read('output/a.txt')).to eql('false')
+    expect(File.read('output/b.txt')).to eql('false')
+  end
+end

--- a/spec/nanoc/regressions/gh_1082d_spec.rb
+++ b/spec/nanoc/regressions/gh_1082d_spec.rb
@@ -1,0 +1,17 @@
+describe 'GH-1082', site: true, stdio: true do
+  before do
+    File.write('content/a.erb', '<%= @item.reps[:default].binary? %>')
+
+    File.write('Rules', <<EOS)
+  compile '/*' do
+    filter :erb
+    write item.identifier.without_ext + '.txt'
+  end
+EOS
+  end
+
+  it 'does not require any items to be compiled' do
+    Nanoc::CLI.run(%w(compile))
+    expect(File.read('output/a.txt')).to eql('false')
+  end
+end

--- a/spec/nanoc/rule_dsl/rule_memory_calculator_spec.rb
+++ b/spec/nanoc/rule_dsl/rule_memory_calculator_spec.rb
@@ -215,10 +215,19 @@ describe(Nanoc::RuleDSL::RuleMemoryCalculator) do
     let(:view_context) { double(:view_context) }
 
     before do
+      Class.new(Nanoc::Filter) do
+        identifier :rule_memory_calculator_spec_snapshot_def_test
+        type text: :binary
+
+        def run(content, params = {})
+          # …
+        end
+      end
+
       rules_proc = proc do
         filter :erb, speed: :over_9000
         layout '/default.*'
-        filter :typohero
+        filter :rule_memory_calculator_spec_snapshot_def_test
       end
       rule = Nanoc::RuleDSL::Rule.new(Nanoc::Int::Pattern.from('/list.*'), :csv, rules_proc)
       rules_collection.add_item_compilation_rule(rule)
@@ -226,20 +235,23 @@ describe(Nanoc::RuleDSL::RuleMemoryCalculator) do
       expect(compilation_context).to receive(:create_view_context).and_return(view_context)
     end
 
-    example do
-      expect(subject[0]).to be_a(Nanoc::Int::SnapshotDef)
-      expect(subject[0].name).to eql(:raw)
-
-      expect(subject[1]).to be_a(Nanoc::Int::SnapshotDef)
-      expect(subject[1].name).to eql(:pre)
-
-      expect(subject[2]).to be_a(Nanoc::Int::SnapshotDef)
-      expect(subject[2].name).to eql(:post)
-
-      expect(subject[3]).to be_a(Nanoc::Int::SnapshotDef)
-      expect(subject[3].name).to eql(:last)
-
+    it 'creates snapshot defs' do
       expect(subject.size).to eql(4)
+      expect(subject).to all(be_a(Nanoc::Int::SnapshotDef))
+    end
+
+    it 'has the right names' do
+      expect(subject[0].name).to eql(:raw)
+      expect(subject[1].name).to eql(:pre)
+      expect(subject[2].name).to eql(:post)
+      expect(subject[3].name).to eql(:last)
+    end
+
+    it 'has the right binary-ness' do
+      expect(subject[0]).not_to be_binary
+      expect(subject[1]).not_to be_binary
+      expect(subject[2]).to be_binary
+      expect(subject[3]).to be_binary
     end
   end
 end


### PR DESCRIPTION
This records the binary-ness in the snapshot definition, so that it can be referenced later, without the item rep needing to be compiled first.

Fixes #1082.