### PR TITLE
Listen on 127.0.0.1, not 0.0.0.0, by default

### DIFF
--- a/lib/nanoc/cli/commands/view.rb
+++ b/lib/nanoc/cli/commands/view.rb
@@ -9,7 +9,7 @@ description <<~EOS
 EOS
 
 required :H, :handler, 'specify the handler to use (webrick/mongrel/...)'
-required :o, :host,    'specify the host to listen on (default: 0.0.0.0)'
+required :o, :host,    'specify the host to listen on (default: 127.0.0.1)'
 required :p, :port,    'specify the port to listen on (default: 3000)'
 
 module Nanoc::CLI::Commands
@@ -25,7 +25,7 @@ module Nanoc::CLI::Commands
       # Set options
       options_for_rack = {
         Port: (options[:port] || 3000).to_i,
-        Host: (options[:host] || '0.0.0.0'),
+        Host: (options[:host] || '127.0.0.1'),
       }
 
       # Get handler
@@ -53,7 +53,7 @@ module Nanoc::CLI::Commands
       end.to_app
 
       # Print a link
-      url = "http://#{options[:host] || 'localhost'}:#{options_for_rack[:Port]}/"
+      url = "http://#{options_for_rack[:Host]}:#{options_for_rack[:Port]}/"
       puts "View the site at #{url}"
 
       # Run autocompiler

--- a/spec/nanoc/cli/commands/view_spec.rb
+++ b/spec/nanoc/cli/commands/view_spec.rb
@@ -58,5 +58,14 @@ describe Nanoc::CLI::Commands::View, site: true, stdio: true do
         expect(Net::HTTP.get('127.0.0.1', '/', 50_385)).to eql("File not found: /\n")
       end
     end
+
+    it 'does not listen on non-local interfaces' do
+      addresses = Socket.getifaddrs.map(&:addr).select(&:ipv4?).map(&:ip_address)
+      non_local_addresses = addresses - ['127.0.0.1']
+
+      run_nanoc_cmd(['view', '--port', '50385']) do
+        expect { Net::HTTP.get(non_local_addresses[0], '/', 50_385) }.to raise_error(Errno::ECONNREFUSED)
+      end
+    end
   end
 end


### PR DESCRIPTION
`nanoc view` listens on all network interfaces by default, which is potentially problematic, as exposes the (compiled) Nanoc site to other devices.

This is a potential security issue.