### PR TITLE
Add asciidoctor filter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ end
 
 group :plugins do
   gem 'adsf'
+  gem 'asciidoctor'
   gem 'bluecloth', platforms: :ruby
   gem 'builder'
   gem 'coderay'

--- a/lib/nanoc/filters.rb
+++ b/lib/nanoc/filters.rb
@@ -5,6 +5,7 @@ module Nanoc::Filters
 end
 
 require_relative 'filters/asciidoc'
+require_relative 'filters/asciidoctor'
 require_relative 'filters/bluecloth'
 require_relative 'filters/colorize_syntax'
 require_relative 'filters/coffeescript'

--- a/lib/nanoc/filters/asciidoctor.rb
+++ b/lib/nanoc/filters/asciidoctor.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Nanoc::Filters
+  class Asciidoctor < Nanoc::Filter
+    identifier :asciidoctor
+
+    requires 'asciidoctor'
+
+    def run(content, params = {})
+      ::Asciidoctor.render(content, params)
+    end
+  end
+end

--- a/spec/nanoc/filters/asciidoctor_spec.rb
+++ b/spec/nanoc/filters/asciidoctor_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+describe Nanoc::Filters::Asciidoctor do
+  subject { filter.setup_and_run(input, params) }
+
+  let(:filter) { described_class.new }
+
+  let(:input) { '== Blah blah' }
+  let(:params) { {} }
+
+  it { is_expected.to match(%r{<h2 id="_blah_blah">Blah blah</h2>}) }
+end


### PR DESCRIPTION
This integrates the `asciidoctor` filter, removing the need for a [separate `nanoc-asciidoctor` gem](https://github.com/nanoc/nanoc-asciidoctor).