### PR TITLE
Precalculate checksums

### DIFF
--- a/lib/nanoc/base/entities.rb
+++ b/lib/nanoc/base/entities.rb
@@ -20,6 +20,7 @@ require_relative 'entities/action_sequence'
 require_relative 'entities/site'
 require_relative 'entities/snapshot_def'
 
+require_relative 'entities/checksum_collection'
 require_relative 'entities/outdatedness_status'
 require_relative 'entities/outdatedness_reasons'
 require_relative 'entities/dependency'

--- a/lib/nanoc/base/entities/checksum_collection.rb
+++ b/lib/nanoc/base/entities/checksum_collection.rb
@@ -1,0 +1,31 @@
+module Nanoc::Int
+  class ChecksumCollection
+    include Nanoc::Int::ContractsSupport
+    extend Nanoc::Int::Memoization
+
+    c_obj = C::Or[Nanoc::Int::Item, Nanoc::Int::Layout, Nanoc::Int::Configuration, Nanoc::Int::CodeSnippet]
+
+    def initialize(checksums)
+      @checksums = checksums
+    end
+
+    contract c_obj => C::Maybe[String]
+    def checksum_for(obj)
+      @checksums[obj.reference]
+    end
+
+    contract c_obj => C::Maybe[String]
+    def content_checksum_for(obj)
+      @checksums[[obj.reference, :content]]
+    end
+
+    contract c_obj => C::Maybe[C::HashOf[Symbol, String]]
+    def attributes_checksum_for(obj)
+      @checksums[[obj.reference, :each_attribute]]
+    end
+
+    def to_h
+      @checksums
+    end
+  end
+end

--- a/lib/nanoc/base/repos/checksum_store.rb
+++ b/lib/nanoc/base/repos/checksum_store.rb
@@ -6,6 +6,7 @@ module Nanoc::Int
   class ChecksumStore < ::Nanoc::Int::Store
     include Nanoc::Int::ContractsSupport
 
+    attr_writer :checksums
     attr_accessor :objects
 
     c_obj = C::Or[Nanoc::Int::Item, Nanoc::Int::Layout, Nanoc::Int::Configuration, Nanoc::Int::CodeSnippet]

--- a/lib/nanoc/base/services/compiler.rb
+++ b/lib/nanoc/base/services/compiler.rb
@@ -60,9 +60,10 @@ module Nanoc::Int
       @action_sequences = run_stage(build_reps_stage)
       run_stage(prune_stage)
       run_stage(load_stores_stage)
-      outdated_items = run_stage(determine_outdatedness_stage)
+      checksums = run_stage(calculate_checksums_stage)
+      outdated_items = run_stage(determine_outdatedness_stage, checksums)
       run_stage(forget_outdated_dependencies_stage, outdated_items)
-      run_stage(store_pre_compilation_state_stage)
+      run_stage(store_pre_compilation_state_stage, checksums)
       run_stage(compile_reps_stage)
       run_stage(store_post_compilation_state_stage)
       run_stage(postprocess_stage)
@@ -133,6 +134,15 @@ module Nanoc::Int
       )
     end
 
+    def calculate_checksums_stage
+      @_calculate_checksums_stage ||= Stages::CalculateChecksums.new(
+        items: @site.items,
+        layouts: @site.layouts,
+        code_snippets: @site.code_snippets,
+        config: @site.config,
+      )
+    end
+
     def determine_outdatedness_stage
       @_determine_outdatedness_stage ||= Stages::DetermineOutdatedness.new(
         reps: reps,
@@ -145,9 +155,6 @@ module Nanoc::Int
       @_store_pre_compilation_state_stage ||= Stages::StorePreCompilationState.new(
         reps: @reps,
         layouts: site.layouts,
-        items: site.items,
-        code_snippets: site.code_snippets,
-        config: site.config,
         checksum_store: checksum_store,
         action_sequence_store: action_sequence_store,
         action_sequences: @action_sequences,

--- a/lib/nanoc/base/services/compiler/stages.rb
+++ b/lib/nanoc/base/services/compiler/stages.rb
@@ -1,6 +1,7 @@
 module Nanoc::Int::Compiler::Stages
 end
 
+require_relative 'stages/calculate_checksums'
 require_relative 'stages/cleanup'
 require_relative 'stages/compile_reps'
 require_relative 'stages/determine_outdatedness'

--- a/lib/nanoc/base/services/compiler/stages/calculate_checksums.rb
+++ b/lib/nanoc/base/services/compiler/stages/calculate_checksums.rb
@@ -1,0 +1,31 @@
+module Nanoc::Int::Compiler::Stages
+  class CalculateChecksums
+    def initialize(items:, layouts:, code_snippets:, config:)
+      @items = items
+      @layouts = layouts
+      @code_snippets = code_snippets
+      @config = config
+    end
+
+    def run
+      checksums = {}
+
+      [@items, @layouts].each do |documents|
+        documents.each do |document|
+          checksums[[document.reference, :content]] =
+            Nanoc::Int::Checksummer.calc_for_content_of(document)
+          checksums[[document.reference, :each_attribute]] =
+            Nanoc::Int::Checksummer.calc_for_each_attribute_of(document)
+        end
+      end
+
+      [@items, @layouts, @code_snippets, [@config]].each do |objs|
+        objs.each do |obj|
+          checksums[obj.reference] = Nanoc::Int::Checksummer.calc(obj)
+        end
+      end
+
+      Nanoc::Int::ChecksumCollection.new(checksums)
+    end
+  end
+end

--- a/lib/nanoc/base/services/compiler/stages/determine_outdatedness.rb
+++ b/lib/nanoc/base/services/compiler/stages/determine_outdatedness.rb
@@ -8,8 +8,9 @@ module Nanoc::Int::Compiler::Stages
       @outdatedness_store = outdatedness_store
     end
 
-    contract C::None => C::Any
-    def run
+    contract Nanoc::Int::ChecksumCollection => C::Any
+    def run(_checksums)
+      # TODO: Pass checksums to outdatedness checker
       outdated_reps_tmp = @reps.select do |r|
         @outdatedness_store.include?(r) || @outdatedness_checker.outdated?(r)
       end

--- a/lib/nanoc/base/services/compiler/stages/store_pre_compilation_state.rb
+++ b/lib/nanoc/base/services/compiler/stages/store_pre_compilation_state.rb
@@ -2,32 +2,25 @@ module Nanoc::Int::Compiler::Stages
   class StorePreCompilationState
     include Nanoc::Int::ContractsSupport
 
-    def initialize(reps:, layouts:, items:, code_snippets:, config:, checksum_store:, action_sequence_store:, action_sequences:)
+    def initialize(reps:, layouts:, checksum_store:, action_sequence_store:, action_sequences:)
       @reps = reps
       @layouts = layouts
-      @items = items
-      @code_snippets = code_snippets
-      @config = config
       @checksum_store = checksum_store
       @action_sequence_store = action_sequence_store
       @action_sequences = action_sequences
     end
 
-    contract C::None => C::Any
-    def run
+    contract Nanoc::Int::ChecksumCollection => C::Any
+    def run(checksums)
       # Calculate action sequence
       (@reps.to_a + @layouts.to_a).each do |obj|
         @action_sequence_store[obj] = @action_sequences[obj].serialize
       end
-
-      # Calculate checksums
-      objects_to_checksum =
-        @items.to_a + @layouts.to_a + @code_snippets + [@config]
-      objects_to_checksum.each { |obj| @checksum_store.add(obj) }
-
-      # Store
-      @checksum_store.store
       @action_sequence_store.store
+
+      # Set checksums
+      @checksum_store.checksums = checksums.to_h
+      @checksum_store.store
     end
   end
 end

--- a/spec/nanoc/base/services/compiler/stages/calculate_checksums_spec.rb
+++ b/spec/nanoc/base/services/compiler/stages/calculate_checksums_spec.rb
@@ -1,0 +1,69 @@
+describe Nanoc::Int::Compiler::Stages::CalculateChecksums do
+  let(:stage) do
+    described_class.new(items: items, layouts: layouts, code_snippets: code_snippets, config: config)
+  end
+
+  let(:config) do
+    Nanoc::Int::Configuration.new.with_defaults
+  end
+
+  let(:code_snippets) do
+    [code_snippet]
+  end
+
+  let(:items) do
+    Nanoc::Int::IdentifiableCollection.new(config, [item])
+  end
+
+  let(:layouts) do
+    Nanoc::Int::IdentifiableCollection.new(config, [layout])
+  end
+
+  let(:code_snippet) do
+    Nanoc::Int::CodeSnippet.new('woof!', 'dog.rb')
+  end
+
+  let(:item) do
+    Nanoc::Int::Item.new('hello there', {}, '/hi.md')
+  end
+
+  let(:layout) do
+    Nanoc::Int::Layout.new('t3mpl4t3', {}, '/page.erb')
+  end
+
+  describe '#run' do
+    subject { stage.run }
+
+    it 'checksums items' do
+      expect(subject.checksum_for(item))
+        .to eq(Nanoc::Int::Checksummer.calc(item))
+
+      expect(subject.content_checksum_for(item))
+        .to eq(Nanoc::Int::Checksummer.calc_for_content_of(item))
+
+      expect(subject.attributes_checksum_for(item))
+        .to eq(Nanoc::Int::Checksummer.calc_for_each_attribute_of(item))
+    end
+
+    it 'checksums layouts' do
+      expect(subject.checksum_for(layout))
+        .to eq(Nanoc::Int::Checksummer.calc(layout))
+
+      expect(subject.content_checksum_for(layout))
+        .to eq(Nanoc::Int::Checksummer.calc_for_content_of(layout))
+
+      expect(subject.attributes_checksum_for(layout))
+        .to eq(Nanoc::Int::Checksummer.calc_for_each_attribute_of(layout))
+    end
+
+    it 'checksums config' do
+      expect(subject.checksum_for(config))
+        .to eq(Nanoc::Int::Checksummer.calc(config))
+    end
+
+    it 'checksums code snippets' do
+      expect(subject.checksum_for(code_snippet))
+        .to eq(Nanoc::Int::Checksummer.calc(code_snippet))
+    end
+  end
+end


### PR DESCRIPTION
This is a refactoring that moves the checksum calculation into a separate stage, so that the calculated checksums can be reused.

Further work in a separate PR:

* Reuse precalculated checksums in the outdatedness checker
* Recalculate finer-grained checksums (content, attributes) only if parent checksums has changed