### PR TITLE
Pass checksums to outdatedness checker

### DIFF
--- a/lib/nanoc/base/services/compiler.rb
+++ b/lib/nanoc/base/services/compiler.rb
@@ -51,6 +51,7 @@ module Nanoc::Int
         dependency_store: @dependency_store,
         action_sequence_store: @action_sequence_store,
         action_sequences: @action_sequences,
+        checksums: @checksums,
         reps: reps,
       )
     end
@@ -96,6 +97,11 @@ module Nanoc::Int
     # TODO: remove
     def build_reps
       @action_sequences = build_reps_stage.run
+    end
+
+    # TODO: remove
+    def calculate_checksums
+      @checksums = run_stage(calculate_checksums_stage)
     end
 
     private

--- a/lib/nanoc/base/services/outdatedness_checker.rb
+++ b/lib/nanoc/base/services/outdatedness_checker.rb
@@ -88,10 +88,11 @@ module Nanoc::Int
     C_OBJ = C::Or[Nanoc::Int::Item, Nanoc::Int::ItemRep, Nanoc::Int::Layout]
     C_ACTION_SEQUENCES = C::HashOf[C_OBJ => Nanoc::Int::ActionSequence]
 
-    contract C::KeywordArgs[site: Nanoc::Int::Site, checksum_store: Nanoc::Int::ChecksumStore, dependency_store: Nanoc::Int::DependencyStore, action_sequence_store: Nanoc::Int::ActionSequenceStore, action_sequences: C_ACTION_SEQUENCES, reps: Nanoc::Int::ItemRepRepo] => C::Any
-    def initialize(site:, checksum_store:, dependency_store:, action_sequence_store:, action_sequences:, reps:)
+    contract C::KeywordArgs[site: Nanoc::Int::Site, checksum_store: Nanoc::Int::ChecksumStore, checksums: Nanoc::Int::ChecksumCollection, dependency_store: Nanoc::Int::DependencyStore, action_sequence_store: Nanoc::Int::ActionSequenceStore, action_sequences: C_ACTION_SEQUENCES, reps: Nanoc::Int::ItemRepRepo] => C::Any
+    def initialize(site:, checksum_store:, checksums:, dependency_store:, action_sequence_store:, action_sequences:, reps:)
       @site = site
       @checksum_store = checksum_store
+      @checksums = checksums
       @dependency_store = dependency_store
       @action_sequence_store = action_sequence_store
       @action_sequences = action_sequences

--- a/lib/nanoc/base/services/outdatedness_checker.rb
+++ b/lib/nanoc/base/services/outdatedness_checker.rb
@@ -78,6 +78,7 @@ module Nanoc::Int
     include Nanoc::Int::ContractsSupport
 
     attr_reader :checksum_store
+    attr_reader :checksums
     attr_reader :dependency_store
     attr_reader :action_sequence_store
     attr_reader :action_sequences

--- a/lib/nanoc/base/services/outdatedness_rules/attributes_modified.rb
+++ b/lib/nanoc/base/services/outdatedness_rules/attributes_modified.rb
@@ -17,7 +17,7 @@ module Nanoc::Int::OutdatednessRules
           return Nanoc::Int::OutdatednessReasons::AttributesModified.new(true)
         end
 
-        new_checksums = Nanoc::Int::Checksummer.calc_for_each_attribute_of(obj)
+        new_checksums = outdatedness_checker.checksums.attributes_checksum_for(obj)
 
         attributes = Set.new(old_checksums.keys) + Set.new(new_checksums.keys)
         changed_attributes = attributes.reject { |a| old_checksums[a] == new_checksums[a] }

--- a/lib/nanoc/base/services/outdatedness_rules/code_snippets_modified.rb
+++ b/lib/nanoc/base/services/outdatedness_rules/code_snippets_modified.rb
@@ -17,7 +17,7 @@ module Nanoc::Int::OutdatednessRules
     memoized def any_snippets_modified?(outdatedness_checker)
       outdatedness_checker.site.code_snippets.any? do |cs|
         ch_old = outdatedness_checker.checksum_store[cs]
-        ch_new = Nanoc::Int::Checksummer.calc(cs)
+        ch_new = outdatedness_checker.checksums.checksum_for(cs)
         ch_old != ch_new
       end
     end

--- a/lib/nanoc/base/services/outdatedness_rules/configuration_modified.rb
+++ b/lib/nanoc/base/services/outdatedness_rules/configuration_modified.rb
@@ -15,7 +15,7 @@ module Nanoc::Int::OutdatednessRules
     memoized def config_modified?(outdatedness_checker)
       obj = outdatedness_checker.site.config
       ch_old = outdatedness_checker.checksum_store[obj]
-      ch_new = Nanoc::Int::Checksummer.calc(obj)
+      ch_new = outdatedness_checker.checksums.checksum_for(obj)
       ch_old != ch_new
     end
   end

--- a/lib/nanoc/base/services/outdatedness_rules/content_modified.rb
+++ b/lib/nanoc/base/services/outdatedness_rules/content_modified.rb
@@ -6,7 +6,7 @@ module Nanoc::Int::OutdatednessRules
       obj = obj.item if obj.is_a?(Nanoc::Int::ItemRep)
 
       ch_old = outdatedness_checker.checksum_store.content_checksum_for(obj)
-      ch_new = Nanoc::Int::Checksummer.calc_for_content_of(obj)
+      ch_new = outdatedness_checker.checksums.content_checksum_for(obj)
       if ch_old != ch_new
         Nanoc::Int::OutdatednessReasons::ContentModified
       end

--- a/lib/nanoc/cli/commands/show-data.rb
+++ b/lib/nanoc/cli/commands/show-data.rb
@@ -144,6 +144,7 @@ module Nanoc::CLI::Commands
     end
 
     def print_outdatedness_reasons_for(obj, compiler)
+      compiler.calculate_checksums
       outdatedness_checker = compiler.create_outdatedness_checker
       reasons = outdatedness_checker.outdatedness_reasons_for(obj)
       if reasons.any?

--- a/spec/nanoc/base/services/outdatedness_checker_spec.rb
+++ b/spec/nanoc/base/services/outdatedness_checker_spec.rb
@@ -164,6 +164,10 @@ describe Nanoc::Int::OutdatednessChecker do
       let(:distant_item) { Nanoc::Int::Item.new('distant stuff', {}, '/distant.md') }
       let(:distant_item_rep) { Nanoc::Int::ItemRep.new(distant_item, :default) }
 
+      let(:items) do
+        Nanoc::Int::IdentifiableCollection.new(config, [item, other_item, distant_item])
+      end
+
       let(:action_sequences) do
         {
           item_rep => new_action_sequence_for_item_rep,

--- a/spec/nanoc/base/services/outdatedness_checker_spec.rb
+++ b/spec/nanoc/base/services/outdatedness_checker_spec.rb
@@ -3,6 +3,7 @@ describe Nanoc::Int::OutdatednessChecker do
     described_class.new(
       site: site,
       checksum_store: checksum_store,
+      checksums: checksums,
       dependency_store: dependency_store,
       action_sequence_store: action_sequence_store,
       action_sequences: action_sequences,
@@ -11,6 +12,8 @@ describe Nanoc::Int::OutdatednessChecker do
   end
 
   let(:checksum_store) { double(:checksum_store) }
+
+  let(:checksums) { Nanoc::Int::ChecksumCollection.new({}) }
 
   let(:dependency_store) do
     Nanoc::Int::DependencyStore.new(items, layouts)

--- a/spec/nanoc/base/services/outdatedness_checker_spec.rb
+++ b/spec/nanoc/base/services/outdatedness_checker_spec.rb
@@ -13,7 +13,14 @@ describe Nanoc::Int::OutdatednessChecker do
 
   let(:checksum_store) { double(:checksum_store) }
 
-  let(:checksums) { Nanoc::Int::ChecksumCollection.new({}) }
+  let(:checksums) do
+    Nanoc::Int::Compiler::Stages::CalculateChecksums.new(
+      items: items,
+      layouts: layouts,
+      code_snippets: code_snippets,
+      config: config,
+    ).run
+  end
 
   let(:dependency_store) do
     Nanoc::Int::DependencyStore.new(items, layouts)
@@ -22,10 +29,12 @@ describe Nanoc::Int::OutdatednessChecker do
   let(:items) { Nanoc::Int::IdentifiableCollection.new(config, [item]) }
   let(:layouts) { Nanoc::Int::IdentifiableCollection.new(config) }
 
+  let(:code_snippets) { [] }
+
   let(:site) do
     Nanoc::Int::Site.new(
       config: config,
-      code_snippets: [],
+      code_snippets: code_snippets,
       data_source: Nanoc::Int::InMemDataSource.new([], []),
     )
   end

--- a/spec/nanoc/base/services/outdatedness_rules_spec.rb
+++ b/spec/nanoc/base/services/outdatedness_rules_spec.rb
@@ -354,6 +354,8 @@ describe Nanoc::Int::OutdatednessRules do
       let(:stored_obj) { raise 'override me' }
       let(:new_obj)    { raise 'override me' }
 
+      let(:items) { [new_obj] }
+
       shared_examples 'a document' do
         let(:stored_obj) { klass.new('a', {}, '/foo.md') }
         let(:new_obj)    { stored_obj }

--- a/spec/nanoc/base/services/outdatedness_rules_spec.rb
+++ b/spec/nanoc/base/services/outdatedness_rules_spec.rb
@@ -36,7 +36,15 @@ describe Nanoc::Int::OutdatednessRules do
     let(:dependency_store) { Nanoc::Int::DependencyStore.new(items, layouts) }
     let(:action_sequence_store) { Nanoc::Int::ActionSequenceStore.new }
     let(:checksum_store) { Nanoc::Int::ChecksumStore.new(objects: objects) }
-    let(:checksums) { Nanoc::Int::ChecksumCollection.new({}) }
+
+    let(:checksums) do
+      Nanoc::Int::Compiler::Stages::CalculateChecksums.new(
+        items: items,
+        layouts: layouts,
+        code_snippets: code_snippets,
+        config: config,
+      ).run
+    end
 
     let(:items) { Nanoc::Int::IdentifiableCollection.new(config, [item]) }
     let(:layouts) { Nanoc::Int::IdentifiableCollection.new(config) }
@@ -63,7 +71,7 @@ describe Nanoc::Int::OutdatednessRules do
         it { is_expected.not_to be }
       end
 
-      context 'only non-outdated snippets' do
+      context 'only outdated snippets' do
         let(:code_snippet) { Nanoc::Int::CodeSnippet.new('asdf', 'lib/foo.md') }
         let(:code_snippet_old) { Nanoc::Int::CodeSnippet.new('aaaaaaaa', 'lib/foo.md') }
         let(:code_snippets) { [code_snippet] }

--- a/spec/nanoc/base/services/outdatedness_rules_spec.rb
+++ b/spec/nanoc/base/services/outdatedness_rules_spec.rb
@@ -8,6 +8,7 @@ describe Nanoc::Int::OutdatednessRules do
       Nanoc::Int::OutdatednessChecker.new(
         site: site,
         checksum_store: checksum_store,
+        checksums: checksums,
         dependency_store: dependency_store,
         action_sequence_store: action_sequence_store,
         action_sequences: action_sequences,
@@ -35,6 +36,7 @@ describe Nanoc::Int::OutdatednessRules do
     let(:dependency_store) { Nanoc::Int::DependencyStore.new(items, layouts) }
     let(:action_sequence_store) { Nanoc::Int::ActionSequenceStore.new }
     let(:checksum_store) { Nanoc::Int::ChecksumStore.new(objects: objects) }
+    let(:checksums) { Nanoc::Int::ChecksumCollection.new({}) }
 
     let(:items) { Nanoc::Int::IdentifiableCollection.new(config, [item]) }
     let(:layouts) { Nanoc::Int::IdentifiableCollection.new(config) }

--- a/spec/nanoc/cli/commands/show_data_spec.rb
+++ b/spec/nanoc/cli/commands/show_data_spec.rb
@@ -167,6 +167,7 @@ describe Nanoc::CLI::Commands::ShowData, stdio: true do
       allow(site).to receive(:compiler).and_return(compiler)
       allow(compiler).to receive(:create_outdatedness_checker).and_return(outdatedness_checker)
       allow(compiler).to receive(:reps).and_return(reps)
+      allow(compiler).to receive(:calculate_checksums)
     end
 
     context 'not outdated' do
@@ -239,6 +240,7 @@ describe Nanoc::CLI::Commands::ShowData, stdio: true do
       allow(runner).to receive(:site).and_return(site)
       allow(site).to receive(:compiler).and_return(compiler)
       allow(compiler).to receive(:create_outdatedness_checker).and_return(outdatedness_checker)
+      allow(compiler).to receive(:calculate_checksums)
     end
 
     context 'not outdated' do


### PR DESCRIPTION
A follow-up to #1159. This makes the outdatedness checker use the already calculated checksums, rather than calculating new ones.