### PR TITLE
Recognise --verbose when calling nanoc without subcommand

### DIFF
--- a/lib/nanoc/cli/commands/compile_listeners/timing_recorder.rb
+++ b/lib/nanoc/cli/commands/compile_listeners/timing_recorder.rb
@@ -3,8 +3,8 @@ module Nanoc::CLI::Commands::CompileListeners
     attr_reader :telemetry
 
     # @see Listener#enable_for?
-    def self.enable_for?(command_runner)
-      command_runner.options.fetch(:verbose, false)
+    def self.enable_for?(_command_runner)
+      Nanoc::CLI.verbosity >= 1
     end
 
     # @param [Enumerable<Nanoc::Int::ItemRep>] reps

--- a/spec/nanoc/regressions/gh_1145_spec.rb
+++ b/spec/nanoc/regressions/gh_1145_spec.rb
@@ -1,0 +1,16 @@
+describe 'GH-1145', site: true, stdio: true do
+  before do
+    File.write('content/foo.txt', 'asdf')
+
+    File.write('Rules', <<EOS)
+compile '/**/*' do
+  filter :erb
+  write '/last.html'
+end
+EOS
+  end
+
+  it 'detects missing output file of non-default rep' do
+    expect { Nanoc::CLI.run(%w(--verbose)) }.to output(/erb /).to_stdout
+  end
+end


### PR DESCRIPTION
Fixes #1145.

The current approach of calling the `compile` command when no subcommand is specified, is problematic. Perhaps Cri (Nanoc’s backing CLI library) needs to able to handle automatic delegation to a dedicated subcommand. (Also see ddfreyne/cri/issues/53).