### PR TITLE
Expose checksums

### DIFF
--- a/lib/nanoc/base/services/compiler.rb
+++ b/lib/nanoc/base/services/compiler.rb
@@ -75,9 +75,9 @@ module Nanoc::Int
       # FIXME: State is ugly
 
       run_stage(preprocess_stage)
-      @action_sequences = run_stage(build_reps_stage)
       run_stage(load_stores_stage)
       @checksums = run_stage(calculate_checksums_stage)
+      @action_sequences = run_stage(build_reps_stage)
       @outdated_items = run_stage(determine_outdatedness_stage)
     end
 


### PR DESCRIPTION
**EXPERIMENT**

After this change, the checksums are available in

```ruby
checksums = @items._context.compilation_context.site.compiler.instance_eval('@checksums')
checksums.checksum_for(SOMETHING)
```

… which is a ton of indirection, though it might make sense to add `#checksum` onto item/layout/… views, so that

```ruby
@item.checksum
```

would return the checksum of that item, so that it can be reused later, e.g. for cache-busting:

```ruby
def fingerprint(pattern)
  checksums = @items.find_all(pattern).map(&:checksum)
  Digest::SHA1.hexdigest(checksums.join(''))[0..15]
end
```

Compare to what is currently necessary to cache-bust:

```ruby
def fingerprint(pattern)
  contents = @items.find_all(pattern).map do |i|
    i.binary? ? File.read(i[:filename]) : i.raw_content
  end
  Digest::SHA1.hexdigest(contents.join(''))[0..15]
end
```