### PR TITLE
Include xml:base attribute on feed element

### DIFF
--- a/lib/nanoc/helpers/blogging.rb
+++ b/lib/nanoc/helpers/blogging.rb
@@ -104,9 +104,9 @@ module Nanoc::Helpers
       end
 
       def build_for_feed(xml)
+        root_url = @config[:base_url] + '/'
         xml.instruct!
-        xml.feed(xmlns: 'http://www.w3.org/2005/Atom') do
-          root_url = @config[:base_url] + '/'
+        xml.feed(xmlns: 'http://www.w3.org/2005/Atom', 'xml:base' => root_url) do
 
           # Add primary attributes
           xml.id root_url


### PR DESCRIPTION
The 'xml:base' attribute is used by feed readers to resolve relative URLs in the feed content. Without it, relative URLs in feeds generator by nanoc are broken.