### PR TITLE
Infer code snippet encoding

### DIFF
--- a/lib/nanoc/base/repos/site_loader.rb
+++ b/lib/nanoc/base/repos/site_loader.rb
@@ -72,11 +72,31 @@ module Nanoc::Int
       config[:lib_dirs].flat_map do |lib|
         Dir["#{lib}/**/*.rb"].sort.map do |filename|
           Nanoc::Int::CodeSnippet.new(
-            File.read(filename),
+            read_code_snippet_contents(filename),
             filename,
           )
         end
       end
+    end
+
+    ENCODING_REGEX = /\A#\s+(-\*-\s+)?(en)?coding: (?<encoding>[^\s]+)(\s+-\*-\s*)?\n{0,2}/
+
+    def encoding_from_magic_comment(raw)
+      match = ENCODING_REGEX.match(raw)
+      match ? match['encoding'] : nil
+    end
+
+    def read_code_snippet_contents(filename)
+      raw = File.read(filename, encoding: 'ASCII-8BIT')
+
+      enc = encoding_from_magic_comment(raw)
+      if enc
+        raw = raw.force_encoding(enc).encode('UTF-8').sub(ENCODING_REGEX, '')
+      else
+        raw.force_encoding('UTF-8')
+      end
+
+      raw
     end
   end
 end

--- a/spec/nanoc/base/repos/site_loader_spec.rb
+++ b/spec/nanoc/base/repos/site_loader_spec.rb
@@ -211,4 +211,52 @@ describe Nanoc::Int::SiteLoader do
       end
     end
   end
+
+  describe '#code_snippets_from_config' do
+    subject { loader.send(:code_snippets_from_config, config) }
+
+    let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+
+    before { FileUtils.mkdir_p('lib') }
+
+    context 'no explicit encoding specified' do
+      example do
+        File.write('lib/asdf.rb', 'hi 🔥', encoding: 'utf-8')
+        expect(subject.size).to eq(1)
+        expect(subject.first.data).to eq('hi 🔥')
+      end
+    end
+
+    context '# encoding: x specified' do
+      example do
+        File.write('lib/asdf.rb', "# encoding: iso-8859-1\n\nBRØKEN", encoding: 'iso-8859-1')
+        expect(subject.size).to eq(1)
+        expect(subject.first.data).to eq('BRØKEN')
+      end
+    end
+
+    context '# coding: x specified' do
+      example do
+        File.write('lib/asdf.rb', "# coding: iso-8859-1\n\nBRØKEN", encoding: 'iso-8859-1')
+        expect(subject.size).to eq(1)
+        expect(subject.first.data).to eq('BRØKEN')
+      end
+    end
+
+    context '# -*- encoding: x -*- specified' do
+      example do
+        File.write('lib/asdf.rb', "# -*- encoding: iso-8859-1 -*-\n\nBRØKEN", encoding: 'iso-8859-1')
+        expect(subject.size).to eq(1)
+        expect(subject.first.data).to eq('BRØKEN')
+      end
+    end
+
+    context '# -*- coding: x -*- specified' do
+      example do
+        File.write('lib/asdf.rb', "# -*- coding: iso-8859-1 -*-\n\nBRØKEN", encoding: 'iso-8859-1')
+        expect(subject.size).to eq(1)
+        expect(subject.first.data).to eq('BRØKEN')
+      end
+    end
+  end
 end

--- a/spec/nanoc/regressions/gh_1171_spec.rb
+++ b/spec/nanoc/regressions/gh_1171_spec.rb
@@ -1,0 +1,55 @@
+describe 'GH-1171', site: true, stdio: true do
+  before do
+    File.write('nanoc.yaml', <<EOS)
+data_sources:
+  -
+    type: filesystem
+    encoding: utf-8
+EOS
+  end
+
+  context 'UTF-8 code in ASCII env' do
+    before do
+      File.write('content/hi.md', '<%= ::EMOJI_🔥 %>', encoding: 'utf-8')
+      File.write('lib/asdf.rb', 'EMOJI_🔥 = "hot"', encoding: 'utf-8')
+
+      File.write('Rules', <<EOS)
+compile '/**/*' do
+  filter :erb
+  write '/last.html'
+end
+EOS
+    end
+
+    around do |ex|
+      orig_encoding = Encoding.default_external
+      Encoding.default_external = 'ASCII'
+      ex.run
+      Encoding.default_external = orig_encoding
+    end
+
+    it 'does not crash' do
+      Nanoc::CLI.run(%w[compile])
+      expect(File.read('output/last.html')).to eql('hot')
+    end
+  end
+
+  context 'ISO 8859-1 code UTF-8 env' do
+    before do
+      File.write('content/hi.md', '<%= ::BRØKEN %>')
+      File.write('lib/asdf.rb', "# encoding: iso-8859-1\n\nBRØKEN = 1", encoding: 'ISO-8859-1')
+
+      File.write('Rules', <<EOS)
+compile '/**/*' do
+  filter :erb
+  write '/last.html'
+end
+EOS
+    end
+
+    it 'detects manually specified encodings' do
+      Nanoc::CLI.run(%w[compile])
+      expect(File.read('output/last.html')).to eql('1')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1171.

Turns out that `eval`’ing a string that has a magic comment (e.g. `# encoding: iso-8859-1`)  already (incorrectly) attempts to do the encoding handling. To work around that, Nanoc now reads the content in the specified encoding, converts it to UTF-8, and removes the magic comment before passing it to `eval`. Yuck!

(I have not found any other way that makes the tests pass.)