### PR TITLE
	Trigger attribute dependencies only if attributes overlap

### DIFF
--- a/lib/nanoc/base/services/outdatedness_checker.rb
+++ b/lib/nanoc/base/services/outdatedness_checker.rb
@@ -176,7 +176,21 @@ module Nanoc::Int
       return true if dependency.from.nil?
 
       status = basic.outdatedness_status_for(dependency.from)
-      (status.props.active & dependency.props.active).any?
+
+      active = status.props.active & dependency.props.active
+      if attributes_unaffected?(status, dependency)
+        active.delete(:attributes)
+      end
+
+      active.any?
+    end
+
+    def attributes_unaffected?(status, dependency)
+      attr_reason = status.reasons.find do |r|
+        r.is_a?(Nanoc::Int::OutdatednessReasons::AttributesModified)
+      end
+
+      attr_reason && dependency.props.attributes.is_a?(Enumerable) && (dependency.props.attributes & attr_reason.attributes).empty?
     end
   end
 end

--- a/spec/nanoc/base/services/outdatedness_checker_spec.rb
+++ b/spec/nanoc/base/services/outdatedness_checker_spec.rb
@@ -217,7 +217,7 @@ describe Nanoc::Int::OutdatednessChecker do
       end
     end
 
-    context 'only attribute dependency' do
+    context 'only generic attribute dependency' do
       before do
         dependency_store.record_dependency(item, other_item, attributes: true)
       end
@@ -236,6 +236,50 @@ describe Nanoc::Int::OutdatednessChecker do
         before { other_item.attributes[:title] = 'omg new title' }
         before { other_item.content = Nanoc::Int::TextualContent.new('omg new content') }
         it { is_expected.to be }
+      end
+
+      context 'path changed' do
+        let(:new_memory_for_other_item_rep) do
+          Nanoc::Int::RuleMemory.new(other_item_rep).tap do |mem|
+            mem.add_filter(:erb, {})
+            mem.add_snapshot(:donkey, '/giraffe.txt')
+          end
+        end
+
+        it { is_expected.not_to be }
+      end
+    end
+
+    context 'only specific attribute dependency' do
+      before do
+        dependency_store.record_dependency(item, other_item, attributes: [:title])
+      end
+
+      context 'attribute changed' do
+        before { other_item.attributes[:title] = 'omg new title' }
+        it { is_expected.to be }
+      end
+
+      context 'other attribute changed' do
+        before { other_item.attributes[:subtitle] = 'tagline here' }
+        it { is_expected.not_to be }
+      end
+
+      context 'raw content changed' do
+        before { other_item.content = Nanoc::Int::TextualContent.new('omg new content') }
+        it { is_expected.not_to be }
+      end
+
+      context 'attribute + raw content changed' do
+        before { other_item.attributes[:title] = 'omg new title' }
+        before { other_item.content = Nanoc::Int::TextualContent.new('omg new content') }
+        it { is_expected.to be }
+      end
+
+      context 'other attribute + raw content changed' do
+        before { other_item.attributes[:subtitle] = 'tagline here' }
+        before { other_item.content = Nanoc::Int::TextualContent.new('omg new content') }
+        it { is_expected.not_to be }
       end
 
       context 'path changed' do


### PR DESCRIPTION
This makes attribute dependencies only cause outdatedness when at least one of the dependency’s attributes are marked as outdated.