### PR TITLE
Declare affected props in outdatedness rule

### DIFF
--- a/lib/nanoc/base/entities/outdatedness_status.rb
+++ b/lib/nanoc/base/entities/outdatedness_status.rb
@@ -10,7 +10,7 @@ module Nanoc::Int
     end
 
     def useful_to_apply?(rule)
-      (rule.instance.reason.props.active - @props.active).any?
+      (rule.affected_props - @props.active).any?
     end
 
     def update(reason)

--- a/lib/nanoc/base/services/outdatedness_rule.rb
+++ b/lib/nanoc/base/services/outdatedness_rule.rb
@@ -12,7 +12,7 @@ module Nanoc::Int
     end
 
     def apply(_obj, _outdatedness_checker)
-      raise NotImplementedError.new('Nanoc::Int::OutdatednessRule subclasses must implement ##reason, and #apply')
+      raise NotImplementedError.new('Nanoc::Int::OutdatednessRule subclasses must implement #apply')
     end
 
     contract C::None => String
@@ -20,9 +20,12 @@ module Nanoc::Int
       "#{self.class.name}(#{reason})"
     end
 
-    # TODO: remove
-    def reason
-      raise NotImplementedError.new('Nanoc::Int::OutdatednessRule subclasses must implement ##reason, and #apply')
+    def self.affects_props(*names)
+      @affected_props = Set.new(names)
+    end
+
+    def self.affected_props
+      @affected_props
     end
   end
 end

--- a/lib/nanoc/base/services/outdatedness_rules.rb
+++ b/lib/nanoc/base/services/outdatedness_rules.rb
@@ -6,9 +6,7 @@ module Nanoc::Int
 
       include Nanoc::Int::ContractsSupport
 
-      def reason
-        Nanoc::Int::OutdatednessReasons::CodeSnippetsModified
-      end
+      affects_props :raw_content, :attributes, :compiled_content, :path
 
       def apply(_obj, outdatedness_checker)
         if any_snippets_modified?(outdatedness_checker)
@@ -31,9 +29,7 @@ module Nanoc::Int
     class ConfigurationModified < OutdatednessRule
       extend Nanoc::Int::Memoization
 
-      def reason
-        Nanoc::Int::OutdatednessReasons::ConfigurationModified
-      end
+      affects_props :raw_content, :attributes, :compiled_content, :path
 
       def apply(_obj, outdatedness_checker)
         if config_modified?(outdatedness_checker)
@@ -53,9 +49,7 @@ module Nanoc::Int
     end
 
     class NotWritten < OutdatednessRule
-      def reason
-        Nanoc::Int::OutdatednessReasons::NotWritten
-      end
+      affects_props :raw_content, :attributes, :compiled_content, :path
 
       def apply(obj, _outdatedness_checker)
         if obj.raw_paths.values.flatten.compact.any? { |fn| !File.file?(fn) }
@@ -65,9 +59,7 @@ module Nanoc::Int
     end
 
     class ContentModified < OutdatednessRule
-      def reason
-        Nanoc::Int::OutdatednessReasons::ContentModified
-      end
+      affects_props :raw_content, :compiled_content
 
       def apply(obj, outdatedness_checker)
         obj = obj.item if obj.is_a?(Nanoc::Int::ItemRep)
@@ -85,9 +77,7 @@ module Nanoc::Int
 
       include Nanoc::Int::ContractsSupport
 
-      def reason
-        Nanoc::Int::OutdatednessReasons::AttributesModified
-      end
+      affects_props :attributes, :compiled_content
 
       contract C::Or[Nanoc::Int::ItemRep, Nanoc::Int::Item, Nanoc::Int::Layout], C::Named['Nanoc::Int::OutdatednessChecker'] => C::Maybe[Nanoc::Int::OutdatednessReasons::Generic]
       def apply(obj, outdatedness_checker)
@@ -108,9 +98,7 @@ module Nanoc::Int
     end
 
     class RulesModified < OutdatednessRule
-      def reason
-        Nanoc::Int::OutdatednessReasons::RulesModified
-      end
+      affects_props :compiled_content, :path
 
       def apply(obj, outdatedness_checker)
         mem_old = outdatedness_checker.rule_memory_store[obj]
@@ -122,9 +110,7 @@ module Nanoc::Int
     end
 
     class PathsModified < OutdatednessRule
-      def reason
-        Nanoc::Int::OutdatednessReasons::PathsModified
-      end
+      affects_props :path
 
       def apply(obj, outdatedness_checker)
         # FIXME: Prefer to not work on serialised version
@@ -143,9 +129,7 @@ module Nanoc::Int
     end
 
     class UsesAlwaysOutdatedFilter < OutdatednessRule
-      def reason
-        Nanoc::Int::OutdatednessReasons::UsesAlwaysOutdatedFilter
-      end
+      affects_props :raw_content, :attributes, :path
 
       def apply(obj, outdatedness_checker)
         mem = outdatedness_checker.action_provider.memory_for(obj)


### PR DESCRIPTION
This refactoring makes an outdatedness rule not have a reason associated with it. The reason was only needed in order to determine the affected props (one or more of `:raw_content`, `:attributes`, `:compiled_content`, `:path`).

This will simplify upcoming changes to the `AttributesModified` reason (which’ll be adjusted to also include a set of affected attributes).