### PR TITLE
Perform writes in separate threads

### DIFF
--- a/lib/nanoc/base/services/compiler/phases/abstract.rb
+++ b/lib/nanoc/base/services/compiler/phases/abstract.rb
@@ -24,6 +24,9 @@ module Nanoc::Int::Compiler::Phases
       raise NotImplementedError
     end
 
+    def finalize
+    end
+
     private
 
     def notify(sym, rep)

--- a/lib/nanoc/base/services/compiler/phases/write.rb
+++ b/lib/nanoc/base/services/compiler/phases/write.rb
@@ -2,17 +2,39 @@ module Nanoc::Int::Compiler::Phases
   class Write < Abstract
     include Nanoc::Int::ContractsSupport
 
+    STOP = Object.new
+
     def initialize(snapshot_repo:, wrapped:)
       super(wrapped: wrapped)
 
       @snapshot_repo = snapshot_repo
+
+      @queue = SizedQueue.new(100)
+      @threads = 3.times.map do
+        Thread.new do
+          loop do
+            e = @queue.pop
+            case e
+            when STOP
+              break
+            else
+              e.call
+            end
+          end
+        end
+      end
     end
 
     contract Nanoc::Int::ItemRep, C::KeywordArgs[is_outdated: C::Bool], C::Func[C::None => C::Any] => C::Any
     def run(rep, is_outdated:) # rubocop:disable Lint/UnusedMethodArgument
       yield
 
-      Nanoc::Int::ItemRepWriter.new.write_all(rep, @snapshot_repo)
+      @queue << -> { Nanoc::Int::ItemRepWriter.new.write_all(rep, @snapshot_repo) }
+    end
+
+    def finalize
+      @threads.size.times { @queue << STOP }
+      @threads.each(&:join)
     end
   end
 end


### PR DESCRIPTION
**WORK IN PROGRESS** — currently rather broken.

* [ ] Make it actually work properly
  * [ ] Synchronise around stdout output
  * [ ] Synchronise around `output.diff` generation
  * [ ] Call `#finalize`
* [ ] Extract `ThreadPool` abstraction (or whatever)

Preliminary tests suggest a 10% speed improvement.