### PR TITLE
Print all outdatedness reasons in show-data command

### DIFF
--- a/lib/nanoc/base/services/outdatedness_checker.rb
+++ b/lib/nanoc/base/services/outdatedness_checker.rb
@@ -114,12 +114,6 @@ module Nanoc::Int
       outdatedness_reasons_for(obj).any?
     end
 
-    contract C::Or[Nanoc::Int::Item, Nanoc::Int::ItemRep, Nanoc::Int::Layout] => C::Maybe[Reasons::Generic]
-    def outdatedness_reason_for(obj)
-      # TODO: stop using this
-      outdatedness_reasons_for(obj).first
-    end
-
     contract C::Or[Nanoc::Int::Item, Nanoc::Int::ItemRep, Nanoc::Int::Layout] => C::IterOf[Reasons::Generic]
     def outdatedness_reasons_for(obj)
       reasons = basic.outdatedness_status_for(obj).reasons

--- a/lib/nanoc/cli/commands/show-data.rb
+++ b/lib/nanoc/cli/commands/show-data.rb
@@ -129,12 +129,7 @@ module Nanoc::CLI::Commands
       sorted_reps_with_prev(items) do |rep, prev|
         puts if prev
         puts "item #{rep.item.identifier}, rep #{rep.name}:"
-        outdatedness_reason = compiler.outdatedness_checker.outdatedness_reason_for(rep)
-        if outdatedness_reason
-          puts "  is outdated: #{outdatedness_reason.message}"
-        else
-          puts '  is not outdated'
-        end
+        print_outdatedness_reasons_for(rep, compiler)
       end
     end
 
@@ -144,13 +139,19 @@ module Nanoc::CLI::Commands
       sorted_with_prev(layouts) do |layout, prev|
         puts if prev
         puts "layout #{layout.identifier}:"
-        outdatedness_reason = compiler.outdatedness_checker.outdatedness_reason_for(layout)
-        if outdatedness_reason
-          puts "  is outdated: #{outdatedness_reason.message}"
-        else
-          puts '  is not outdated'
+        print_outdatedness_reasons_for(layout, compiler)
+      end
+    end
+
+    def print_outdatedness_reasons_for(obj, compiler)
+      reasons = compiler.outdatedness_checker.outdatedness_reasons_for(obj)
+      if reasons.any?
+        puts '  is outdated:'
+        reasons.each do |reason|
+          puts "    - #{reason.message}"
         end
-        puts
+      else
+        puts '  is not outdated'
       end
     end
   end

--- a/spec/nanoc/cli/commands/show_data_spec.rb
+++ b/spec/nanoc/cli/commands/show_data_spec.rb
@@ -125,4 +125,151 @@ describe Nanoc::CLI::Commands::ShowData, stdio: true do
       end
     end
   end
+
+  describe '#print_item_rep_outdatedness' do
+    subject { runner.send(:print_item_rep_outdatedness, items, compiler) }
+
+    let(:runner) do
+      described_class.new(options, arguments, command)
+    end
+
+    let(:options) { {} }
+    let(:arguments) { [] }
+    let(:command) { double(:command) }
+
+    let(:config) { Nanoc::Int::Configuration.new }
+
+    let(:items) do
+      Nanoc::Int::IdentifiableCollection.new(
+        config,
+        [
+          item_about,
+          item_dog,
+        ],
+      )
+    end
+
+    let(:item_about) { Nanoc::Int::Item.new('About Me', {}, '/about.md') }
+    let(:item_dog)   { Nanoc::Int::Item.new('About My Dog', {}, '/dog.md') }
+
+    let(:item_rep_about) { Nanoc::Int::ItemRep.new(item_about, :default) }
+    let(:item_rep_dog)   { Nanoc::Int::ItemRep.new(item_dog, :default) }
+
+    let(:site) { double(:site) }
+    let(:compiler) { double(:compiler) }
+    let(:outdatedness_checker) { double(:outdatedness_checker) }
+
+    let(:reps) do
+      {
+        item_about => [item_rep_about],
+        item_dog => [item_rep_dog],
+      }
+    end
+
+    before do
+      allow(runner).to receive(:site).and_return(site)
+      allow(site).to receive(:compiler).and_return(compiler)
+      allow(compiler).to receive(:outdatedness_checker).and_return(outdatedness_checker)
+      allow(compiler).to receive(:reps).and_return(reps)
+    end
+
+    context 'not outdated' do
+      before do
+        allow(outdatedness_checker).to receive(:outdatedness_reasons_for).with(item_rep_about).and_return([])
+        allow(outdatedness_checker).to receive(:outdatedness_reasons_for).with(item_rep_dog).and_return([])
+      end
+
+      example do
+        expect { subject }.to output(%r{^item /about.md, rep default:\n  is not outdated$}).to_stdout
+      end
+
+      example do
+        expect { subject }.to output(%r{^item /dog.md, rep default:\n  is not outdated$}).to_stdout
+      end
+    end
+
+    context 'outdated' do
+      before do
+        reasons_about =
+          [
+            Nanoc::Int::OutdatednessReasons::ContentModified,
+            Nanoc::Int::OutdatednessReasons::AttributesModified.new([:title]),
+          ]
+
+        reasons_dog =
+          [Nanoc::Int::OutdatednessReasons::DependenciesOutdated]
+
+        allow(outdatedness_checker).to receive(:outdatedness_reasons_for)
+          .with(item_rep_about).and_return(reasons_about)
+
+        allow(outdatedness_checker).to receive(:outdatedness_reasons_for)
+          .with(item_rep_dog).and_return(reasons_dog)
+      end
+
+      example do
+        expect { subject }.to output(%r{^item /about.md, rep default:\n  is outdated:\n    - The content of this item has been modified since the last time the site was compiled.\n    - The attributes of this item have been modified since the last time the site was compiled.$}).to_stdout
+      end
+
+      example do
+        expect { subject }.to output(%r{^item /dog.md, rep default:\n  is outdated:\n    - This item uses content or attributes that have changed since the last time the site was compiled.$}).to_stdout
+      end
+    end
+  end
+
+  describe '#print_layouts' do
+    subject { runner.send(:print_layouts, layouts, compiler) }
+
+    let(:runner) do
+      described_class.new(options, arguments, command)
+    end
+
+    let(:options) { {} }
+    let(:arguments) { [] }
+    let(:command) { double(:command) }
+
+    let(:config) { Nanoc::Int::Configuration.new }
+
+    let(:layouts) do
+      Nanoc::Int::IdentifiableCollection.new(config, [layout])
+    end
+
+    let(:layout) { Nanoc::Int::Layout.new('stuff', {}, '/default.erb') }
+
+    let(:site) { double(:site) }
+    let(:compiler) { double(:compiler) }
+    let(:outdatedness_checker) { double(:outdatedness_checker) }
+
+    before do
+      allow(runner).to receive(:site).and_return(site)
+      allow(site).to receive(:compiler).and_return(compiler)
+      allow(compiler).to receive(:outdatedness_checker).and_return(outdatedness_checker)
+    end
+
+    context 'not outdated' do
+      before do
+        allow(outdatedness_checker).to receive(:outdatedness_reasons_for).with(layout).and_return([])
+      end
+
+      example do
+        expect { subject }.to output(%r{^layout /default.erb:\n  is not outdated$}).to_stdout
+      end
+    end
+
+    context 'outdated' do
+      before do
+        reasons =
+          [
+            Nanoc::Int::OutdatednessReasons::ContentModified,
+            Nanoc::Int::OutdatednessReasons::AttributesModified.new([:title]),
+          ]
+
+        allow(outdatedness_checker).to receive(:outdatedness_reasons_for)
+          .with(layout).and_return(reasons)
+      end
+
+      example do
+        expect { subject }.to output(%r{^layout /default.erb:\n  is outdated:\n    - The content of this item has been modified since the last time the site was compiled.\n    - The attributes of this item have been modified since the last time the site was compiled.$}).to_stdout
+      end
+    end
+  end
 end

--- a/spec/nanoc/integration/outdatedness_integration_spec.rb
+++ b/spec/nanoc/integration/outdatedness_integration_spec.rb
@@ -40,7 +40,7 @@ EOS
         output(/^item \/foo\.md, rep default:\n  is not outdated/).to_stdout,
       )
       expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
-        output(/^item \/bar\.md, rep default:\n  is outdated: /).to_stdout,
+        output(/^item \/bar\.md, rep default:\n  is outdated:/).to_stdout,
       )
     end
 
@@ -49,7 +49,7 @@ EOS
       FileUtils.touch('content/foo.md', mtime: time)
 
       expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
-        output(/^item \/foo\.md, rep default:\n  is outdated: /).to_stdout,
+        output(/^item \/foo\.md, rep default:\n  is outdated:/).to_stdout,
       )
       expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
         output(/^item \/bar\.md, rep default:\n  is not outdated/).to_stdout,
@@ -61,10 +61,10 @@ EOS
       FileUtils.touch('content/foo.md', mtime: time)
 
       expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
-        output(/^item \/foo\.md, rep default:\n  is outdated: /).to_stdout,
+        output(/^item \/foo\.md, rep default:\n  is outdated:/).to_stdout,
       )
       expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
-        output(/^item \/bar\.md, rep default:\n  is outdated: /).to_stdout,
+        output(/^item \/bar\.md, rep default:\n  is outdated:/).to_stdout,
       )
     end
   end
@@ -104,7 +104,7 @@ EOS
         output(/^item \/foo\.md, rep default:\n  is not outdated/).to_stdout,
       )
       expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
-        output(/^item \/bar\.md, rep default:\n  is outdated: /).to_stdout,
+        output(/^item \/bar\.md, rep default:\n  is outdated:/).to_stdout,
       )
     end
 
@@ -112,10 +112,10 @@ EOS
       File.write('content/foo.md', "---\ntitle: hello\n---\n\nfoooOoooOOoooOooo")
 
       expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
-        output(/^item \/foo\.md, rep default:\n  is outdated: /).to_stdout,
+        output(/^item \/foo\.md, rep default:\n  is outdated:/).to_stdout,
       )
       expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
-        output(/^item \/bar\.md, rep default:\n  is outdated: /).to_stdout,
+        output(/^item \/bar\.md, rep default:\n  is outdated:/).to_stdout,
       )
     end
 
@@ -123,7 +123,7 @@ EOS
       File.write('content/foo.md', "---\ntitle: bye\n---\n\nfoo")
 
       expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
-        output(/^item \/foo\.md, rep default:\n  is outdated: /).to_stdout,
+        output(/^item \/foo\.md, rep default:\n  is outdated:/).to_stdout,
       )
       expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
         output(/^item \/bar\.md, rep default:\n  is not outdated/).to_stdout,
@@ -166,7 +166,7 @@ EOS
         output(/^item \/foo\.md, rep default:\n  is not outdated/).to_stdout,
       )
       expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
-        output(/^item \/bar\.md, rep default:\n  is outdated: /).to_stdout,
+        output(/^item \/bar\.md, rep default:\n  is outdated:/).to_stdout,
       )
     end
 
@@ -174,10 +174,10 @@ EOS
       File.write('content/foo.md', "---\ntitle: hello\n---\n\nfoooOoooOOoooOooo")
 
       expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
-        output(/^item \/foo\.md, rep default:\n  is outdated: /).to_stdout,
+        output(/^item \/foo\.md, rep default:\n  is outdated:/).to_stdout,
       )
       expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
-        output(/^item \/bar\.md, rep default:\n  is outdated: /).to_stdout,
+        output(/^item \/bar\.md, rep default:\n  is outdated:/).to_stdout,
       )
     end
 
@@ -185,10 +185,10 @@ EOS
       File.write('content/foo.md', "---\ntitle: bye\n---\n\nfoo")
 
       expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
-        output(/^item \/foo\.md, rep default:\n  is outdated: /).to_stdout,
+        output(/^item \/foo\.md, rep default:\n  is outdated:/).to_stdout,
       )
       expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
-        output(/^item \/bar\.md, rep default:\n  is outdated: /).to_stdout,
+        output(/^item \/bar\.md, rep default:\n  is outdated:/).to_stdout,
       )
     end
 
@@ -206,7 +206,7 @@ end
 EOS
 
       expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
-        output(/^item \/foo\.md, rep default:\n  is outdated: /).to_stdout,
+        output(/^item \/foo\.md, rep default:\n  is outdated:/).to_stdout,
       )
       expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
         output(/^item \/bar\.md, rep default:\n  is not outdated/).to_stdout,

--- a/spec/nanoc/integration/partial_recompilation_spec.rb
+++ b/spec/nanoc/integration/partial_recompilation_spec.rb
@@ -20,9 +20,9 @@ EOS
     expect(File.file?('output/bar.html')).not_to be
 
     expect { Nanoc::CLI.run(%w(show-data --no-color)) }
-      .to(output(/^item \/foo\.md, rep default:\n  is outdated: /).to_stdout)
+      .to(output(/^item \/foo\.md, rep default:\n  is outdated:/).to_stdout)
     expect { Nanoc::CLI.run(%w(show-data --no-color)) }
-      .to(output(/^item \/bar\.md, rep default:\n  is outdated: /).to_stdout)
+      .to(output(/^item \/bar\.md, rep default:\n  is outdated:/).to_stdout)
 
     expect { Nanoc::CLI.run(%w(compile --verbose)) rescue nil }
       .to output(/create.*output\/foo\.html/).to_stdout
@@ -30,7 +30,7 @@ EOS
     expect { Nanoc::CLI.run(%w(show-data --no-color)) }
       .to(output(/^item \/foo\.md, rep default:\n  is not outdated/).to_stdout)
     expect { Nanoc::CLI.run(%w(show-data --no-color)) }
-      .to(output(/^item \/bar\.md, rep default:\n  is outdated: /).to_stdout)
+      .to(output(/^item \/bar\.md, rep default:\n  is outdated:/).to_stdout)
 
     expect(File.file?('output/foo.html')).to be
     expect(File.file?('output/bar.html')).not_to be
@@ -43,6 +43,6 @@ EOS
     expect { Nanoc::CLI.run(%w(show-data --no-color)) }
       .to(output(/^item \/foo\.md, rep default:\n  is not outdated/).to_stdout)
     expect { Nanoc::CLI.run(%w(show-data --no-color)) }
-      .to(output(/^item \/bar\.md, rep default:\n  is outdated: /).to_stdout)
+      .to(output(/^item \/bar\.md, rep default:\n  is outdated:/).to_stdout)
   end
 end

--- a/spec/nanoc/regressions/gh_970b_spec.rb
+++ b/spec/nanoc/regressions/gh_970b_spec.rb
@@ -33,7 +33,7 @@ EOS
       output(/^item \/foo\.md, rep default:\n  is not outdated/).to_stdout,
     )
     expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
-      output(/^item \/bar\.md, rep default:\n  is outdated: /).to_stdout,
+      output(/^item \/bar\.md, rep default:\n  is outdated:/).to_stdout,
     )
   end
 
@@ -41,10 +41,10 @@ EOS
     File.write('content/foo.md', 'FOO!')
 
     expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
-      output(/^item \/foo\.md, rep default:\n  is outdated: /).to_stdout,
+      output(/^item \/foo\.md, rep default:\n  is outdated:/).to_stdout,
     )
     expect { Nanoc::CLI.run(%w(show-data --no-color)) }.to(
-      output(/^item \/bar\.md, rep default:\n  is outdated: /).to_stdout,
+      output(/^item \/bar\.md, rep default:\n  is outdated:/).to_stdout,
     )
   end
 end

--- a/test/base/test_outdatedness_checker.rb
+++ b/test/base/test_outdatedness_checker.rb
@@ -18,7 +18,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.load_stores
       outdatedness_checker = site.compiler.send :outdatedness_checker
       rep = site.compiler.reps[site.items.find { |i| i.identifier == '/' }][0]
-      assert_nil outdatedness_checker.outdatedness_reason_for(rep)
+      assert_nil outdatedness_checker.outdatedness_reasons_for(rep).first
     end
   end
 
@@ -44,7 +44,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.load_stores
       outdatedness_checker = site.compiler.send :outdatedness_checker
       rep = site.compiler.reps[site.items.find { |i| i.identifier == '/' }][0]
-      assert_equal ::Nanoc::Int::OutdatednessReasons::ContentModified, outdatedness_checker.outdatedness_reason_for(rep)
+      assert_equal ::Nanoc::Int::OutdatednessReasons::ContentModified, outdatedness_checker.outdatedness_reasons_for(rep).first
     end
   end
 
@@ -70,7 +70,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.load_stores
       outdatedness_checker = site.compiler.send :outdatedness_checker
       rep = site.compiler.reps[site.items.find { |i| i.identifier == '/' }][0]
-      assert_equal ::Nanoc::Int::OutdatednessReasons::NotWritten, outdatedness_checker.outdatedness_reason_for(rep)
+      assert_equal ::Nanoc::Int::OutdatednessReasons::NotWritten, outdatedness_checker.outdatedness_reasons_for(rep).first
     end
   end
 
@@ -97,7 +97,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.load_stores
       outdatedness_checker = site.compiler.send :outdatedness_checker
       rep = site.compiler.reps[site.items.find { |i| i.identifier == '/new/' }][0]
-      assert_equal ::Nanoc::Int::OutdatednessReasons::ContentModified, outdatedness_checker.outdatedness_reason_for(rep)
+      assert_equal ::Nanoc::Int::OutdatednessReasons::ContentModified, outdatedness_checker.outdatedness_reasons_for(rep).first
     end
   end
 
@@ -124,7 +124,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.load_stores
       outdatedness_checker = site.compiler.send :outdatedness_checker
       rep = site.compiler.reps[site.items.find { |i| i.identifier == '/new/' }][0]
-      assert_equal ::Nanoc::Int::OutdatednessReasons::AttributesModified, outdatedness_checker.outdatedness_reason_for(rep).class
+      assert_equal ::Nanoc::Int::OutdatednessReasons::AttributesModified, outdatedness_checker.outdatedness_reasons_for(rep).first.class
     end
   end
 
@@ -152,7 +152,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
 
       outdatedness_checker = site.compiler.send :outdatedness_checker
       rep = site.compiler.reps[site.items.find { |i| i.identifier == '/' }][0]
-      assert_equal ::Nanoc::Int::OutdatednessReasons::DependenciesOutdated, outdatedness_checker.outdatedness_reason_for(rep)
+      assert_equal ::Nanoc::Int::OutdatednessReasons::DependenciesOutdated, outdatedness_checker.outdatedness_reasons_for(rep).first
     end
   end
 
@@ -186,7 +186,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
 
       outdatedness_checker = site.compiler.send :outdatedness_checker
       rep = site.compiler.reps[site.items.find { |i| i.identifier == '/a/' }][0]
-      assert_equal ::Nanoc::Int::OutdatednessReasons::DependenciesOutdated, outdatedness_checker.outdatedness_reason_for(rep)
+      assert_equal ::Nanoc::Int::OutdatednessReasons::DependenciesOutdated, outdatedness_checker.outdatedness_reasons_for(rep).first
     end
   end
 
@@ -223,7 +223,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
 
       outdatedness_checker = site.compiler.send :outdatedness_checker
       rep = site.compiler.reps[site.items.find { |i| i.identifier == '/a/' }][0]
-      assert_equal ::Nanoc::Int::OutdatednessReasons::DependenciesOutdated, outdatedness_checker.outdatedness_reason_for(rep)
+      assert_equal ::Nanoc::Int::OutdatednessReasons::DependenciesOutdated, outdatedness_checker.outdatedness_reasons_for(rep).first
     end
   end
 
@@ -257,7 +257,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
 
       outdatedness_checker = site.compiler.send :outdatedness_checker
       rep = site.compiler.reps[site.items.find { |i| i.identifier == '/a/' }][0]
-      assert_equal ::Nanoc::Int::OutdatednessReasons::DependenciesOutdated, outdatedness_checker.outdatedness_reason_for(rep)
+      assert_equal ::Nanoc::Int::OutdatednessReasons::DependenciesOutdated, outdatedness_checker.outdatedness_reasons_for(rep).first
     end
   end
 
@@ -293,7 +293,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
 
       outdatedness_checker = site.compiler.send :outdatedness_checker
       rep = site.compiler.reps[site.items.find { |i| i.identifier == '/a/' }][0]
-      assert_equal ::Nanoc::Int::OutdatednessReasons::DependenciesOutdated, outdatedness_checker.outdatedness_reason_for(rep)
+      assert_equal ::Nanoc::Int::OutdatednessReasons::DependenciesOutdated, outdatedness_checker.outdatedness_reasons_for(rep).first
     end
   end
 
@@ -320,7 +320,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.load_stores
       outdatedness_checker = site.compiler.send :outdatedness_checker
       rep = site.compiler.reps[site.items.find { |i| i.identifier == '/' }][0]
-      assert_equal ::Nanoc::Int::OutdatednessReasons::CodeSnippetsModified, outdatedness_checker.outdatedness_reason_for(rep)
+      assert_equal ::Nanoc::Int::OutdatednessReasons::CodeSnippetsModified, outdatedness_checker.outdatedness_reasons_for(rep).first
     end
   end
 
@@ -352,7 +352,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.load_stores
       outdatedness_checker = site.compiler.send :outdatedness_checker
       rep = site.compiler.reps[site.items.find { |i| i.identifier == '/' }][0]
-      assert_equal ::Nanoc::Int::OutdatednessReasons::ConfigurationModified, outdatedness_checker.outdatedness_reason_for(rep)
+      assert_equal ::Nanoc::Int::OutdatednessReasons::ConfigurationModified, outdatedness_checker.outdatedness_reasons_for(rep).first
     end
   end
 
@@ -377,7 +377,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.load_stores
       outdatedness_checker = site.compiler.send :outdatedness_checker
       rep = site.compiler.reps[site.items.find { |i| i.identifier == '/' }][0]
-      assert_nil outdatedness_checker.outdatedness_reason_for(rep)
+      assert_nil outdatedness_checker.outdatedness_reasons_for(rep).first
     end
   end
 
@@ -421,7 +421,7 @@ class Nanoc::Int::OutdatednessCheckerTest < Nanoc::TestCase
       site.compiler.load_stores
       outdatedness_checker = site.compiler.send :outdatedness_checker
       rep = site.compiler.reps[site.items.find { |i| i.identifier == '/' }][0]
-      assert_equal ::Nanoc::Int::OutdatednessReasons::RulesModified, outdatedness_checker.outdatedness_reason_for(rep)
+      assert_equal ::Nanoc::Int::OutdatednessReasons::RulesModified, outdatedness_checker.outdatedness_reasons_for(rep).first
     end
   end
 


### PR DESCRIPTION
Printing all outdatedness reasons is the right thing to do (why only print one if there’s multiple?), and it allows the otherwise unused `#outdatedness_reason_for` method to be removed.