### PR TITLE
Add --preprocess to shell command

### DIFF
--- a/lib/nanoc/cli/commands/shell.rb
+++ b/lib/nanoc/cli/commands/shell.rb
@@ -6,13 +6,14 @@ aliases 'console'
 description "
 Open an IRB shell on a context that contains @items, @layouts, and @config.
 "
+flag :p, :preprocess, 'run preprocessor'
 
 module Nanoc::CLI::Commands
   class Shell < ::Nanoc::CLI::CommandRunner
     def run
       require 'pry'
 
-      load_site
+      load_site(preprocess: options[:preprocess])
 
       Nanoc::Int::Context.new(env).pry
     end


### PR DESCRIPTION
This adds a `-p`/`--preprocess` option to `shell`, which makes the _preprocessed_ site content available.

This PR also cleans up the specs a little — I only now found out about `expect_any_instance_of`!