### PR TITLE
Disallow full identifiers from ending with a slash

### DIFF
--- a/lib/nanoc/base/entities/document.rb
+++ b/lib/nanoc/base/entities/document.rb
@@ -15,7 +15,7 @@ module Nanoc
       end
 
       # @return [Nanoc::Identifier]
-      attr_accessor :identifier
+      attr_reader :identifier
 
       # @return [String, nil]
       attr_accessor :checksum_data
@@ -79,6 +79,11 @@ module Nanoc
       # @return Unique reference to this object
       def reference
         raise NotImplementedError
+      end
+
+      contract C::Or[Nanoc::Identifier, String] => Nanoc::Identifier
+      def identifier=(new_identifier)
+        @identifier = Nanoc::Identifier.from(new_identifier)
       end
 
       contract C::None => String

--- a/lib/nanoc/base/entities/identifier.rb
+++ b/lib/nanoc/base/entities/identifier.rb
@@ -13,6 +13,13 @@ module Nanoc
     end
 
     # @api private
+    class InvalidFullIdentifierError < ::Nanoc::Error
+      def initialize(string)
+        super("Invalid full identifier (ends with a slash): #{string.inspect}")
+      end
+    end
+
+    # @api private
     class InvalidTypeError < ::Nanoc::Error
       def initialize(type)
         super("Invalid type for identifier: #{type.inspect} (can be :full or :legacy)")
@@ -60,9 +67,9 @@ module Nanoc
       when :legacy
         @string = "/#{string}/".gsub(/^\/+|\/+$/, '/').freeze
       when :full
-        if string !~ /\A\//
-          raise InvalidIdentifierError.new(string)
-        end
+        raise InvalidIdentifierError.new(string) if string !~ /\A\//
+        raise InvalidFullIdentifierError.new(string) if string =~ /\/\z/
+
         @string = string.dup.freeze
       else
         raise InvalidTypeError.new(@type)

--- a/spec/nanoc/base/entities/document_spec.rb
+++ b/spec/nanoc/base/entities/document_spec.rb
@@ -225,4 +225,34 @@ shared_examples 'a document' do
       expect(subject.attributes).to eq(at: 'ribut')
     end
   end
+
+  describe '#identifier=' do
+    let(:document) { described_class.new('stuff', {}, '/foo.md') }
+
+    it 'allows changing to a string that contains a full identifier' do
+      expect { document.identifier = '/thing' }.not_to raise_error
+
+      expect(document.identifier).to eq('/thing')
+      expect(document.identifier).to be_full
+    end
+
+    it 'refuses changing to a string that does not contain a full identifier' do
+      expect { document.identifier = '/thing/' }
+        .to raise_error(Nanoc::Identifier::InvalidFullIdentifierError)
+    end
+
+    it 'allos changing to a full identifier' do
+      document.identifier = Nanoc::Identifier.new('/thing')
+
+      expect(document.identifier.to_s).to eq('/thing')
+      expect(document.identifier).to be_full
+    end
+
+    it 'allos changing to a legacy identifier' do
+      document.identifier = Nanoc::Identifier.new('/thing/', type: :legacy)
+
+      expect(document.identifier).to eq('/thing/')
+      expect(document.identifier).to be_legacy
+    end
+  end
 end

--- a/spec/nanoc/base/entities/identifier_spec.rb
+++ b/spec/nanoc/base/entities/identifier_spec.rb
@@ -67,6 +67,16 @@ describe Nanoc::Identifier do
           .to raise_error(Nanoc::Identifier::InvalidIdentifierError)
       end
 
+      it 'refuses string ending with a slash' do
+        expect { described_class.new('/foo/') }
+          .to raise_error(Nanoc::Identifier::InvalidFullIdentifierError)
+      end
+
+      it 'refuses string with only slash' do
+        expect { described_class.new('/') }
+          .to raise_error(Nanoc::Identifier::InvalidFullIdentifierError)
+      end
+
       it 'has proper string representation' do
         expect(described_class.new('/foo').to_s).to eql('/foo')
       end
@@ -422,7 +432,7 @@ describe Nanoc::Identifier do
     end
 
     context 'full type' do
-      let(:identifier) { described_class.new('/foo/', type: :full) }
+      let(:identifier) { described_class.new('/foo', type: :full) }
       it { is_expected.to eql(false) }
     end
   end
@@ -436,7 +446,7 @@ describe Nanoc::Identifier do
     end
 
     context 'full type' do
-      let(:identifier) { described_class.new('/foo/', type: :full) }
+      let(:identifier) { described_class.new('/foo', type: :full) }
       it { is_expected.to eql(true) }
     end
   end
@@ -445,7 +455,7 @@ describe Nanoc::Identifier do
     subject { identifier.components }
 
     context 'no components' do
-      let(:identifier) { described_class.new('/') }
+      let(:identifier) { described_class.new('/', type: :legacy) }
       it { is_expected.to eql([]) }
     end
 

--- a/spec/nanoc/base/item_rep_writer_spec.rb
+++ b/spec/nanoc/base/item_rep_writer_spec.rb
@@ -4,7 +4,7 @@ describe Nanoc::Int::ItemRepWriter do
   describe '#write' do
     let(:raw_path) { 'output/blah.dat' }
 
-    let(:item) { Nanoc::Int::Item.new(orig_content, {}, '/') }
+    let(:item) { Nanoc::Int::Item.new(orig_content, {}, '/foo') }
 
     let(:item_rep) do
       Nanoc::Int::ItemRep.new(item, :default).tap do |ir|

--- a/spec/nanoc/base/services/executor_spec.rb
+++ b/spec/nanoc/base/services/executor_spec.rb
@@ -653,7 +653,7 @@ describe Nanoc::Int::Executor do
       let(:arg) { '/default' }
 
       let(:layouts) do
-        [Nanoc::Int::Layout.new('head <%= @foo %> foot', {}, '/default/')]
+        [Nanoc::Int::Layout.new('head <%= @foo %> foot', {}, Nanoc::Identifier.new('/default/', type: :legacy))]
       end
 
       it { is_expected.to eq(layouts[0]) }

--- a/spec/nanoc/base/views/document_view_spec.rb
+++ b/spec/nanoc/base/views/document_view_spec.rb
@@ -27,7 +27,7 @@ shared_examples 'a document view' do
   end
 
   describe '#frozen?' do
-    let(:document) { entity_class.new('content', {}, '/asdf/') }
+    let(:document) { entity_class.new('content', {}, '/asdf') }
 
     subject { view.frozen? }
 
@@ -42,10 +42,10 @@ shared_examples 'a document view' do
   end
 
   describe '#== and #eql?' do
-    let(:document) { entity_class.new('content', {}, '/asdf/') }
+    let(:document) { entity_class.new('content', {}, '/asdf') }
 
     context 'comparing with document with same identifier' do
-      let(:other) { entity_class.new('content', {}, '/asdf/') }
+      let(:other) { entity_class.new('content', {}, '/asdf') }
 
       it 'is ==' do
         expect(view).to eq(other)
@@ -57,7 +57,7 @@ shared_examples 'a document view' do
     end
 
     context 'comparing with document with different identifier' do
-      let(:other) { entity_class.new('content', {}, '/fdsa/') }
+      let(:other) { entity_class.new('content', {}, '/fdsa') }
 
       it 'is not ==' do
         expect(view).not_to eq(other)
@@ -69,7 +69,7 @@ shared_examples 'a document view' do
     end
 
     context 'comparing with document view with same identifier' do
-      let(:other) { other_view_class.new(entity_class.new('content', {}, '/asdf/'), nil) }
+      let(:other) { other_view_class.new(entity_class.new('content', {}, '/asdf'), nil) }
 
       it 'is ==' do
         expect(view).to eq(other)
@@ -81,7 +81,7 @@ shared_examples 'a document view' do
     end
 
     context 'comparing with document view with different identifier' do
-      let(:other) { other_view_class.new(entity_class.new('content', {}, '/fdsa/'), nil) }
+      let(:other) { other_view_class.new(entity_class.new('content', {}, '/fdsa'), nil) }
 
       it 'is not ==' do
         expect(view).not_to eq(other)
@@ -106,7 +106,7 @@ shared_examples 'a document view' do
   end
 
   describe '#[]' do
-    let(:document) { entity_class.new('stuff', { animal: 'donkey' }, '/foo/') }
+    let(:document) { entity_class.new('stuff', { animal: 'donkey' }, '/foo') }
 
     subject { view[key] }
 
@@ -154,7 +154,7 @@ shared_examples 'a document view' do
   end
 
   describe '#attributes' do
-    let(:document) { entity_class.new('stuff', { animal: 'donkey' }, '/foo/') }
+    let(:document) { entity_class.new('stuff', { animal: 'donkey' }, '/foo') }
 
     subject { view.attributes }
 
@@ -179,7 +179,7 @@ shared_examples 'a document view' do
   end
 
   describe '#fetch' do
-    let(:document) { entity_class.new('stuff', { animal: 'donkey' }, '/foo/') }
+    let(:document) { entity_class.new('stuff', { animal: 'donkey' }, '/foo') }
 
     context 'with existant key' do
       let(:key) { :animal }
@@ -260,7 +260,7 @@ shared_examples 'a document view' do
   end
 
   describe '#key?' do
-    let(:document) { entity_class.new('stuff', { animal: 'donkey' }, '/foo/') }
+    let(:document) { entity_class.new('stuff', { animal: 'donkey' }, '/foo') }
 
     subject { view.key?(key) }
 
@@ -308,15 +308,15 @@ shared_examples 'a document view' do
   end
 
   describe '#hash' do
-    let(:document) { double(:document, identifier: '/foo/') }
+    let(:document) { double(:document, identifier: '/foo') }
 
     subject { view.hash }
 
-    it { should == described_class.hash ^ '/foo/'.hash }
+    it { should == described_class.hash ^ '/foo'.hash }
   end
 
   describe '#raw_content' do
-    let(:document) { entity_class.new('stuff', { animal: 'donkey' }, '/foo/') }
+    let(:document) { entity_class.new('stuff', { animal: 'donkey' }, '/foo') }
 
     subject { view.raw_content }
 

--- a/spec/nanoc/base/views/item_rep_view_spec.rb
+++ b/spec/nanoc/base/views/item_rep_view_spec.rb
@@ -31,7 +31,7 @@ describe Nanoc::ItemRepView do
 
   describe '#frozen?' do
     let(:item_rep) { Nanoc::Int::ItemRep.new(item, :jacques) }
-    let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo/') }
+    let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo') }
     let(:view) { described_class.new(item_rep, view_context) }
 
     subject { view.frozen? }
@@ -48,11 +48,11 @@ describe Nanoc::ItemRepView do
 
   describe '#== and #eql?' do
     let(:item_rep) { Nanoc::Int::ItemRep.new(item, :jacques) }
-    let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo/') }
+    let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo') }
     let(:view) { described_class.new(item_rep, view_context) }
 
     context 'comparing with item rep with same identifier' do
-      let(:other_item) { double(:other_item, identifier: '/foo/') }
+      let(:other_item) { double(:other_item, identifier: '/foo') }
       let(:other) { double(:other_item_rep, item: other_item, name: :jacques) }
 
       it 'is ==' do
@@ -65,7 +65,7 @@ describe Nanoc::ItemRepView do
     end
 
     context 'comparing with item rep with different identifier' do
-      let(:other_item) { double(:other_item, identifier: '/bar/') }
+      let(:other_item) { double(:other_item, identifier: '/bar') }
       let(:other) { double(:other_item_rep, item: other_item, name: :jacques) }
 
       it 'is not ==' do
@@ -78,7 +78,7 @@ describe Nanoc::ItemRepView do
     end
 
     context 'comparing with item rep with different name' do
-      let(:other_item) { double(:other_item, identifier: '/foo/') }
+      let(:other_item) { double(:other_item, identifier: '/foo') }
       let(:other) { double(:other_item_rep, item: other_item, name: :marvin) }
 
       it 'is not ==' do
@@ -91,7 +91,7 @@ describe Nanoc::ItemRepView do
     end
 
     context 'comparing with item rep with same identifier' do
-      let(:other_item) { double(:other_item, identifier: '/foo/') }
+      let(:other_item) { double(:other_item, identifier: '/foo') }
       let(:other) { described_class.new(double(:other_item_rep, item: other_item, name: :jacques), view_context) }
 
       it 'is ==' do
@@ -104,7 +104,7 @@ describe Nanoc::ItemRepView do
     end
 
     context 'comparing with item rep with different identifier' do
-      let(:other_item) { double(:other_item, identifier: '/bar/') }
+      let(:other_item) { double(:other_item, identifier: '/bar') }
       let(:other) { described_class.new(double(:other_item_rep, item: other_item, name: :jacques), view_context) }
 
       it 'is not equal' do
@@ -114,7 +114,7 @@ describe Nanoc::ItemRepView do
     end
 
     context 'comparing with item rep with different name' do
-      let(:other_item) { double(:other_item, identifier: '/foo/') }
+      let(:other_item) { double(:other_item, identifier: '/foo') }
       let(:other) { described_class.new(double(:other_item_rep, item: other_item, name: :marvin), view_context) }
 
       it 'is not equal' do
@@ -124,7 +124,7 @@ describe Nanoc::ItemRepView do
     end
 
     context 'comparing with something that is not an item rep' do
-      let(:other_item) { double(:other_item, identifier: '/foo/') }
+      let(:other_item) { double(:other_item, identifier: '/foo') }
       let(:other) { :donkey }
 
       it 'is not equal' do
@@ -136,12 +136,12 @@ describe Nanoc::ItemRepView do
 
   describe '#hash' do
     let(:item_rep) { Nanoc::Int::ItemRep.new(item, :jacques) }
-    let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo/') }
+    let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo') }
     let(:view) { described_class.new(item_rep, view_context) }
 
     subject { view.hash }
 
-    it { should == described_class.hash ^ Nanoc::Identifier.new('/foo/').hash ^ :jacques.hash }
+    it { should == described_class.hash ^ Nanoc::Identifier.new('/foo').hash ^ :jacques.hash }
   end
 
   describe '#snapshot?' do
@@ -349,7 +349,7 @@ describe Nanoc::ItemRepView do
 
   describe '#binary?' do
     let(:item_rep) { Nanoc::Int::ItemRep.new(item, :jacques) }
-    let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo/') }
+    let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo') }
     let(:view) { described_class.new(item_rep, view_context) }
 
     subject { view.binary? }
@@ -383,7 +383,7 @@ describe Nanoc::ItemRepView do
 
   describe '#item' do
     let(:item_rep) { Nanoc::Int::ItemRep.new(item, :jacques) }
-    let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo/') }
+    let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo') }
     let(:view) { described_class.new(item_rep, view_context) }
 
     subject { view.item }
@@ -399,11 +399,11 @@ describe Nanoc::ItemRepView do
 
   describe '#inspect' do
     let(:item_rep) { Nanoc::Int::ItemRep.new(item, :jacques) }
-    let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo/') }
+    let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo') }
     let(:view) { described_class.new(item_rep, view_context) }
 
     subject { view.inspect }
 
-    it { is_expected.to eql('<Nanoc::ItemRepView item.identifier=/foo/ name=jacques>') }
+    it { is_expected.to eql('<Nanoc::ItemRepView item.identifier=/foo name=jacques>') }
   end
 end

--- a/spec/nanoc/base/views/item_view_spec.rb
+++ b/spec/nanoc/base/views/item_view_spec.rb
@@ -53,13 +53,13 @@ describe Nanoc::ItemWithRepsView do
     subject { view.parent }
 
     context 'with parent' do
-      let(:parent_item) do
-        Nanoc::Int::Item.new('parent', {}, '/parent/')
-      end
-
       context 'full identifier' do
         let(:identifier) do
           Nanoc::Identifier.new('/parent/me.md')
+        end
+
+        let(:parent_item) do
+          Nanoc::Int::Item.new('parent', {}, '/parent.md')
         end
 
         it 'raises' do
@@ -70,6 +70,10 @@ describe Nanoc::ItemWithRepsView do
       context 'legacy identifier' do
         let(:identifier) do
           Nanoc::Identifier.new('/parent/me/', type: :legacy)
+        end
+
+        let(:parent_item) do
+          Nanoc::Int::Item.new('parent', {}, Nanoc::Identifier.new('/parent/', type: :legacy))
         end
 
         it 'returns a view for the parent' do
@@ -91,8 +95,9 @@ describe Nanoc::ItemWithRepsView do
         end
 
         context 'with root parent' do
-          let(:parent_item) { Nanoc::Int::Item.new('parent', {}, '/') }
+          let(:parent_item) { Nanoc::Int::Item.new('parent', {}, parent_identifier) }
           let(:identifier) { Nanoc::Identifier.new('/me/', type: :legacy) }
+          let(:parent_identifier) { Nanoc::Identifier.new('/', type: :legacy) }
 
           it 'returns a view for the parent' do
             expect(subject.class).to eql(Nanoc::ItemWithRepsView)
@@ -133,10 +138,6 @@ describe Nanoc::ItemWithRepsView do
       Nanoc::Int::Item.new('me', {}, identifier)
     end
 
-    let(:children) do
-      [Nanoc::Int::Item.new('child', {}, '/me/child/')]
-    end
-
     let(:view) { described_class.new(item, view_context) }
 
     let(:items) do
@@ -156,6 +157,10 @@ describe Nanoc::ItemWithRepsView do
         Nanoc::Identifier.new('/me.md')
       end
 
+      let(:children) do
+        [Nanoc::Int::Item.new('child', {}, '/me/child.md')]
+      end
+
       it 'raises' do
         expect { subject }.to raise_error(Nanoc::Int::Errors::CannotGetParentOrChildrenOfNonLegacyItem)
       end
@@ -164,6 +169,10 @@ describe Nanoc::ItemWithRepsView do
     context 'legacy identifier' do
       let(:identifier) do
         Nanoc::Identifier.new('/me/', type: :legacy)
+      end
+
+      let(:children) do
+        [Nanoc::Int::Item.new('child', {}, Nanoc::Identifier.new('/me/child/', type: :legacy))]
       end
 
       it 'returns views for the children' do
@@ -208,7 +217,7 @@ describe Nanoc::ItemWithRepsView do
     let(:view) { described_class.new(item, view_context) }
 
     let(:item) do
-      Nanoc::Int::Item.new('content', {}, '/asdf/')
+      Nanoc::Int::Item.new('content', {}, '/asdf')
     end
 
     let(:reps) do
@@ -355,11 +364,11 @@ describe Nanoc::ItemWithRepsView do
   end
 
   describe '#inspect' do
-    let(:item) { Nanoc::Int::Item.new('content', {}, '/asdf/') }
+    let(:item) { Nanoc::Int::Item.new('content', {}, '/asdf') }
     let(:view) { described_class.new(item, nil) }
 
     subject { view.inspect }
 
-    it { is_expected.to eql('<Nanoc::ItemWithRepsView identifier=/asdf/>') }
+    it { is_expected.to eql('<Nanoc::ItemWithRepsView identifier=/asdf>') }
   end
 end

--- a/spec/nanoc/base/views/layout_view_spec.rb
+++ b/spec/nanoc/base/views/layout_view_spec.rb
@@ -6,11 +6,11 @@ describe Nanoc::LayoutView do
   it_behaves_like 'a document view'
 
   describe '#inspect' do
-    let(:item) { Nanoc::Int::Layout.new('content', {}, '/asdf/') }
+    let(:item) { Nanoc::Int::Layout.new('content', {}, '/asdf') }
     let(:view) { described_class.new(item, nil) }
 
     subject { view.inspect }
 
-    it { is_expected.to eql('<Nanoc::LayoutView identifier=/asdf/>') }
+    it { is_expected.to eql('<Nanoc::LayoutView identifier=/asdf>') }
   end
 end

--- a/spec/nanoc/base/views/mutable_document_view_spec.rb
+++ b/spec/nanoc/base/views/mutable_document_view_spec.rb
@@ -17,7 +17,7 @@ shared_examples 'a mutable document view' do
   let(:snapshot_repo) { double(:snapshot_repo) }
 
   describe '#raw_content=' do
-    let(:document) { entity_class.new('content', {}, '/asdf/') }
+    let(:document) { entity_class.new('content', {}, '/asdf') }
 
     it 'sets raw content' do
       expect { view.raw_content = 'donkey' }
@@ -28,7 +28,7 @@ shared_examples 'a mutable document view' do
   end
 
   describe '#[]=' do
-    let(:document) { entity_class.new('content', {}, '/asdf/') }
+    let(:document) { entity_class.new('content', {}, '/asdf') }
 
     it 'sets attributes' do
       view[:title] = 'Donkey'
@@ -89,7 +89,7 @@ shared_examples 'a mutable document view' do
   end
 
   describe '#update_attributes' do
-    let(:document) { entity_class.new('content', {}, '/asdf/') }
+    let(:document) { entity_class.new('content', {}, '/asdf') }
 
     let(:update) { { friend: 'Giraffe' } }
 

--- a/spec/nanoc/base/views/mutable_identifiable_collection_view_spec.rb
+++ b/spec/nanoc/base/views/mutable_identifiable_collection_view_spec.rb
@@ -13,22 +13,22 @@ shared_examples 'a mutable identifiable collection' do
     let(:wrapped) do
       collection_class.new(
         config,
-        [double(:identifiable, identifier: Nanoc::Identifier.new('/asdf/'))],
+        [double(:identifiable, identifier: Nanoc::Identifier.new('/asdf'))],
       )
     end
 
     it 'deletes matching' do
-      view.delete_if { |i| i.identifier == '/asdf/' }
+      view.delete_if { |i| i.identifier == '/asdf' }
       expect(view.unwrap).to be_empty
     end
 
     it 'does not mutate' do
-      view.delete_if { |i| i.identifier == '/asdf/' }
+      view.delete_if { |i| i.identifier == '/asdf' }
       expect(wrapped).not_to be_empty
     end
 
     it 'deletes no non-matching' do
-      view.delete_if { |i| i.identifier == '/blah/' }
+      view.delete_if { |i| i.identifier == '/blah' }
       expect(wrapped).not_to be_empty
     end
 

--- a/spec/nanoc/base/views/mutable_item_collection_view_spec.rb
+++ b/spec/nanoc/base/views/mutable_item_collection_view_spec.rb
@@ -12,7 +12,7 @@ describe Nanoc::MutableItemCollectionView do
 
   describe '#create' do
     let(:item) do
-      Nanoc::Int::Layout.new('content', {}, '/asdf/')
+      Nanoc::Int::Layout.new('content', {}, '/asdf')
     end
 
     let(:wrapped) do
@@ -22,21 +22,21 @@ describe Nanoc::MutableItemCollectionView do
     let(:view) { described_class.new(wrapped, nil) }
 
     it 'creates an object' do
-      view.create('new content', { title: 'New Page' }, '/new/')
+      view.create('new content', { title: 'New Page' }, '/new')
 
       expect(view.unwrap.size).to eq(2)
-      expect(view.unwrap['/new/'].content.string).to eq('new content')
+      expect(view.unwrap['/new'].content.string).to eq('new content')
     end
 
     it 'does not update wrapped' do
-      view.create('new content', { title: 'New Page' }, '/new/')
+      view.create('new content', { title: 'New Page' }, '/new')
 
       expect(wrapped.size).to eq(1)
       expect(wrapped['/new']).to be_nil
     end
 
     it 'returns self' do
-      ret = view.create('new content', { title: 'New Page' }, '/new/')
+      ret = view.create('new content', { title: 'New Page' }, '/new')
       expect(ret).to equal(view)
     end
   end

--- a/spec/nanoc/base/views/mutable_item_view_spec.rb
+++ b/spec/nanoc/base/views/mutable_item_view_spec.rb
@@ -4,7 +4,7 @@ describe Nanoc::MutableItemView do
   let(:entity_class) { Nanoc::Int::Item }
   it_behaves_like 'a mutable document view'
 
-  let(:item) { entity_class.new('content', {}, '/asdf/') }
+  let(:item) { entity_class.new('content', {}, '/asdf') }
   let(:view) { described_class.new(item, nil) }
 
   it 'does have rep access' do
@@ -14,11 +14,11 @@ describe Nanoc::MutableItemView do
   end
 
   describe '#inspect' do
-    let(:item) { Nanoc::Int::Item.new('content', {}, '/asdf/') }
+    let(:item) { Nanoc::Int::Item.new('content', {}, '/asdf') }
     let(:view) { described_class.new(item, nil) }
 
     subject { view.inspect }
 
-    it { is_expected.to eql('<Nanoc::MutableItemView identifier=/asdf/>') }
+    it { is_expected.to eql('<Nanoc::MutableItemView identifier=/asdf>') }
   end
 end

--- a/spec/nanoc/base/views/mutable_layout_collection_view_spec.rb
+++ b/spec/nanoc/base/views/mutable_layout_collection_view_spec.rb
@@ -12,7 +12,7 @@ describe Nanoc::MutableLayoutCollectionView do
 
   describe '#create' do
     let(:layout) do
-      Nanoc::Int::Layout.new('content', {}, '/asdf/')
+      Nanoc::Int::Layout.new('content', {}, '/asdf')
     end
 
     let(:wrapped) do
@@ -22,21 +22,21 @@ describe Nanoc::MutableLayoutCollectionView do
     let(:view) { described_class.new(wrapped, nil) }
 
     it 'creates an object' do
-      view.create('new content', { title: 'New Page' }, '/new/')
+      view.create('new content', { title: 'New Page' }, '/new')
 
       expect(view.unwrap.size).to eq(2)
-      expect(view.unwrap['/new/'].content.string).to eq('new content')
+      expect(view.unwrap['/new'].content.string).to eq('new content')
     end
 
     it 'does not update wrapped' do
-      view.create('new content', { title: 'New Page' }, '/new/')
+      view.create('new content', { title: 'New Page' }, '/new')
 
       expect(wrapped.size).to eq(1)
       expect(wrapped['/new']).to be_nil
     end
 
     it 'returns self' do
-      ret = view.create('new content', { title: 'New Page' }, '/new/')
+      ret = view.create('new content', { title: 'New Page' }, '/new')
       expect(ret).to equal(view)
     end
   end

--- a/spec/nanoc/base/views/mutable_layout_view_spec.rb
+++ b/spec/nanoc/base/views/mutable_layout_view_spec.rb
@@ -5,11 +5,11 @@ describe Nanoc::MutableLayoutView do
   it_behaves_like 'a mutable document view'
 
   describe '#inspect' do
-    let(:item) { Nanoc::Int::Item.new('content', {}, '/asdf/') }
+    let(:item) { Nanoc::Int::Item.new('content', {}, '/asdf') }
     let(:view) { described_class.new(item, nil) }
 
     subject { view.inspect }
 
-    it { is_expected.to eql('<Nanoc::MutableLayoutView identifier=/asdf/>') }
+    it { is_expected.to eql('<Nanoc::MutableLayoutView identifier=/asdf>') }
   end
 end

--- a/spec/nanoc/base/views/post_compile_item_rep_view_spec.rb
+++ b/spec/nanoc/base/views/post_compile_item_rep_view_spec.rb
@@ -2,7 +2,7 @@
 
 describe Nanoc::PostCompileItemRepView do
   let(:item_rep) { Nanoc::Int::ItemRep.new(item, :jacques) }
-  let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo/') }
+  let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo') }
   let(:view) { described_class.new(item_rep, view_context) }
 
   let(:view_context) do

--- a/spec/nanoc/data_sources/filesystem_spec.rb
+++ b/spec/nanoc/data_sources/filesystem_spec.rb
@@ -47,7 +47,7 @@ describe Nanoc::DataSources::Filesystem do
 
           expect(subject[0].content.string).to eq('test 1')
           expect(subject[0].attributes).to eq(expected_attributes)
-          expect(subject[0].identifier).to eq(Nanoc::Identifier.new('/bar/'))
+          expect(subject[0].identifier).to eq(Nanoc::Identifier.new('/bar/', type: :legacy))
           expect(subject[0].checksum_data).to be_nil
           expect(subject[0].attributes_checksum_data).to be_a(String)
           expect(subject[0].attributes_checksum_data.size).to eq(20)

--- a/spec/nanoc/helpers/blogging_spec.rb
+++ b/spec/nanoc/helpers/blogging_spec.rb
@@ -10,13 +10,13 @@ describe Nanoc::Helpers::Blogging, helper: true do
     subject { helper.articles }
 
     before do
-      ctx.create_item('blah', { kind: 'item' }, '/0/')
-      ctx.create_item('blah blah', { kind: 'article' }, '/1/')
-      ctx.create_item('blah blah blah', { kind: 'article' }, '/2/')
+      ctx.create_item('blah', { kind: 'item' }, '/0')
+      ctx.create_item('blah blah', { kind: 'article' }, '/1')
+      ctx.create_item('blah blah blah', { kind: 'article' }, '/2')
     end
 
     it 'returns the two articles' do
-      expect(subject.map(&:identifier)).to match_array(['/1/', '/2/'])
+      expect(subject.map(&:identifier)).to match_array(['/1', '/2'])
     end
   end
 
@@ -25,28 +25,28 @@ describe Nanoc::Helpers::Blogging, helper: true do
 
     before do
       attrs = { kind: 'item' }
-      ctx.create_item('blah', attrs, '/0/')
+      ctx.create_item('blah', attrs, '/0')
 
       attrs = { kind: 'article', created_at: (Date.today - 1).to_s }
-      ctx.create_item('blah blah', attrs, '/1/')
+      ctx.create_item('blah blah', attrs, '/1')
 
       attrs = { kind: 'article', created_at: (Time.now - 500).to_s }
-      ctx.create_item('blah blah blah', attrs, '/2/')
+      ctx.create_item('blah blah blah', attrs, '/2')
     end
 
     it 'returns the two articles in descending order' do
-      expect(subject.map(&:identifier)).to eq(['/2/', '/1/'])
+      expect(subject.map(&:identifier)).to eq(['/2', '/1'])
     end
   end
 
   describe '#url_for' do
-    subject { helper.url_for(ctx.items['/stuff/']) }
+    subject { helper.url_for(ctx.items['/stuff']) }
 
     let(:item_attributes) { {} }
 
     before do
-      ctx.create_item('Stuff', item_attributes, '/stuff/')
-      ctx.create_rep(ctx.items['/stuff/'], '/rep/path/stuff.html')
+      ctx.create_item('Stuff', item_attributes, '/stuff')
+      ctx.create_rep(ctx.items['/stuff'], '/rep/path/stuff.html')
 
       ctx.config[:base_url] = base_url
     end
@@ -98,10 +98,10 @@ describe Nanoc::Helpers::Blogging, helper: true do
     let(:item_attributes) { {} }
 
     before do
-      ctx.create_item('Feed', item_attributes, '/feed/')
-      ctx.create_rep(ctx.items['/feed/'], '/feed.xml')
+      ctx.create_item('Feed', item_attributes, '/feed')
+      ctx.create_rep(ctx.items['/feed'], '/feed.xml')
 
-      ctx.item = ctx.items['/feed/']
+      ctx.item = ctx.items['/feed']
       ctx.config[:base_url] = base_url
     end
 
@@ -166,15 +166,15 @@ describe Nanoc::Helpers::Blogging, helper: true do
   end
 
   describe '#atom_tag_for' do
-    subject { helper.atom_tag_for(ctx.items['/stuff/']) }
+    subject { helper.atom_tag_for(ctx.items['/stuff']) }
 
     let(:item_attributes) { { created_at: '2015-05-19 12:34:56' } }
     let(:item_rep_path) { '/stuff.xml' }
     let(:base_url) { 'http://url.base' }
 
     before do
-      ctx.create_item('Stuff', item_attributes, '/stuff/')
-      ctx.create_rep(ctx.items['/stuff/'], item_rep_path)
+      ctx.create_item('Stuff', item_attributes, '/stuff')
+      ctx.create_rep(ctx.items['/stuff'], item_rep_path)
 
       ctx.config[:base_url] = base_url
     end
@@ -186,7 +186,7 @@ describe Nanoc::Helpers::Blogging, helper: true do
 
     context 'item without path' do
       let(:item_rep_path) { nil }
-      it { is_expected.to eql('tag:url.base,2015-05-19:/stuff/') }
+      it { is_expected.to eql('tag:url.base,2015-05-19:/stuff') }
     end
 
     context 'bare URL without subdir' do

--- a/spec/nanoc/helpers/link_to_spec.rb
+++ b/spec/nanoc/helpers/link_to_spec.rb
@@ -36,21 +36,21 @@ describe Nanoc::Helpers::LinkTo, helper: true do
 
     context 'with rep' do
       before do
-        ctx.create_item('content', {}, '/target/')
-        ctx.create_rep(ctx.items['/target/'], '/target.html')
+        ctx.create_item('content', {}, '/target')
+        ctx.create_rep(ctx.items['/target'], '/target.html')
       end
 
-      let(:target) { ctx.items['/target/'].reps[:default] }
+      let(:target) { ctx.items['/target'].reps[:default] }
 
       it { is_expected.to eql('<a href="/target.html">Text</a>') }
     end
 
     context 'with item' do
       before do
-        ctx.create_item('content', {}, '/target/')
+        ctx.create_item('content', {}, '/target')
       end
 
-      let(:target) { ctx.items['/target/'] }
+      let(:target) { ctx.items['/target'] }
 
       before do
         ctx.create_rep(target, '/target.html')
@@ -77,11 +77,11 @@ describe Nanoc::Helpers::LinkTo, helper: true do
 
     context 'with nil path' do
       before do
-        ctx.create_item('content', {}, '/target/')
-        ctx.create_rep(ctx.items['/target/'], nil)
+        ctx.create_item('content', {}, '/target')
+        ctx.create_rep(ctx.items['/target'], nil)
       end
 
-      let(:target) { ctx.items['/target/'].reps[:default] }
+      let(:target) { ctx.items['/target'].reps[:default] }
 
       it 'raises' do
         expect { subject }.to raise_error(RuntimeError)

--- a/test/base/test_data_source.rb
+++ b/test/base/test_data_source.rb
@@ -37,20 +37,20 @@ class Nanoc::DataSourceTest < Nanoc::TestCase
   def test_new_item
     data_source = Nanoc::DataSource.new(nil, nil, nil, nil)
 
-    item = data_source.new_item('stuff', { title: 'Stuff!' }, '/asdf/', checksum_data: 'abcdef')
+    item = data_source.new_item('stuff', { title: 'Stuff!' }, '/asdf', checksum_data: 'abcdef')
     assert_equal 'stuff', item.content.string
     assert_equal 'Stuff!', item.attributes[:title]
-    assert_equal Nanoc::Identifier.new('/asdf/'), item.identifier
+    assert_equal Nanoc::Identifier.new('/asdf'), item.identifier
     assert_equal 'abcdef', item.checksum_data
   end
 
   def test_new_item_with_checksums
     data_source = Nanoc::DataSource.new(nil, nil, nil, nil)
 
-    item = data_source.new_item('stuff', { title: 'Stuff!' }, '/asdf/', content_checksum_data: 'con-cs', attributes_checksum_data: 'attr-cs')
+    item = data_source.new_item('stuff', { title: 'Stuff!' }, '/asdf', content_checksum_data: 'con-cs', attributes_checksum_data: 'attr-cs')
     assert_equal 'stuff', item.content.string
     assert_equal 'Stuff!', item.attributes[:title]
-    assert_equal Nanoc::Identifier.new('/asdf/'), item.identifier
+    assert_equal Nanoc::Identifier.new('/asdf'), item.identifier
     assert_equal 'con-cs', item.content_checksum_data
     assert_equal 'attr-cs', item.attributes_checksum_data
   end
@@ -58,20 +58,20 @@ class Nanoc::DataSourceTest < Nanoc::TestCase
   def test_new_layout
     data_source = Nanoc::DataSource.new(nil, nil, nil, nil)
 
-    layout = data_source.new_layout('stuff', { title: 'Stuff!' }, '/asdf/', checksum_data: 'abcdef')
+    layout = data_source.new_layout('stuff', { title: 'Stuff!' }, '/asdf', checksum_data: 'abcdef')
     assert_equal 'stuff', layout.content.string
     assert_equal 'Stuff!', layout.attributes[:title]
-    assert_equal Nanoc::Identifier.new('/asdf/'), layout.identifier
+    assert_equal Nanoc::Identifier.new('/asdf'), layout.identifier
     assert_equal 'abcdef', layout.checksum_data
   end
 
   def test_new_layout_with_checksums
     data_source = Nanoc::DataSource.new(nil, nil, nil, nil)
 
-    layout = data_source.new_layout('stuff', { title: 'Stuff!' }, '/asdf/', content_checksum_data: 'con-cs', attributes_checksum_data: 'attr-cs')
+    layout = data_source.new_layout('stuff', { title: 'Stuff!' }, '/asdf', content_checksum_data: 'con-cs', attributes_checksum_data: 'attr-cs')
     assert_equal 'stuff', layout.content.string
     assert_equal 'Stuff!', layout.attributes[:title]
-    assert_equal Nanoc::Identifier.new('/asdf/'), layout.identifier
+    assert_equal Nanoc::Identifier.new('/asdf'), layout.identifier
     assert_equal 'con-cs', layout.content_checksum_data
     assert_equal 'attr-cs', layout.attributes_checksum_data
   end

--- a/test/base/test_item_array.rb
+++ b/test/base/test_item_array.rb
@@ -6,32 +6,32 @@ class Nanoc::Int::IdentifiableCollectionTest < Nanoc::TestCase
   def setup
     super
 
-    @one = Nanoc::Int::Item.new('Item One', {}, '/one/')
-    @two = Nanoc::Int::Item.new('Item Two', {}, '/two/')
+    @one = Nanoc::Int::Item.new('Item One', {}, '/one')
+    @two = Nanoc::Int::Item.new('Item Two', {}, '/two')
 
     @items = Nanoc::Int::ItemCollection.new({}, [@one, @two])
   end
 
   def test_change_item_identifier
-    assert_equal @one, @items['/one/']
-    assert_nil @items['/foo/']
+    assert_equal @one, @items['/one']
+    assert_nil @items['/foo']
 
-    @one.identifier = '/foo/'
+    @one.identifier = '/foo'
 
-    assert_nil @items['/one/']
-    assert_equal @one, @items['/foo/']
+    assert_nil @items['/one']
+    assert_equal @one, @items['/foo']
   end
 
   def test_enumerable
-    assert_equal @one, @items.find { |i| i.identifier == '/one/' }
+    assert_equal @one, @items.find { |i| i.identifier == '/one' }
   end
 
   def test_less_than_less_than
-    assert_nil @items['/foo/']
+    assert_nil @items['/foo']
 
-    foo = Nanoc::Int::Item.new('Item Foo', {}, '/foo/')
+    foo = Nanoc::Int::Item.new('Item Foo', {}, '/foo')
     @items = Nanoc::Int::ItemCollection.new({}, [@one, @two, foo])
 
-    assert_equal foo, @items['/foo/']
+    assert_equal foo, @items['/foo']
   end
 end

--- a/test/cli/commands/test_compile.rb
+++ b/test/cli/commands/test_compile.rb
@@ -166,7 +166,7 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
 
   def test_file_action_printer_normal
     # Create data
-    item = Nanoc::Int::Item.new('content', {}, '/')
+    item = Nanoc::Int::Item.new('content', {}, '/a')
     rep = Nanoc::Int::ItemRep.new(item, :default)
     rep.raw_paths[:last] = ['output/foo.txt']
     rep.compiled = true
@@ -188,7 +188,7 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
 
   def test_file_action_printer_skip
     # Create data
-    item = Nanoc::Int::Item.new('content', {}, '/')
+    item = Nanoc::Int::Item.new('content', {}, '/a')
     rep = Nanoc::Int::ItemRep.new(item, :default)
     rep.raw_paths[:last] = ['output/foo.txt']
 

--- a/test/filters/test_handlebars.rb
+++ b/test/filters/test_handlebars.rb
@@ -9,12 +9,12 @@ class Nanoc::Filters::HandlebarsTest < Nanoc::TestCase
       item = Nanoc::Int::Item.new(
         'content',
         { title: 'Max Payne', protagonist: 'Max Payne', location: 'here' },
-        '/games/max-payne/',
+        '/games/max-payne',
       )
       layout = Nanoc::Int::Layout.new(
         'layout content',
         { name: 'Max Payne' },
-        '/default/',
+        '/default',
       )
       config = { animals: 'cats and dogs' }
 
@@ -43,7 +43,7 @@ class Nanoc::Filters::HandlebarsTest < Nanoc::TestCase
       item = Nanoc::Int::Item.new(
         'content',
         { title: 'Max Payne', protagonist: 'Max Payne', location: 'here' },
-        '/games/max-payne/',
+        '/games/max-payne',
       )
 
       # Create filter

--- a/test/filters/test_mustache.rb
+++ b/test/filters/test_mustache.rb
@@ -9,7 +9,7 @@ class Nanoc::Filters::MustacheTest < Nanoc::TestCase
       item = Nanoc::Int::Item.new(
         'content',
         { title: 'Max Payne', protagonist: 'Max Payne' },
-        '/games/max-payne/',
+        '/games/max-payne',
       )
 
       # Create filter
@@ -27,7 +27,7 @@ class Nanoc::Filters::MustacheTest < Nanoc::TestCase
       item = Nanoc::Int::Item.new(
         'content',
         { title: 'Max Payne', protagonist: 'Max Payne' },
-        '/games/max-payne/',
+        '/games/max-payne',
       )
 
       # Create filter

--- a/test/filters/test_relativize_paths.rb
+++ b/test/filters/test_relativize_paths.rb
@@ -13,7 +13,7 @@ class Nanoc::Filters::RelativizePathsTest < Nanoc::TestCase
         Nanoc::Int::Item.new(
           'content',
           {},
-          '/foo/bar/baz/',
+          '/foo/bar/baz',
         ),
         :blah,
       )
@@ -39,7 +39,7 @@ class Nanoc::Filters::RelativizePathsTest < Nanoc::TestCase
         Nanoc::Int::Item.new(
           'content',
           {},
-          '/foo/bar/baz/',
+          '/foo/bar/baz',
         ),
         :blah,
       )
@@ -65,7 +65,7 @@ class Nanoc::Filters::RelativizePathsTest < Nanoc::TestCase
         Nanoc::Int::Item.new(
           'content',
           {},
-          '/foo/bar/baz/',
+          '/foo/bar/baz',
         ),
         :blah,
       )
@@ -91,7 +91,7 @@ class Nanoc::Filters::RelativizePathsTest < Nanoc::TestCase
         Nanoc::Int::Item.new(
           'content',
           {},
-          '/foo/bar/baz/',
+          '/foo/bar/baz',
         ),
         :blah,
       )
@@ -129,7 +129,7 @@ EOS
         Nanoc::Int::Item.new(
           'content',
           {},
-          '/foo/bar/baz/',
+          '/foo/bar/baz',
         ),
         :blah,
       )
@@ -167,7 +167,7 @@ EOS
         Nanoc::Int::Item.new(
           'content',
           {},
-          '/foo/bar/baz/',
+          '/foo/bar/baz',
         ),
         :blah,
       )
@@ -193,7 +193,7 @@ EOS
         Nanoc::Int::Item.new(
           'content',
           {},
-          '/foo/bar/baz/',
+          '/foo/bar/baz',
         ),
         :blah,
       )
@@ -219,7 +219,7 @@ EOS
         Nanoc::Int::Item.new(
           'content',
           {},
-          '/foo/bar/baz/',
+          '/foo/bar/baz',
         ),
         :blah,
       )
@@ -245,7 +245,7 @@ EOS
         Nanoc::Int::Item.new(
           'content',
           {},
-          '/foo/bar/baz/',
+          '/foo/bar/baz',
         ),
         :blah,
       )
@@ -271,7 +271,7 @@ EOS
         Nanoc::Int::Item.new(
           'content',
           {},
-          '/foo/bar/baz/',
+          '/foo/bar/baz',
         ),
         :blah,
       )
@@ -297,7 +297,7 @@ EOS
         Nanoc::Int::Item.new(
           'content',
           {},
-          '/foo/bar/baz/',
+          '/foo/bar/baz',
         ),
         :blah,
       )
@@ -323,7 +323,7 @@ EOS
         Nanoc::Int::Item.new(
           'content',
           {},
-          '/foo/bar/baz/',
+          '/foo/bar/baz',
         ),
         :blah,
       )
@@ -349,7 +349,7 @@ EOS
         Nanoc::Int::Item.new(
           'content',
           {},
-          '/foo/bar/baz/',
+          '/foo/bar/baz',
         ),
         :blah,
       )
@@ -375,7 +375,7 @@ EOS
         Nanoc::Int::Item.new(
           'content',
           {},
-          '/foo/bar/baz/',
+          '/foo/bar/baz',
         ),
         :blah,
       )
@@ -399,7 +399,7 @@ EOS
         Nanoc::Int::Item.new(
           'content',
           {},
-          '/foo/bar/baz/',
+          '/foo/bar/baz',
         ),
         :blah,
       )
@@ -435,7 +435,7 @@ EOS
         Nanoc::Int::Item.new(
           'content',
           {},
-          '/foo/bar/baz/',
+          '/foo/bar/baz',
         ),
         :blah,
       )
@@ -461,7 +461,7 @@ EOS
         Nanoc::Int::Item.new(
           'content',
           {},
-          '/foo/bar/baz/',
+          '/foo/bar/baz',
         ),
         :blah,
       )
@@ -487,7 +487,7 @@ EOS
         Nanoc::Int::Item.new(
           'content',
           {},
-          '/foo/bar/baz/',
+          '/foo/bar/baz',
         ),
         :blah,
       )
@@ -513,7 +513,7 @@ EOS
         Nanoc::Int::Item.new(
           'content',
           {},
-          '/foo/bar/baz/',
+          '/foo/bar/baz',
         ),
         :blah,
       )
@@ -542,7 +542,7 @@ EOS
         Nanoc::Int::Item.new(
           'content',
           {},
-          '/foo/bar/baz/',
+          '/foo/bar/baz',
         ),
         :blah,
       )
@@ -568,7 +568,7 @@ EOS
         Nanoc::Int::Item.new(
           'content',
           {},
-          '/foo/bar/baz/',
+          '/foo/bar/baz',
         ),
         :blah,
       )
@@ -595,7 +595,7 @@ EOS
           Nanoc::Int::Item.new(
             'content',
             {},
-            '/foo/bar/baz/',
+            '/foo/bar/baz',
           ),
           :blah,
         )
@@ -628,7 +628,7 @@ XML
           Nanoc::Int::Item.new(
             'content',
             {},
-            '/foo/bar/baz/',
+            '/foo/bar/baz',
           ),
           :blah,
         )
@@ -660,7 +660,7 @@ XML
           Nanoc::Int::Item.new(
             'content',
             {},
-            '/foo/bar/baz/',
+            '/foo/bar/baz',
           ),
           :blah,
         )
@@ -697,7 +697,7 @@ XML
           Nanoc::Int::Item.new(
             'content',
             {},
-            '/foo/bar/baz/',
+            '/foo/bar/baz',
           ),
           :blah,
         )
@@ -739,7 +739,7 @@ XML
           Nanoc::Int::Item.new(
             'content',
             {},
-            '/foo/bar/baz/',
+            '/foo/bar/baz',
           ),
           :blah,
         )
@@ -774,7 +774,7 @@ XML
           Nanoc::Int::Item.new(
             'content',
             {},
-            '/foo/baz/',
+            '/foo/baz',
           ),
           :blah,
         )
@@ -808,7 +808,7 @@ XML
           Nanoc::Int::Item.new(
             'content',
             {},
-            '/foo/baz/',
+            '/foo/baz',
           ),
           :blah,
         )
@@ -839,7 +839,7 @@ XML
         Nanoc::Int::Item.new(
           'content',
           {},
-          '/foo/bar/baz/',
+          '/foo/bar/baz',
         ),
         :blah,
       )

--- a/test/filters/test_sass.rb
+++ b/test/filters/test_sass.rb
@@ -304,7 +304,7 @@ class Nanoc::Filters::SassTest < Nanoc::TestCase
         Nanoc::Int::Item.new(
           'blah',
           { content_filename: 'content/xyzzy.sass' },
-          '/blah/',
+          '/blah',
         ),
         nil,
       ),

--- a/test/filters/test_xsl.rb
+++ b/test/filters/test_xsl.rb
@@ -113,9 +113,9 @@ EOS
   def test_filter_as_layout
     if_have 'nokogiri' do
       # Create our data objects
-      item = Nanoc::Int::Item.new(SAMPLE_XML_IN, {}, '/content/')
+      item = Nanoc::Int::Item.new(SAMPLE_XML_IN, {}, '/content')
       item = Nanoc::ItemWithRepsView.new(item, new_view_context)
-      layout = Nanoc::Int::Layout.new(SAMPLE_XSL, {}, '/layout/')
+      layout = Nanoc::Int::Layout.new(SAMPLE_XSL, {}, '/layout')
       layout = Nanoc::LayoutView.new(layout, new_view_context)
 
       # Create an instance of the filter
@@ -139,9 +139,9 @@ EOS
   def test_filter_with_params
     if_have 'nokogiri' do
       # Create our data objects
-      item = Nanoc::Int::Item.new(SAMPLE_XML_IN_WITH_PARAMS, {}, '/content/')
+      item = Nanoc::Int::Item.new(SAMPLE_XML_IN_WITH_PARAMS, {}, '/content')
       item = Nanoc::ItemWithRepsView.new(item, new_view_context)
-      layout = Nanoc::Int::Layout.new(SAMPLE_XSL_WITH_PARAMS, {}, '/layout/')
+      layout = Nanoc::Int::Layout.new(SAMPLE_XSL_WITH_PARAMS, {}, '/layout')
       layout = Nanoc::LayoutView.new(layout, new_view_context)
 
       # Create an instance of the filter
@@ -165,9 +165,9 @@ EOS
   def test_filter_with_omit_xml_decl
     if_have 'nokogiri' do
       # Create our data objects
-      item = Nanoc::Int::Item.new(SAMPLE_XML_IN_WITH_OMIT_XML_DECL, {}, '/content/')
+      item = Nanoc::Int::Item.new(SAMPLE_XML_IN_WITH_OMIT_XML_DECL, {}, '/content')
       item = Nanoc::ItemWithRepsView.new(item, new_view_context)
-      layout = Nanoc::Int::Layout.new(SAMPLE_XSL_WITH_OMIT_XML_DECL, {}, '/layout/')
+      layout = Nanoc::Int::Layout.new(SAMPLE_XSL_WITH_OMIT_XML_DECL, {}, '/layout')
       layout = Nanoc::LayoutView.new(layout, new_view_context)
 
       # Create an instance of the filter

--- a/test/helpers/test_capturing.rb
+++ b/test/helpers/test_capturing.rb
@@ -80,7 +80,7 @@ class Nanoc::Helpers::CapturingTest < Nanoc::TestCase
       foot
 EOS
 
-    item = Nanoc::Int::Item.new('content', {}, '/')
+    item = Nanoc::Int::Item.new('content', {}, '/asdf')
     view_context = view_context_for(item)
     @item = Nanoc::ItemWithRepsView.new(item, view_context_for(item))
     @config = Nanoc::ConfigView.new(Nanoc::Int::Configuration.new, view_context)

--- a/test/helpers/test_xml_sitemap.rb
+++ b/test/helpers/test_xml_sitemap.rb
@@ -35,24 +35,24 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
       items = []
 
       # Create item 1
-      item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'), @view_context)
+      item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one'), @view_context)
       items << item
       create_item_rep(item.unwrap, :one_a, '/item-one/a/')
       create_item_rep(item.unwrap, :one_b, '/item-one/b/')
 
       # Create item 2
-      item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('some content 2', { is_hidden: true }, '/item-two/'), @view_context)
+      item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('some content 2', { is_hidden: true }, '/item-two'), @view_context)
       items << item
 
       # Create item 3
       attrs = { mtime: Time.parse('2004-07-12 00:00:00 +02:00'), changefreq: 'daily', priority: 0.5 }
-      item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('some content 3', attrs, '/item-three/'), @view_context)
+      item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('some content 3', attrs, '/item-three'), @view_context)
       items << item
       create_item_rep(item.unwrap, :three_a, '/item-three/a/')
       create_item_rep(item.unwrap, :three_b, '/item-three/b/')
 
       # Create item 4
-      item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('some content 4', {}, '/item-four/'), @view_context)
+      item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('some content 4', {}, '/item-four'), @view_context)
       items << item
       create_item_rep(item.unwrap, :four_a, nil)
 
@@ -60,7 +60,7 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
       @items = Nanoc::Int::ItemCollection.new({}, items)
 
       # Create sitemap item
-      @item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), @view_context)
+      @item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap'), @view_context)
 
       # Create site
       config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
@@ -99,7 +99,7 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
       # Create items
       items = []
       items << nil
-      item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'), @view_context)
+      item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one'), @view_context)
       items << item
       create_item_rep(item.unwrap, :one_a, '/item-one/a/')
       create_item_rep(item.unwrap, :one_b, '/item-one/b/')
@@ -107,7 +107,7 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
       @items = Nanoc::Int::ItemCollection.new({})
 
       # Create sitemap item
-      @item = Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/')
+      @item = Nanoc::Int::Item.new('sitemap content', {}, '/sitemap')
 
       # Create site
       config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
@@ -136,13 +136,13 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
   def test_filter
     if_have 'builder', 'nokogiri' do
       # Create items
-      item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one/'), @view_context)
+      item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one'), @view_context)
       @items = Nanoc::Int::ItemCollection.new({}, [item])
       create_item_rep(item.unwrap, :one_a, '/item-one/a/')
       create_item_rep(item.unwrap, :one_b, '/item-one/b/')
 
       # Create sitemap item
-      @item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), @view_context)
+      @item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap'), @view_context)
 
       # Create site
       config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
@@ -168,22 +168,22 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
     if_have 'builder', 'nokogiri' do
       # Create items
       items = []
-      item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('some content 1', {}, '/george/'), @view_context)
+      item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('some content 1', {}, '/george'), @view_context)
       items << item
       create_item_rep(item.unwrap, :a_alice,   '/george/alice/')
       create_item_rep(item.unwrap, :b_zoey,    '/george/zoey/')
-      item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('some content 1', {}, '/walton/'), @view_context)
+      item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('some content 1', {}, '/walton'), @view_context)
       items << item
       create_item_rep(item.unwrap, :a_eve,     '/walton/eve/')
       create_item_rep(item.unwrap, :b_bob,     '/walton/bob/')
-      item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('some content 1', {}, '/lucas/'), @view_context)
+      item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('some content 1', {}, '/lucas'), @view_context)
       items << item
       create_item_rep(item.unwrap, :a_trudy,   '/lucas/trudy/')
       create_item_rep(item.unwrap, :b_mallory, '/lucas/mallory/')
       @items = Nanoc::Int::ItemCollection.new({}, items)
 
       # Create sitemap item
-      @item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), @view_context)
+      @item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap'), @view_context)
 
       # Create site
       config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
@@ -210,12 +210,12 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
   def test_url_escape
     if_have 'builder', 'nokogiri' do
       # Create items
-      item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('some content 1', {}, '/george/'), @view_context)
+      item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('some content 1', {}, '/george'), @view_context)
       @items = Nanoc::Int::ItemCollection.new({}, [item])
       create_item_rep(item.unwrap, :default, '/cool projects/проверка')
 
       # Create sitemap item
-      @item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap/'), @view_context)
+      @item = Nanoc::ItemWithRepsView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap'), @view_context)
 
       # Create site
       config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })


### PR DESCRIPTION
Full identifiers (e.g. `"/foo.md"` — compare to legacy identifiers such as `"/foo/"`) can never end with a slash. Nanoc does not currently enforce this, and silently allows a potentially buggy code.

This PR makes full identifiers that end with a slash explicitly invalid.

(It turns out that many of the tests cases were accidentally wrong. Yikes!)

This PR also makes `Nanoc::Document#identifier=` properly coerce the argument to an identifier, so that `@item.identifier = 'hah'` no longer turns the identifier from a `Nanoc::Identifier` into a `String`.