### PR TITLE
Add --diff option to compile command

### DIFF
--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -4,6 +4,7 @@ description <<-EOS
 Compile all items of the current site.
 EOS
 flag nil, :profile, 'profile compilation' if Nanoc::Feature.enabled?(Nanoc::Feature::PROFILER)
+flag nil, :diff, 'generate diff'
 
 require_relative 'compile_listeners/abstract'
 require_relative 'compile_listeners/debug_printer'

--- a/lib/nanoc/cli/commands/compile_listeners/diff_generator.rb
+++ b/lib/nanoc/cli/commands/compile_listeners/diff_generator.rb
@@ -2,7 +2,7 @@ module Nanoc::CLI::Commands::CompileListeners
   class DiffGenerator < Abstract
     # @see Listener#enable_for?
     def self.enable_for?(command_runner)
-      command_runner.site.config[:enable_output_diff]
+      command_runner.site.config[:enable_output_diff] || command_runner.options[:diff]
     end
 
     # @see Listener#start

--- a/spec/nanoc/cli/commands/compile/diff_generator_spec.rb
+++ b/spec/nanoc/cli/commands/compile/diff_generator_spec.rb
@@ -1,0 +1,44 @@
+describe Nanoc::CLI::Commands::CompileListeners::DiffGenerator do
+  describe '.enable_for?' do
+    subject { described_class.enable_for?(command_runner) }
+
+    let(:options) { {} }
+    let(:config_hash) { {} }
+
+    let(:arguments) { double(:arguments) }
+    let(:command) { double(:command) }
+
+    let(:site) do
+      Nanoc::Int::Site.new(
+        config: config,
+        code_snippets: code_snippets,
+        data_source: Nanoc::Int::InMemDataSource.new(items, layouts),
+      )
+    end
+
+    let(:config) { Nanoc::Int::Configuration.new(hash: config_hash).with_defaults }
+    let(:items) { [] }
+    let(:layouts) { [] }
+    let(:code_snippets) { [] }
+
+    let(:command_runner) do
+      Nanoc::CLI::Commands::Compile.new(options, arguments, command).tap do |cr|
+        cr.site = site
+      end
+    end
+
+    context 'default' do
+      it { is_expected.not_to be }
+    end
+
+    context 'enabled in config' do
+      let(:config_hash) { { enable_output_diff: true } }
+      it { is_expected.to be }
+    end
+
+    context 'enabled on command line' do
+      let(:options) { { diff: true } }
+      it { is_expected.to be }
+    end
+  end
+end

--- a/spec/nanoc/integration/compile_command_spec.rb
+++ b/spec/nanoc/integration/compile_command_spec.rb
@@ -1,0 +1,31 @@
+describe 'Compile command', site: true, stdio: true do
+  describe 'diff generation' do
+    before do
+      File.write('content/foo.md', "I am foo!\n")
+
+      File.write('Rules', <<EOS)
+compile '/foo.*' do
+  write '/foo.html'
+end
+EOS
+    end
+
+    it 'does not generate diff by default' do
+      FileUtils.mkdir_p('output')
+      File.write('output/foo.html', "I am old foo!\n")
+
+      Nanoc::CLI.run(%w[compile])
+
+      expect(File.file?('output.diff')).not_to be
+    end
+
+    it 'honors --diff' do
+      FileUtils.mkdir_p('output')
+      File.write('output/foo.html', "I am old foo!\n")
+
+      Nanoc::CLI.run(%w[compile --diff])
+
+      expect(File.file?('output.diff')).to be
+    end
+  end
+end


### PR DESCRIPTION
This allows

```
nanoc compile --diff
```

or

```
nanoc --diff
```

to enable one-off diff generation.