### PR TITLE
Do not print multiple skips

### DIFF
--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -356,7 +356,7 @@ module Nanoc::CLI::Commands
         Nanoc::Int::NotificationCenter.remove(:rep_written, self)
 
         @reps.reject(&:compiled?).each do |rep|
-          raw_paths = rep.raw_paths.values.flatten
+          raw_paths = rep.raw_paths.values.flatten.uniq
           raw_paths.each do |raw_path|
             log(:low, :skip, raw_path, nil)
           end

--- a/spec/nanoc/regressions/gh_1102_spec.rb
+++ b/spec/nanoc/regressions/gh_1102_spec.rb
@@ -1,0 +1,26 @@
+describe 'GH-1102', site: true, stdio: true do
+  before do
+    File.write('content/index.html', '<%= "things" %>')
+
+    File.write('Rules', <<EOS)
+  compile '/**/*.html' do
+    filter :erb
+    write item.identifier.to_s
+  end
+EOS
+  end
+
+  before do
+    Nanoc::CLI.run(%w(compile))
+  end
+
+  it 'does not output filename more than once' do
+    regex = /skip.*index\.html.*skip.*index\.html/m
+    expect { Nanoc::CLI.run(%w(compile --verbose)) }.not_to output(regex).to_stdout
+  end
+
+  it 'outputs filename' do
+    regex = /skip.*index\.html/
+    expect { Nanoc::CLI.run(%w(compile --verbose)) }.to output(regex).to_stdout
+  end
+end


### PR DESCRIPTION
Fixes #1102.

Now that the same raw path can be shared by multiple snapshots, the compile command accidentally printed the paths for every snapshot.