### PR TITLE
No successors

### DIFF
--- a/lib/nanoc/base/entities/directed_graph.rb
+++ b/lib/nanoc/base/entities/directed_graph.rb
@@ -7,28 +7,30 @@ module Nanoc::Int
   # @example Creating and using a directed graph
   #
   #   # Create a graph with three vertices
-  #   graph = Nanoc::Int::DirectedGraph.new(%w( a b c d e ))
+  #   graph = Nanoc::Int::DirectedGraph.new(%w( a b c d e f g ))
   #
   #   # Add edges
   #   graph.add_edge('a', 'b')
   #   graph.add_edge('b', 'c')
+  #   graph.add_edge('b', 'f')
+  #   graph.add_edge('b', 'g')
   #   graph.add_edge('c', 'd')
-  #   graph.add_edge('b', 'e')
+  #   graph.add_edge('d', 'e')
   #
-  #   # Get (direct) successors
-  #   graph.direct_successors_of('a').sort
-  #     # => %w( b )
-  #   graph.successors_of('a').sort
-  #     # => %w( b c d e )
+  #   # Get (direct) predecessors
+  #   graph.direct_predecessors_of('b').sort
+  #     # => %w( a )
+  #   graph.predecessors_of('e').sort
+  #     # => %w( a b c d )
   #
   #   # Modify edges
   #   graph.delete_edges_to('c')
   #
-  #   # Get (direct) successors again
-  #   graph.direct_successors_of('a').sort
-  #     # => %w( b )
-  #   graph.successors_of('a').sort
-  #     # => %w( b e )
+  #   # Get (direct) predecessors again
+  #   graph.direct_predecessors_of('e').sort
+  #     # => %w( d )
+  #   graph.predecessors_of('e').sort
+  #     # => %w( c d )
   #
   # @api private
   class DirectedGraph
@@ -148,16 +150,6 @@ module Nanoc::Int
       @predecessors[to] ||= recursively_find_vertices(to, :direct_predecessors_of)
     end
 
-    # Returns the successors of the given vertex, i.e. the vertices y for
-    # which there is a path from the given vertex x to y.
-    #
-    # @param from The vertex of which the successors should be calculated
-    #
-    # @return [Array] Successors of the given vertex
-    def successors_of(from)
-      @successors[from] ||= recursively_find_vertices(from, :direct_successors_of)
-    end
-
     def props_for(from, to)
       @edge_props[[from, to]]
     end
@@ -187,7 +179,6 @@ module Nanoc::Int
     # graph representation is changed.
     def invalidate_caches
       @predecessors = {}
-      @successors   = {}
     end
 
     # Recursively finds vertices, starting at the vertex start, using the

--- a/lib/nanoc/base/entities/directed_graph.rb
+++ b/lib/nanoc/base/entities/directed_graph.rb
@@ -44,7 +44,6 @@ module Nanoc::Int
         @vertices[v] = @next_vertex_idx.tap { @next_vertex_idx += 1 }
       end
 
-      @from_graph = {}
       @to_graph   = {}
 
       @edge_props = {}
@@ -55,8 +54,8 @@ module Nanoc::Int
     def inspect
       s = []
 
-      @vertices.each_pair do |v1, _|
-        direct_successors_of(v1).each do |v2|
+      @vertices.each_pair do |v2, _|
+        direct_predecessors_of(v2).each do |v1|
           s << [v1.inspect + ' -> ' + v2.inspect + ' props=' + @edge_props[[v1, v2]].inspect]
         end
       end
@@ -76,9 +75,6 @@ module Nanoc::Int
     def add_edge(from, to, props: nil)
       add_vertex(from)
       add_vertex(to)
-
-      @from_graph[from] ||= Set.new
-      @from_graph[from] << to
 
       @to_graph[to] ||= Set.new
       @to_graph[to] << from
@@ -110,7 +106,6 @@ module Nanoc::Int
       return if @to_graph[to].nil?
 
       @to_graph[to].each do |from|
-        @from_graph[from].delete(to)
         @edge_props.delete([from, to])
       end
       @to_graph.delete(to)
@@ -128,16 +123,6 @@ module Nanoc::Int
     # @return [Array] Direct predecessors of the given vertex
     def direct_predecessors_of(to)
       @to_graph[to].to_a
-    end
-
-    # Returns the direct successors of the given vertex, i.e. the vertices y
-    # where there is an edge from the given vertex x to y.
-    #
-    # @param from The vertex of which the successors should be calculated
-    #
-    # @return [Array] Direct successors of the given vertex
-    def direct_successors_of(from)
-      @from_graph[from].to_a
     end
 
     # Returns the predecessors of the given vertex, i.e. the vertices x for
@@ -165,8 +150,8 @@ module Nanoc::Int
     # @return [Array] The list of all edges in this graph.
     def edges
       result = []
-      @vertices.each_pair do |v1, i1|
-        direct_successors_of(v1).map { |v2| [@vertices[v2], v2] }.each do |i2, v2|
+      @vertices.each_pair do |v2, i2|
+        direct_predecessors_of(v2).map { |v1| [@vertices[v1], v1] }.each do |i1, v1|
           result << [i1, i2, @edge_props[[v1, v2]]]
         end
       end

--- a/spec/nanoc/base/directed_graph_spec.rb
+++ b/spec/nanoc/base/directed_graph_spec.rb
@@ -101,33 +101,6 @@ describe Nanoc::Int::DirectedGraph do
     end
   end
 
-  describe '#direct_successors_of' do
-    subject { graph.direct_successors_of('2') }
-
-    context 'no edges' do
-      it { is_expected.to be_empty }
-    end
-
-    context 'one edge to' do
-      before { graph.add_edge('1', '2') }
-      it { is_expected.to be_empty }
-    end
-
-    context 'one edge from' do
-      before { graph.add_edge('2', '3') }
-      it { is_expected.to eq(['3']) }
-    end
-
-    context 'two edges from' do
-      before do
-        graph.add_edge('2', '1')
-        graph.add_edge('2', '3')
-      end
-
-      it { is_expected.to match_array(%w[1 3]) }
-    end
-  end
-
   describe '#predecessors_of' do
     subject { graph.predecessors_of('2') }
 

--- a/spec/nanoc/base/directed_graph_spec.rb
+++ b/spec/nanoc/base/directed_graph_spec.rb
@@ -156,34 +156,6 @@ describe Nanoc::Int::DirectedGraph do
     end
   end
 
-  describe '#successors_of' do
-    subject { graph.successors_of('2') }
-
-    context 'no successors' do
-      before do
-        graph.add_edge('1', '2')
-      end
-
-      it { is_expected.to be_empty }
-    end
-
-    context 'direct predecessor' do
-      before do
-        graph.add_edge('1', '2')
-        graph.add_edge('2', '3')
-      end
-
-      context 'no indirect successors' do
-        it { is_expected.to match_array(['3']) }
-      end
-
-      context 'indirect successors' do
-        before { graph.add_edge('3', '1') }
-        it { is_expected.to match_array(%w[1 2 3]) }
-      end
-    end
-  end
-
   describe '#inspect' do
     subject { graph.inspect }
 

--- a/test/base/test_directed_graph.rb
+++ b/test/base/test_directed_graph.rb
@@ -6,12 +6,10 @@ class Nanoc::Int::DirectedGraphTest < Nanoc::TestCase
   def test_add_edge
     graph = Nanoc::Int::DirectedGraph.new([1, 2, 3])
 
-    assert_equal [], graph.successors_of(1)
     assert_equal [], graph.predecessors_of(2)
 
     graph.add_edge(1, 2)
 
-    assert_equal [2], graph.successors_of(1)
     assert_equal [1], graph.predecessors_of(2)
   end
 
@@ -66,7 +64,6 @@ class Nanoc::Int::DirectedGraphTest < Nanoc::TestCase
     assert_equal [], graph.direct_predecessors_of(4)
     assert_equal [], graph.predecessors_of(4)
     assert_equal [], graph.direct_successors_of(4)
-    assert_equal [], graph.successors_of(4)
   end
 
   def test_example

--- a/test/base/test_directed_graph.rb
+++ b/test/base/test_directed_graph.rb
@@ -33,29 +33,20 @@ class Nanoc::Int::DirectedGraphTest < Nanoc::TestCase
     graph.add_edge(3, 1)
 
     assert_equal [2, 3], graph.direct_predecessors_of(1).sort
-    assert_equal [2, 3], graph.direct_successors_of(1).sort
     assert_equal [1, 3], graph.direct_predecessors_of(2).sort
-    assert_equal [1, 3], graph.direct_successors_of(2).sort
     assert_equal [1, 2], graph.direct_predecessors_of(3).sort
-    assert_equal [1, 2], graph.direct_successors_of(3).sort
 
     graph.delete_edges_to(1)
 
     assert_equal [], graph.direct_predecessors_of(1).sort
-    assert_equal [2, 3], graph.direct_successors_of(1).sort
     assert_equal [1, 3], graph.direct_predecessors_of(2).sort
-    assert_equal [3], graph.direct_successors_of(2).sort
     assert_equal [1, 2], graph.direct_predecessors_of(3).sort
-    assert_equal [2], graph.direct_successors_of(3).sort
 
     graph.delete_edges_to(2)
 
     assert_equal [], graph.direct_predecessors_of(1).sort
-    assert_equal [3], graph.direct_successors_of(1).sort
     assert_equal [], graph.direct_predecessors_of(2).sort
-    assert_equal [3], graph.direct_successors_of(2).sort
     assert_equal [1, 2], graph.direct_predecessors_of(3).sort
-    assert_equal [], graph.direct_successors_of(3).sort
   end
 
   def test_should_return_empty_array_for_nonexistant_vertices
@@ -63,7 +54,6 @@ class Nanoc::Int::DirectedGraphTest < Nanoc::TestCase
 
     assert_equal [], graph.direct_predecessors_of(4)
     assert_equal [], graph.predecessors_of(4)
-    assert_equal [], graph.direct_successors_of(4)
   end
 
   def test_example


### PR DESCRIPTION
This removes

* `DirectedGraph#direct_successors_of`
* `DirectedGraph#successors_of`

as neither are needed.

This change will make the directed graph class _slightly_ faster, as it no longer has to construct lists of successors.