### PR TITLE
Support HTML5 in relativize_paths + colorize_syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :plugins do
   gem 'mime-types'
   gem 'mustache', '~> 1.0'
   gem 'nokogiri', '~> 1.6'
+  gem 'nokogumbo', '~> 1.4'
   gem 'pandoc-ruby'
   gem 'pygments.rb', '~> 1.1', '>= 1.1.1', platforms: %i[ruby mswin]
   gem 'rack'

--- a/lib/nanoc/checking/checks/external_links.rb
+++ b/lib/nanoc/checking/checks/external_links.rb
@@ -11,8 +11,6 @@ module ::Nanoc::Checking::Checks
     identifiers :external_links, :elinks
 
     def run
-      require 'nokogiri'
-
       # Find all broken external hrefs
       # TODO: de-duplicate this (duplicated in internal links check)
       filenames = output_filenames.select { |f| File.extname(f) == '.html' && !excluded_file?(f) }

--- a/lib/nanoc/filters/colorize_syntax.rb
+++ b/lib/nanoc/filters/colorize_syntax.rb
@@ -96,8 +96,13 @@ module Nanoc::Filters
       syntax = params[:syntax] || :html
       case syntax
       when :html
+        require 'nokogiri'
         klass = Nokogiri::HTML
+      when :html5
+        require 'nokogumbo'
+        klass = Nokogiri::HTML5
       when :xml, :xhtml
+        require 'nokogiri'
         klass = Nokogiri::XML
       else
         raise "unknown syntax: #{syntax.inspect} (expected :html or :xml)"
@@ -128,7 +133,7 @@ module Nanoc::Filters
         # Highlight
         raw = strip(element.inner_text)
         highlighted_code = highlight(raw, language, params)
-        element.children = Nokogiri::HTML.fragment(strip(highlighted_code), 'utf-8')
+        element.children = parse_fragment(klass, strip(highlighted_code))
 
         # Add language-something class
         unless has_class
@@ -141,8 +146,24 @@ module Nanoc::Filters
         highlight_postprocess(language, element.parent)
       end
 
-      method = "to_#{syntax}".to_sym
-      doc.send(method, encoding: 'UTF-8')
+      case syntax
+      when :html5
+        doc.to_s
+      else
+        doc.send("to_#{syntax}", encoding: 'UTF-8')
+      end
+    end
+
+    def parse_full(klass, content)
+      if klass.to_s == 'Nokogiri::HTML5'
+        klass.parse(content)
+      else
+        klass.parse(content, nil, 'UTF-8')
+      end
+    end
+
+    def parse_fragment(klass, content)
+      klass.fragment(content)
     end
 
     # Parses the given content using the given class. This method also handles
@@ -151,16 +172,15 @@ module Nanoc::Filters
     #
     # @param [String] content The content to parse
     #
-    # @param [Class] klass The Nokogiri parser class (either Nokogiri::HTML
-    #   or Nokogiri::XML)
+    # @param [Class] klass The Nokogiri parser class
     #
     # @param [Boolean] is_fullpage true if the given content is a full page,
     #   false if it is a fragment
     def parse(content, klass, is_fullpage)
       if is_fullpage
-        klass.parse(content, nil, 'UTF-8')
+        parse_full(klass, content)
       else
-        klass.fragment(content)
+        parse_fragment(klass, content)
       end
     rescue => e
       if e.message =~ /can't modify frozen string/

--- a/lib/nanoc/filters/colorize_syntax.rb
+++ b/lib/nanoc/filters/colorize_syntax.rb
@@ -133,12 +133,7 @@ module Nanoc::Filters
         highlight_postprocess(language, element.parent)
       end
 
-      case syntax
-      when :html5
-        doc.to_s
-      else
-        doc.send("to_#{syntax}", encoding: 'UTF-8')
-      end
+      serialize(doc, syntax)
     end
 
     def parser_for(syntax)
@@ -154,6 +149,15 @@ module Nanoc::Filters
         Nokogiri::XML
       else
         raise "unknown syntax: #{syntax.inspect} (expected :html, :html5, or :xml)"
+      end
+    end
+
+    def serialize(doc, syntax)
+      case syntax
+      when :html5
+        doc.to_s
+      else
+        doc.send("to_#{syntax}", encoding: 'UTF-8')
       end
     end
 

--- a/lib/nanoc/filters/colorize_syntax.rb
+++ b/lib/nanoc/filters/colorize_syntax.rb
@@ -155,7 +155,7 @@ module Nanoc::Filters
     def serialize(doc, syntax)
       case syntax
       when :html5
-        doc.to_s
+        doc.to_html
       else
         doc.send("to_#{syntax}", encoding: 'UTF-8')
       end

--- a/lib/nanoc/filters/relativize_paths.rb
+++ b/lib/nanoc/filters/relativize_paths.rb
@@ -38,7 +38,7 @@ module Nanoc::Filters
       case params[:type]
       when :css
         relativize_css(content)
-      when :html, :xml, :xhtml
+      when :html, :html5, :xml, :xhtml
         relativize_html_like(content, params)
       else
         raise 'The relativize_paths needs to know the type of content to ' \
@@ -63,13 +63,18 @@ module Nanoc::Filters
       namespaces = params.fetch(:namespaces, {})
       type       = params.fetch(:type)
 
-      require 'nokogiri'
       case type
       when :html
+        require 'nokogiri'
         klass = ::Nokogiri::HTML
+      when :html5
+        require 'nokogumbo'
+        klass = ::Nokogiri::HTML5
       when :xml
+        require 'nokogiri'
         klass = ::Nokogiri::XML
       when :xhtml
+        require 'nokogiri'
         klass = ::Nokogiri::XML
         # FIXME: cleanup because it is ugly
         # this cleans the XHTML namespace to process fragments and full
@@ -95,7 +100,13 @@ module Nanoc::Filters
           end
         end
       end
-      doc.send("to_#{type}")
+
+      case type
+      when :html5
+        doc.to_html
+      else
+        doc.send("to_#{type}")
+      end
     end
 
     def nokogiri_process_comment(node, doc, selectors, namespaces, klass, type)

--- a/test/filters/colorize_syntax/test_common.rb
+++ b/test/filters/colorize_syntax/test_common.rb
@@ -51,6 +51,30 @@ EOS
     end
   end
 
+  def test_full_page_html5
+    # Create filter
+    filter = ::Nanoc::Filters::ColorizeSyntax.new
+
+    # Get input and expected output
+    input = <<EOS
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Foo</title>
+</head>
+<body>
+  <pre title="moo"><code class="language-ruby"># comment</code></pre>
+</body>
+</html>
+EOS
+    expected_output_regex = %r{^<!DOCTYPE html>\s*<html>\s*<head>\s*<meta charset="utf-8">\s*<title>Foo</title>\s*</head>\s*<body>\s*<pre title="moo"><code class="language-ruby"># comment</code></pre>\s*</body>\s*</html>}
+
+    # Run filter
+    actual_output = filter.setup_and_run(input, syntax: :html5, default_colorizer: :dummy, is_fullpage: true)
+    assert_match expected_output_regex, actual_output
+  end
+
   def test_colorize_syntax_with_missing_executables
     if_have 'nokogiri' do
       begin

--- a/test/filters/test_relativize_paths.rb
+++ b/test/filters/test_relativize_paths.rb
@@ -117,6 +117,44 @@ EOS
     assert_match(expected1, actual_content)
   end
 
+  def test_filter_html5_with_boilerplate
+    # Create filter with mock item
+    filter = Nanoc::Filters::RelativizePaths.new
+
+    # Mock item
+    filter.instance_eval do
+      @item_rep = Nanoc::Int::ItemRep.new(
+        Nanoc::Int::Item.new(
+          'content',
+          {},
+          '/foo/bar/baz/',
+        ),
+        :blah,
+      )
+      @item_rep.paths[:last] = ['/foo/bar/baz/']
+    end
+
+    # Set content
+    raw_content = <<EOS
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Hello</title>
+  </head>
+  <body>
+    <a href=/foo>foo</a>
+  </body>
+</html>
+EOS
+    expected0 = %r{<a href="\.\./\.\.">foo</a>}
+    expected1 = %r{\A\s*<!DOCTYPE html\s*>\s*<html>\s*<head>\s*<title>Hello</title>\s*</head>\s*<body>\s*<a href="../..">foo</a>\s*</body>\s*</html>\s*\Z}m
+
+    # Test
+    actual_content = filter.setup_and_run(raw_content, type: :html5)
+    assert_match(expected0, actual_content)
+    assert_match(expected1, actual_content)
+  end
+
   def test_filter_html_multiple
     # Create filter with mock item
     filter = Nanoc::Filters::RelativizePaths.new


### PR DESCRIPTION
Fixes #1152.

* [x] HTML5 support for `:relativize_paths`
* [x] HTML5 support for `:colorize_syntax`