### PR TITLE
Use validator.nu for validating HTML

### DIFF
--- a/lib/nanoc/checking/checks/html.rb
+++ b/lib/nanoc/checking/checks/html.rb
@@ -8,7 +8,7 @@ module ::Nanoc::Checking::Checks
     end
 
     def validator_class
-      ::W3CValidators::MarkupValidator
+      ::W3CValidators::NuValidator
     end
   end
 end

--- a/lib/nanoc/checking/checks/w3c_validator.rb
+++ b/lib/nanoc/checking/checks/w3c_validator.rb
@@ -3,6 +3,7 @@ module ::Nanoc::Checking::Checks
   class W3CValidator < ::Nanoc::Checking::Check
     def run
       require 'w3c_validators'
+      require 'resolv-replace'
 
       Dir[@config[:output_dir] + '/**/*.' + extension].each do |filename|
         results = validator_class.new.validate_file(filename)

--- a/test/checking/checks/test_html.rb
+++ b/test/checking/checks/test_html.rb
@@ -39,9 +39,10 @@ class Nanoc::Checking::Checks::HTMLTest < Nanoc::TestCase
 
         # Check
         refute check.issues.empty?
-        assert_equal 2, check.issues.size
-        assert_equal 'line 1: no document type declaration; will parse without validation: <h2>Hi!</h1>', check.issues.to_a[0].description
-        assert_equal 'line 1: end tag for element "H1" which is not open: <h2>Hi!</h1>', check.issues.to_a[1].description
+        assert_equal 3, check.issues.size
+        assert_equal 'line 1: Start tag seen without seeing a doctype first. Expected e.g. “<!DOCTYPE html>”.: <h2>Hi!</h1>', check.issues.to_a[0].description
+        assert_equal 'line 1: Element “head” is missing a required instance of child element “title”.: <h2>Hi!</h1>', check.issues.to_a[1].description
+        assert_equal 'line 1: End tag “h1” seen, but there were open elements.: <h2>Hi!</h1>', check.issues.to_a[2].description
       end
     end
   end

--- a/test/fixtures/vcr_cassettes/html_run_error.yml
+++ b/test/fixtures/vcr_cassettes/html_run_error.yml
@@ -2,16 +2,13 @@
 http_interactions:
 - request:
     method: post
-    uri: https://validator.w3.org/check
+    uri: https://validator.nu/?out=json&parser=html&showsource=yes
     body:
       encoding: UTF-8
-      string: "--349832898984244898448024464570528145\r\nContent-Disposition: form-data;
-        name=\"output\"\r\n\r\nsoap12\r\n--349832898984244898448024464570528145\r\nContent-Disposition:
-        form-data; name=\"uploaded_file\"; filename=\"output/blah.html\"\r\nContent-Type:
-        text/html\r\n\r\n<h2>Hi!</h1>\r\n--349832898984244898448024464570528145--\r\n"
+      string: "<h2>Hi!</h1>"
     headers:
       Content-Type:
-      - multipart/form-data; boundary=349832898984244898448024464570528145
+      - text/html; charset=utf-8
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -23,80 +20,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Date:
-      - Sat, 17 Dec 2016 08:33:18 GMT
       Server:
-      - Apache/2.4.10 (Debian)
-      X-W3c-Validator-Recursion:
-      - '1'
-      X-W3c-Validator-Status:
-      - Invalid
-      X-W3c-Validator-Errors:
-      - '2'
-      X-W3c-Validator-Warnings:
-      - '4'
+      - nginx/1.11.10
+      Date:
+      - Sat, 04 Mar 2017 21:33:40 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
-      Content-Type:
-      - application/soap+xml; charset=UTF-8
+      Connection:
+      - keep-alive
+      Accept-Encoding:
+      - gzip
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - content-type
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Cache-Control:
+      - no-cache
       Strict-Transport-Security:
-      - max-age=15552015; preload
-      Public-Key-Pins:
-      - pin-sha256="cN0QSpPIkuwpT6iP2YjEo1bEwGpH/yiUn6yhdy+HNto="; pin-sha256="WGJkyYjx1QMdMe0UqlyOKXtydPDVrk7sl2fV+nNm1r4=";
-        pin-sha256="LrKdTxZLRTvyHM4/atX2nquX9BeHRZMCxg3cf4rhc2I="; max-age=864000
-      X-Frame-Options:
-      - deny
-      X-Xss-Protection:
-      - 1; mode=block
+      - max-age=31536000; includeSubDomains; preload
     body:
-      encoding: UTF-8
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<env:Envelope xmlns:env=\"http://www.w3.org/2003/05/soap-envelope\">\n<env:Body>\n<m:markupvalidationresponse
-        env:encodingStyle=\"http://www.w3.org/2003/05/soap-encoding\" xmlns:m=\"http://www.w3.org/2005/10/markup-validator\">\n
-        \   \n    <m:uri>output/blah.html</m:uri>\n    <m:checkedby>http://validator.w3.org/</m:checkedby>\n
-        \   <m:doctype></m:doctype>\n    <m:charset>utf-8</m:charset>\n    <m:validity>false</m:validity>\n
-        \   <m:warnings>\n        <m:warningcount>4</m:warningcount>\n        <m:warninglist>\n
-        \          \n\n\n\n\n  <m:warning><m:messageid>W04</m:messageid><m:message>No
-        Character Encoding Found!\n    \n      Falling back to \n    \n    UTF-8.\n
-        \ </m:message></m:warning>\n\n\n\n  <m:warning><m:messageid>W06</m:messageid><m:message>Unable
-        to Determine Parse Mode!</m:message></m:warning>\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n
-        \ <m:warning><m:messageid>W27</m:messageid><m:message>No Character encoding
-        declared at document level</m:message></m:warning>\n\n\n\n\n\n\n\n        </m:warninglist>\n
-        \   </m:warnings>\n    <m:errors>\n        <m:errorcount>2</m:errorcount>\n
-        \       <m:errorlist>\n\n            <m:error>\n                <m:line>1</m:line>\n
-        \               <m:col>1</m:col>\n                <m:message>no document type
-        declaration; will parse without validation</m:message>\n                <m:messageid>187</m:messageid>\n
-        \               <m:explanation>  <![CDATA[\n                      <p class=\"helpwanted\">\n
-        \     <a\n        href=\"feedback.html?uri=;errmsg_id=187#errormsg\"\n\ttitle=\"Suggest
-        improvements on this error message through our feedback channels\" \n      >&#x2709;</a>\n
-        \   </p>\n\n    <div class=\"ve mid-187\">\n    <p>The document type could
-        not be determined, because the document had no correct DOCTYPE declaration.
-        The document does not look like HTML, therefore automatic fallback could not
-        be performed, and the document was only checked against basic markup syntax.</p>\n
-        \   <p>Learn <a href=\"docs/help.html#faq-doctype\">how to add a doctype to
-        your document</a> \n    from our <acronym title=\"Frequently Asked Questions\">FAQ</acronym>,
-        or use the validator's\n    <code>Document Type</code> option to validate
-        your document against a specific Document Type.</p>\n  </div>\n\n                  ]]>\n
-        \               </m:explanation>\n                <m:source><![CDATA[<strong
-        title=\"Position where error was detected.\">&#60;</strong>h2&#62;Hi!&#60;/h1&#62;]]></m:source>\n
-        \           </m:error>\n           \n            <m:error>\n                <m:line>1</m:line>\n
-        \               <m:col>12</m:col>\n                <m:message>end tag for
-        element &quot;H1&quot; which is not open</m:message>\n                <m:messageid>79</m:messageid>\n
-        \               <m:explanation>  <![CDATA[\n                      <p class=\"helpwanted\">\n
-        \     <a\n        href=\"feedback.html?uri=;errmsg_id=79#errormsg\"\n\ttitle=\"Suggest
-        improvements on this error message through our feedback channels\" \n      >&#x2709;</a>\n
-        \   </p>\n\n    <div class=\"ve mid-79\">\n    <p>\n      The Validator found
-        an end tag for the above element, but that element is\n      not currently
-        open. This is often caused by a leftover end tag from an\n      element that
-        was removed during editing, or by an implicitly closed\n      element (if
-        you have an error related to an element being used where it\n      is not
-        allowed, this is almost certainly the case). In the latter case\n      this
-        error will disappear as soon as you fix the original problem.\n    </p>\n
-        \   <p>\n      If this error occurred in a script section of your document,
-        you should probably\n      read this <a href=\"docs/help.html#faq-javascript\">FAQ
-        entry</a>.\n    </p>\n  </div>\n\n                  ]]>\n                </m:explanation>\n
-        \               <m:source><![CDATA[&#60;h2&#62;Hi!&#60;/h1<strong title=\"Position
-        where error was detected.\">&#62;</strong>]]></m:source>\n            </m:error>\n
-        \          \n        </m:errorlist>\n    </m:errors>\n</m:markupvalidationresponse>\n</env:Body>\n</env:Envelope>\n"
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJtZXNzYWdlcyI6W3sidHlwZSI6ImVycm9yIiwibGFzdExpbmUiOjEsImxhc3RDb2x1bW4iOjQsImZpcnN0Q29sdW1uIjoxLCJtZXNzYWdlIjoiU3RhcnQgdGFnIHNlZW4gd2l0aG91dCBzZWVpbmcgYSBkb2N0eXBlIGZpcnN0LiBFeHBlY3RlZCBlLmcuIOKAnDwhRE9DVFlQRSBodG1sPuKAnS4iLCJleHRyYWN0IjoiPGgyPkhpITwvaCIsImhpbGl0ZVN0YXJ0IjowLCJoaWxpdGVMZW5ndGgiOjR9LHsidHlwZSI6ImVycm9yIiwibGFzdExpbmUiOjEsImxhc3RDb2x1bW4iOjQsImZpcnN0Q29sdW1uIjoxLCJtZXNzYWdlIjoiRWxlbWVudCDigJxoZWFk4oCdIGlzIG1pc3NpbmcgYSByZXF1aXJlZCBpbnN0YW5jZSBvZiBjaGlsZCBlbGVtZW50IOKAnHRpdGxl4oCdLiIsImV4dHJhY3QiOiI8aDI+SGkhPC9oIiwiaGlsaXRlU3RhcnQiOjAsImhpbGl0ZUxlbmd0aCI6NH0seyJ0eXBlIjoiZXJyb3IiLCJsYXN0TGluZSI6MSwibGFzdENvbHVtbiI6MTIsImZpcnN0Q29sdW1uIjo4LCJtZXNzYWdlIjoiRW5kIHRhZyDigJxoMeKAnSBzZWVuLCBidXQgdGhlcmUgd2VyZSBvcGVuIGVsZW1lbnRzLiIsImV4dHJhY3QiOiI8aDI+SGkhPC9oMT4iLCJoaWxpdGVTdGFydCI6NywiaGlsaXRlTGVuZ3RoIjo1fV0sInNvdXJjZSI6eyJ0eXBlIjoidGV4dC9odG1sIiwiZW5jb2RpbmciOiJVVEYtOCIsImNvZGUiOiI8aDI+SGkhPC9oMT4ifX0K
     http_version: 
-  recorded_at: Sat, 17 Dec 2016 08:33:19 GMT
+  recorded_at: Sat, 04 Mar 2017 21:33:40 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
`validator.nu` is the preferred validator.

The `require 'resolv-replace'` is needed to avoid w3c-validators/w3c_validators/issues/35. :(