### PR TITLE
Do not reuse cached binary content

### DIFF
--- a/lib/nanoc/base/services/compiler/phases/cache.rb
+++ b/lib/nanoc/base/services/compiler/phases/cache.rb
@@ -26,7 +26,12 @@ module Nanoc::Int::Compiler::Phases
 
     contract Nanoc::Int::ItemRep, C::KeywordArgs[is_outdated: C::Bool] => C::Bool
     def can_reuse_content_for_rep?(rep, is_outdated:)
-      !is_outdated && !@compiled_content_cache[rep].nil?
+      if is_outdated
+        false
+      else
+        cache = @compiled_content_cache[rep]
+        cache ? cache.none? { |_snapshot_name, content| content.binary? } : false
+      end
     end
   end
 end

--- a/spec/nanoc/regressions/gh_1094_spec.rb
+++ b/spec/nanoc/regressions/gh_1094_spec.rb
@@ -1,0 +1,22 @@
+describe 'GH-1094', site: true, stdio: true do
+  before do
+    File.write('content/a.dat', 'foo')
+    File.write('content/index.html', '<%= @items["/*.dat"].compiled_content %>')
+
+    File.write('Rules', <<EOS)
+  compile '/**/*.html' do
+    filter :erb
+    write item.identifier.to_s
+  end
+
+  passthrough '/**/*.dat'
+EOS
+  end
+
+  it 'raises CannotGetCompiledContentOfBinaryItem twice' do
+    2.times do
+      expect { Nanoc::CLI.run(%w(compile)) }
+        .to raise_wrapped_error(an_instance_of(Nanoc::Int::Errors::CannotGetCompiledContentOfBinaryItem))
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -174,6 +174,32 @@ RSpec::Matchers.define :yield_from_fiber do |expected|
   end
 end
 
+RSpec::Matchers.define :raise_wrapped_error do |expected|
+  supports_block_expectations
+
+  include RSpec::Matchers::Composable
+
+  match do |actual|
+    begin
+      actual.call
+    rescue Nanoc::Int::Errors::CompilationError => e
+      values_match?(expected, e.unwrap)
+    end
+  end
+
+  description do
+    "raise wrapped error #{expected.inspect}"
+  end
+
+  failure_message do |_actual|
+    "expected that proc would raise wrapped error #{expected.inspect}"
+  end
+
+  failure_message_when_negated do |_actual|
+    "expected that proc would not raise wrapped error #{expected.inspect}"
+  end
+end
+
 RSpec::Matchers.define :be_some_textual_content do |expected|
   include RSpec::Matchers::Composable
 


### PR DESCRIPTION
Fixes #1094.

Nanoc attempts to cache _binary_ content, which fails because the temporary files for binary content will have been removed in between runs.