### PR TITLE
Refactor: Make OutdatednessRule#apply return reason

### DIFF
--- a/lib/nanoc/base/services/outdatedness_checker.rb
+++ b/lib/nanoc/base/services/outdatedness_checker.rb
@@ -58,10 +58,13 @@ module Nanoc::Int
         rules.inject(status) do |acc, rule|
           if !acc.useful_to_apply?(rule)
             acc
-          elsif rule.instance.call(obj, @outdatedness_checker)
-            acc.update(rule.instance.reason)
           else
-            acc
+            reason = rule.instance.call(obj, @outdatedness_checker)
+            if reason
+              acc.update(reason)
+            else
+              acc
+            end
           end
         end
       end


### PR DESCRIPTION
By making `OutdatednessRule#apply` return a reason rather than a boolean, the reason can be qualified. This will make it easier to later on return _which_ attributes have been modified, rather than returning whether or not any attributes have been modified at all. Knowing which attributes have been modified will prevent another category of needless recompilations.