### PR TITLE
Use per-attribute checksums to determine outdatedness

### DIFF
--- a/lib/nanoc/base/entities/outdatedness_reasons.rb
+++ b/lib/nanoc/base/entities/outdatedness_reasons.rb
@@ -49,10 +49,18 @@ module Nanoc::Int
       Props.new(raw_content: true, compiled_content: true),
     )
 
-    AttributesModified = Generic.new(
-      'The attributes of this item have been modified since the last time the site was compiled.',
-      Props.new(attributes: true, compiled_content: true),
-    )
+    class AttributesModified < Generic
+      attr_reader :attributes
+
+      def initialize(attributes)
+        super(
+          'The attributes of this item have been modified since the last time the site was compiled.',
+          Props.new(attributes: true, compiled_content: true),
+        )
+
+        @attributes = attributes
+      end
+    end
 
     PathsModified = Generic.new(
       'One or more output paths of this item have been modified since the last time the site was compiled.',

--- a/lib/nanoc/base/repos/checksum_store.rb
+++ b/lib/nanoc/base/repos/checksum_store.rb
@@ -28,7 +28,7 @@ module Nanoc::Int
     def add(obj)
       if obj.is_a?(Nanoc::Int::Document)
         @checksums[[obj.reference, :content]] = Nanoc::Int::Checksummer.calc_for_content_of(obj)
-        @checksums[[obj.reference, :attributes]] = Nanoc::Int::Checksummer.calc_for_attributes_of(obj)
+        @checksums[[obj.reference, :each_attribute]] = Nanoc::Int::Checksummer.calc_for_each_attribute_of(obj)
       end
 
       @checksums[obj.reference] = Nanoc::Int::Checksummer.calc(obj)
@@ -41,9 +41,9 @@ module Nanoc::Int
       @checksums[[obj.reference, :content]]
     end
 
-    contract c_obj => C::Maybe[String]
+    contract c_obj => C::Maybe[C::HashOf[Symbol, String]]
     def attributes_checksum_for(obj)
-      @checksums[[obj.reference, :attributes]]
+      @checksums[[obj.reference, :each_attribute]]
     end
 
     protected

--- a/lib/nanoc/base/services/checksummer.rb
+++ b/lib/nanoc/base/services/checksummer.rb
@@ -48,8 +48,10 @@ module Nanoc::Int
         obj.content_checksum_data || obj.checksum_data || Nanoc::Int::Checksummer.calc(obj.content)
       end
 
-      def calc_for_attributes_of(obj)
-        obj.attributes_checksum_data || obj.checksum_data || Nanoc::Int::Checksummer.calc(obj.attributes)
+      def calc_for_each_attribute_of(obj, digest_class = CompactDigest)
+        obj.attributes.each_with_object({}) do |(key, value), memo|
+          memo[key] = Nanoc::Int::Checksummer.calc(value, digest_class)
+        end
       end
 
       private

--- a/spec/nanoc/base/checksummer_spec.rb
+++ b/spec/nanoc/base/checksummer_spec.rb
@@ -23,6 +23,26 @@ end
 describe Nanoc::Int::Checksummer do
   subject { described_class.calc(obj, Nanoc::Int::Checksummer::VerboseDigest) }
 
+  describe '.calc_for_each_attribute_of' do
+    let(:obj) { Nanoc::Int::Item.new('asdf', { 'foo' => 'bar' }, '/foo.md') }
+
+    context 'compact' do
+      subject do
+        described_class.calc_for_each_attribute_of(obj)
+      end
+
+      it { is_expected.to have_key(:foo) }
+    end
+
+    context 'verbose' do
+      subject do
+        described_class.calc_for_each_attribute_of(obj, Nanoc::Int::Checksummer::VerboseDigest)
+      end
+
+      it { is_expected.to eq(foo: 'String<bar>') }
+    end
+  end
+
   context 'String' do
     let(:obj) { 'hello' }
     it { is_expected.to eql('String<hello>') }

--- a/spec/nanoc/base/repos/checksum_store_spec.rb
+++ b/spec/nanoc/base/repos/checksum_store_spec.rb
@@ -3,8 +3,11 @@ describe Nanoc::Int::ChecksumStore do
 
   let(:objects) { [item, code_snippet] }
 
-  let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo.md') }
-  let(:other_item) { Nanoc::Int::Item.new('asdf', {}, '/sneaky.md') }
+  let(:item) { Nanoc::Int::Item.new('asdf', item_attributes, '/foo.md') }
+  let(:other_item) { Nanoc::Int::Item.new('asdf', other_item_attributes, '/sneaky.md') }
+
+  let(:item_attributes) { {} }
+  let(:other_item_attributes) { {} }
 
   let(:code_snippet) { Nanoc::Int::CodeSnippet.new('def hi ; end', 'lib/foo.rb') }
   let(:other_code_snippet) { Nanoc::Int::CodeSnippet.new('def ho ; end', 'lib/bar.rb') }
@@ -90,6 +93,15 @@ describe Nanoc::Int::ChecksumStore do
 
     it 'has attributes checksum' do
       expect(store.attributes_checksum_for(item)).not_to be_nil
+      expect(store.attributes_checksum_for(item)).to eq({})
+    end
+
+    context 'item has attributes' do
+      let(:item_attributes) { { animal: 'donkey' } }
+
+      it 'has attribute checksum for specified attribute' do
+        expect(store.attributes_checksum_for(item)).to have_key(:animal)
+      end
     end
 
     context 'after storing and loading' do
@@ -117,6 +129,14 @@ describe Nanoc::Int::ChecksumStore do
 
     it 'has attributes checksum' do
       expect(store.attributes_checksum_for(other_item)).not_to be_nil
+    end
+
+    context 'item has attributes' do
+      let(:other_item_attributes) { { location: 'Bernauer Str.' } }
+
+      it 'has attribute checksum for specified attribute' do
+        expect(store.attributes_checksum_for(other_item)).to have_key(:location)
+      end
     end
 
     context 'after storing and loading' do

--- a/spec/nanoc/base/services/outdatedness_rules_spec.rb
+++ b/spec/nanoc/base/services/outdatedness_rules_spec.rb
@@ -213,8 +213,58 @@ describe Nanoc::Int::OutdatednessRules do
 
         context 'checksum available, but attributes different' do
           let(:old_item) { Nanoc::Int::Item.new('stuff', { greeting: 'hi' }, '/foo.md') }
+
           before { checksum_store.add(old_item) }
+
           it { is_expected.to be }
+
+          it 'has the one changed attribute' do
+            expect(subject.attributes).to contain_exactly(:greeting)
+          end
+        end
+
+        context 'attribute kept identical' do
+          let(:item)     { Nanoc::Int::Item.new('stuff', { greeting: 'hi' }, '/foo.md') }
+          let(:old_item) { Nanoc::Int::Item.new('stuff', { greeting: 'hi' }, '/foo.md') }
+
+          before { checksum_store.add(old_item) }
+
+          it 'has the one changed attribute' do
+            expect(subject).to be_nil
+          end
+        end
+
+        context 'attribute changed' do
+          let(:item)     { Nanoc::Int::Item.new('stuff', { greeting: 'hi' }, '/foo.md') }
+          let(:old_item) { Nanoc::Int::Item.new('stuff', { greeting: 'ho' }, '/foo.md') }
+
+          before { checksum_store.add(old_item) }
+
+          it 'has the one changed attribute' do
+            expect(subject.attributes).to contain_exactly(:greeting)
+          end
+        end
+
+        context 'attribute deleted' do
+          let(:item)     { Nanoc::Int::Item.new('stuff', { greeting: 'hi' }, '/foo.md') }
+          let(:old_item) { Nanoc::Int::Item.new('stuff', {}, '/foo.md') }
+
+          before { checksum_store.add(old_item) }
+
+          it 'has the one changed attribute' do
+            expect(subject.attributes).to contain_exactly(:greeting)
+          end
+        end
+
+        context 'attribute added' do
+          let(:item)     { Nanoc::Int::Item.new('stuff', {}, '/foo.md') }
+          let(:old_item) { Nanoc::Int::Item.new('stuff', { greeting: 'hi' }, '/foo.md') }
+
+          before { checksum_store.add(old_item) }
+
+          it 'has the one changed attribute' do
+            expect(subject.attributes).to contain_exactly(:greeting)
+          end
         end
       end
 
@@ -238,8 +288,14 @@ describe Nanoc::Int::OutdatednessRules do
 
         context 'checksum available, but attributes different' do
           let(:old_item) { Nanoc::Int::Item.new('stuff', { greeting: 'hi' }, '/foo.md') }
+
           before { checksum_store.add(old_item) }
+
           it { is_expected.to be }
+
+          it 'has the one changed attribute' do
+            expect(subject.attributes).to contain_exactly(:greeting)
+          end
         end
       end
     end
@@ -382,8 +438,10 @@ describe Nanoc::Int::OutdatednessRules do
             before { checksum_store.add(stored_obj) }
 
             context 'but checksum data afterwards' do
+              # NOTE: ignored for attributes!
+
               let(:new_obj) { klass.new('a', {}, '/foo.md', checksum_data: 'cs-data-new') }
-              it { is_expected.to eql([true, true]) }
+              it { is_expected.to eql([true, false]) }
             end
 
             context 'and unchanged' do
@@ -415,6 +473,8 @@ describe Nanoc::Int::OutdatednessRules do
         end
 
         context 'attributes_checksum_data' do
+          # NOTE: attributes_checksum_data is ignored!
+
           let(:stored_obj) { klass.new('a', {}, '/foo.md', attributes_checksum_data: 'cs-data') }
           let(:new_obj)    { stored_obj }
 
@@ -427,7 +487,7 @@ describe Nanoc::Int::OutdatednessRules do
 
             context 'but checksum data afterwards' do
               let(:new_obj) { klass.new('a', {}, '/foo.md', attributes_checksum_data: 'cs-data-new') }
-              it { is_expected.to eql([false, true]) }
+              it { is_expected.to eql([false, false]) }
             end
 
             context 'and unchanged' do

--- a/test/base/test_outdatedness_checker.rb
+++ b/test/base/test_outdatedness_checker.rb
@@ -124,7 +124,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.load_stores
       outdatedness_checker = site.compiler.send :outdatedness_checker
       rep = site.compiler.reps[site.items.find { |i| i.identifier == '/new/' }][0]
-      assert_equal ::Nanoc::Int::OutdatednessReasons::AttributesModified, outdatedness_checker.outdatedness_reason_for(rep)
+      assert_equal ::Nanoc::Int::OutdatednessReasons::AttributesModified, outdatedness_checker.outdatedness_reason_for(rep).class
     end
   end
 


### PR DESCRIPTION
This is in preparation for fine-grained attribute dependencies.

This might cause a small slowdown, but the fine-grained attribute triggering (which will come later) will likely more than make up for that. Additionally, some checksum caching could be introduced at a later point to mitigate any slowdowns.