### PR TITLE
Original encoding extension point for subclasses

### DIFF
--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -419,6 +419,14 @@ module Nanoc::DataSources
       raise Errors::InvalidMetadata.new(filename, meta.class)
     end
 
+    def original_encoding(filename, data)
+      if @config && @config[:encoding]
+        Encoding.find(@config[:encoding])
+      else
+        data.encoding
+      end
+    end
+
     # Reads the content of the file with the given name and returns a string
     # in UTF-8 encoding. The original encoding of the string is derived from
     # the default external encoding, but this can be overridden by the
@@ -433,12 +441,8 @@ module Nanoc::DataSources
 
       # Fix
       if data.respond_to?(:encode!)
-        if @config && @config[:encoding]
-          original_encoding = Encoding.find(@config[:encoding])
-          data.force_encoding(@config[:encoding])
-        else
-          original_encoding = data.encoding
-        end
+        original_encoding = original_encoding(filename, data)
+        data.force_encoding(original_encoding) if original_encoding != data.encoding
 
         begin
           data.encode!('UTF-8')

--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -115,7 +115,7 @@ module Nanoc::DataSources
       is_binary = content_filename && !@site_config[:text_extensions].include?(File.extname(content_filename)[1..-1])
 
       if is_binary && klass == Nanoc::Int::Item
-        meta = (meta_filename && YAML.load_file(meta_filename)) || {}
+        meta = (meta_filename && parse_metadata(read(meta_filename), meta_filename)) || {}
 
         ProtoDocument.new(is_binary: true, filename: content_filename, attributes: meta)
       elsif is_binary && klass == Nanoc::Int::Layout


### PR DESCRIPTION
Possibility to redefine original encoding for Filesystem class descendants. It may be useful for redefine original encoding for each item

### Detailed description

original_encoding extracted to protected function
fix processing of binary files metadata

### To do

* [ ] Tests
* [ ] Documentation
* [ ] Feature flags

### Related issues

None
