### PR TITLE
Do not use items/layouts (mutable identifier) as hash key

### DIFF
--- a/spec/nanoc/regressions/gh_1185_spec.rb
+++ b/spec/nanoc/regressions/gh_1185_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+describe 'GH-1185', site: true, stdio: true do
+  before do
+    File.write('content/foo.html', 'stuff')
+
+    File.write('Rules', <<~EOS)
+      preprocess do
+        @items['/foo.*'].identifier = '/bar.html'
+      end
+
+      compile '/**/*' do
+        filter :erb
+        write ext: 'html'
+      end
+    EOS
+  end
+
+  it 'does not crash' do
+    Nanoc::CLI.run(%w[compile])
+  end
+end


### PR DESCRIPTION
`Document`’s `@identifier` is mutable, and is therefore not a good candidate for use in a hash key.

* [x] Add test case
* [x] Remove invariant check

Fixes #1185.