### PR TITLE
Always use GET, not HEAD, for external links

### DIFF
--- a/lib/nanoc/checking/checks/external_links.rb
+++ b/lib/nanoc/checking/checks/external_links.rb
@@ -69,13 +69,10 @@ module ::Nanoc::Checking::Checks
         begin
           Timeout.timeout(timeouts[i]) do
             res = request_url_once(url)
-            if res.code == '405'
-              res = request_url_once(url, Net::HTTP::Get)
-            end
           end
         rescue => e
           last_err = e
-          next # can not allow
+          next
         end
 
         if res.code =~ /^3..$/
@@ -122,8 +119,8 @@ module ::Nanoc::Checking::Checks
       path
     end
 
-    def request_url_once(url, req_method = Net::HTTP::Head)
-      req = req_method.new(path_for_url(url))
+    def request_url_once(url)
+      req = Net::HTTP::Get.new(path_for_url(url))
       http = Net::HTTP.new(url.host, url.port)
       if url.instance_of? URI::HTTPS
         http.use_ssl = true

--- a/test/checking/checks/test_external_links.rb
+++ b/test/checking/checks/test_external_links.rb
@@ -51,20 +51,6 @@ class Nanoc::Checking::Checks::ExternalLinksTest < Nanoc::TestCase
     end
   end
 
-  def test_fallback_to_get_when_head_is_not_allowed
-    with_site do |site|
-      # Create check
-      check = Nanoc::Checking::Checks::ExternalLinks.create(site)
-      def check.request_url_once(url, req_method = Net::HTTP::Head)
-        Net::HTTPResponse.new('1.1', req_method == Net::HTTP::Head || url.path == '/405' ? '405' : '200', 'okay')
-      end
-
-      # Test
-      assert_nil check.validate('http://127.0.0.1:9204')
-      refute_nil check.validate('http://127.0.0.1:9204/405')
-    end
-  end
-
   def test_path_for_url
     with_site do |site|
       check = Nanoc::Checking::Checks::ExternalLinks.create(site)


### PR DESCRIPTION
Fixes #1178.

This makes the external links checker always use GET rather than HEAD (and falling back to GET only on 405 Method Not Allowed), because using HEAD is not always reliable, sadly.