### PR TITLE
Use post-compile views in checks

### DIFF
--- a/lib/nanoc/base/views/post_compile_item_rep_view.rb
+++ b/lib/nanoc/base/views/post_compile_item_rep_view.rb
@@ -16,5 +16,9 @@ module Nanoc
 
       content.string
     end
+
+    def raw_path(snapshot: :last)
+      @item_rep.raw_path(snapshot: snapshot)
+    end
   end
 end

--- a/lib/nanoc/checking/check.rb
+++ b/lib/nanoc/checking/check.rb
@@ -23,7 +23,7 @@ module Nanoc::Checking
       view_context = site.compiler.compilation_context.create_view_context(Nanoc::Int::DependencyTracker::Null.new)
 
       context = {
-        items: Nanoc::ItemCollectionWithRepsView.new(site.items, view_context),
+        items: Nanoc::PostCompileItemCollectionView.new(site.items, view_context),
         layouts: Nanoc::LayoutCollectionView.new(site.layouts, view_context),
         config: Nanoc::ConfigView.new(site.config, view_context),
         output_filenames: output_filenames,

--- a/spec/nanoc/base/views/post_compile_item_rep_view_spec.rb
+++ b/spec/nanoc/base/views/post_compile_item_rep_view_spec.rb
@@ -34,6 +34,64 @@ describe Nanoc::PostCompileItemRepView do
     end
   end
 
+  describe '#raw_path' do
+    context 'no args' do
+      subject { view.raw_path }
+
+      it 'does not raise' do
+        subject
+      end
+
+      context 'no path specified' do
+        it { is_expected.to be_nil }
+      end
+
+      context 'path for default snapshot specified' do
+        before do
+          item_rep.raw_paths = { last: ['output/about/index.html'] }
+        end
+
+        it { is_expected.to eql('output/about/index.html') }
+      end
+
+      context 'path specified, but not for default snapshot' do
+        before do
+          item_rep.raw_paths = { pre: ['output/about/index.html'] }
+        end
+
+        it { is_expected.to be_nil }
+      end
+    end
+
+    context 'snapshot arg' do
+      subject { view.raw_path(snapshot: :special) }
+
+      it 'does not raise' do
+        subject
+      end
+
+      context 'no path specified' do
+        it { is_expected.to be_nil }
+      end
+
+      context 'path for default snapshot specified' do
+        before do
+          item_rep.raw_paths = { special: ['output/about/index.html'] }
+        end
+
+        it { is_expected.to eql('output/about/index.html') }
+      end
+
+      context 'path specified, but not for default snapshot' do
+        before do
+          item_rep.raw_paths = { pre: ['output/about/index.html'] }
+        end
+
+        it { is_expected.to be_nil }
+      end
+    end
+  end
+
   describe '#compiled_content' do
     subject { view.compiled_content }
 

--- a/spec/nanoc/regressions/gh_1130_spec.rb
+++ b/spec/nanoc/regressions/gh_1130_spec.rb
@@ -1,0 +1,19 @@
+describe 'GH-1130', site: true, stdio: true do
+  before do
+    File.write('content/foo', 'asdf')
+
+    File.write('Rules', <<EOS)
+passthrough '/**/*'
+EOS
+
+    File.write('Checks', <<EOS)
+check :wat do
+  @items.flat_map(&:reps).map(&:raw_path)
+end
+EOS
+  end
+
+  it 'does not raise fiber error' do
+    Nanoc::CLI.run(%w(check wat))
+  end
+end


### PR DESCRIPTION
Fixes #1130.

There are three different view contexts in Nanoc:

1. Preprocess: reps do not exist
2. Compilation: reps exist; accessing data might create dependencies
3. Postprocess: reps exist, accessing data will not create dependencies

The checks should use the postprocess views, rather than the compilation views.