### PR TITLE
Merge config recursively

### DIFF
--- a/lib/nanoc/base/entities/configuration.rb
+++ b/lib/nanoc/base/entities/configuration.rb
@@ -106,9 +106,14 @@ module Nanoc::Int
       @wrapped[key] = value
     end
 
+    def merge_recursively(c1, c2)
+      c1.merge(c2) { |_, v1, v2| v1.is_a?(Hash) && v2.is_a?(Hash) ? merge_recursively(v1, v2) : v2 }
+    end
+    private :merge_recursively
+
     contract C::Or[Hash, self] => self
     def merge(hash)
-      self.class.new(hash: @wrapped.merge(hash.to_h), env_name: @env_name)
+      self.class.new(hash: merge_recursively(@wrapped, hash.to_h), env_name: @env_name)
     end
 
     contract C::Any => self

--- a/spec/nanoc/base/entities/configuration_spec.rb
+++ b/spec/nanoc/base/entities/configuration_spec.rb
@@ -84,6 +84,19 @@ describe Nanoc::Int::Configuration do
     end
   end
 
+  describe '#merge' do
+    let(:hash1) { { foo: { bar: 'baz', baz: ['biz'] } } }
+    let(:hash2) { { foo: { bar: :boz, biz: 'buz' } } }
+    let(:config1) { described_class.new(hash: hash1) }
+    let(:config2) { described_class.new(hash: hash2) }
+
+    subject { config1.merge(config2).to_h }
+
+    it 'contains the recursive merge of both configurations' do
+      expect(subject).to include(foo: { bar: :boz, baz: ['biz'], biz: 'buz' })
+    end
+  end
+
   context 'with environments defined' do
     let(:hash) { { foo: 'bar', environments: { test: { foo: 'test-bar' }, default: { foo: 'default-bar' } } } }
     let(:config) { described_class.new(hash: hash, env_name: env_name).with_environment }


### PR DESCRIPTION
I faced the following situation:
  - I want `nanoc.yaml` to only define the `rsync` deployment url
  - I want a parent `nanoc.yaml` to define other `rsync options`

----
`parent.yaml`
```
deploy:
  default:
    kind: rsync
    options:
      - --verbose
      - --progress
      - --recursive
      - --links
      - --chmod=D755,F644
      - --times
      - --partial
      - --progress
      - --compress
      - --delete-during
      - --force
      - --exclude='.git'
```
`nanoc.yaml`
```
deploy:
  default:
    dst: 'example.com:/srv/www'

parent_config_file: _factory/nanoc.yaml
```

Without merging hashes recursively, parent config gets completely overridden.