### PR TITLE
Improve helper handling in Nanoc::Int::Context

### DIFF
--- a/lib/nanoc/base/entities/code_snippet.rb
+++ b/lib/nanoc/base/entities/code_snippet.rb
@@ -34,6 +34,7 @@ module Nanoc::Int
     #
     # @return [void]
     def load
+      eval('def self.use_helper(mod); Nanoc::Int::Context.instance_eval { include mod }; end', TOPLEVEL_BINDING)
       eval(@data, TOPLEVEL_BINDING, @filename)
       nil
     end

--- a/lib/nanoc/rule_dsl/compiler_dsl.rb
+++ b/lib/nanoc/rule_dsl/compiler_dsl.rb
@@ -4,7 +4,7 @@ module Nanoc::RuleDSL
   # Contains methods that will be executed by the site’s `Rules` file.
   #
   # @api private
-  class CompilerDSL
+  class CompilerDSL < Nanoc::Int::Context
     # The current rules filename.
     #
     # @return [String] The current rules filename.
@@ -23,6 +23,7 @@ module Nanoc::RuleDSL
     def initialize(rules_collection, config)
       @rules_collection = rules_collection
       @config = config
+      super({ config: config })
     end
 
     # Creates a preprocessor block that will be executed after all data is

--- a/spec/nanoc/base/entities/code_snippet_spec.rb
+++ b/spec/nanoc/base/entities/code_snippet_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+describe Nanoc::Int::CodeSnippet do
+  subject(:code_snippet) { described_class.new(data, 'lib/foo.rb') }
+
+  describe '#load' do
+    subject { code_snippet.load }
+
+    describe 'calling #include' do
+      let(:data) do
+        <<~EOS
+          module CodeSnippetSpecHelper1
+            def fe345b48e4
+              "fe345b48e4"
+            end
+          end
+
+          include CodeSnippetSpecHelper1
+        EOS
+      end
+
+      it 'makes helper functions available in contexts' do
+        expect { subject }
+          .to change { [Nanoc::Int::Context.new({}).respond_to?(:fe345b48e4), Complex.respond_to?(:fe345b48e4)] }
+          .from([false, false])
+          .to([true, true])
+      end
+    end
+
+    describe 'calling #use_helper' do
+      let(:data) do
+        <<~EOS
+          module CodeSnippetSpecHelper2
+            def e0f0c30b5e
+              "e0f0c30b5e"
+            end
+          end
+
+          use_helper CodeSnippetSpecHelper2
+        EOS
+      end
+
+      it 'makes helper functions available everywhere' do
+        expect { subject }
+          .to change { [Nanoc::Int::Context.new({}).respond_to?(:e0f0c30b5e), Complex.respond_to?(:e0f0c30b5e)] }
+          .from([false, false])
+          .to([true, false])
+      end
+    end
+  end
+end

--- a/spec/nanoc/cli/commands/shell_spec.rb
+++ b/spec/nanoc/cli/commands/shell_spec.rb
@@ -8,6 +8,12 @@ describe Nanoc::CLI::Commands::Shell, site: true, stdio: true do
     end
 
     it 'can be invoked' do
+      rules_collection = Nanoc::RuleDSL::RulesCollection.new
+      config = Nanoc::Int::Configuration.new.with_defaults
+
+      dsl = Nanoc::RuleDSL::CompilerDSL.new(rules_collection, config)
+      allow(Nanoc::RuleDSL::CompilerDSL).to receive(:new).and_return(dsl)
+
       context = Object.new
       allow(Nanoc::Int::Context).to receive(:new).with(anything).and_return(context)
       expect(context).to receive(:pry)

--- a/test/rule_dsl/test_compiler_dsl.rb
+++ b/test/rule_dsl/test_compiler_dsl.rb
@@ -438,4 +438,11 @@ EOS
     compiler_dsl.instance_eval { $venetian = @config[:venetian] }
     assert_equal 'snares', $venetian
   end
+
+  def test_config_without_sigil
+    $venetian = 'unsnares'
+    compiler_dsl = Nanoc::RuleDSL::CompilerDSL.new(nil, venetian: 'snares')
+    compiler_dsl.instance_eval { $venetian = config[:venetian] }
+    assert_equal 'snares', $venetian
+  end
 end


### PR DESCRIPTION
Fixes #1169.

This introduces `use_helper` to load helpers. Helpers loaded with `use_helper` will only be available in contexts where it makes sense, so they don’t pollute the global namespace.

```ruby
module GreetingHelper
  def greeting
    'hello'
  end
end

use_helper GreetingHelper
```