### PR TITLE
Improve handling of labels in telemetry API

### DIFF
--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -193,16 +193,14 @@ module Nanoc::CLI::Commands
       def profiling_table
         headers = ['', 'count', 'min', 'avg', 'max', 'tot']
 
-        metric_set = @telemetry.summary(:filter_total)
-        rows = metric_set.labels.map do |label|
-          metric = metric_set.get(label)
-          filter_name = label[:filter_name].to_s
+        rows = @telemetry.summary(:filter_total).map do |labels, summary|
+          filter_name = labels[:filter_name].to_s
 
-          count = metric.count
-          min   = metric.min
-          avg   = metric.avg
-          tot   = metric.sum
-          max   = metric.max
+          count = summary.count
+          min   = summary.min
+          avg   = summary.avg
+          tot   = summary.sum
+          max   = summary.max
 
           [filter_name, count.to_s] + [min, avg, max, tot].map { |r| "#{format('%4.2f', r)}s" }
         end

--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -207,7 +207,7 @@ module Nanoc::CLI::Commands
       end
 
       def print_profiling_feedback
-        return if @telemetry.summary(:filter_total).labels.empty?
+        return if @telemetry.summary(:filter_total).empty?
 
         if @reps.any? { |r| !r.compiled? }
           $stderr.puts

--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -170,7 +170,7 @@ module Nanoc::CLI::Commands
           stopwatch = stopwatches.fetch(rep).pop
           stopwatch.stop
 
-          @telemetry.summary(:filter_total).observe(stopwatch.duration, filter_name: filter_name)
+          @telemetry.summary(:filter_total).observe(stopwatch.duration, filter_name.to_s)
         end
 
         Nanoc::Int::NotificationCenter.on(:compilation_suspended) do |rep, _exception|
@@ -193,9 +193,7 @@ module Nanoc::CLI::Commands
       def profiling_table
         headers = ['', 'count', 'min', 'avg', 'max', 'tot']
 
-        rows = @telemetry.summary(:filter_total).map do |labels, summary|
-          filter_name = labels[:filter_name].to_s
-
+        rows = @telemetry.summary(:filter_total).map do |filter_name, summary|
           count = summary.count
           min   = summary.min
           avg   = summary.avg

--- a/lib/nanoc/telemetry/labelled_counter.rb
+++ b/lib/nanoc/telemetry/labelled_counter.rb
@@ -4,23 +4,23 @@ module Nanoc::Telemetry
       @counters = {}
     end
 
-    def increment(labels)
-      get(labels).increment
+    def increment(label)
+      get(label).increment
     end
 
-    def get(labels)
-      @counters.fetch(labels) { @counters[labels] = Counter.new }
+    def get(label)
+      @counters.fetch(label) { @counters[label] = Counter.new }
     end
 
     # TODO: add #labels
 
-    def value(labels)
-      get(labels).value
+    def value(label)
+      get(label).value
     end
 
     def values
-      @counters.each_with_object({}) do |(labels, counter), res|
-        res[labels] = counter.value
+      @counters.each_with_object({}) do |(label, counter), res|
+        res[label] = counter.value
       end
     end
   end

--- a/lib/nanoc/telemetry/labelled_counter.rb
+++ b/lib/nanoc/telemetry/labelled_counter.rb
@@ -12,7 +12,7 @@ module Nanoc::Telemetry
       @counters.fetch(label) { @counters[label] = Counter.new }
     end
 
-    # TODO: add #labels
+    # TODO: add #empty?
 
     def value(label)
       get(label).value

--- a/lib/nanoc/telemetry/labelled_summary.rb
+++ b/lib/nanoc/telemetry/labelled_summary.rb
@@ -20,6 +20,10 @@ module Nanoc::Telemetry
       get(labels).quantile(fraction)
     end
 
+    def map
+      @summaries.map { |(labels, summary)| yield(labels, summary) }
+    end
+
     # TODO: add quantiles(fraction)
     # TODO: add min(labels)
     # TODO: add mins

--- a/lib/nanoc/telemetry/labelled_summary.rb
+++ b/lib/nanoc/telemetry/labelled_summary.rb
@@ -4,32 +4,32 @@ module Nanoc::Telemetry
       @summaries = {}
     end
 
-    def observe(value, labels)
-      get(labels).observe(value)
+    def observe(value, label)
+      get(label).observe(value)
     end
 
-    def get(labels)
-      @summaries.fetch(labels) { @summaries[labels] = Summary.new }
+    def get(label)
+      @summaries.fetch(label) { @summaries[label] = Summary.new }
     end
 
     def labels
       @summaries.keys
     end
 
-    def quantile(fraction, labels)
-      get(labels).quantile(fraction)
+    def quantile(fraction, label)
+      get(label).quantile(fraction)
     end
 
     def map
-      @summaries.map { |(labels, summary)| yield(labels, summary) }
+      @summaries.map { |(label, summary)| yield(label, summary) }
     end
 
     # TODO: add quantiles(fraction)
-    # TODO: add min(labels)
+    # TODO: add min(label)
     # TODO: add mins
-    # TODO: add max(labels)
+    # TODO: add max(label)
     # TODO: add maxs
-    # TODO: add sum(labels)
+    # TODO: add sum(label)
     # TODO: add sums
   end
 end

--- a/lib/nanoc/telemetry/labelled_summary.rb
+++ b/lib/nanoc/telemetry/labelled_summary.rb
@@ -12,8 +12,8 @@ module Nanoc::Telemetry
       @summaries.fetch(label) { @summaries[label] = Summary.new }
     end
 
-    def labels
-      @summaries.keys
+    def empty?
+      @summaries.empty?
     end
 
     def quantile(fraction, label)

--- a/spec/nanoc/telemetry/labelled_counter_spec.rb
+++ b/spec/nanoc/telemetry/labelled_counter_spec.rb
@@ -3,8 +3,8 @@ describe Nanoc::Telemetry::LabelledCounter do
 
   describe 'new counter' do
     it 'starts at 0' do
-      expect(subject.value(filter: :erb)).to eq(0)
-      expect(subject.value(filter: :haml)).to eq(0)
+      expect(subject.value(:erb)).to eq(0)
+      expect(subject.value(:haml)).to eq(0)
     end
 
     it 'has no values' do
@@ -13,43 +13,43 @@ describe Nanoc::Telemetry::LabelledCounter do
   end
 
   describe '#increment' do
-    subject { counter.increment(filter: :erb) }
+    subject { counter.increment(:erb) }
 
     it 'increments the matching value' do
       expect { subject }
-        .to change { counter.value(filter: :erb) }
+        .to change { counter.value(:erb) }
         .from(0)
         .to(1)
     end
 
     it 'does not increment any other value' do
-      expect(counter.value(filter: :haml)).to eq(0)
+      expect(counter.value(:haml)).to eq(0)
       expect { subject }
-        .not_to change { counter.value(filter: :haml) }
+        .not_to change { counter.value(:haml) }
     end
 
     it 'correctly changes #values' do
       expect { subject }
         .to change { counter.values }
         .from({})
-        .to({ filter: :erb } => 1)
+        .to(erb: 1)
     end
   end
 
   describe '#get' do
-    subject { counter.get(filter: :erb) }
+    subject { counter.get(:erb) }
 
     context 'not incremented' do
       its(:value) { is_expected.to eq(0) }
     end
 
     context 'incremented' do
-      before { counter.increment(filter: :erb) }
+      before { counter.increment(:erb) }
       its(:value) { is_expected.to eq(1) }
     end
 
     context 'other incremented' do
-      before { counter.increment(filter: :haml) }
+      before { counter.increment(:haml) }
       its(:value) { is_expected.to eq(0) }
     end
   end

--- a/spec/nanoc/telemetry/labelled_summary_spec.rb
+++ b/spec/nanoc/telemetry/labelled_summary_spec.rb
@@ -37,6 +37,19 @@ describe Nanoc::Telemetry::LabelledSummary do
     end
   end
 
+  describe '#map' do
+    before do
+      subject.observe(2.1, filter: :erb)
+      subject.observe(4.1, filter: :erb)
+      subject.observe(5.3, filter: :haml)
+    end
+
+    it 'yields labels and summary' do
+      res = subject.map { |labels, summary| [labels[:filter], summary.avg.round(3)] }
+      expect(res).to eql([[:erb, 3.1], [:haml, 5.3]])
+    end
+  end
+
   describe '#quantile' do
     before do
       subject.observe(2.1, filter: :erb)

--- a/spec/nanoc/telemetry/labelled_summary_spec.rb
+++ b/spec/nanoc/telemetry/labelled_summary_spec.rb
@@ -1,11 +1,11 @@
 describe Nanoc::Telemetry::LabelledSummary do
   subject(:summary) { described_class.new }
 
-  describe '#labels' do
-    subject { summary.labels }
+  describe '#empty?' do
+    subject { summary.empty? }
 
     context 'empty summary' do
-      it { is_expected.to eq([]) }
+      it { is_expected.to be }
     end
 
     context 'some observations' do
@@ -15,7 +15,7 @@ describe Nanoc::Telemetry::LabelledSummary do
         summary.observe(3.0, :haml)
       end
 
-      it { is_expected.to eq([:erb, :haml]) }
+      it { is_expected.not_to be }
     end
   end
 

--- a/spec/nanoc/telemetry/labelled_summary_spec.rb
+++ b/spec/nanoc/telemetry/labelled_summary_spec.rb
@@ -10,67 +10,67 @@ describe Nanoc::Telemetry::LabelledSummary do
 
     context 'some observations' do
       before do
-        summary.observe(7.2, filter: :erb)
-        summary.observe(5.3, filter: :erb)
-        summary.observe(3.0, filter: :haml)
+        summary.observe(7.2, :erb)
+        summary.observe(5.3, :erb)
+        summary.observe(3.0, :haml)
       end
 
-      it { is_expected.to eq([{ filter: :erb }, { filter: :haml }]) }
+      it { is_expected.to eq([:erb, :haml]) }
     end
   end
 
   describe '#get' do
-    subject { summary.get(filter: :erb) }
+    subject { summary.get(:erb) }
 
     context 'empty summary' do
       its(:count) { is_expected.to eq(0) }
     end
 
     context 'one observation with that label' do
-      before { summary.observe(0.1, filter: :erb) }
+      before { summary.observe(0.1, :erb) }
       its(:count) { is_expected.to eq(1) }
     end
 
     context 'one observation with a different label' do
-      before { summary.observe(0.1, filter: :haml) }
+      before { summary.observe(0.1, :haml) }
       its(:count) { is_expected.to eq(0) }
     end
   end
 
   describe '#map' do
     before do
-      subject.observe(2.1, filter: :erb)
-      subject.observe(4.1, filter: :erb)
-      subject.observe(5.3, filter: :haml)
+      subject.observe(2.1, :erb)
+      subject.observe(4.1, :erb)
+      subject.observe(5.3, :haml)
     end
 
-    it 'yields labels and summary' do
-      res = subject.map { |labels, summary| [labels[:filter], summary.avg.round(3)] }
+    it 'yields label and summary' do
+      res = subject.map { |label, summary| [label, summary.avg.round(3)] }
       expect(res).to eql([[:erb, 3.1], [:haml, 5.3]])
     end
   end
 
   describe '#quantile' do
     before do
-      subject.observe(2.1, filter: :erb)
-      subject.observe(4.1, filter: :erb)
-      subject.observe(5.3, filter: :haml)
+      subject.observe(2.1, :erb)
+      subject.observe(4.1, :erb)
+      subject.observe(5.3, :haml)
     end
 
     it 'has proper quantiles for :erb' do
-      expect(subject.quantile(0.00, filter: :erb)).to be_within(0.000001).of(2.1)
-      expect(subject.quantile(0.25, filter: :erb)).to be_within(0.000001).of(2.6)
-      expect(subject.quantile(0.50, filter: :erb)).to be_within(0.000001).of(3.1)
-      expect(subject.quantile(0.90, filter: :erb)).to be_within(0.000001).of(3.9)
-      expect(subject.quantile(0.99, filter: :erb)).to be_within(0.000001).of(4.08)
+      expect(subject.quantile(0.00, :erb)).to be_within(0.000001).of(2.1)
+      expect(subject.quantile(0.25, :erb)).to be_within(0.000001).of(2.6)
+      expect(subject.quantile(0.50, :erb)).to be_within(0.000001).of(3.1)
+      expect(subject.quantile(0.90, :erb)).to be_within(0.000001).of(3.9)
+      expect(subject.quantile(0.99, :erb)).to be_within(0.000001).of(4.08)
     end
 
     it 'has proper quantiles for :erb' do
-      expect(subject.quantile(0.00, filter: :haml)).to be_within(0.000001).of(5.3)
-      expect(subject.quantile(0.25, filter: :haml)).to be_within(0.000001).of(5.3)
-      expect(subject.quantile(0.50, filter: :haml)).to be_within(0.000001).of(5.3)
-      expect(subject.quantile(0.90, filter: :haml)).to be_within(0.000001).of(5.3)
-      expect(subject.quantile(0.99, filter: :haml)).to be_within(0.000001).of(5.3)
+      expect(subject.quantile(0.00, :haml)).to be_within(0.000001).of(5.3)
+      expect(subject.quantile(0.25, :haml)).to be_within(0.000001).of(5.3)
+      expect(subject.quantile(0.50, :haml)).to be_within(0.000001).of(5.3)
+      expect(subject.quantile(0.90, :haml)).to be_within(0.000001).of(5.3)
+      expect(subject.quantile(0.99, :haml)).to be_within(0.000001).of(5.3)
     end
   end
 end

--- a/spec/nanoc/telemetry_spec.rb
+++ b/spec/nanoc/telemetry_spec.rb
@@ -3,24 +3,24 @@ describe Nanoc::Telemetry do
 
   example do
     expect(subject.counter(:filters).values).to eq({})
-    expect(subject.counter(:filters).get(identifier: :erb).value).to eq(0)
-    expect(subject.counter(:filters).value(identifier: :erb)).to eq(0)
+    expect(subject.counter(:filters).get(:erb).value).to eq(0)
+    expect(subject.counter(:filters).value(:erb)).to eq(0)
 
-    subject.counter(:filters).increment(identifier: :erb)
-    expect(subject.counter(:filters).values).to eq({ identifier: :erb } => 1)
-    expect(subject.counter(:filters).get(identifier: :erb).value).to eq(1)
-    expect(subject.counter(:filters).value(identifier: :erb)).to eq(1)
+    subject.counter(:filters).increment(:erb)
+    expect(subject.counter(:filters).values).to eq(erb: 1)
+    expect(subject.counter(:filters).get(:erb).value).to eq(1)
+    expect(subject.counter(:filters).value(:erb)).to eq(1)
   end
 
   example do
-    subject.summary(:filters).observe(0.1, identifier: :erb)
-    expect(subject.summary(:filters).quantile(0.0, identifier: :erb)).to be_within(0.00001).of(0.1)
-    expect(subject.summary(:filters).quantile(0.5, identifier: :erb)).to be_within(0.00001).of(0.1)
-    expect(subject.summary(:filters).quantile(1.0, identifier: :erb)).to be_within(0.00001).of(0.1)
+    subject.summary(:filters).observe(0.1, :erb)
+    expect(subject.summary(:filters).quantile(0.0, :erb)).to be_within(0.00001).of(0.1)
+    expect(subject.summary(:filters).quantile(0.5, :erb)).to be_within(0.00001).of(0.1)
+    expect(subject.summary(:filters).quantile(1.0, :erb)).to be_within(0.00001).of(0.1)
 
-    subject.summary(:filters).observe(1.1, identifier: :erb)
-    expect(subject.summary(:filters).quantile(0.0, identifier: :erb)).to be_within(0.00001).of(0.1)
-    expect(subject.summary(:filters).quantile(0.5, identifier: :erb)).to be_within(0.00001).of(0.6)
-    expect(subject.summary(:filters).quantile(1.0, identifier: :erb)).to be_within(0.00001).of(1.1)
+    subject.summary(:filters).observe(1.1, :erb)
+    expect(subject.summary(:filters).quantile(0.0, :erb)).to be_within(0.00001).of(0.1)
+    expect(subject.summary(:filters).quantile(0.5, :erb)).to be_within(0.00001).of(0.6)
+    expect(subject.summary(:filters).quantile(1.0, :erb)).to be_within(0.00001).of(1.1)
   end
 end


### PR DESCRIPTION
* [x] Rename labels (plural) to label (singular)
* [x] Allow using non-hash values as context
* [x] Add `#map` for ease of use
* [ ] … and maybe make Enumerable?