### PR TITLE
Pass action sequences to outdatedness checker

### DIFF
--- a/lib/nanoc/base/services/compiler/stages/determine_outdatedness.rb
+++ b/lib/nanoc/base/services/compiler/stages/determine_outdatedness.rb
@@ -8,12 +8,10 @@ module Nanoc::Int::Compiler::Stages
       @outdatedness_store = outdatedness_store
     end
 
-    C_OBJ = C::Or[Nanoc::Int::Item, Nanoc::Int::ItemRep, Nanoc::Int::Layout]
-
-    contract C::HashOf[C_OBJ => Nanoc::Int::ActionSequence], C::Func[C::IterOf[Nanoc::Int::Item] => C::Any] => C::Any
-    def run(action_sequences)
+    contract C::Func[C::IterOf[Nanoc::Int::Item] => C::Any] => C::Any
+    def run
       outdated_reps_tmp = @reps.select do |r|
-        @outdatedness_store.include?(r) || @outdatedness_checker.outdated?(r, action_sequences)
+        @outdatedness_store.include?(r) || @outdatedness_checker.outdated?(r)
       end
 
       outdated_items = outdated_reps_tmp.map(&:item).uniq

--- a/lib/nanoc/base/services/outdatedness_checker.rb
+++ b/lib/nanoc/base/services/outdatedness_checker.rb
@@ -82,35 +82,32 @@ module Nanoc::Int
     attr_reader :checksum_store
     attr_reader :dependency_store
     attr_reader :action_sequence_store
-    attr_reader :action_provider
+    attr_reader :action_sequences
     attr_reader :site
 
     Reasons = Nanoc::Int::OutdatednessReasons
 
     C_OBJ = C::Or[Nanoc::Int::Item, Nanoc::Int::ItemRep, Nanoc::Int::Layout]
+    C_ACTION_SEQUENCES = C::HashOf[C_OBJ => Nanoc::Int::ActionSequence]
 
-    # FIXME: Replace C::Any with proper types
-    contract C::KeywordArgs[site: Nanoc::Int::Site, checksum_store: Nanoc::Int::ChecksumStore, dependency_store: Nanoc::Int::DependencyStore, action_sequence_store: Nanoc::Int::ActionSequenceStore, action_provider: C::Any, reps: Nanoc::Int::ItemRepRepo] => C::Any
-    def initialize(site:, checksum_store:, dependency_store:, action_sequence_store:, action_provider:, reps:)
+    contract C::KeywordArgs[site: Nanoc::Int::Site, checksum_store: Nanoc::Int::ChecksumStore, dependency_store: Nanoc::Int::DependencyStore, action_sequence_store: Nanoc::Int::ActionSequenceStore, action_sequences: C_ACTION_SEQUENCES, reps: Nanoc::Int::ItemRepRepo] => C::Any
+    def initialize(site:, checksum_store:, dependency_store:, action_sequence_store:, action_sequences:, reps:)
       @site = site
       @checksum_store = checksum_store
       @dependency_store = dependency_store
       @action_sequence_store = action_sequence_store
-      @action_provider = action_provider
+      @action_sequences = action_sequences
       @reps = reps
 
       @objects_outdated_due_to_dependencies = {}
     end
 
     def action_sequence_for(rep)
-      # TODO: Pass in action_sequences instead
-      @action_provider.action_sequence_for(rep)
+      @action_sequences.fetch(rep)
     end
-    memoize :action_sequence_for
 
-    contract C_OBJ, C::Maybe[C::HashOf[C_OBJ => Nanoc::Int::ActionSequence]] => C::Bool
-    def outdated?(obj, _action_sequences = nil)
-      # TODO: use action_sequences
+    contract C_OBJ => C::Bool
+    def outdated?(obj)
       outdatedness_reasons_for(obj).any?
     end
 

--- a/spec/nanoc/base/services/outdatedness_checker_spec.rb
+++ b/spec/nanoc/base/services/outdatedness_checker_spec.rb
@@ -5,7 +5,7 @@ describe Nanoc::Int::OutdatednessChecker do
       checksum_store: checksum_store,
       dependency_store: dependency_store,
       action_sequence_store: action_sequence_store,
-      action_provider: action_provider,
+      action_sequences: action_sequences,
       reps: reps,
     )
   end
@@ -38,7 +38,9 @@ describe Nanoc::Int::OutdatednessChecker do
 
   let(:new_action_sequence_for_item_rep) { old_action_sequence_for_item_rep }
 
-  let(:action_provider) { double(:action_provider) }
+  let(:action_sequences) do
+    { item_rep => new_action_sequence_for_item_rep }
+  end
 
   let(:reps) do
     Nanoc::Int::ItemRepRepo.new
@@ -52,8 +54,6 @@ describe Nanoc::Int::OutdatednessChecker do
   before do
     reps << item_rep
     action_sequence_store[item_rep] = old_action_sequence_for_item_rep.serialize
-
-    allow(action_provider).to receive(:action_sequence_for).with(item_rep).and_return(new_action_sequence_for_item_rep)
   end
 
   describe 'basic outdatedness reasons' do
@@ -131,6 +131,13 @@ describe Nanoc::Int::OutdatednessChecker do
 
     let(:new_action_sequence_for_other_item_rep) { old_action_sequence_for_other_item_rep }
 
+    let(:action_sequences) do
+      {
+        item_rep => new_action_sequence_for_item_rep,
+        other_item_rep => new_action_sequence_for_other_item_rep,
+      }
+    end
+
     before do
       reps << other_item_rep
       action_sequence_store[other_item_rep] = old_action_sequence_for_other_item_rep.serialize
@@ -138,7 +145,6 @@ describe Nanoc::Int::OutdatednessChecker do
       checksum_store.add(other_item)
       checksum_store.add(config)
 
-      allow(action_provider).to receive(:action_sequence_for).with(other_item_rep).and_return(new_action_sequence_for_other_item_rep)
       allow(site).to receive(:code_snippets).and_return([])
       allow(site).to receive(:config).and_return(config)
     end
@@ -147,11 +153,18 @@ describe Nanoc::Int::OutdatednessChecker do
       let(:distant_item) { Nanoc::Int::Item.new('distant stuff', {}, '/distant.md') }
       let(:distant_item_rep) { Nanoc::Int::ItemRep.new(distant_item, :default) }
 
+      let(:action_sequences) do
+        {
+          item_rep => new_action_sequence_for_item_rep,
+          other_item_rep => new_action_sequence_for_other_item_rep,
+          distant_item_rep => new_action_sequence_for_other_item_rep,
+        }
+      end
+
       before do
         reps << distant_item_rep
         checksum_store.add(distant_item)
         action_sequence_store[distant_item_rep] = old_action_sequence_for_other_item_rep.serialize
-        allow(action_provider).to receive(:action_sequence_for).with(distant_item_rep).and_return(new_action_sequence_for_other_item_rep)
       end
 
       context 'on attribute + attribute' do

--- a/spec/nanoc/base/services/outdatedness_rules_spec.rb
+++ b/spec/nanoc/base/services/outdatedness_rules_spec.rb
@@ -10,7 +10,7 @@ describe Nanoc::Int::OutdatednessRules do
         checksum_store: checksum_store,
         dependency_store: dependency_store,
         action_sequence_store: action_sequence_store,
-        action_provider: action_provider,
+        action_sequences: action_sequences,
         reps: reps,
       )
     end
@@ -30,7 +30,7 @@ describe Nanoc::Int::OutdatednessRules do
       )
     end
 
-    let(:action_provider) { double(:action_provider) }
+    let(:action_sequences) { {} }
     let(:reps) { Nanoc::Int::ItemRepRepo.new }
     let(:dependency_store) { Nanoc::Int::DependencyStore.new(dependency_store_objects) }
     let(:action_sequence_store) { Nanoc::Int::ActionSequenceStore.new }
@@ -309,9 +309,10 @@ describe Nanoc::Int::OutdatednessRules do
         end
       end
 
+      let(:action_sequences) { { item_rep => new_mem } }
+
       before do
         action_sequence_store[item_rep] = old_mem.serialize
-        allow(action_provider).to receive(:action_sequence_for).with(item_rep).and_return(new_mem)
       end
 
       context 'memory is the same' do
@@ -334,9 +335,7 @@ describe Nanoc::Int::OutdatednessRules do
     context 'PathsModified' do
       let(:rule_class) { Nanoc::Int::OutdatednessRules::PathsModified }
 
-      before do
-        allow(action_provider).to receive(:action_sequence_for).with(item_rep).and_return(new_mem)
-      end
+      let(:action_sequences) { { item_rep => new_mem } }
 
       context 'old mem does not exist' do
         let(:new_mem) do
@@ -513,9 +512,7 @@ describe Nanoc::Int::OutdatednessRules do
     describe 'UsesAlwaysOutdatedFilter' do
       let(:rule_class) { Nanoc::Int::OutdatednessRules::UsesAlwaysOutdatedFilter }
 
-      before do
-        allow(action_provider).to receive(:action_sequence_for).with(item_rep).and_return(mem)
-      end
+      let(:action_sequences) { { item_rep => mem } }
 
       context 'unknown filter' do
         let(:mem) do


### PR DESCRIPTION
This passes the already calculated action sequences to the outdatedness checker, which will prevent redundant recalculation.