### PR TITLE
Cache rule memory calculator results

### DIFF
--- a/lib/nanoc/base/services/compiler.rb
+++ b/lib/nanoc/base/services/compiler.rb
@@ -164,7 +164,7 @@ module Nanoc::Int
       builder = Nanoc::Int::ItemRepBuilder.new(
         site, action_provider, @reps
       )
-      builder.run
+      @memories = builder.run
     end
 
     def compilation_context

--- a/lib/nanoc/base/services/compiler.rb
+++ b/lib/nanoc/base/services/compiler.rb
@@ -225,7 +225,7 @@ module Nanoc::Int
     end
 
     def determine_outdatedness
-      determine_outdatedness_stage.run do |outdated_items|
+      determine_outdatedness_stage.run(@memories) do |outdated_items|
         @outdated_items = outdated_items
       end
     end

--- a/lib/nanoc/base/services/compiler.rb
+++ b/lib/nanoc/base/services/compiler.rb
@@ -214,7 +214,7 @@ module Nanoc::Int
       @_compile_reps_stage ||= Stages::CompileReps.new(
         outdatedness_store: @outdatedness_store,
         dependency_store: @dependency_store,
-        action_provider: action_provider,
+        memories: @memories,
         compilation_context: compilation_context,
         compiled_content_cache: compiled_content_cache,
       )

--- a/lib/nanoc/base/services/compiler/phases/recalculate.rb
+++ b/lib/nanoc/base/services/compiler/phases/recalculate.rb
@@ -4,10 +4,10 @@ module Nanoc::Int::Compiler::Phases
   class Recalculate < Abstract
     include Nanoc::Int::ContractsSupport
 
-    def initialize(action_provider:, dependency_store:, compilation_context:)
+    def initialize(memories:, dependency_store:, compilation_context:)
       super(wrapped: nil)
 
-      @action_provider = action_provider
+      @memories = memories
       @dependency_store = dependency_store
       @compilation_context = compilation_context
     end
@@ -21,7 +21,7 @@ module Nanoc::Int::Compiler::Phases
 
       @compilation_context.snapshot_repo.set(rep, :last, rep.item.content)
 
-      actions = @action_provider.memory_for(rep)
+      actions = @memories[rep]
       actions.each do |action|
         case action
         when Nanoc::Int::ProcessingActions::Filter

--- a/lib/nanoc/base/services/compiler/stages/compile_reps.rb
+++ b/lib/nanoc/base/services/compiler/stages/compile_reps.rb
@@ -1,9 +1,9 @@
 module Nanoc::Int::Compiler::Stages
   class CompileReps
-    def initialize(outdatedness_store:, dependency_store:, action_provider:, compilation_context:, compiled_content_cache:)
+    def initialize(outdatedness_store:, dependency_store:, memories:, compilation_context:, compiled_content_cache:)
       @outdatedness_store = outdatedness_store
       @dependency_store = dependency_store
-      @action_provider = action_provider
+      @memories = memories
       @compilation_context = compilation_context
       @compiled_content_cache = compiled_content_cache
     end
@@ -33,7 +33,7 @@ module Nanoc::Int::Compiler::Stages
     def item_rep_compiler
       @_item_rep_compiler ||= begin
         recalculate_phase = Nanoc::Int::Compiler::Phases::Recalculate.new(
-          action_provider: @action_provider,
+          memories: @memories,
           dependency_store: @dependency_store,
           compilation_context: @compilation_context,
         )

--- a/lib/nanoc/base/services/compiler/stages/determine_outdatedness.rb
+++ b/lib/nanoc/base/services/compiler/stages/determine_outdatedness.rb
@@ -11,9 +11,9 @@ module Nanoc::Int::Compiler::Stages
     C_OBJ = C::Or[Nanoc::Int::Item, Nanoc::Int::ItemRep, Nanoc::Int::Layout]
 
     contract C::HashOf[C_OBJ => Nanoc::Int::RuleMemory], C::Func[C::IterOf[Nanoc::Int::Item] => C::Any] => C::Any
-    def run(_memories)
+    def run(memories)
       outdated_reps_tmp = @reps.select do |r|
-        @outdatedness_store.include?(r) || @outdatedness_checker.outdated?(r)
+        @outdatedness_store.include?(r) || @outdatedness_checker.outdated?(r, memories)
       end
 
       outdated_items = outdated_reps_tmp.map(&:item).uniq

--- a/lib/nanoc/base/services/compiler/stages/determine_outdatedness.rb
+++ b/lib/nanoc/base/services/compiler/stages/determine_outdatedness.rb
@@ -1,12 +1,17 @@
 module Nanoc::Int::Compiler::Stages
   class DetermineOutdatedness
+    include Nanoc::Int::ContractsSupport
+
     def initialize(reps:, outdatedness_checker:, outdatedness_store:)
       @reps = reps
       @outdatedness_checker = outdatedness_checker
       @outdatedness_store = outdatedness_store
     end
 
-    def run
+    C_OBJ = C::Or[Nanoc::Int::Item, Nanoc::Int::ItemRep, Nanoc::Int::Layout]
+
+    contract C::HashOf[C_OBJ => Nanoc::Int::RuleMemory], C::Func[C::IterOf[Nanoc::Int::Item] => C::Any] => C::Any
+    def run(_memories)
       outdated_reps_tmp = @reps.select do |r|
         @outdatedness_store.include?(r) || @outdatedness_checker.outdated?(r)
       end

--- a/lib/nanoc/base/services/item_rep_builder.rb
+++ b/lib/nanoc/base/services/item_rep_builder.rb
@@ -16,11 +16,13 @@ module Nanoc::Int
         end
       end
 
-      Nanoc::Int::ItemRepRouter.new(@reps, @action_provider, @site).run
+      memories = Nanoc::Int::ItemRepRouter.new(@reps, @action_provider, @site).run
 
       @reps.each do |rep|
-        rep.snapshot_defs = @action_provider.memory_for(rep).snapshots_defs
+        rep.snapshot_defs = memories[rep].snapshots_defs
       end
+
+      memories
     end
   end
 end

--- a/lib/nanoc/base/services/item_rep_router.rb
+++ b/lib/nanoc/base/services/item_rep_router.rb
@@ -24,6 +24,7 @@ module Nanoc::Int
     end
 
     def run
+      memories = {}
       assigned_paths = {}
       @reps.each do |rep|
         # Sigh. We route reps twice, because the first time, the paths might not have converged
@@ -35,12 +36,16 @@ module Nanoc::Int
           route_rep(rep, paths, snapshot_names, {})
         end
 
-        @action_provider.memory_for(rep).paths.each do |(snapshot_names, paths)|
+        mem = @action_provider.memory_for(rep)
+        memories[rep] = mem
+        mem.paths.each do |(snapshot_names, paths)|
           route_rep(rep, paths, snapshot_names, assigned_paths)
         end
 
         # TODO: verify that paths converge
       end
+
+      memories
     end
 
     contract Nanoc::Int::ItemRep, C::IterOf[String], C::IterOf[Symbol], C::HashOf[String => Nanoc::Int::ItemRep] => C::Any

--- a/lib/nanoc/base/services/outdatedness_checker.rb
+++ b/lib/nanoc/base/services/outdatedness_checker.rb
@@ -87,6 +87,8 @@ module Nanoc::Int
 
     Reasons = Nanoc::Int::OutdatednessReasons
 
+    C_OBJ = C::Or[Nanoc::Int::Item, Nanoc::Int::ItemRep, Nanoc::Int::Layout]
+
     # FIXME: Replace C::Any with proper types
     contract C::KeywordArgs[site: Nanoc::Int::Site, checksum_store: Nanoc::Int::ChecksumStore, dependency_store: Nanoc::Int::DependencyStore, rule_memory_store: Nanoc::Int::RuleMemoryStore, action_provider: C::Any, reps: Nanoc::Int::ItemRepRepo] => C::Any
     def initialize(site:, checksum_store:, dependency_store:, rule_memory_store:, action_provider:, reps:)
@@ -106,7 +108,7 @@ module Nanoc::Int
     end
     memoize :memory_for
 
-    contract C::Or[Nanoc::Int::Item, Nanoc::Int::ItemRep, Nanoc::Int::Layout] => C::Bool
+    contract C_OBJ, C::Maybe[C::HashOf[C_OBJ => Nanoc::Int::RuleMemory]] => C::Bool
     # Checks whether the given object is outdated and therefore needs to be
     # recompiled.
     #
@@ -114,7 +116,8 @@ module Nanoc::Int
     #   whose outdatedness should be checked.
     #
     # @return [Boolean] true if the object is outdated, false otherwise
-    def outdated?(obj)
+    def outdated?(obj, _memories = nil)
+      # TODO: use memories
       !outdatedness_reason_for(obj).nil?
     end
 

--- a/lib/nanoc/base/services/outdatedness_checker.rb
+++ b/lib/nanoc/base/services/outdatedness_checker.rb
@@ -100,6 +100,12 @@ module Nanoc::Int
       @objects_outdated_due_to_dependencies = {}
     end
 
+    def memory_for(rep)
+      # TODO: Pass in memories instead
+      @action_provider.memory_for(rep)
+    end
+    memoize :memory_for
+
     contract C::Or[Nanoc::Int::Item, Nanoc::Int::ItemRep, Nanoc::Int::Layout] => C::Bool
     # Checks whether the given object is outdated and therefore needs to be
     # recompiled.

--- a/lib/nanoc/base/services/outdatedness_rules/paths_modified.rb
+++ b/lib/nanoc/base/services/outdatedness_rules/paths_modified.rb
@@ -6,7 +6,7 @@ module Nanoc::Int::OutdatednessRules
       # FIXME: Prefer to not work on serialised version
 
       mem_old = outdatedness_checker.rule_memory_store[obj]
-      mem_new = outdatedness_checker.action_provider.memory_for(obj).serialize
+      mem_new = outdatedness_checker.memory_for(obj).serialize
       return true if mem_old.nil?
 
       paths_old = mem_old.select { |pa| pa[0] == :snapshot }

--- a/lib/nanoc/base/services/outdatedness_rules/rules_modified.rb
+++ b/lib/nanoc/base/services/outdatedness_rules/rules_modified.rb
@@ -4,7 +4,7 @@ module Nanoc::Int::OutdatednessRules
 
     def apply(obj, outdatedness_checker)
       mem_old = outdatedness_checker.rule_memory_store[obj]
-      mem_new = outdatedness_checker.action_provider.memory_for(obj).serialize
+      mem_new = outdatedness_checker.memory_for(obj).serialize
       unless mem_old.eql?(mem_new)
         Nanoc::Int::OutdatednessReasons::RulesModified
       end

--- a/lib/nanoc/base/services/outdatedness_rules/uses_always_outdated_filter.rb
+++ b/lib/nanoc/base/services/outdatedness_rules/uses_always_outdated_filter.rb
@@ -3,7 +3,7 @@ module Nanoc::Int::OutdatednessRules
     affects_props :raw_content, :attributes, :path
 
     def apply(obj, outdatedness_checker)
-      mem = outdatedness_checker.action_provider.memory_for(obj)
+      mem = outdatedness_checker.memory_for(obj)
       if any_always_outdated?(mem)
         Nanoc::Int::OutdatednessReasons::UsesAlwaysOutdatedFilter
       end

--- a/spec/nanoc/base/compiler_spec.rb
+++ b/spec/nanoc/base/compiler_spec.rb
@@ -68,8 +68,9 @@ describe Nanoc::Int::Compiler do
     allow(outdatedness_checker).to receive(:outdated?).with(rep).and_return(true)
     allow(outdatedness_checker).to receive(:outdated?).with(other_rep).and_return(true)
 
-    allow(action_provider).to receive(:memory_for).with(rep).and_return(memory)
-    allow(action_provider).to receive(:memory_for).with(other_rep).and_return(memory)
+    # FIXME: eww
+    memories = { rep => memory, other_rep => memory }
+    compiler.instance_variable_set(:@memories, memories)
 
     allow(Nanoc::Int::NotificationCenter).to receive(:post)
   end
@@ -99,10 +100,6 @@ describe Nanoc::Int::Compiler do
 
     context 'interrupted compilation' do
       let(:item) { Nanoc::Int::Item.new('other=<%= @items["/other.*"].compiled_content %>', {}, '/hi.md') }
-
-      before do
-        expect(action_provider).to receive(:memory_for).with(other_rep).and_return(memory)
-      end
 
       it 'generates expected output' do
         expect(compiler.snapshot_repo.get(rep, :last)).to be_nil

--- a/spec/nanoc/base/services/compiler/stages/compile_reps_spec.rb
+++ b/spec/nanoc/base/services/compiler/stages/compile_reps_spec.rb
@@ -3,7 +3,7 @@ describe Nanoc::Int::Compiler::Stages::CompileReps do
     described_class.new(
       outdatedness_store: outdatedness_store,
       dependency_store: dependency_store,
-      action_provider: action_provider,
+      memories: memories,
       compilation_context: compilation_context,
       compiled_content_cache: compiled_content_cache,
     )
@@ -20,6 +20,7 @@ describe Nanoc::Int::Compiler::Stages::CompileReps do
   end
 
   let(:action_provider) { double(:action_provider) }
+  let(:memories) { double(:memories) }
   let(:reps) { Nanoc::Int::ItemRepRepo.new }
   let(:compiled_content_cache) { Nanoc::Int::CompiledContentCache.new(items: items) }
   let(:snapshot_repo) { Nanoc::Int::SnapshotRepo.new }
@@ -70,8 +71,8 @@ describe Nanoc::Int::Compiler::Stages::CompileReps do
       rep.snapshot_defs << Nanoc::Int::SnapshotDef.new(:last, binary: false)
     end
 
-    allow(action_provider).to receive(:memory_for).with(rep).and_return(memory)
-    allow(action_provider).to receive(:memory_for).with(other_rep).and_return(memory)
+    allow(memories).to receive(:[]).with(rep).and_return(memory)
+    allow(memories).to receive(:[]).with(other_rep).and_return(memory)
   end
 
   describe '#compile_reps' do


### PR DESCRIPTION
This prevents the rule memories from being recalculated when it’s not necessary. Calculating the rule memory is fairly expensive, so this leads to a nice speedup.

The design of the way the rule memory is passed around is not ideal. The `ItemRepRouter` is the service that calculates the final rule memory, and it returns that, so that it can be reused elsewhere. This is weird because `ItemRepRouter` both returns something and modifies item reps. Anyway, something to refactor later.