### PR TITLE
Add basic telemetry implementation

### DIFF
--- a/lib/nanoc.rb
+++ b/lib/nanoc.rb
@@ -45,6 +45,7 @@ require 'English'
 # Load Nanoc
 require 'nanoc/version'
 require 'nanoc/base'
+require 'nanoc/telemetry'
 require 'nanoc/checking'
 require 'nanoc/deploying'
 require 'nanoc/extra'

--- a/lib/nanoc/telemetry.rb
+++ b/lib/nanoc/telemetry.rb
@@ -1,0 +1,16 @@
+module Nanoc
+  # @api private
+  module Telemetry
+    def self.new
+      Registry.new
+    end
+  end
+end
+
+require_relative 'telemetry/counter'
+require_relative 'telemetry/summary'
+
+require_relative 'telemetry/labelled_counter'
+require_relative 'telemetry/labelled_summary'
+
+require_relative 'telemetry/registry'

--- a/lib/nanoc/telemetry.rb
+++ b/lib/nanoc/telemetry.rb
@@ -14,3 +14,4 @@ require_relative 'telemetry/labelled_counter'
 require_relative 'telemetry/labelled_summary'
 
 require_relative 'telemetry/registry'
+require_relative 'telemetry/stopwatch'

--- a/lib/nanoc/telemetry/counter.rb
+++ b/lib/nanoc/telemetry/counter.rb
@@ -1,0 +1,13 @@
+module Nanoc::Telemetry
+  class Counter
+    attr_reader :value
+
+    def initialize
+      @value = 0
+    end
+
+    def increment
+      @value += 1
+    end
+  end
+end

--- a/lib/nanoc/telemetry/labelled_counter.rb
+++ b/lib/nanoc/telemetry/labelled_counter.rb
@@ -1,0 +1,27 @@
+module Nanoc::Telemetry
+  class LabelledCounter
+    def initialize
+      @counters = {}
+    end
+
+    def increment(labels)
+      get(labels).increment
+    end
+
+    def get(labels)
+      @counters.fetch(labels) { @counters[labels] = Counter.new }
+    end
+
+    # TODO: add #labels
+
+    def value(labels)
+      get(labels).value
+    end
+
+    def values
+      @counters.each_with_object({}) do |(labels, counter), res|
+        res[labels] = counter.value
+      end
+    end
+  end
+end

--- a/lib/nanoc/telemetry/labelled_summary.rb
+++ b/lib/nanoc/telemetry/labelled_summary.rb
@@ -1,0 +1,31 @@
+module Nanoc::Telemetry
+  class LabelledSummary
+    def initialize
+      @summaries = {}
+    end
+
+    def observe(value, labels)
+      get(labels).observe(value)
+    end
+
+    def get(labels)
+      @summaries.fetch(labels) { @summaries[labels] = Summary.new }
+    end
+
+    def labels
+      @summaries.keys
+    end
+
+    def quantile(fraction, labels)
+      get(labels).quantile(fraction)
+    end
+
+    # TODO: add quantiles(fraction)
+    # TODO: add min(labels)
+    # TODO: add mins
+    # TODO: add max(labels)
+    # TODO: add maxs
+    # TODO: add sum(labels)
+    # TODO: add sums
+  end
+end

--- a/lib/nanoc/telemetry/registry.rb
+++ b/lib/nanoc/telemetry/registry.rb
@@ -1,0 +1,16 @@
+module Nanoc::Telemetry
+  class Registry
+    def initialize
+      @counters = {}
+      @summaries = {}
+    end
+
+    def counter(name)
+      @counters.fetch(name) { @counters[name] = LabelledCounter.new }
+    end
+
+    def summary(name)
+      @summaries.fetch(name) { @summaries[name] = LabelledSummary.new }
+    end
+  end
+end

--- a/lib/nanoc/telemetry/stopwatch.rb
+++ b/lib/nanoc/telemetry/stopwatch.rb
@@ -1,0 +1,41 @@
+module Nanoc::Telemetry
+  class Stopwatch
+    attr_reader :duration
+
+    class AlreadyRunningError < StandardError
+      def message
+        'Cannot start, because stopwatch is already running'
+      end
+    end
+
+    class NotRunningError < StandardError
+      def message
+        'Cannot stop, because stopwatch is not running'
+      end
+    end
+
+    def initialize
+      @duration = 0.0
+      @last_start = nil
+    end
+
+    def start
+      raise AlreadyRunningError if running?
+      @last_start = Time.now
+    end
+
+    def stop
+      raise NotRunningError unless running?
+      @duration += (Time.now - @last_start)
+      @last_start = nil
+    end
+
+    def running?
+      !@last_start.nil?
+    end
+
+    def stopped?
+      !running?
+    end
+  end
+end

--- a/lib/nanoc/telemetry/summary.rb
+++ b/lib/nanoc/telemetry/summary.rb
@@ -1,0 +1,53 @@
+module Nanoc::Telemetry
+  class Summary
+    class EmptySummaryError < StandardError
+      def message
+        'Cannot calculate quantile for empty summary'
+      end
+    end
+
+    def initialize
+      @values = []
+    end
+
+    def observe(value)
+      @values << value
+      @sorted_values = nil
+    end
+
+    def count
+      @values.size
+    end
+
+    def sum
+      raise EmptySummaryError if @values.empty?
+      @values.reduce(:+)
+    end
+
+    def avg
+      sum / count
+    end
+
+    def min
+      quantile(0.0)
+    end
+
+    def max
+      quantile(1.0)
+    end
+
+    def quantile(fraction)
+      raise EmptySummaryError if @values.empty?
+
+      target = (@values.size - 1) * fraction.to_f
+      interp = target % 1.0
+      sorted_values[target.floor] * (1.0 - interp) + sorted_values[target.ceil] * interp
+    end
+
+    private
+
+    def sorted_values
+      @sorted_values ||= @values.sort
+    end
+  end
+end

--- a/spec/nanoc/cli/commands/compile/timing_recorder_spec.rb
+++ b/spec/nanoc/cli/commands/compile/timing_recorder_spec.rb
@@ -59,8 +59,7 @@ describe Nanoc::CLI::Commands::Compile::TimingRecorder, stdio: true do
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 7))
     Nanoc::Int::NotificationCenter.post(:filtering_ended, rep, :erb)
 
-    # FIXME: wrong count (should be 1, not 2)
     expect { listener.stop }
-      .to output(/^erb \|     2   1\.00s   2\.50s   4\.00s   5\.00s$/).to_stdout
+      .to output(/^erb \|     1   5\.00s   5\.00s   5\.00s   5\.00s$/).to_stdout
   end
 end

--- a/spec/nanoc/telemetry/counter_spec.rb
+++ b/spec/nanoc/telemetry/counter_spec.rb
@@ -1,0 +1,18 @@
+describe Nanoc::Telemetry::Counter do
+  subject(:counter) { described_class.new }
+
+  it 'starts at 0' do
+    expect(counter.value).to eq(0)
+  end
+
+  describe '#increment' do
+    subject { counter.increment }
+
+    it 'increments' do
+      expect { subject }
+        .to change { counter.value }
+        .from(0)
+        .to(1)
+    end
+  end
+end

--- a/spec/nanoc/telemetry/labelled_counter_spec.rb
+++ b/spec/nanoc/telemetry/labelled_counter_spec.rb
@@ -1,0 +1,56 @@
+describe Nanoc::Telemetry::LabelledCounter do
+  subject(:counter) { described_class.new }
+
+  describe 'new counter' do
+    it 'starts at 0' do
+      expect(subject.value(filter: :erb)).to eq(0)
+      expect(subject.value(filter: :haml)).to eq(0)
+    end
+
+    it 'has no values' do
+      expect(subject.values).to eq({})
+    end
+  end
+
+  describe '#increment' do
+    subject { counter.increment(filter: :erb) }
+
+    it 'increments the matching value' do
+      expect { subject }
+        .to change { counter.value(filter: :erb) }
+        .from(0)
+        .to(1)
+    end
+
+    it 'does not increment any other value' do
+      expect(counter.value(filter: :haml)).to eq(0)
+      expect { subject }
+        .not_to change { counter.value(filter: :haml) }
+    end
+
+    it 'correctly changes #values' do
+      expect { subject }
+        .to change { counter.values }
+        .from({})
+        .to({ filter: :erb } => 1)
+    end
+  end
+
+  describe '#get' do
+    subject { counter.get(filter: :erb) }
+
+    context 'not incremented' do
+      its(:value) { is_expected.to eq(0) }
+    end
+
+    context 'incremented' do
+      before { counter.increment(filter: :erb) }
+      its(:value) { is_expected.to eq(1) }
+    end
+
+    context 'other incremented' do
+      before { counter.increment(filter: :haml) }
+      its(:value) { is_expected.to eq(0) }
+    end
+  end
+end

--- a/spec/nanoc/telemetry/labelled_summary_spec.rb
+++ b/spec/nanoc/telemetry/labelled_summary_spec.rb
@@ -1,0 +1,63 @@
+describe Nanoc::Telemetry::LabelledSummary do
+  subject(:summary) { described_class.new }
+
+  describe '#labels' do
+    subject { summary.labels }
+
+    context 'empty summary' do
+      it { is_expected.to eq([]) }
+    end
+
+    context 'some observations' do
+      before do
+        summary.observe(7.2, filter: :erb)
+        summary.observe(5.3, filter: :erb)
+        summary.observe(3.0, filter: :haml)
+      end
+
+      it { is_expected.to eq([{ filter: :erb }, { filter: :haml }]) }
+    end
+  end
+
+  describe '#get' do
+    subject { summary.get(filter: :erb) }
+
+    context 'empty summary' do
+      its(:count) { is_expected.to eq(0) }
+    end
+
+    context 'one observation with that label' do
+      before { summary.observe(0.1, filter: :erb) }
+      its(:count) { is_expected.to eq(1) }
+    end
+
+    context 'one observation with a different label' do
+      before { summary.observe(0.1, filter: :haml) }
+      its(:count) { is_expected.to eq(0) }
+    end
+  end
+
+  describe '#quantile' do
+    before do
+      subject.observe(2.1, filter: :erb)
+      subject.observe(4.1, filter: :erb)
+      subject.observe(5.3, filter: :haml)
+    end
+
+    it 'has proper quantiles for :erb' do
+      expect(subject.quantile(0.00, filter: :erb)).to be_within(0.000001).of(2.1)
+      expect(subject.quantile(0.25, filter: :erb)).to be_within(0.000001).of(2.6)
+      expect(subject.quantile(0.50, filter: :erb)).to be_within(0.000001).of(3.1)
+      expect(subject.quantile(0.90, filter: :erb)).to be_within(0.000001).of(3.9)
+      expect(subject.quantile(0.99, filter: :erb)).to be_within(0.000001).of(4.08)
+    end
+
+    it 'has proper quantiles for :erb' do
+      expect(subject.quantile(0.00, filter: :haml)).to be_within(0.000001).of(5.3)
+      expect(subject.quantile(0.25, filter: :haml)).to be_within(0.000001).of(5.3)
+      expect(subject.quantile(0.50, filter: :haml)).to be_within(0.000001).of(5.3)
+      expect(subject.quantile(0.90, filter: :haml)).to be_within(0.000001).of(5.3)
+      expect(subject.quantile(0.99, filter: :haml)).to be_within(0.000001).of(5.3)
+    end
+  end
+end

--- a/spec/nanoc/telemetry/stopwatch_spec.rb
+++ b/spec/nanoc/telemetry/stopwatch_spec.rb
@@ -1,0 +1,59 @@
+describe Nanoc::Telemetry::Stopwatch do
+  subject(:stopwatch) { described_class.new }
+
+  it 'is zero by default' do
+    expect(stopwatch.duration).to eq(0.0)
+  end
+
+  # TODO: if running, raise error when asking for #duration
+
+  it 'records correct duration after start+stop' do
+    Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 0))
+    stopwatch.start
+
+    Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
+    stopwatch.stop
+
+    expect(stopwatch.duration).to eq(1.0)
+  end
+
+  it 'records correct duration after start+stop+start+stop' do
+    Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 0))
+    stopwatch.start
+
+    Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
+    stopwatch.stop
+
+    Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 3))
+    stopwatch.start
+
+    Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 6))
+    stopwatch.stop
+
+    expect(stopwatch.duration).to eq(1.0 + 3.0)
+  end
+
+  it 'errors when stopping when not started' do
+    expect { stopwatch.stop }.to raise_error(Nanoc::Telemetry::Stopwatch::NotRunningError)
+  end
+
+  it 'errors when starting when already started' do
+    stopwatch.start
+    expect { stopwatch.start }.to raise_error(Nanoc::Telemetry::Stopwatch::AlreadyRunningError)
+  end
+
+  it 'reports running status' do
+    expect(stopwatch).not_to be_running
+    expect(stopwatch).to be_stopped
+
+    stopwatch.start
+
+    expect(stopwatch).to be_running
+    expect(stopwatch).not_to be_stopped
+
+    stopwatch.stop
+
+    expect(stopwatch).not_to be_running
+    expect(stopwatch).to be_stopped
+  end
+end

--- a/spec/nanoc/telemetry/summary_spec.rb
+++ b/spec/nanoc/telemetry/summary_spec.rb
@@ -1,0 +1,66 @@
+describe Nanoc::Telemetry::Summary do
+  subject(:summary) { described_class.new }
+
+  context 'no observations' do
+    it 'errors on #min' do
+      expect { subject.min }
+        .to raise_error(Nanoc::Telemetry::Summary::EmptySummaryError)
+    end
+
+    it 'errors on #max' do
+      expect { subject.max }
+        .to raise_error(Nanoc::Telemetry::Summary::EmptySummaryError)
+    end
+
+    it 'errors on #avg' do
+      expect { subject.avg }
+        .to raise_error(Nanoc::Telemetry::Summary::EmptySummaryError)
+    end
+
+    it 'errors on #sum' do
+      expect { subject.sum }
+        .to raise_error(Nanoc::Telemetry::Summary::EmptySummaryError)
+    end
+
+    its(:count) { is_expected.to eq(0) }
+  end
+
+  context 'one observation' do
+    before { subject.observe(2.1) }
+
+    its(:count) { is_expected.to eq(1) }
+    its(:sum) { is_expected.to eq(2.1) }
+    its(:avg) { is_expected.to eq(2.1) }
+    its(:min) { is_expected.to eq(2.1) }
+    its(:max) { is_expected.to eq(2.1) }
+
+    it 'has proper quantiles' do
+      expect(subject.quantile(0.00)).to eq(2.1)
+      expect(subject.quantile(0.25)).to eq(2.1)
+      expect(subject.quantile(0.50)).to eq(2.1)
+      expect(subject.quantile(0.90)).to eq(2.1)
+      expect(subject.quantile(0.99)).to eq(2.1)
+    end
+  end
+
+  context 'two observations' do
+    before do
+      subject.observe(2.1)
+      subject.observe(4.1)
+    end
+
+    its(:count) { is_expected.to be_within(0.000001).of(2) }
+    its(:sum) { is_expected.to be_within(0.000001).of(6.2) }
+    its(:avg) { is_expected.to be_within(0.000001).of(3.1) }
+    its(:min) { is_expected.to be_within(0.000001).of(2.1) }
+    its(:max) { is_expected.to be_within(0.000001).of(4.1) }
+
+    it 'has proper quantiles' do
+      expect(subject.quantile(0.00)).to be_within(0.000001).of(2.1)
+      expect(subject.quantile(0.25)).to be_within(0.000001).of(2.6)
+      expect(subject.quantile(0.50)).to be_within(0.000001).of(3.1)
+      expect(subject.quantile(0.90)).to be_within(0.000001).of(3.9)
+      expect(subject.quantile(0.99)).to be_within(0.000001).of(4.08)
+    end
+  end
+end

--- a/spec/nanoc/telemetry_spec.rb
+++ b/spec/nanoc/telemetry_spec.rb
@@ -1,0 +1,26 @@
+describe Nanoc::Telemetry do
+  subject { described_class.new }
+
+  example do
+    expect(subject.counter(:filters).values).to eq({})
+    expect(subject.counter(:filters).get(identifier: :erb).value).to eq(0)
+    expect(subject.counter(:filters).value(identifier: :erb)).to eq(0)
+
+    subject.counter(:filters).increment(identifier: :erb)
+    expect(subject.counter(:filters).values).to eq({ identifier: :erb } => 1)
+    expect(subject.counter(:filters).get(identifier: :erb).value).to eq(1)
+    expect(subject.counter(:filters).value(identifier: :erb)).to eq(1)
+  end
+
+  example do
+    subject.summary(:filters).observe(0.1, identifier: :erb)
+    expect(subject.summary(:filters).quantile(0.0, identifier: :erb)).to be_within(0.00001).of(0.1)
+    expect(subject.summary(:filters).quantile(0.5, identifier: :erb)).to be_within(0.00001).of(0.1)
+    expect(subject.summary(:filters).quantile(1.0, identifier: :erb)).to be_within(0.00001).of(0.1)
+
+    subject.summary(:filters).observe(1.1, identifier: :erb)
+    expect(subject.summary(:filters).quantile(0.0, identifier: :erb)).to be_within(0.00001).of(0.1)
+    expect(subject.summary(:filters).quantile(0.5, identifier: :erb)).to be_within(0.00001).of(0.6)
+    expect(subject.summary(:filters).quantile(1.0, identifier: :erb)).to be_within(0.00001).of(1.1)
+  end
+end


### PR DESCRIPTION
This generalises the telemetry that’s currently already in Nanoc, to be more usable for other purposes.