### PR TITLE
Fix FogWrapper not closing file

### DIFF
--- a/lib/nanoc/deploying/deployers/fog.rb
+++ b/lib/nanoc/deploying/deployers/fog.rb
@@ -35,12 +35,13 @@ module Nanoc::Deploying::Deployers
         log_effectful("uploading #{source_filename} -> #{destination_key}")
 
         unless dry_run?
-          # FIXME: source_filename file is never closed
-          @directory.files.create(
-            key: destination_key,
-            body: File.open(source_filename),
-            public: true,
-          )
+          File.open(source_filename) do |io|
+            @directory.files.create(
+              key: destination_key,
+              body: io,
+              public: true,
+            )
+          end
         end
       end
 

--- a/spec/nanoc/deploying/fog_spec.rb
+++ b/spec/nanoc/deploying/fog_spec.rb
@@ -48,6 +48,10 @@ describe Nanoc::Deploying::Deployers::Fog, stdio: true do
           'remote/bucky/woof',
         ])
     end
+
+    it 'does not leave lingering open files' do
+      expect { subject }.not_to leak_open_files
+    end
   end
 
   context 'dry run' do


### PR DESCRIPTION
This doesn’t quite have much of an effect, because the files don’t stay open for long. Perhaps for very large sites deployed with fog, it’d run out of file descriptors.