### PR TITLE
Search for parent directory containing Nanoc site

### DIFF
--- a/lib/nanoc/spec.rb
+++ b/lib/nanoc/spec.rb
@@ -3,6 +3,16 @@
 module Nanoc
   # @api private
   module Spec
+    module Helper
+      def chdir(dir)
+        here = Dir.getwd
+        Dir.chdir(dir)
+        yield
+      ensure
+        Dir.chdir(here)
+      end
+    end
+
     class HelperContext
       # @return [Nanoc::Int::DependencyTracker]
       attr_reader :dependency_tracker

--- a/spec/nanoc/cli/command_runner_spec.rb
+++ b/spec/nanoc/cli/command_runner_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+describe Nanoc::CLI::CommandRunner, stdio: true do
+  describe '.find_site_dir' do
+    subject { described_class.find_site_dir }
+
+    context 'config file in current dir' do
+      before { File.write('nanoc.yaml', 'hi') }
+
+      it 'returns the current dir' do
+        expect(subject).to eq(File.expand_path(Dir.getwd))
+      end
+    end
+
+    context 'config file in parent dir' do
+      around do |ex|
+        FileUtils.mkdir_p('root/sub')
+        File.write('root/nanoc.yaml', 'hi')
+        chdir('root/sub') { ex.run }
+      end
+
+      it 'returns the parent dir' do
+        expect(subject).to match(/root$/)
+      end
+    end
+
+    context 'config file in grandparent dir' do
+      around do |ex|
+        FileUtils.mkdir_p('root/sub1/sub2')
+        File.write('root/nanoc.yaml', 'hi')
+        chdir('root/sub1/sub2') { ex.run }
+      end
+
+      it 'returns the parent dir' do
+        expect(subject).to match(/root$/)
+      end
+    end
+
+    context 'no config file in ancestral paths' do
+      it 'returns nil' do
+        expect(subject).to be_nil
+      end
+    end
+  end
+
+  describe '.enter_site_dir' do
+    subject do
+      described_class.enter_site_dir
+      Dir.getwd
+    end
+
+    context 'config file in current dir' do
+      before { File.write('nanoc.yaml', 'hi') }
+
+      it 'returns the current dir' do
+        expect(subject).to eq(File.expand_path(Dir.getwd))
+      end
+    end
+
+    context 'config file in parent dir' do
+      around do |ex|
+        FileUtils.mkdir_p('root/sub')
+        File.write('root/nanoc.yaml', 'hi')
+        chdir('root/sub') { ex.run }
+      end
+
+      it 'returns the parent dir' do
+        expect(subject).to match(/root$/)
+      end
+    end
+
+    context 'config file in grandparent dir' do
+      around do |ex|
+        FileUtils.mkdir_p('root/sub1/sub2')
+        File.write('root/nanoc.yaml', 'hi')
+        chdir('root/sub1/sub2') { ex.run }
+      end
+
+      it 'enters the parent dir' do
+        expect(subject).to match(/root$/)
+      end
+    end
+
+    context 'no config file in ancestral paths' do
+      it 'raises' do
+        expect { subject }.to raise_error(::Nanoc::Int::Errors::GenericTrivial, 'The current working directory, nor any of its parents, seems to be a Nanoc site.')
+      end
+    end
+  end
+end

--- a/spec/nanoc/cli/commands/show_rules_spec.rb
+++ b/spec/nanoc/cli/commands/show_rules_spec.rb
@@ -107,6 +107,7 @@ describe Nanoc::CLI::Commands::ShowRules, stdio: true do
 
     before do
       expect(compiler).to receive(:build_reps).once
+      expect(Nanoc::CLI::CommandRunner).to receive(:find_site_dir).and_return(Dir.getwd)
     end
 
     it 'writes item and layout rules to stdout' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,10 @@ require 'fuubar'
 Nanoc::CLI.setup
 
 RSpec.configure do |c|
+  c.include(Nanoc::Spec::Helper)
+
+  c.include(Nanoc::Spec::HelperHelper, helper: true)
+
   c.fuubar_progress_bar_options = {
     format: '%c/%C |<%b>%i| %p%%',
   }
@@ -29,16 +33,13 @@ RSpec.configure do |c|
 
   c.around(:each) do |example|
     Dir.mktmpdir('nanoc-test') do |dir|
-      FileUtils.cd(dir) do
-        example.run
-      end
+      chdir(dir) { example.run }
     end
   end
 
   c.around(:each, chdir: false) do |example|
-    FileUtils.cd(__dir__ + '/..') do
-      example.run
-    end
+    Dir.chdir(__dir__ + '/..')
+    example.run
   end
 
   c.before(:each) do
@@ -70,8 +71,6 @@ RSpec.configure do |c|
 
     File.write('Rules', 'passthrough "/**/*"')
   end
-
-  c.include(Nanoc::Spec::HelperHelper, helper: true)
 
   # Set focus if any
   if ENV.fetch('FOCUS', false)


### PR DESCRIPTION
Let `nanoc` search in ancestral directories for a site.

### Detailed description

This change makes it possible to run `nanoc` or `bundle exec nanoc` from a directory that is a subdirectory of a Nanoc site. If the site directory is not the current directory, Nanoc will `cd` to the site directory first.

### Related issues

Implements nanoc/features#19.
