### PR TITLE
Remove <meta> tag inserted by Nokogiri.

### DIFF
--- a/lib/nanoc/filters/relativize_paths.rb
+++ b/lib/nanoc/filters/relativize_paths.rb
@@ -78,7 +78,8 @@ module Nanoc::Filters
         content = content.sub(%r{(<html[^>]+)xmlns="http://www.w3.org/1999/xhtml"}, '\1')
       end
 
-      nokogiri_process(content, selectors, namespaces, klass, type)
+      result = nokogiri_process(content, selectors, namespaces, klass, type)
+      result.sub %r{\s*<meta http-equiv="Content-Type" content="[^"]+">}, ''
     end
 
     def nokogiri_process(content, selectors, namespaces, klass, type)

--- a/test/filters/test_relativize_paths.rb
+++ b/test/filters/test_relativize_paths.rb
@@ -109,7 +109,7 @@ class Nanoc::Filters::RelativizePathsTest < Nanoc::TestCase
 </html>
 EOS
     expected0 = %r{<a href="\.\./\.\.">foo</a>}
-    expected1 = %r{\A\s*<!DOCTYPE html\s*>\s*<html>\s*<head>(.|\s)*<title>Hello</title>\s*</head>\s*<body>\s*<a href="../..">foo</a>\s*</body>\s*</html>\s*\Z}m
+    expected1 = %r{\A\s*<!DOCTYPE html\s*>\s*<html>\s*<head>\s*<title>Hello</title>\s*</head>\s*<body>\s*<a href="../..">foo</a>\s*</body>\s*</html>\s*\Z}m
 
     # Test
     actual_content = filter.setup_and_run(raw_content, type: :html)


### PR DESCRIPTION
This pull request removes the `<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">` inserted by Nokogiri, which makes `nanoc check html` fail.

It's a wontfix for Nokogiri (sparklemotion/nokogiri#1008).