### PR TITLE
Add telemetry for phases

### DIFF
--- a/lib/nanoc/base/services/compiler/phases.rb
+++ b/lib/nanoc/base/services/compiler/phases.rb
@@ -1,6 +1,8 @@
 module Nanoc::Int::Compiler::Phases
 end
 
+require_relative 'phases/abstract'
+
 require_relative 'phases/recalculate'
 require_relative 'phases/cache'
 require_relative 'phases/resume'

--- a/lib/nanoc/base/services/compiler/phases/abstract.rb
+++ b/lib/nanoc/base/services/compiler/phases/abstract.rb
@@ -1,0 +1,34 @@
+module Nanoc::Int::Compiler::Phases
+  class Abstract
+    include Nanoc::Int::ContractsSupport
+
+    def initialize(wrapped:, name:)
+      @name = name
+      @wrapped = wrapped
+    end
+
+    def call(rep, is_outdated:)
+      notify(:phase_started, rep)
+      run(rep, is_outdated: is_outdated) do
+        notify(:phase_yielded, rep)
+        @wrapped.call(rep, is_outdated: is_outdated)
+        notify(:phase_resumed, rep)
+      end
+      notify(:phase_ended, rep)
+    rescue
+      notify(:phase_aborted, rep)
+      raise
+    end
+
+    contract Nanoc::Int::ItemRep, C::KeywordArgs[is_outdated: C::Bool], C::Func[C::None => C::Any] => C::Any
+    def run(_rep, is_outdated:) # rubocop:disable Lint/UnusedMethodArgument
+      raise NotImplementedError
+    end
+
+    private
+
+    def notify(sym, rep)
+      Nanoc::Int::NotificationCenter.post(sym, @name, rep)
+    end
+  end
+end

--- a/lib/nanoc/base/services/compiler/phases/mark_done.rb
+++ b/lib/nanoc/base/services/compiler/phases/mark_done.rb
@@ -1,15 +1,18 @@
 module Nanoc::Int::Compiler::Phases
-  class MarkDone
+  class MarkDone < Abstract
     include Nanoc::Int::ContractsSupport
 
+    NAME = 'mark_done'.freeze
+
     def initialize(wrapped:, outdatedness_store:)
-      @wrapped = wrapped
+      super(wrapped: wrapped, name: NAME)
+
       @outdatedness_store = outdatedness_store
     end
 
-    contract Nanoc::Int::ItemRep, C::KeywordArgs[is_outdated: C::Bool] => C::Any
-    def run(rep, is_outdated:)
-      @wrapped.run(rep, is_outdated: is_outdated)
+    contract Nanoc::Int::ItemRep, C::KeywordArgs[is_outdated: C::Bool], C::Func[C::None => C::Any] => C::Any
+    def run(rep, is_outdated:) # rubocop:disable Lint/UnusedMethodArgument
+      yield
       @outdatedness_store.remove(rep)
     end
   end

--- a/lib/nanoc/base/services/compiler/phases/recalculate.rb
+++ b/lib/nanoc/base/services/compiler/phases/recalculate.rb
@@ -1,16 +1,20 @@
 module Nanoc::Int::Compiler::Phases
   # Provides functionality for (re)calculating the content of an item rep, without caching or
   # outdatedness checking.
-  class Recalculate
+  class Recalculate < Abstract
     include Nanoc::Int::ContractsSupport
 
+    NAME = 'recalculate'.freeze
+
     def initialize(action_provider:, dependency_store:, compilation_context:)
+      super(wrapped: nil, name: NAME)
+
       @action_provider = action_provider
       @dependency_store = dependency_store
       @compilation_context = compilation_context
     end
 
-    contract Nanoc::Int::ItemRep, C::KeywordArgs[is_outdated: C::Bool] => C::Any
+    contract Nanoc::Int::ItemRep, C::KeywordArgs[is_outdated: C::Bool], C::Func[C::None => C::Any] => C::Any
     def run(rep, is_outdated:) # rubocop:disable Lint/UnusedMethodArgument
       dependency_tracker = Nanoc::Int::DependencyTracker.new(@dependency_store)
       dependency_tracker.enter(rep.item)

--- a/lib/nanoc/base/services/compiler/phases/write.rb
+++ b/lib/nanoc/base/services/compiler/phases/write.rb
@@ -1,15 +1,18 @@
 module Nanoc::Int::Compiler::Phases
-  class Write
+  class Write < Abstract
     include Nanoc::Int::ContractsSupport
 
+    NAME = 'write'.freeze
+
     def initialize(snapshot_repo:, wrapped:)
+      super(wrapped: wrapped, name: NAME)
+
       @snapshot_repo = snapshot_repo
-      @wrapped = wrapped
     end
 
-    contract Nanoc::Int::ItemRep, C::KeywordArgs[is_outdated: C::Bool] => C::Any
-    def run(rep, is_outdated:)
-      @wrapped.run(rep, is_outdated: is_outdated)
+    contract Nanoc::Int::ItemRep, C::KeywordArgs[is_outdated: C::Bool], C::Func[C::None => C::Any] => C::Any
+    def run(rep, is_outdated:) # rubocop:disable Lint/UnusedMethodArgument
+      yield
 
       Nanoc::Int::ItemRepWriter.new.write_all(rep, @snapshot_repo)
     end

--- a/lib/nanoc/base/services/compiler/stages/compile_reps.rb
+++ b/lib/nanoc/base/services/compiler/stages/compile_reps.rb
@@ -27,7 +27,7 @@ module Nanoc::Int::Compiler::Stages
     end
 
     def compile_rep(rep, is_outdated:)
-      item_rep_compiler.run(rep, is_outdated: is_outdated)
+      item_rep_compiler.call(rep, is_outdated: is_outdated)
     end
 
     def item_rep_compiler

--- a/lib/nanoc/cli.rb
+++ b/lib/nanoc/cli.rb
@@ -34,6 +34,14 @@ module Nanoc::CLI
     @debug = boolean
   end
 
+  def self.verbosity
+    @verbosity || 0
+  end
+
+  def self.verbosity=(val)
+    @verbosity = val
+  end
+
   # Invokes the Nanoc command-line tool with the given arguments.
   #
   # @param [Array<String>] args An array of command-line arguments

--- a/lib/nanoc/cli/commands/nanoc.rb
+++ b/lib/nanoc/cli/commands/nanoc.rb
@@ -24,8 +24,9 @@ opt :C, :'no-color', 'disable color' do
   $stderr.add_stream_cleaner(Nanoc::CLI::StreamCleaners::ANSIColors)
 end
 
-opt :V, :verbose, 'make output more detailed' do
+opt :V, :verbose, 'make output more detailed', multiple: true do |val|
   Nanoc::CLI::Logger.instance.level = :low
+  Nanoc::CLI.verbosity = val.size
 end
 
 opt :v, :version, 'show version information and quit' do

--- a/spec/nanoc/base/compiler_spec.rb
+++ b/spec/nanoc/base/compiler_spec.rb
@@ -70,6 +70,8 @@ describe Nanoc::Int::Compiler do
 
     allow(action_provider).to receive(:memory_for).with(rep).and_return(memory)
     allow(action_provider).to receive(:memory_for).with(other_rep).and_return(memory)
+
+    allow(Nanoc::Int::NotificationCenter).to receive(:post)
   end
 
   describe '#compile_rep' do

--- a/spec/nanoc/base/services/compiler/phases/abstract_spec.rb
+++ b/spec/nanoc/base/services/compiler/phases/abstract_spec.rb
@@ -1,0 +1,49 @@
+describe Nanoc::Int::Compiler::Phases::Abstract do
+  subject(:phase) do
+    described_class.new(wrapped: wrapped, name: 'my_phase')
+  end
+
+  let(:item) { Nanoc::Int::Item.new('foo', {}, '/stuff.md') }
+  let(:rep) { Nanoc::Int::ItemRep.new(item, :default) }
+
+  let(:wrapped) { nil }
+
+  describe '#run' do
+    subject { phase.run(rep, is_outdated: false) {} }
+
+    it 'raises' do
+      expect { subject }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#call' do
+    subject { phase.call(rep, is_outdated: false) }
+
+    let(:phase) do
+      Class.new(described_class) do
+        def run(_rep, is_outdated:) # rubocop:disable Lint/UnusedMethodArgument
+          yield
+        end
+      end.new(wrapped: wrapped, name: 'my_phase')
+    end
+
+    let(:wrapped) do
+      Class.new(described_class) do
+        def run(_rep, is_outdated:); end
+      end.new(wrapped: nil, name: 'wrapped_phase')
+    end
+
+    it 'sends the proper notifications' do
+      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:phase_started, 'my_phase', rep).ordered
+      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:phase_yielded, 'my_phase', rep).ordered
+
+      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:phase_started, 'wrapped_phase', rep).ordered
+      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:phase_ended, 'wrapped_phase', rep).ordered
+
+      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:phase_resumed, 'my_phase', rep).ordered
+      expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:phase_ended, 'my_phase', rep).ordered
+
+      subject
+    end
+  end
+end


### PR DESCRIPTION
This introduces a superclass for all phases, that can notify started/stopped, yielded to/resumed from children, and abortion due to exception:

This will make it easier to add telemetry:

* start: start recording
* yield: stop  recording
* resume: restart recording
* end: stop recording
* abort: stop recording (recording might already be turned off)

This will only be printed if `--verbose` is given at least twice (e.g. `nanoc co -VV`).

![screen shot 2017-03-13 at 18 28 36](https://cloud.githubusercontent.com/assets/6269/23867040/f32c81a8-081a-11e7-9ed1-34cd03b19276.png)
