### PR TITLE
Use Marshal.dump instead of YAML.dump for speed

### DIFF
--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -183,7 +183,7 @@ module Nanoc::DataSources
 
     def attributes_checksum_data_for(proto_doc, content_filename, meta_filename)
       Digest::SHA1.digest(
-        YAML.dump(
+        Marshal.dump(
           attributes: proto_doc.attributes_checksum_data,
           extra_attributes: extra_attributes_for(content_filename, meta_filename),
         ),


### PR DESCRIPTION
`Marshal.dump` is faster than `YAML.dump` (2000–3000%).