### PR TITLE
Report file name when slim encounters compilation errors

### DIFF
--- a/lib/nanoc/filters/slim.rb
+++ b/lib/nanoc/filters/slim.rb
@@ -20,7 +20,7 @@ module Nanoc::Filters
       # Create context
       context = ::Nanoc::Int::Context.new(assigns)
 
-      ::Slim::Template.new(params) { content }.render(context) { assigns[:content] }
+      ::Slim::Template.new(filename, params) { content }.render(context) { assigns[:content] }
     end
   end
 end

--- a/test/filters/test_slim.rb
+++ b/test/filters/test_slim.rb
@@ -28,4 +28,28 @@ class Nanoc::Filters::SlimTest < Nanoc::TestCase
       assert_equal('<p>The rabbit is on the branch.</p>', result)
     end
   end
+
+  def new_view_context
+    Nanoc::ViewContext.new(
+      reps: :__irrelevat_reps,
+      items: :__irrelevat_items,
+      dependency_tracker: :__irrelevant_dependency_tracker,
+      compilation_context: :__irrelevat_compiler,
+      snapshot_repo: :__irrelevant_snapshot_repo,
+    )
+  end
+
+  def test_filter_slim_reports_filename
+    if_have 'slim' do
+      layout = Nanoc::Int::Layout.new('', {}, '/layout.slim')
+      layout = Nanoc::LayoutView.new(layout, new_view_context)
+
+      assigns = { layout: layout }
+
+      filter = ::Nanoc::Filters::Slim.new(assigns)
+
+      error = assert_raises(NameError) { filter.setup_and_run('deliberate=failure') }
+      assert_match(%r{^layout /layout.slim}, error.backtrace[1])
+    end
+  end
 end


### PR DESCRIPTION
### Detailed description

When slim reports errors it currently looks like this:

```
Slim::Parser::SyntaxError: Expected attribute
  (__TEMPLATE__), Line 16, Column 13
  | id: 'webpage-description' }
```

It can be hard to find the offending file, so pass `filename` to slim to have errors reported like so:

```
Slim::Parser::SyntaxError: Expected attribute
  layout /default.slim, Line 16, Column 13
    | id: 'webpage-description' }
```

### To do

* [x] Review test (it's my first minitest spec)