### PR TITLE
Add support for nanoc-rust gem

### DIFF
--- a/bin/nanoc
+++ b/bin/nanoc
@@ -2,6 +2,13 @@
 # frozen_string_literal: true
 
 require 'nanoc'
+
+begin
+  require 'nanoc-rust'
+  NanocRust.activate!
+rescue LoadError
+end
+
 require 'nanoc/cli'
 
 if File.file?('Gemfile') && !defined?(Bundler)


### PR DESCRIPTION
The `nanoc-rust` gem contains parts of Nanoc reimplemented in Rust.

This PR will attempt to load the `nanoc-rust` gem and call `NanocRust.activate!`, which replaces Ruby bits with their Rust equivalent.

⚠️  **Experimental** — although there’s no harm in releasing this, as long as you don’t enable `nanoc-rust` unless you know what you’re doing.