### PR TITLE
Store fine-grained attributes

### DIFF
--- a/lib/nanoc/base/entities/props.rb
+++ b/lib/nanoc/base/entities/props.rb
@@ -100,7 +100,7 @@ module Nanoc::Int
     def to_h
       {
         raw_content: raw_content?,
-        attributes: attributes?,
+        attributes: attributes,
         compiled_content: compiled_content?,
         path: path?,
       }

--- a/lib/nanoc/base/entities/props.rb
+++ b/lib/nanoc/base/entities/props.rb
@@ -3,12 +3,22 @@ module Nanoc::Int
   class Props
     include Nanoc::Int::ContractsSupport
 
-    contract C::KeywordArgs[raw_content: C::Optional[C::Bool], attributes: C::Optional[C::Bool], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]] => C::Any
+    attr_reader :attributes
+
+    C_ATTRS = C::Or[C::IterOf[Symbol], C::Bool]
+    contract C::KeywordArgs[raw_content: C::Optional[C::Bool], attributes: C::Optional[C_ATTRS], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]] => C::Any
     def initialize(raw_content: false, attributes: false, compiled_content: false, path: false)
       @raw_content = raw_content
-      @attributes = attributes
       @compiled_content = compiled_content
       @path = path
+
+      @attributes =
+        case attributes
+        when Enumerable
+          Set.new(attributes)
+        else
+          attributes
+        end
     end
 
     contract C::None => String
@@ -30,7 +40,12 @@ module Nanoc::Int
 
     contract C::None => C::Bool
     def attributes?
-      @attributes
+      case @attributes
+      when Enumerable
+        @attributes.any?
+      else
+        @attributes
+      end
     end
 
     contract C::None => C::Bool
@@ -47,10 +62,28 @@ module Nanoc::Int
     def merge(other)
       Props.new(
         raw_content: raw_content? || other.raw_content?,
-        attributes: attributes? || other.attributes?,
+        attributes: merge_attributes(other),
         compiled_content: compiled_content? || other.compiled_content?,
         path: path? || other.path?,
       )
+    end
+
+    def merge_attributes(other)
+      case attributes
+      when true
+        true
+      when false
+        other.attributes
+      else
+        case other.attributes
+        when true
+          true
+        when false
+          attributes
+        else
+          attributes + other.attributes
+        end
+      end
     end
 
     contract C::None => Set

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -58,7 +58,9 @@ module Nanoc::Int
       end
     end
 
-    contract C::Maybe[C::Or[Nanoc::Int::Item, Nanoc::Int::Layout]], C::Maybe[C::Or[Nanoc::Int::Item, Nanoc::Int::Layout]], C::KeywordArgs[raw_content: C::Optional[C::Bool], attributes: C::Optional[C::Bool], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]] => C::Any
+    C_DOC = C::Or[Nanoc::Int::Item, Nanoc::Int::Layout]
+    C_ATTR = C::Or[C::IterOf[Symbol], C::Bool]
+    contract C::Maybe[C_DOC], C::Maybe[C_DOC], C::KeywordArgs[raw_content: C::Optional[C::Bool], attributes: C::Optional[C_ATTR], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]] => C::Any
     # Records a dependency from `src` to `dst` in the dependency graph. When
     # `dst` is oudated, `src` will also become outdated.
     #
@@ -75,7 +77,6 @@ module Nanoc::Int
       new_props = Nanoc::Int::Props.new(raw_content: raw_content, attributes: attributes, compiled_content: compiled_content, path: path)
       props = existing_props.merge(new_props)
 
-      # Warning! dst and src are *reversed* here!
       @graph.add_edge(dst, src, props: props.to_h) unless src == dst
     end
 

--- a/lib/nanoc/base/services/dependency_tracker.rb
+++ b/lib/nanoc/base/services/dependency_tracker.rb
@@ -4,7 +4,8 @@ module Nanoc::Int
     include Nanoc::Int::ContractsSupport
 
     C_OBJ = C::Or[Nanoc::Int::Item, Nanoc::Int::Layout]
-    C_ARGS = C::KeywordArgs[raw_content: C::Optional[C::Bool], attributes: C::Optional[C::Bool], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]]
+    C_ATTR = C::Or[C::IterOf[Symbol], C::Bool]
+    C_ARGS = C::KeywordArgs[raw_content: C::Optional[C::Bool], attributes: C::Optional[C_ATTR], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]]
 
     class Null
       include Nanoc::Int::ContractsSupport

--- a/lib/nanoc/base/views/mixins/document_view_mixin.rb
+++ b/lib/nanoc/base/views/mixins/document_view_mixin.rb
@@ -36,19 +36,20 @@ module Nanoc
 
     # @see Hash#[]
     def [](key)
-      @context.dependency_tracker.bounce(unwrap, attributes: true)
+      @context.dependency_tracker.bounce(unwrap, attributes: [key])
       unwrap.attributes[key]
     end
 
     # @return [Hash]
     def attributes
+      # TODO: Refine dependencies
       @context.dependency_tracker.bounce(unwrap, attributes: true)
       unwrap.attributes
     end
 
     # @see Hash#fetch
     def fetch(key, fallback = NONE, &_block)
-      @context.dependency_tracker.bounce(unwrap, attributes: true)
+      @context.dependency_tracker.bounce(unwrap, attributes: [key])
 
       if unwrap.attributes.key?(key)
         unwrap.attributes[key]
@@ -63,7 +64,7 @@ module Nanoc
 
     # @see Hash#key?
     def key?(key)
-      @context.dependency_tracker.bounce(unwrap, attributes: true)
+      @context.dependency_tracker.bounce(unwrap, attributes: [key])
       unwrap.attributes.key?(key)
     end
 

--- a/spec/nanoc/base/entities/props_spec.rb
+++ b/spec/nanoc/base/entities/props_spec.rb
@@ -58,6 +58,16 @@ describe Nanoc::Int::Props do
       let(:props) { described_class.new(raw_content: true, attributes: true, compiled_content: true, path: true) }
       it { is_expected.to be }
     end
+
+    context 'attributes is empty list' do
+      let(:props) { described_class.new(attributes: []) }
+      it { is_expected.not_to be }
+    end
+
+    context 'attributes is non-empty list' do
+      let(:props) { described_class.new(attributes: [:donkey]) }
+      it { is_expected.to be }
+    end
   end
 
   describe '#compiled_content?' do
@@ -132,6 +142,92 @@ describe Nanoc::Int::Props do
       let(:other_props) { props_all }
 
       it { is_expected.to eql(Set.new(%i(raw_content attributes compiled_content path))) }
+    end
+  end
+
+  describe '#merge_attributes' do
+    let(:props_attrs_true) do
+      described_class.new(attributes: true)
+    end
+
+    let(:props_attrs_false) do
+      described_class.new(attributes: false)
+    end
+
+    let(:props_attrs_list_a) do
+      described_class.new(attributes: %i(donkey giraffe))
+    end
+
+    let(:props_attrs_list_b) do
+      described_class.new(attributes: %i(giraffe zebra))
+    end
+
+    subject { props.merge(other_props).attributes }
+
+    context 'false + false' do
+      let(:props) { props_attrs_false }
+      let(:other_props) { props_attrs_false }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'false + true' do
+      let(:props) { props_attrs_false }
+      let(:other_props) { props_attrs_true }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'false + list' do
+      let(:props) { props_attrs_false }
+      let(:other_props) { props_attrs_list_a }
+
+      it { is_expected.to be_a(Set) }
+      it { is_expected.to match_array(%i(donkey giraffe)) }
+    end
+
+    context 'true + false' do
+      let(:props) { props_attrs_true }
+      let(:other_props) { props_attrs_false }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'true + true' do
+      let(:props) { props_attrs_true }
+      let(:other_props) { props_attrs_true }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'true + list' do
+      let(:props) { props_attrs_true }
+      let(:other_props) { props_attrs_list_a }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'list + false' do
+      let(:props) { props_attrs_list_a }
+      let(:other_props) { props_attrs_false }
+
+      it { is_expected.to be_a(Set) }
+      it { is_expected.to match_array(%i(donkey giraffe)) }
+    end
+
+    context 'list + true' do
+      let(:props) { props_attrs_list_a }
+      let(:other_props) { props_attrs_true }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'list + list' do
+      let(:props) { props_attrs_list_a }
+      let(:other_props) { props_attrs_list_b }
+
+      it { is_expected.to be_a(Set) }
+      it { is_expected.to match_array(%i(donkey giraffe zebra)) }
     end
   end
 

--- a/spec/nanoc/base/repos/dependency_store_spec.rb
+++ b/spec/nanoc/base/repos/dependency_store_spec.rb
@@ -192,4 +192,76 @@ describe Nanoc::Int::DependencyStore do
       end
     end
   end
+
+  describe '#record_dependency' do
+    context 'no props' do
+      subject { store.record_dependency(obj_a, obj_b) }
+
+      it 'records a dependency' do
+        expect { subject }
+          .to change { store.objects_causing_outdatedness_of(obj_a) }
+          .from([])
+          .to([obj_b])
+      end
+    end
+
+    context 'compiled content prop' do
+      subject { store.record_dependency(obj_a, obj_b, compiled_content: true) }
+
+      it 'records a dependency' do
+        expect { subject }
+          .to change { store.objects_causing_outdatedness_of(obj_a) }
+          .from([])
+          .to([obj_b])
+      end
+
+      it 'records a dependency with the right props' do
+        subject
+        deps = store.dependencies_causing_outdatedness_of(obj_a)
+
+        expect(deps.first.props.attributes?).not_to be
+        expect(deps.first.props.compiled_content?).to be
+      end
+    end
+
+    context 'attribute prop (true)' do
+      subject { store.record_dependency(obj_a, obj_b, attributes: true) }
+
+      it 'records a dependency' do
+        expect { subject }
+          .to change { store.objects_causing_outdatedness_of(obj_a) }
+          .from([])
+          .to([obj_b])
+      end
+
+      it 'records a dependency with the right props' do
+        subject
+        deps = store.dependencies_causing_outdatedness_of(obj_a)
+
+        expect(deps.first.props.attributes?).to be
+        expect(deps.first.props.attributes).to be
+        expect(deps.first.props.compiled_content?).not_to be
+      end
+    end
+
+    context 'attribute prop (true)' do
+      subject { store.record_dependency(obj_a, obj_b, attributes: [:giraffe]) }
+
+      it 'records a dependency' do
+        expect { subject }
+          .to change { store.objects_causing_outdatedness_of(obj_a) }
+          .from([])
+          .to([obj_b])
+      end
+
+      it 'records a dependency with the right props' do
+        subject
+        deps = store.dependencies_causing_outdatedness_of(obj_a)
+
+        expect(deps.first.props.attributes?).to be
+        expect(deps.first.props.attributes).to match_array([:giraffe])
+        expect(deps.first.props.compiled_content?).not_to be
+      end
+    end
+  end
 end

--- a/spec/nanoc/base/services/executor_spec.rb
+++ b/spec/nanoc/base/services/executor_spec.rb
@@ -434,7 +434,7 @@ describe Nanoc::Int::Executor do
         allow(dependency_tracker).to receive(:enter)
           .with(layout, raw_content: true, attributes: false, compiled_content: false, path: false)
         allow(dependency_tracker).to receive(:enter)
-          .with(layout, raw_content: false, attributes: true, compiled_content: false, path: false)
+          .with(layout, raw_content: false, attributes: [:bug], compiled_content: false, path: false)
         allow(dependency_tracker).to receive(:exit)
         subject
         expect(snapshot_repo.get(rep, :last).string).to eq('head Gum Emperor foot')


### PR DESCRIPTION
This changes the dependency props to allow `attributes` to be either a boolean or a list of symbols:

* `true` means depending on _all_ attributes
* `false` means depending on _no_ attributes
* a list means depending on the given attributes

Next step: update outdatedness checker.