### PR TITLE
Add nice dependency cycle error

### DIFF
--- a/lib/nanoc/base/entities/directed_graph.rb
+++ b/lib/nanoc/base/entities/directed_graph.rb
@@ -158,6 +158,22 @@ module Nanoc::Int
 
     # @group Querying the graph
 
+    def any_cycle
+      path = [@vertices.keys.first]
+
+      loop do
+        nexts = direct_successors_of(path.last)
+        cycle_start_index = path.find_index { |node| nexts.include?(node) }
+        if cycle_start_index
+          break path[cycle_start_index..-1]
+        elsif nexts.empty?
+          break nil
+        else
+          path << nexts.sample
+        end
+      end
+    end
+
     # Returns the direct predecessors of the given vertex, i.e. the vertices
     # x where there is an edge from x to the given vertex y.
     #

--- a/lib/nanoc/base/errors.rb
+++ b/lib/nanoc/base/errors.rb
@@ -68,7 +68,7 @@ module Nanoc::Int
 
     # Error that is raised during site compilation when an item (directly or
     # indirectly) includes its own item content, leading to endless recursion.
-    class RecursiveCompilation < Generic
+    class DependencyCycle < Generic
       # @param [Array<Nanoc::Int::ItemRep>] reps A list of item representations
       #   that mutually depend on each other
       def initialize(reps)

--- a/lib/nanoc/base/errors.rb
+++ b/lib/nanoc/base/errors.rb
@@ -69,11 +69,16 @@ module Nanoc::Int
     # Error that is raised during site compilation when an item (directly or
     # indirectly) includes its own item content, leading to endless recursion.
     class DependencyCycle < Generic
-      # @param [Array<Nanoc::Int::ItemRep>] reps A list of item representations
-      #   that mutually depend on each other
-      def initialize(reps)
-        list = reps.map(&:inspect).join("\n")
-        super("The site cannot be compiled because the following items mutually depend on each other:\n#{list}.")
+      def initialize(graph)
+        cycle = graph.any_cycle
+
+        msg_bits = []
+        msg_bits << 'The site cannot be compiled because there is a dependency cycle:'
+        msg_bits << ''
+        cycle.each.with_index { |r, i| msg_bits << "    (#{i + 1}) item #{r.item.identifier}, rep #{r.name.inspect}, depends on" }
+        msg_bits.last << ' (1)'
+
+        super(msg_bits.map { |x| x + "\n" }.join(''))
       end
     end
 

--- a/lib/nanoc/base/services/item_rep_selector.rb
+++ b/lib/nanoc/base/services/item_rep_selector.rb
@@ -30,7 +30,7 @@ module Nanoc::Int
 
       # Check whether everything was compiled
       unless graph.vertices.empty?
-        raise Nanoc::Int::Errors::RecursiveCompilation.new(graph.vertices)
+        raise Nanoc::Int::Errors::DependencyCycle.new(graph.vertices)
       end
     end
 

--- a/lib/nanoc/base/services/item_rep_selector.rb
+++ b/lib/nanoc/base/services/item_rep_selector.rb
@@ -30,7 +30,7 @@ module Nanoc::Int
 
       # Check whether everything was compiled
       unless graph.vertices.empty?
-        raise Nanoc::Int::Errors::DependencyCycle.new(graph.vertices)
+        raise Nanoc::Int::Errors::DependencyCycle.new(graph)
       end
     end
 

--- a/spec/nanoc/base/directed_graph_spec.rb
+++ b/spec/nanoc/base/directed_graph_spec.rb
@@ -1,0 +1,54 @@
+describe Nanoc::Int::DirectedGraph do
+  subject(:graph) { described_class.new([1, 2, 3]) }
+
+  describe '#any_cycle' do
+    subject { graph.any_cycle }
+
+    context 'no cycles' do
+      it { is_expected.to be_nil }
+    end
+
+    context 'one cycle without head' do
+      before do
+        graph.add_edge(1, 2)
+        graph.add_edge(2, 1)
+      end
+
+      it { is_expected.to eq([1, 2]) }
+    end
+
+    context 'one cycle with head' do
+      before do
+        graph.add_edge(1, 2)
+        graph.add_edge(2, 3)
+        graph.add_edge(3, 2)
+      end
+
+      it { is_expected.to eq([2, 3]) }
+    end
+
+    context 'large cycle' do
+      before do
+        graph.add_edge(1, 2)
+        graph.add_edge(2, 3)
+        graph.add_edge(3, 4)
+        graph.add_edge(4, 5)
+        graph.add_edge(5, 1)
+      end
+
+      it { is_expected.to eq([1, 2, 3, 4, 5]) }
+    end
+
+    context 'large cycle with head' do
+      before do
+        graph.add_edge(1, 2)
+        graph.add_edge(2, 3)
+        graph.add_edge(3, 4)
+        graph.add_edge(4, 5)
+        graph.add_edge(5, 2)
+      end
+
+      it { is_expected.to eq([2, 3, 4, 5]) }
+    end
+  end
+end

--- a/spec/nanoc/base/errors/dependency_cycle_spec.rb
+++ b/spec/nanoc/base/errors/dependency_cycle_spec.rb
@@ -1,0 +1,32 @@
+describe Nanoc::Int::Errors::DependencyCycle do
+  subject(:error) { described_class.new(graph) }
+
+  let(:graph) do
+    Nanoc::Int::DirectedGraph.new([]).tap do |g|
+      g.add_edge(rep_a, rep_b)
+      g.add_edge(rep_b, rep_c)
+      g.add_edge(rep_c, rep_d)
+      g.add_edge(rep_d, rep_e)
+      g.add_edge(rep_e, rep_b)
+    end
+  end
+
+  let(:rep_a) { Nanoc::Int::ItemRep.new(Nanoc::Int::Item.new('a', {}, '/a.md'), :default) }
+  let(:rep_b) { Nanoc::Int::ItemRep.new(Nanoc::Int::Item.new('b', {}, '/b.md'), :default) }
+  let(:rep_c) { Nanoc::Int::ItemRep.new(Nanoc::Int::Item.new('c', {}, '/c.md'), :default) }
+  let(:rep_d) { Nanoc::Int::ItemRep.new(Nanoc::Int::Item.new('d', {}, '/d.md'), :default) }
+  let(:rep_e) { Nanoc::Int::ItemRep.new(Nanoc::Int::Item.new('e', {}, '/e.md'), :default) }
+
+  it 'has an informative error message' do
+    expected = <<EOS
+The site cannot be compiled because there is a dependency cycle:
+
+    (1) item /b.md, rep :default, depends on
+    (2) item /c.md, rep :default, depends on
+    (3) item /d.md, rep :default, depends on
+    (4) item /e.md, rep :default, depends on (1)
+EOS
+
+    expect(error.message).to eql(expected)
+  end
+end

--- a/spec/nanoc/regressions/gh_1040_spec.rb
+++ b/spec/nanoc/regressions/gh_1040_spec.rb
@@ -17,6 +17,6 @@ EOS
   end
 
   it 'errors' do
-    expect { Nanoc::CLI.run(%w(compile)) }.to raise_error(Nanoc::Int::Errors::RecursiveCompilation)
+    expect { Nanoc::CLI.run(%w(compile)) }.to raise_error(Nanoc::Int::Errors::DependencyCycle)
   end
 end

--- a/test/base/test_compiler.rb
+++ b/test/base/test_compiler.rb
@@ -114,7 +114,7 @@ class Nanoc::Int::CompilerTest < Nanoc::TestCase
       end
 
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
-      assert_raises Nanoc::Int::Errors::RecursiveCompilation do
+      assert_raises Nanoc::Int::Errors::DependencyCycle do
         site.compile
       end
     end


### PR DESCRIPTION
Fixes #1111. This prints the first cycle, which should be enough information:

```
The site cannot be compiled because there is a dependency cycle:

    (1) item /b.md, rep :default, depends on
    (2) item /c.md, rep :default, depends on
    (3) item /d.md, rep :default, depends on
    (4) item /e.md, rep :default, depends on (1)
```