### PR TITLE
Cache #find_all

### DIFF
--- a/lib/nanoc/base/entities/identifiable_collection.rb
+++ b/lib/nanoc/base/entities/identifiable_collection.rb
@@ -39,8 +39,11 @@ module Nanoc::Int
 
     contract C::Any => C::IterOf[C::RespondTo[:identifier]]
     def find_all(arg)
-      pat = Nanoc::Int::Pattern.from(arg)
-      select { |i| pat.match?(i.identifier) }
+      if frozen?
+        find_all_memoized(arg)
+      else
+        find_all_unmemoized(arg)
+      end
     end
 
     contract C::None => C::ArrayOf[C::RespondTo[:identifier]]
@@ -82,6 +85,18 @@ module Nanoc::Int
       get_unmemoized(arg)
     end
     memoize :get_memoized
+
+    contract C::Any => C::IterOf[C::RespondTo[:identifier]]
+    def find_all_unmemoized(arg)
+      pat = Nanoc::Int::Pattern.from(arg)
+      select { |i| pat.match?(i.identifier) }
+    end
+
+    contract C::Any => C::IterOf[C::RespondTo[:identifier]]
+    def find_all_memoized(arg)
+      find_all_unmemoized(arg)
+    end
+    memoize :find_all_memoized
 
     def object_with_identifier(identifier)
       if frozen?

--- a/lib/nanoc/base/entities/identifiable_collection.rb
+++ b/lib/nanoc/base/entities/identifiable_collection.rb
@@ -37,6 +37,12 @@ module Nanoc::Int
       end
     end
 
+    contract C::Any => C::IterOf[C::RespondTo[:identifier]]
+    def find_all(arg)
+      pat = Nanoc::Int::Pattern.from(arg)
+      select { |i| pat.match?(i.identifier) }
+    end
+
     contract C::None => C::ArrayOf[C::RespondTo[:identifier]]
     def to_a
       @objects.to_a

--- a/lib/nanoc/base/views/identifiable_collection_view.rb
+++ b/lib/nanoc/base/views/identifiable_collection_view.rb
@@ -43,8 +43,7 @@ module Nanoc
     #
     # @return [Enumerable]
     def find_all(arg)
-      pat = Nanoc::Int::Pattern.from(arg)
-      select { |i| pat.match?(i.identifier) }
+      @objects.find_all(arg).map { |i| view_class.new(i, @context) }
     end
 
     # @overload [](string)

--- a/spec/nanoc/base/entities/identifiable_collection_spec.rb
+++ b/spec/nanoc/base/entities/identifiable_collection_spec.rb
@@ -9,4 +9,38 @@ describe Nanoc::Int::IdentifiableCollection do
 
     it { is_expected.to be_a(described_class) }
   end
+
+  describe '#find_all' do
+    let(:objects) do
+      [
+        double(:identifiable, identifier: Nanoc::Identifier.new('/about.css')),
+        double(:identifiable, identifier: Nanoc::Identifier.new('/about.md')),
+        double(:identifiable, identifier: Nanoc::Identifier.new('/style.css')),
+      ]
+    end
+
+    let(:arg) { raise 'override me' }
+
+    subject { identifiable_collection.find_all(arg) }
+
+    context 'with string' do
+      let(:arg) { '/*.css' }
+
+      it 'contains objects' do
+        expect(subject.size).to eql(2)
+        expect(subject.find { |iv| iv.identifier == '/about.css' }).to eq(objects[0])
+        expect(subject.find { |iv| iv.identifier == '/style.css' }).to eq(objects[2])
+      end
+    end
+
+    context 'with regex' do
+      let(:arg) { %r{\.css\z} }
+
+      it 'contains objects' do
+        expect(subject.size).to eql(2)
+        expect(subject.find { |iv| iv.identifier == '/about.css' }).to eq(objects[0])
+        expect(subject.find { |iv| iv.identifier == '/style.css' }).to eq(objects[2])
+      end
+    end
+  end
 end


### PR DESCRIPTION
This speeds up `#find_all`, as it’s often called with the same argument. This also speeds up other methods that rely on it, such as `#children_of`.