### PR TITLE
Always recompile reps that use always-outdated filters

### DIFF
--- a/lib/nanoc/base/entities/outdatedness_reasons.rb
+++ b/lib/nanoc/base/entities/outdatedness_reasons.rb
@@ -58,5 +58,10 @@ module Nanoc::Int
       'One or more output paths of this item have been modified since the last time the site was compiled.',
       Props.new(path: true),
     )
+
+    UsesAlwaysOutdatedFilter = Generic.new(
+      'This item rep uses one or more filters that cannot track dependencies, and will thus always be considered as outdated.',
+      Props.new(raw_content: true, attributes: true, compiled_content: true),
+    )
   end
 end

--- a/lib/nanoc/base/services/filter.rb
+++ b/lib/nanoc/base/services/filter.rb
@@ -93,6 +93,21 @@ module Nanoc
         (@to || :text) == :binary
       end
 
+      # @return [Boolean]
+      #
+      # @api private
+      def always_outdated?
+        @always_outdated || false
+      end
+
+      # Marks this filter as always causing the item rep to be outdated. This is useful for filters
+      # that cannot do dependency tracking properly.
+      #
+      # @return [void]
+      def always_outdated
+        @always_outdated = true
+      end
+
       # @overload requires(*requires)
       #   Sets the required libraries for this filter.
       #   @param [Array<String>] requires A list of library names that are required

--- a/lib/nanoc/base/services/outdatedness_checker.rb
+++ b/lib/nanoc/base/services/outdatedness_checker.rb
@@ -19,6 +19,7 @@ module Nanoc::Int
           Rules::NotWritten,
           Rules::CodeSnippetsModified,
           Rules::ConfigurationModified,
+          Rules::UsesAlwaysOutdatedFilter,
         ].freeze
 
       RULES_FOR_LAYOUT =
@@ -26,6 +27,7 @@ module Nanoc::Int
           Rules::RulesModified,
           Rules::ContentModified,
           Rules::AttributesModified,
+          Rules::UsesAlwaysOutdatedFilter,
         ].freeze
 
       contract C::KeywordArgs[outdatedness_checker: OutdatednessChecker, reps: Nanoc::Int::ItemRepRepo] => C::Any

--- a/lib/nanoc/base/services/outdatedness_rules.rb
+++ b/lib/nanoc/base/services/outdatedness_rules.rb
@@ -117,5 +117,21 @@ module Nanoc::Int
         paths_old != paths_new
       end
     end
+
+    class UsesAlwaysOutdatedFilter < OutdatednessRule
+      def reason
+        Nanoc::Int::OutdatednessReasons::UsesAlwaysOutdatedFilter
+      end
+
+      def apply(obj, outdatedness_checker)
+        mem = outdatedness_checker.action_provider.memory_for(obj)
+
+        mem
+          .select { |a| a.is_a?(Nanoc::Int::ProcessingActions::Filter) }
+          .map { |a| Nanoc::Filter.named(a.filter_name) }
+          .compact
+          .any?(&:always_outdated?)
+      end
+    end
   end
 end

--- a/lib/nanoc/filters/xsl.rb
+++ b/lib/nanoc/filters/xsl.rb
@@ -5,6 +5,8 @@ module Nanoc::Filters
 
     requires 'nokogiri'
 
+    always_outdated
+
     # Runs the item content through an [XSLT](http://www.w3.org/TR/xslt)
     # stylesheet using  [Nokogiri](http://nokogiri.org/).
     #

--- a/spec/nanoc/base/filter_spec.rb
+++ b/spec/nanoc/base/filter_spec.rb
@@ -37,6 +37,42 @@ describe Nanoc::Filter do
     end
   end
 
+  describe '.always_outdated? + .always_outdated' do
+    context 'not always outdated' do
+      let(:filter_class) do
+        Class.new(Nanoc::Filter) do
+          identifier :bea22a356b6b031cea1e615087179803818c6a53
+
+          def run(content, _params)
+            content.upcase
+          end
+        end
+      end
+
+      it 'is not always outdated' do
+        expect(filter_class).not_to be_always_outdated
+      end
+    end
+
+    context 'always outdated' do
+      let(:filter_class) do
+        Class.new(Nanoc::Filter) do
+          identifier :d7413fa71223e5e69b03a0abfa25806e07e14f3a
+
+          always_outdated
+
+          def run(content, _params)
+            content.upcase
+          end
+        end
+      end
+
+      it 'is always outdated' do
+        expect(filter_class).to be_always_outdated
+      end
+    end
+  end
+
   describe '#depend_on' do
     subject { filter.depend_on(item_views) }
 

--- a/spec/nanoc/base/services/outdatedness_rules_spec.rb
+++ b/spec/nanoc/base/services/outdatedness_rules_spec.rb
@@ -435,5 +435,46 @@ describe Nanoc::Int::OutdatednessRules do
 
       # …
     end
+
+    describe 'UsesAlwaysOutdatedFilter' do
+      let(:rule_class) { Nanoc::Int::OutdatednessRules::UsesAlwaysOutdatedFilter }
+
+      before do
+        allow(action_provider).to receive(:memory_for).with(item_rep).and_return(mem)
+      end
+
+      context 'unknown filter' do
+        let(:mem) do
+          Nanoc::Int::RuleMemory.new(item_rep).tap do |mem|
+            mem.add_snapshot(:donkey, '/foo.md')
+            mem.add_filter(:asdf, {})
+          end
+        end
+
+        it { is_expected.not_to be }
+      end
+
+      context 'known filter, not always outdated' do
+        let(:mem) do
+          Nanoc::Int::RuleMemory.new(item_rep).tap do |mem|
+            mem.add_snapshot(:donkey, '/foo.md')
+            mem.add_filter(:erb, {})
+          end
+        end
+
+        it { is_expected.not_to be }
+      end
+
+      context 'known filter, always outdated' do
+        let(:mem) do
+          Nanoc::Int::RuleMemory.new(item_rep).tap do |mem|
+            mem.add_snapshot(:donkey, '/foo.md')
+            mem.add_filter(:xsl, {})
+          end
+        end
+
+        it { is_expected.to be }
+      end
+    end
   end
 end

--- a/spec/nanoc/regressions/gh_924_spec.rb
+++ b/spec/nanoc/regressions/gh_924_spec.rb
@@ -1,0 +1,89 @@
+describe 'GH-924', site: true, stdio: true do
+  before do
+    File.write('nanoc.yaml', <<EOS)
+text_extensions: [ 'xml', 'xsl' ]
+EOS
+
+    File.write('content/index.xml', '<root/>')
+
+    File.write('layouts/default.xsl', <<EOS)
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet version="1.0"
+  xmlns="http://www.w3.org/1999/xhtml"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  exclude-result-prefixes="xhtml">
+<xsl:output encoding="UTF-8"
+  doctype-public="-//W3C//DTD XHTML 1.1//EN"
+  doctype-system="http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"
+  indent="yes" />
+<xsl:strip-space elements="*" />
+
+<xsl:include href='layouts/snippet.xsl' />
+
+</xsl:stylesheet>
+EOS
+
+    File.write('layouts/snippet.xsl', <<EOS)
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet version="1.0"
+  xmlns="http://www.w3.org/1999/xhtml"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  exclude-result-prefixes="xhtml">
+
+<xsl:template match="/root">
+  <html>
+    <head>
+      <title>Original Title</title>
+    </head>
+    <body>
+      <p>Test Body</p>
+    </body>
+  </html>
+</xsl:template>
+
+</xsl:stylesheet>
+EOS
+
+    File.write('Rules', <<EOS)
+compile '/index.xml' do
+  layout '/default.xsl'
+  write '/index.xhtml'
+end
+
+layout '/**/*.xsl', :xsl
+EOS
+  end
+
+  before do
+    Nanoc::CLI.run(%w(compile))
+  end
+
+  example do
+    File.write('layouts/snippet.xsl', <<EOS)
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet version="1.0"
+  xmlns="http://www.w3.org/1999/xhtml"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  exclude-result-prefixes="xhtml">
+
+<xsl:template match="/root">
+  <html>
+    <head>
+      <title>Changed Title</title>
+    </head>
+    <body>
+      <p>Test Body</p>
+    </body>
+  </html>
+</xsl:template>
+
+</xsl:stylesheet>
+EOS
+
+    expect { Nanoc::CLI.run(%w(compile)) }
+      .to change { File.read('output/index.xhtml') }
+      .from(/<title>Original Title/)
+      .to(/<title>Changed Title/)
+  end
+end


### PR DESCRIPTION
This allows filters to be declared as `always_outdated`, which means that item reps that use this filter will always be considered as outdated. This is useful for filters that cannot track dependencies properly.

Fixes #924.