### PR TITLE
Make item/layout collection dependencies finer-grained

### DIFF
--- a/lib/nanoc/base/entities/outdatedness_reasons.rb
+++ b/lib/nanoc/base/entities/outdatedness_reasons.rb
@@ -46,15 +46,24 @@ module Nanoc::Int
       Props.new(raw_content: true, compiled_content: true),
     )
 
-    ItemCollectionExtended = Generic.new(
-      'A new item has been added to the site.',
-      Props.new(raw_content: true),
-    )
+    class DocumentCollectionExtended < Generic
+      attr_reader :objects
 
-    LayoutCollectionExtended = Generic.new(
-      'A new layout has been added to the site.',
-      Props.new(raw_content: true),
-    )
+      def initialize(objects)
+        super(
+          'New items/layouts have been added to the site.',
+          Props.new(raw_content: true),
+        )
+
+        @objects = objects
+      end
+    end
+
+    class ItemCollectionExtended < DocumentCollectionExtended
+    end
+
+    class LayoutCollectionExtended < DocumentCollectionExtended
+    end
 
     class AttributesModified < Generic
       attr_reader :attributes

--- a/lib/nanoc/base/entities/props.rb
+++ b/lib/nanoc/base/entities/props.rb
@@ -9,7 +9,7 @@ module Nanoc::Int
     attr_reader :raw_content
 
     # TODO: Split raw_content for documents and collections
-    C_RAW_CONTENT = C::Or[C::IterOf[String], C::Bool]
+    C_RAW_CONTENT = C::Or[C::IterOf[C::Or[String, Regexp]], C::Bool]
     C_ATTRS = C::Or[C::IterOf[Symbol], C::Bool]
     contract C::KeywordArgs[raw_content: C::Optional[C_RAW_CONTENT], attributes: C::Optional[C_ATTRS], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]] => C::Any
     def initialize(raw_content: false, attributes: false, compiled_content: false, path: false)

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -88,7 +88,7 @@ module Nanoc::Int
       refs2objs(@graph.direct_predecessors_of(obj2ref(object)))
     end
 
-    C_RAW_CONTENT = C::Or[C::IterOf[String], C::Bool]
+    C_RAW_CONTENT = C::Or[C::IterOf[C::Or[String, Regexp]], C::Bool]
     C_ATTR = C::Or[C::IterOf[Symbol], C::Bool]
     C_KEYWORD_PROPS = C::KeywordArgs[raw_content: C::Optional[C_RAW_CONTENT], attributes: C::Optional[C_ATTR], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]]
 

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -85,8 +85,10 @@ module Nanoc::Int
       refs2objs(@graph.direct_predecessors_of(obj2ref(object)))
     end
 
+    C_RAW_CONTENT = C::Or[C::IterOf[String], C::Bool]
     C_ATTR = C::Or[C::IterOf[Symbol], C::Bool]
-    C_KEYWORD_PROPS = C::KeywordArgs[raw_content: C::Optional[C::Bool], attributes: C::Optional[C_ATTR], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]]
+    C_KEYWORD_PROPS = C::KeywordArgs[raw_content: C::Optional[C_RAW_CONTENT], attributes: C::Optional[C_ATTR], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]]
+
     contract C::Maybe[C_OBJ_SRC], C::Maybe[C_OBJ_DST], C_KEYWORD_PROPS => C::Any
     # Records a dependency from `src` to `dst` in the dependency graph. When
     # `dst` is oudated, `src` will also become outdated.

--- a/lib/nanoc/base/repos/dependency_store.rb
+++ b/lib/nanoc/base/repos/dependency_store.rb
@@ -59,9 +59,12 @@ module Nanoc::Int
       add_vertex_for(layouts)
     end
 
-    contract C::None => C::Bool
-    def any_new_objects?
-      @new_objects.any?
+    def new_items
+      @new_objects.select { |o| o.is_a?(Nanoc::Int::Item) }
+    end
+
+    def new_layouts
+      @new_objects.select { |o| o.is_a?(Nanoc::Int::Layout) }
     end
 
     # Returns the direct dependencies for the given object.

--- a/lib/nanoc/base/services/dependency_tracker.rb
+++ b/lib/nanoc/base/services/dependency_tracker.rb
@@ -6,7 +6,7 @@ module Nanoc::Int
     include Nanoc::Int::ContractsSupport
 
     C_OBJ = C::Or[Nanoc::Int::Item, Nanoc::Int::Layout, Nanoc::Int::Configuration, Nanoc::Int::IdentifiableCollection]
-    C_RAW_CONTENT = C::Or[C::IterOf[String], C::Bool]
+    C_RAW_CONTENT = C::Or[C::IterOf[C::Or[String, Regexp]], C::Bool]
     C_ATTR = C::Or[C::IterOf[Symbol], C::Bool]
     C_ARGS = C::KeywordArgs[raw_content: C::Optional[C_RAW_CONTENT], attributes: C::Optional[C_ATTR], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]]
 

--- a/lib/nanoc/base/services/dependency_tracker.rb
+++ b/lib/nanoc/base/services/dependency_tracker.rb
@@ -6,8 +6,9 @@ module Nanoc::Int
     include Nanoc::Int::ContractsSupport
 
     C_OBJ = C::Or[Nanoc::Int::Item, Nanoc::Int::Layout, Nanoc::Int::Configuration, Nanoc::Int::IdentifiableCollection]
+    C_RAW_CONTENT = C::Or[C::IterOf[String], C::Bool]
     C_ATTR = C::Or[C::IterOf[Symbol], C::Bool]
-    C_ARGS = C::KeywordArgs[raw_content: C::Optional[C::Bool], attributes: C::Optional[C_ATTR], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]]
+    C_ARGS = C::KeywordArgs[raw_content: C::Optional[C_RAW_CONTENT], attributes: C::Optional[C_ATTR], compiled_content: C::Optional[C::Bool], path: C::Optional[C::Bool]]
 
     class Null
       include Nanoc::Int::ContractsSupport

--- a/lib/nanoc/base/services/outdatedness_rules/item_collection_extended.rb
+++ b/lib/nanoc/base/services/outdatedness_rules/item_collection_extended.rb
@@ -6,8 +6,10 @@ module Nanoc::Int::OutdatednessRules
 
     contract Nanoc::Int::ItemCollection, C::Named['Nanoc::Int::OutdatednessChecker'] => C::Maybe[Nanoc::Int::OutdatednessReasons::Generic]
     def apply(_obj, outdatedness_checker)
-      if outdatedness_checker.dependency_store.any_new_objects?
-        Nanoc::Int::OutdatednessReasons::ItemCollectionExtended
+      new_items = outdatedness_checker.dependency_store.new_items
+
+      if new_items.any?
+        Nanoc::Int::OutdatednessReasons::ItemCollectionExtended.new(new_items)
       end
     end
   end

--- a/lib/nanoc/base/services/outdatedness_rules/layout_collection_extended.rb
+++ b/lib/nanoc/base/services/outdatedness_rules/layout_collection_extended.rb
@@ -6,8 +6,10 @@ module Nanoc::Int::OutdatednessRules
 
     contract Nanoc::Int::LayoutCollection, C::Named['Nanoc::Int::OutdatednessChecker'] => C::Maybe[Nanoc::Int::OutdatednessReasons::Generic]
     def apply(_obj, outdatedness_checker)
-      if outdatedness_checker.dependency_store.any_new_objects?
-        Nanoc::Int::OutdatednessReasons::LayoutCollectionExtended
+      new_layouts = outdatedness_checker.dependency_store.new_layouts
+
+      if new_layouts.any?
+        Nanoc::Int::OutdatednessReasons::LayoutCollectionExtended.new(new_layouts)
       end
     end
   end

--- a/lib/nanoc/base/views/identifiable_collection_view.rb
+++ b/lib/nanoc/base/views/identifiable_collection_view.rb
@@ -47,7 +47,18 @@ module Nanoc
     #
     # @return [Enumerable]
     def find_all(arg)
-      @context.dependency_tracker.bounce(unwrap, raw_content: true)
+      # TODO: support regex
+      prop_attribute =
+        case arg
+        when String
+          [arg]
+        when Nanoc::Identifier
+          [arg.to_s]
+        else
+          true
+        end
+
+      @context.dependency_tracker.bounce(unwrap, raw_content: prop_attribute)
       @objects.find_all(arg).map { |i| view_class.new(i, @context) }
     end
 
@@ -74,7 +85,18 @@ module Nanoc
     #
     #   @return [#identifier] if an object was found
     def [](arg)
-      @context.dependency_tracker.bounce(unwrap, raw_content: true)
+      # TODO: support regex
+      prop_attribute =
+        case arg
+        when String
+          [arg]
+        when Nanoc::Identifier
+          [arg.to_s]
+        else
+          true
+        end
+
+      @context.dependency_tracker.bounce(unwrap, raw_content: prop_attribute)
       res = @objects[arg]
       res && view_class.new(res, @context)
     end

--- a/lib/nanoc/base/views/identifiable_collection_view.rb
+++ b/lib/nanoc/base/views/identifiable_collection_view.rb
@@ -47,13 +47,12 @@ module Nanoc
     #
     # @return [Enumerable]
     def find_all(arg)
-      # TODO: support regex
       prop_attribute =
         case arg
-        when String
-          [arg]
-        when Nanoc::Identifier
+        when String, Nanoc::Identifier
           [arg.to_s]
+        when Regexp
+          [arg]
         else
           true
         end
@@ -85,13 +84,12 @@ module Nanoc
     #
     #   @return [#identifier] if an object was found
     def [](arg)
-      # TODO: support regex
       prop_attribute =
         case arg
-        when String
-          [arg]
-        when Nanoc::Identifier
+        when String, Nanoc::Identifier
           [arg.to_s]
+        when Regexp
+          [arg]
         else
           true
         end

--- a/spec/nanoc/base/entities/props_spec.rb
+++ b/spec/nanoc/base/entities/props_spec.rb
@@ -31,7 +31,41 @@ describe Nanoc::Int::Props do
   end
 
   describe '#raw_content?' do
-    # …
+    subject { props.raw_content? }
+
+    context 'nothing active' do
+      it { is_expected.not_to be }
+    end
+
+    context 'raw_content active' do
+      let(:props) { described_class.new(raw_content: true) }
+      it { is_expected.to be }
+    end
+
+    context 'raw_content and compiled_content active' do
+      let(:props) { described_class.new(raw_content: true, compiled_content: true) }
+      it { is_expected.to be }
+    end
+
+    context 'compiled_content active' do
+      let(:props) { described_class.new(compiled_content: true) }
+      it { is_expected.not_to be }
+    end
+
+    context 'all active' do
+      let(:props) { described_class.new(raw_content: true, attributes: true, compiled_content: true, path: true) }
+      it { is_expected.to be }
+    end
+
+    context 'raw_content is empty list' do
+      let(:props) { described_class.new(raw_content: []) }
+      it { is_expected.not_to be }
+    end
+
+    context 'raw_content is non-empty list' do
+      let(:props) { described_class.new(raw_content: ['/asdf.*']) }
+      it { is_expected.to be }
+    end
   end
 
   describe '#attributes?' do
@@ -230,6 +264,92 @@ describe Nanoc::Int::Props do
 
       it { is_expected.to be_a(Set) }
       it { is_expected.to match_array(%i[donkey giraffe zebra]) }
+    end
+  end
+
+  describe '#merge_raw_content' do
+    let(:props_raw_content_true) do
+      described_class.new(raw_content: true)
+    end
+
+    let(:props_raw_content_false) do
+      described_class.new(raw_content: false)
+    end
+
+    let(:props_raw_content_list_a) do
+      described_class.new(raw_content: %w[donkey giraffe])
+    end
+
+    let(:props_raw_content_list_b) do
+      described_class.new(raw_content: %w[giraffe zebra])
+    end
+
+    subject { props.merge(other_props).raw_content }
+
+    context 'false + false' do
+      let(:props) { props_raw_content_false }
+      let(:other_props) { props_raw_content_false }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'false + true' do
+      let(:props) { props_raw_content_false }
+      let(:other_props) { props_raw_content_true }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'false + list' do
+      let(:props) { props_raw_content_false }
+      let(:other_props) { props_raw_content_list_a }
+
+      it { is_expected.to be_a(Set) }
+      it { is_expected.to match_array(%w[donkey giraffe]) }
+    end
+
+    context 'true + false' do
+      let(:props) { props_raw_content_true }
+      let(:other_props) { props_raw_content_false }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'true + true' do
+      let(:props) { props_raw_content_true }
+      let(:other_props) { props_raw_content_true }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'true + list' do
+      let(:props) { props_raw_content_true }
+      let(:other_props) { props_raw_content_list_a }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'list + false' do
+      let(:props) { props_raw_content_list_a }
+      let(:other_props) { props_raw_content_false }
+
+      it { is_expected.to be_a(Set) }
+      it { is_expected.to match_array(%w[donkey giraffe]) }
+    end
+
+    context 'list + true' do
+      let(:props) { props_raw_content_list_a }
+      let(:other_props) { props_raw_content_true }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'list + list' do
+      let(:props) { props_raw_content_list_a }
+      let(:other_props) { props_raw_content_list_b }
+
+      it { is_expected.to be_a(Set) }
+      it { is_expected.to match_array(%w[donkey giraffe zebra]) }
     end
   end
 

--- a/spec/nanoc/base/services/outdatedness_checker_spec.rb
+++ b/spec/nanoc/base/services/outdatedness_checker_spec.rb
@@ -572,11 +572,53 @@ describe Nanoc::Int::OutdatednessChecker do
         end
       end
 
-      context 'dependency on specific new items' do
+      context 'dependency on specific new items (string)' do
         before do
           dependency_tracker = Nanoc::Int::DependencyTracker.new(dependency_store)
           dependency_tracker.enter(item)
           dependency_tracker.bounce(items, raw_content: ['/new*'])
+          dependency_store.store
+        end
+
+        context 'nothing changed' do
+          it { is_expected.not_to be }
+        end
+
+        context 'matching item added' do
+          before do
+            new_item = Nanoc::Int::Item.new('stuff', {}, '/newblahz.md')
+            dependency_store.items = Nanoc::Int::ItemCollection.new(config, items.to_a + [new_item])
+            dependency_store.load
+          end
+
+          it { is_expected.to be }
+        end
+
+        context 'non-matching item added' do
+          before do
+            new_item = Nanoc::Int::Item.new('stuff', {}, '/nublahz.md')
+            dependency_store.items = Nanoc::Int::ItemCollection.new(config, items.to_a + [new_item])
+            dependency_store.load
+          end
+
+          it { is_expected.not_to be }
+        end
+
+        context 'item removed' do
+          before do
+            dependency_store.items = Nanoc::Int::ItemCollection.new(config, [])
+            dependency_store.load
+          end
+
+          it { is_expected.not_to be }
+        end
+      end
+
+      context 'dependency on specific new items (regex)' do
+        before do
+          dependency_tracker = Nanoc::Int::DependencyTracker.new(dependency_store)
+          dependency_tracker.enter(item)
+          dependency_tracker.bounce(items, raw_content: [%r{^/new.*}])
           dependency_store.store
         end
 

--- a/spec/nanoc/base/views/identifiable_collection_view_spec.rb
+++ b/spec/nanoc/base/views/identifiable_collection_view_spec.rb
@@ -145,7 +145,7 @@ shared_examples 'an identifiable collection' do
       it { is_expected.to equal(nil) }
 
       it 'creates dependency' do
-        expect(dependency_tracker).to receive(:bounce).with(wrapped, raw_content: true)
+        expect(dependency_tracker).to receive(:bounce).with(wrapped, raw_content: ['/donkey.*'])
         subject
       end
     end
@@ -154,7 +154,7 @@ shared_examples 'an identifiable collection' do
       let(:arg) { '/home.erb' }
 
       it 'creates dependency' do
-        expect(dependency_tracker).to receive(:bounce).with(wrapped, raw_content: true)
+        expect(dependency_tracker).to receive(:bounce).with(wrapped, raw_content: ['/home.erb'])
         subject
       end
 
@@ -172,7 +172,7 @@ shared_examples 'an identifiable collection' do
       let(:arg) { Nanoc::Identifier.new('/home.erb') }
 
       it 'creates dependency' do
-        expect(dependency_tracker).to receive(:bounce).with(wrapped, raw_content: true)
+        expect(dependency_tracker).to receive(:bounce).with(wrapped, raw_content: ['/home.erb'])
         subject
       end
 
@@ -189,7 +189,7 @@ shared_examples 'an identifiable collection' do
         let(:config) { { string_pattern_type: 'legacy' } }
 
         it 'creates dependency' do
-          expect(dependency_tracker).to receive(:bounce).with(wrapped, raw_content: true)
+          expect(dependency_tracker).to receive(:bounce).with(wrapped, raw_content: ['/home.*'])
           subject
         end
 
@@ -200,7 +200,7 @@ shared_examples 'an identifiable collection' do
 
       context 'globs enabled' do
         it 'creates dependency' do
-          expect(dependency_tracker).to receive(:bounce).with(wrapped, raw_content: true)
+          expect(dependency_tracker).to receive(:bounce).with(wrapped, raw_content: ['/home.*'])
           subject
         end
 
@@ -243,6 +243,11 @@ shared_examples 'an identifiable collection' do
     context 'with string' do
       let(:arg) { '/*.css' }
 
+      it 'creates dependency' do
+        expect(dependency_tracker).to receive(:bounce).with(wrapped, raw_content: ['/*.css'])
+        subject
+      end
+
       it 'contains views' do
         expect(subject.size).to eql(2)
         about_css = subject.find { |iv| iv.identifier == '/about.css' }
@@ -254,6 +259,11 @@ shared_examples 'an identifiable collection' do
 
     context 'with regex' do
       let(:arg) { %r{\.css\z} }
+
+      it 'creates dependency' do
+        expect(dependency_tracker).to receive(:bounce).with(wrapped, raw_content: true)
+        subject
+      end
 
       it 'contains views' do
         expect(subject.size).to eql(2)

--- a/spec/nanoc/base/views/identifiable_collection_view_spec.rb
+++ b/spec/nanoc/base/views/identifiable_collection_view_spec.rb
@@ -215,7 +215,7 @@ shared_examples 'an identifiable collection' do
       let(:arg) { %r{\A/home} }
 
       it 'creates dependency' do
-        expect(dependency_tracker).to receive(:bounce).with(wrapped, raw_content: true)
+        expect(dependency_tracker).to receive(:bounce).with(wrapped, raw_content: [%r{\A/home}])
         subject
       end
 
@@ -261,7 +261,7 @@ shared_examples 'an identifiable collection' do
       let(:arg) { %r{\.css\z} }
 
       it 'creates dependency' do
-        expect(dependency_tracker).to receive(:bounce).with(wrapped, raw_content: true)
+        expect(dependency_tracker).to receive(:bounce).with(wrapped, raw_content: [%r{\.css\z}])
         subject
       end
 

--- a/spec/nanoc/helpers/rendering_spec.rb
+++ b/spec/nanoc/helpers/rendering_spec.rb
@@ -29,7 +29,7 @@ describe Nanoc::Helpers::Rendering, helper: true do
 
           it 'tracks proper dependencies' do
             expect(ctx.dependency_tracker).to receive(:enter)
-              .with(an_instance_of(Nanoc::Int::LayoutCollection), raw_content: true, attributes: false, compiled_content: false, path: false)
+              .with(an_instance_of(Nanoc::Int::LayoutCollection), raw_content: ['/partial/'], attributes: false, compiled_content: false, path: false)
               .ordered
             expect(ctx.dependency_tracker).to receive(:enter)
               .with(layout, raw_content: true, attributes: false, compiled_content: false, path: false)


### PR DESCRIPTION
Dependencies on the item/layout collection are currently all-or-nothing. Any item that directly or indirectly accesses `@items` or `@layouts` will have a a dependency on the entire collection of items/layouts. This means that adding a new item or a new layout will cause these items to be marked as outdated, even if they won’t depend on that specific new layout.

This PR makes `@items[]` and `@items.find_all` (same for `@layout`) generate finer-grained dependencies, which only depend on a subset of the collection of items (or layouts). This way, adding a new item or layout is less likely to cause other items to be recompiled.