### PR TITLE
Let #load_site load site

### DIFF
--- a/lib/nanoc/cli/command_runner.rb
+++ b/lib/nanoc/cli/command_runner.rb
@@ -77,6 +77,8 @@ module Nanoc::CLI
       $stderr.print 'Loading site… '
       $stderr.flush
 
+      site
+
       if preprocess
         site.compiler.action_provider.preprocess(site)
       end

--- a/spec/nanoc/cli/command_runner_spec.rb
+++ b/spec/nanoc/cli/command_runner_spec.rb
@@ -87,4 +87,16 @@ describe Nanoc::CLI::CommandRunner, stdio: true do
       end
     end
   end
+
+  describe '#load_site' do
+    let(:command_runner) { described_class.new(nil, nil, nil) }
+
+    subject { command_runner.load_site }
+
+    before { File.write('nanoc.yaml', '{}') }
+
+    example do
+      expect { subject }.to change { command_runner.instance_variable_get(:@site) }.from(nil).to(satisfy { |e| !e.nil? })
+    end
+  end
 end


### PR DESCRIPTION
`#load_site` no longer loads the site, because of #1210. This PR fixes that.

Fixes #1211.