### PR TITLE
Fine grained config dependencies

### DIFF
--- a/lib/nanoc/base/entities/dependency.rb
+++ b/lib/nanoc/base/entities/dependency.rb
@@ -6,16 +6,18 @@ module Nanoc::Int
   class Dependency
     include Nanoc::Int::ContractsSupport
 
-    contract C::None => C::Maybe[C::Or[Nanoc::Int::Item, Nanoc::Int::Layout]]
+    C_OBJ = C::Or[Nanoc::Int::Item, Nanoc::Int::Layout, Nanoc::Int::Configuration]
+
+    contract C::None => C::Maybe[C_OBJ]
     attr_reader :from
 
-    contract C::None => C::Maybe[C::Or[Nanoc::Int::Item, Nanoc::Int::Layout]]
+    contract C::None => C::Maybe[C_OBJ]
     attr_reader :to
 
     contract C::None => Nanoc::Int::Props
     attr_reader :props
 
-    contract C::Maybe[C::Or[Nanoc::Int::Item, Nanoc::Int::Layout]], C::Maybe[C::Or[Nanoc::Int::Item, Nanoc::Int::Layout]], Nanoc::Int::Props => C::Any
+    contract C::Maybe[C_OBJ], C::Maybe[C_OBJ], Nanoc::Int::Props => C::Any
     def initialize(from, to, props)
       @from  = from
       @to    = to

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -22,7 +22,9 @@ module Nanoc::Int
       @graph = Nanoc::Int::DirectedGraph.new([nil] + objs2refs(@items) + objs2refs(@layouts))
     end
 
-    contract C::Or[Nanoc::Int::Item, Nanoc::Int::ItemRep, Nanoc::Int::Layout] => C::ArrayOf[Nanoc::Int::Dependency]
+    # FIXME: ItemRep?
+    C_OBJ = C::Or[Nanoc::Int::Item, Nanoc::Int::ItemRep, Nanoc::Int::Layout, Nanoc::Int::Configuration]
+    contract C_OBJ => C::ArrayOf[Nanoc::Int::Dependency]
     def dependencies_causing_outdatedness_of(object)
       objects_causing_outdatedness_of(object).map do |other_object|
         props = props_for(other_object, object)
@@ -75,9 +77,8 @@ module Nanoc::Int
       end
     end
 
-    C_DOC = C::Or[Nanoc::Int::Item, Nanoc::Int::Layout]
     C_ATTR = C::Or[C::IterOf[Symbol], C::Bool]
-    contract C::Maybe[C_DOC], C::Maybe[C_DOC], C::KeywordArgs[raw_content: C::Optional[C::Bool], attributes: C::Optional[C_ATTR], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]] => C::Any
+    contract C::Maybe[C_OBJ], C::Maybe[C_OBJ], C::KeywordArgs[raw_content: C::Optional[C::Bool], attributes: C::Optional[C_ATTR], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]] => C::Any
     # Records a dependency from `src` to `dst` in the dependency graph. When
     # `dst` is oudated, `src` will also become outdated.
     #

--- a/lib/nanoc/base/services/dependency_tracker.rb
+++ b/lib/nanoc/base/services/dependency_tracker.rb
@@ -5,7 +5,7 @@ module Nanoc::Int
   class DependencyTracker
     include Nanoc::Int::ContractsSupport
 
-    C_OBJ = C::Or[Nanoc::Int::Item, Nanoc::Int::Layout]
+    C_OBJ = C::Or[Nanoc::Int::Item, Nanoc::Int::Layout, Nanoc::Int::Configuration]
     C_ATTR = C::Or[C::IterOf[Symbol], C::Bool]
     C_ARGS = C::KeywordArgs[raw_content: C::Optional[C::Bool], attributes: C::Optional[C_ATTR], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]]
 

--- a/lib/nanoc/base/views/config_view.rb
+++ b/lib/nanoc/base/views/config_view.rb
@@ -18,6 +18,7 @@ module Nanoc
 
     # @see Hash#fetch
     def fetch(key, fallback = NONE, &_block)
+      @context.dependency_tracker.bounce(unwrap, attributes: [key])
       @config.fetch(key) do
         if !fallback.equal?(NONE)
           fallback
@@ -31,16 +32,19 @@ module Nanoc
 
     # @see Hash#key?
     def key?(key)
+      @context.dependency_tracker.bounce(unwrap, attributes: [key])
       @config.key?(key)
     end
 
     # @see Hash#[]
     def [](key)
+      @context.dependency_tracker.bounce(unwrap, attributes: [key])
       @config[key]
     end
 
     # @see Hash#each
     def each(&block)
+      @context.dependency_tracker.bounce(unwrap, attributes: true)
       @config.each(&block)
     end
   end

--- a/spec/nanoc/base/views/config_view_spec.rb
+++ b/spec/nanoc/base/views/config_view_spec.rb
@@ -7,7 +7,19 @@ describe Nanoc::ConfigView do
 
   let(:hash) { { amount: 9000, animal: 'donkey' } }
 
-  let(:view) { described_class.new(config, nil) }
+  let(:view) { described_class.new(config, view_context) }
+
+  let(:view_context) do
+    Nanoc::ViewContext.new(
+      reps: double(:reps),
+      items: double(:items),
+      dependency_tracker: dependency_tracker,
+      compilation_context: double(:compilation_context),
+      snapshot_repo: double(:snapshot_repo),
+    )
+  end
+
+  let(:dependency_tracker) { double(:dependency_tracker) }
 
   describe '#frozen?' do
     subject { view.frozen? }
@@ -25,6 +37,10 @@ describe Nanoc::ConfigView do
   describe '#[]' do
     subject { view[key] }
 
+    before do
+      expect(dependency_tracker).to receive(:bounce).with(config, attributes: [key])
+    end
+
     context 'with existant key' do
       let(:key) { :animal }
       it { is_expected.to eql('donkey') }
@@ -37,6 +53,10 @@ describe Nanoc::ConfigView do
   end
 
   describe '#fetch' do
+    before do
+      expect(dependency_tracker).to receive(:bounce).with(config, attributes: [key])
+    end
+
     context 'with existant key' do
       let(:key) { :animal }
 
@@ -71,6 +91,10 @@ describe Nanoc::ConfigView do
   describe '#key?' do
     subject { view.key?(key) }
 
+    before do
+      expect(dependency_tracker).to receive(:bounce).with(config, attributes: [key])
+    end
+
     context 'with existant key' do
       let(:key) { :animal }
       it { is_expected.to eql(true) }
@@ -83,6 +107,10 @@ describe Nanoc::ConfigView do
   end
 
   describe '#each' do
+    before do
+      expect(dependency_tracker).to receive(:bounce).with(config, attributes: true)
+    end
+
     example do
       res = []
       view.each { |k, v| res << [k, v] }

--- a/test/helpers/test_blogging.rb
+++ b/test/helpers/test_blogging.rb
@@ -28,6 +28,24 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     item
   end
 
+  def setup
+    super
+
+    config = Nanoc::Int::Configuration.new.with_defaults
+    items = Nanoc::Int::IdentifiableCollection.new(config)
+    layouts = Nanoc::Int::IdentifiableCollection.new(config)
+    dep_store = Nanoc::Int::DependencyStore.new(items, layouts)
+    dependency_tracker = Nanoc::Int::DependencyTracker.new(dep_store)
+
+    @view_context = Nanoc::ViewContext.new(
+      reps: :__irrelevant__,
+      items: nil,
+      dependency_tracker: dependency_tracker,
+      compilation_context: :__irrelevant__,
+      snapshot_repo: :__irrelevant_snapshot_repo,
+    )
+  end
+
   def test_atom_feed
     if_have 'builder' do
       # Create items
@@ -51,7 +69,8 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items[2].expects(:compiled_content).with(snapshot: :pre).returns('item 2 content')
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
       @item = mock
@@ -82,7 +101,8 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items[2].expects(:compiled_content).returns('item 2 content')
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
       @item = mock
@@ -113,7 +133,8 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items[2].expects(:compiled_content).returns('item 2 content')
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
       @item = mock
@@ -144,7 +165,8 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items[2].expects(:compiled_content).returns('item 2 content')
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
       @item = mock
@@ -165,7 +187,8 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items = [mock_item, mock_item]
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
       @item = mock
@@ -190,7 +213,8 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items = [mock_item, mock_article]
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: nil }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: nil })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
       @item = mock
@@ -215,7 +239,8 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items = [mock_item, mock_article]
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
       @item = mock
@@ -240,7 +265,8 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items = [mock_item, mock_article]
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
       @item = mock
@@ -270,7 +296,8 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items[0].expects(:compiled_content).returns('item 1 content')
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com/' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com/' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
       @item = mock
@@ -312,7 +339,8 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items = [mock_item, mock_article]
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
       @item = mock
@@ -339,7 +367,8 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items[2].stubs(:[]).with(:created_at).returns(nil)
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
       @item = mock
@@ -365,7 +394,8 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items[1].expects(:compiled_content).with(snapshot: :pre).returns('asdf')
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
       @item = mock
@@ -390,15 +420,15 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items[1].expects(:compiled_content).with(snapshot: :pre).returns('asdf')
 
       # Mock site
-      @config = Nanoc::ConfigView.new(
+      config_hash =
         {
           author_name: 'Bob',
           author_uri: 'http://example.com/~bob/',
           title: 'My Blog Or Something',
           base_url: 'http://example.com',
-        },
-        nil,
-      )
+        }
+      config = Nanoc::Int::Configuration.new(hash: config_hash)
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
       @item = mock
@@ -422,7 +452,8 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items[1].expects(:compiled_content).with(snapshot: :pre).returns('asdf')
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
       @item = mock
@@ -446,7 +477,8 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       end
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
       @item = mock
@@ -479,7 +511,8 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items[1].stubs(:[]).with(:created_at).returns('22-03-2009')
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
       @item = mock
@@ -508,7 +541,8 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items[1].stubs(:[]).with(:created_at).returns('01-01-2014')
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
       @item = mock
@@ -532,7 +566,8 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items = [mock_article]
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
       @item = mock
@@ -553,7 +588,8 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items = [mock_article]
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
       @item = mock
@@ -574,7 +610,8 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items = [mock_article]
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
       @item = mock
@@ -595,7 +632,8 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items = [mock_article]
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
       @item = mock
@@ -616,7 +654,8 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items = [mock_article]
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
       @item = mock
@@ -638,7 +677,8 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items[0].stubs(:path).returns(nil)
 
       # Mock site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
       @item = mock

--- a/test/helpers/test_xml_sitemap.rb
+++ b/test/helpers/test_xml_sitemap.rb
@@ -8,9 +8,20 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
   def setup
     super
 
+    config = Nanoc::Int::Configuration.new.with_defaults
+    items = Nanoc::Int::IdentifiableCollection.new(config)
+    layouts = Nanoc::Int::IdentifiableCollection.new(config)
+    dep_store = Nanoc::Int::DependencyStore.new(items, layouts)
+    dependency_tracker = Nanoc::Int::DependencyTracker.new(dep_store)
+
     @reps = Nanoc::Int::ItemRepRepo.new
-    dependency_tracker = Nanoc::Int::DependencyTracker.new(nil)
-    @view_context = Nanoc::ViewContext.new(reps: @reps, items: nil, dependency_tracker: dependency_tracker, compilation_context: :__irrelevant__, snapshot_repo: :__irrelevant_snapshot_repo)
+    @view_context = Nanoc::ViewContext.new(
+      reps: @reps,
+      items: nil,
+      dependency_tracker: dependency_tracker,
+      compilation_context: :__irrelevant__,
+      snapshot_repo: :__irrelevant_snapshot_repo,
+    )
 
     @items = nil
     @item = nil
@@ -52,7 +63,8 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
       @item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), @view_context)
 
       # Create site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Build sitemap
       res = xml_sitemap
@@ -98,7 +110,8 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
       @item = Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/')
 
       # Create site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Build sitemap
       res = xml_sitemap(items: [item])
@@ -132,7 +145,8 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
       @item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), @view_context)
 
       # Create site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Build sitemap
       res = xml_sitemap(rep_select: ->(rep) { rep.name == :one_a })
@@ -172,7 +186,8 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
       @item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), @view_context)
 
       # Create site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Build sitemap
       res = xml_sitemap(items: @items)
@@ -203,7 +218,8 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
       @item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), @view_context)
 
       # Create site
-      @config = Nanoc::ConfigView.new({ base_url: 'http://example.com' }, nil)
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Build sitemap
       res = xml_sitemap(items: @items)


### PR DESCRIPTION
Track dependencies onto `@config`, so that later on, the outdatedness checker can use that information to prevent recompilation if the configuration has changed but no dependency on `@config` exists.

This PR does *not* change the outdatedness checker yet. That change will come later!