### PR TITLE
Let #load_site not set site ivar

### DIFF
--- a/lib/nanoc/cli/command_runner.rb
+++ b/lib/nanoc/cli/command_runner.rb
@@ -15,27 +15,6 @@ module Nanoc::CLI
       end
     end
 
-    # Gets the site ({Nanoc::Int::Site} instance) in the current directory and
-    # loads its data.
-    #
-    # @return [Nanoc::Int::Site] The site in the current working directory
-    def site
-      # Load site if possible
-      @site ||= nil
-      if is_in_site_dir? && @site.nil?
-        @site = Nanoc::Int::SiteLoader.new.new_from_cwd
-      end
-
-      @site
-    end
-
-    # For debugging purposes.
-    #
-    # @api private
-    def site=(new_site)
-      @site = new_site
-    end
-
     # @return [Boolean] true if the current working directory is a Nanoc site
     #   directory, false otherwise
     def in_site_dir?
@@ -77,13 +56,15 @@ module Nanoc::CLI
       $stderr.print 'Loading site… '
       $stderr.flush
 
-      site
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
 
       if preprocess
         site.compiler.action_provider.preprocess(site)
       end
 
       $stderr.puts 'done'
+
+      site
     end
 
     # @return [Boolean] true if debug output is enabled, false if not

--- a/lib/nanoc/cli/commands/check.rb
+++ b/lib/nanoc/cli/commands/check.rb
@@ -14,9 +14,9 @@ module Nanoc::CLI::Commands
   class Check < ::Nanoc::CLI::CommandRunner
     def run
       validate_options_and_arguments
-      load_site(preprocess: true)
+      @site = load_site(preprocess: true)
 
-      runner = Nanoc::Checking::Runner.new(site)
+      runner = Nanoc::Checking::Runner.new(@site)
 
       if options[:list]
         runner.list_checks

--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -19,11 +19,11 @@ module Nanoc::CLI::Commands
     def run
       time_before = Time.now
 
-      load_site
+      @site = load_site
 
       puts 'Compiling site…'
       run_listeners_while do
-        site.compile
+        @site.compile
       end
 
       time_after = Time.now
@@ -45,7 +45,7 @@ module Nanoc::CLI::Commands
     def setup_listeners
       @listeners =
         @listener_classes
-        .select { |klass| klass.enable_for?(self) }
+        .select { |klass| klass.enable_for?(self, @site) }
         .map    { |klass| klass.new(reps: reps) }
 
       @listeners.each(&:start_safely)
@@ -68,7 +68,7 @@ module Nanoc::CLI::Commands
     end
 
     def reps
-      site.compiler.reps
+      @site.compiler.reps
     end
   end
 end

--- a/lib/nanoc/cli/commands/compile_listeners/abstract.rb
+++ b/lib/nanoc/cli/commands/compile_listeners/abstract.rb
@@ -4,7 +4,7 @@ module Nanoc::CLI::Commands::CompileListeners
   class Abstract
     def initialize(*); end
 
-    def self.enable_for?(command_runner) # rubocop:disable Lint/UnusedMethodArgument
+    def self.enable_for?(command_runner, site) # rubocop:disable Lint/UnusedMethodArgument
       true
     end
 

--- a/lib/nanoc/cli/commands/compile_listeners/debug_printer.rb
+++ b/lib/nanoc/cli/commands/compile_listeners/debug_printer.rb
@@ -3,7 +3,7 @@
 module Nanoc::CLI::Commands::CompileListeners
   class DebugPrinter < Abstract
     # @see Listener#enable_for?
-    def self.enable_for?(command_runner)
+    def self.enable_for?(command_runner, _site)
       command_runner.debug?
     end
 

--- a/lib/nanoc/cli/commands/compile_listeners/diff_generator.rb
+++ b/lib/nanoc/cli/commands/compile_listeners/diff_generator.rb
@@ -3,8 +3,8 @@
 module Nanoc::CLI::Commands::CompileListeners
   class DiffGenerator < Abstract
     # @see Listener#enable_for?
-    def self.enable_for?(command_runner)
-      command_runner.site.config[:enable_output_diff] || command_runner.options[:diff]
+    def self.enable_for?(command_runner, site)
+      site.config[:enable_output_diff] || command_runner.options[:diff]
     end
 
     # @see Listener#start

--- a/lib/nanoc/cli/commands/compile_listeners/timing_recorder.rb
+++ b/lib/nanoc/cli/commands/compile_listeners/timing_recorder.rb
@@ -5,7 +5,7 @@ module Nanoc::CLI::Commands::CompileListeners
     attr_reader :telemetry
 
     # @see Listener#enable_for?
-    def self.enable_for?(_command_runner)
+    def self.enable_for?(_command_runner, _site)
       Nanoc::CLI.verbosity >= 1
     end
 

--- a/lib/nanoc/cli/commands/deploy.rb
+++ b/lib/nanoc/cli/commands/deploy.rb
@@ -15,7 +15,7 @@ option :n, :'dry-run',      'show what would be deployed'
 module Nanoc::CLI::Commands
   class Deploy < ::Nanoc::CLI::CommandRunner
     def run
-      load_site(preprocess: true)
+      @site = load_site(preprocess: true)
 
       if options[:'list-deployers']
         list_deployers
@@ -80,14 +80,14 @@ module Nanoc::CLI::Commands
 
     def deployer_for(config)
       deployer_class_for_config(config).new(
-        site.config[:output_dir],
+        @site.config[:output_dir],
         config,
         dry_run: options[:'dry-run'],
       )
     end
 
     def check
-      runner = Nanoc::Checking::Runner.new(site)
+      runner = Nanoc::Checking::Runner.new(@site)
       if runner.dsl_present?
         puts 'Running issue checks…'
         is_success = runner.run_for_deploy
@@ -103,7 +103,7 @@ module Nanoc::CLI::Commands
     end
 
     def deploy_configs
-      site.config.fetch(:deploy, {})
+      @site.config.fetch(:deploy, {})
     end
 
     def deployer_class_for_config(config)

--- a/lib/nanoc/cli/commands/prune.rb
+++ b/lib/nanoc/cli/commands/prune.rb
@@ -17,13 +17,13 @@ flag :n, :'dry-run', 'print files to be deleted instead of actually deleting the
 module Nanoc::CLI::Commands
   class Prune < ::Nanoc::CLI::CommandRunner
     def run
-      load_site(preprocess: true)
-      site.compiler.build_reps
+      @site = load_site(preprocess: true)
+      @site.compiler.build_reps
 
       if options.key?(:yes)
-        Nanoc::Pruner.new(site.config, site.compiler.reps, exclude: prune_config_exclude).run
+        Nanoc::Pruner.new(@site.config, @site.compiler.reps, exclude: prune_config_exclude).run
       elsif options.key?(:'dry-run')
-        Nanoc::Pruner.new(site.config, site.compiler.reps, exclude: prune_config_exclude, dry_run: true).run
+        Nanoc::Pruner.new(@site.config, @site.compiler.reps, exclude: prune_config_exclude, dry_run: true).run
       else
         $stderr.puts 'WARNING: Since the prune command is a destructive command, it requires an additional --yes flag in order to work.'
         $stderr.puts
@@ -35,7 +35,7 @@ module Nanoc::CLI::Commands
     protected
 
     def prune_config
-      site.config[:prune] || {}
+      @site.config[:prune] || {}
     end
 
     def prune_config_exclude

--- a/lib/nanoc/cli/commands/shell.rb
+++ b/lib/nanoc/cli/commands/shell.rb
@@ -13,13 +13,13 @@ module Nanoc::CLI::Commands
     def run
       require 'pry'
 
-      load_site(preprocess: options[:preprocess])
+      @site = load_site(preprocess: options[:preprocess])
 
       Nanoc::Int::Context.new(env).pry
     end
 
     def env
-      self.class.env_for_site(site)
+      self.class.env_for_site(@site)
     end
 
     def self.reps_for(site)

--- a/lib/nanoc/cli/commands/show-data.rb
+++ b/lib/nanoc/cli/commands/show-data.rb
@@ -11,14 +11,14 @@ EOS
 module Nanoc::CLI::Commands
   class ShowData < ::Nanoc::CLI::CommandRunner
     def run
-      load_site(preprocess: true)
+      @site = load_site(preprocess: true)
 
       # Get data
-      items   = site.items
-      layouts = site.layouts
+      items   = @site.items
+      layouts = @site.layouts
 
       # Get dependency tracker
-      compiler = site.compiler
+      compiler = @site.compiler
       compiler.load_stores
       dependency_store = compiler.dependency_store
 
@@ -45,7 +45,7 @@ module Nanoc::CLI::Commands
     def sorted_reps_with_prev(items)
       prev = nil
       items.sort_by(&:identifier).each do |item|
-        site.compiler.reps[item].sort_by { |r| r.name.to_s }.each do |rep|
+        @site.compiler.reps[item].sort_by { |r| r.name.to_s }.each do |rep|
           yield(rep, prev)
           prev = rep
         end

--- a/lib/nanoc/cli/commands/show-plugins.rb
+++ b/lib/nanoc/cli/commands/show-plugins.rb
@@ -18,6 +18,7 @@ module Nanoc::CLI::Commands
 
       # Get list of plugins (before and after)
       plugins_before = PLUGIN_CLASSES.keys.each_with_object({}) { |c, acc| acc[c] = c.all }
+      site = load_site
       site&.code_snippets
       plugins_after = PLUGIN_CLASSES.keys.each_with_object({}) { |c, acc| acc[c] = c.all }
 

--- a/lib/nanoc/cli/commands/show-rules.rb
+++ b/lib/nanoc/cli/commands/show-rules.rb
@@ -10,15 +10,15 @@ Prints the rules used for all items and layouts in the current site.
 module Nanoc::CLI::Commands
   class ShowRules < ::Nanoc::CLI::CommandRunner
     def run
-      load_site
+      @site = load_site
 
       @c = Nanoc::CLI::ANSIStringColorizer
 
-      compiler = site.compiler
+      compiler = @site.compiler
       compiler.build_reps
       @reps = compiler.reps
 
-      action_provider = site.compiler.action_provider
+      action_provider = @site.compiler.action_provider
       unless action_provider.respond_to?(:rules_collection)
         raise(
           ::Nanoc::Int::Errors::GenericTrivial,
@@ -27,8 +27,8 @@ module Nanoc::CLI::Commands
       end
       @rules = action_provider.rules_collection
 
-      site.items.sort_by(&:identifier).each   { |e| explain_item(e) }
-      site.layouts.sort_by(&:identifier).each { |e| explain_layout(e) }
+      @site.items.sort_by(&:identifier).each   { |e| explain_item(e) }
+      @site.layouts.sort_by(&:identifier).each { |e| explain_layout(e) }
     end
 
     def explain_item(item)

--- a/lib/nanoc/cli/commands/view.rb
+++ b/lib/nanoc/cli/commands/view.rb
@@ -20,7 +20,7 @@ module Nanoc::CLI::Commands
       load_adsf
       require 'rack'
 
-      load_site
+      @site = load_site
 
       # Set options
       options_for_rack = {
@@ -40,7 +40,7 @@ module Nanoc::CLI::Commands
       end
 
       # Build app
-      site = self.site
+      site = @site
       app = Rack::Builder.new do
         use Rack::CommonLogger
         use Rack::ShowExceptions

--- a/spec/nanoc/cli/command_runner_spec.rb
+++ b/spec/nanoc/cli/command_runner_spec.rb
@@ -95,8 +95,13 @@ describe Nanoc::CLI::CommandRunner, stdio: true do
 
     before { File.write('nanoc.yaml', '{}') }
 
-    example do
-      expect { subject }.to change { command_runner.instance_variable_get(:@site) }.from(nil).to(satisfy { |e| !e.nil? })
+    it 'does not set @site' do
+      expect(command_runner.instance_variable_get(:@site)).to be_nil
+      expect { subject }.not_to change { command_runner.instance_variable_get(:@site) }
+    end
+
+    it 'returns site' do
+      expect(subject).to be_a(Nanoc::Int::Site)
     end
   end
 end

--- a/spec/nanoc/cli/commands/compile/diff_generator_spec.rb
+++ b/spec/nanoc/cli/commands/compile/diff_generator_spec.rb
@@ -2,7 +2,7 @@
 
 describe Nanoc::CLI::Commands::CompileListeners::DiffGenerator do
   describe '.enable_for?' do
-    subject { described_class.enable_for?(command_runner) }
+    subject { described_class.enable_for?(command_runner, site) }
 
     let(:options) { {} }
     let(:config_hash) { {} }
@@ -24,9 +24,7 @@ describe Nanoc::CLI::Commands::CompileListeners::DiffGenerator do
     let(:code_snippets) { [] }
 
     let(:command_runner) do
-      Nanoc::CLI::Commands::Compile.new(options, arguments, command).tap do |cr|
-        cr.site = site
-      end
+      Nanoc::CLI::Commands::Compile.new(options, arguments, command)
     end
 
     context 'default' do

--- a/spec/nanoc/cli/commands/show_data_spec.rb
+++ b/spec/nanoc/cli/commands/show_data_spec.rb
@@ -155,6 +155,10 @@ describe Nanoc::CLI::Commands::ShowData, stdio: true do
   describe '#print_item_rep_outdatedness' do
     subject { runner.send(:print_item_rep_outdatedness, items, compiler) }
 
+    before do
+      runner.instance_variable_set(:@site, site)
+    end
+
     let(:runner) do
       described_class.new(options, arguments, command)
     end

--- a/spec/nanoc/cli/commands/show_rules_spec.rb
+++ b/spec/nanoc/cli/commands/show_rules_spec.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
-describe Nanoc::CLI::Commands::ShowRules, stdio: true do
+describe Nanoc::CLI::Commands::ShowRules, stdio: true, site: true do
   describe '#run' do
     subject { runner.run }
 
     let(:runner) do
-      described_class.new(options, arguments, command).tap do |runner|
-        runner.site = site
-      end
+      described_class.new(options, arguments, command)
     end
 
     let(:options) { {} }
@@ -105,16 +103,13 @@ describe Nanoc::CLI::Commands::ShowRules, stdio: true do
         .gsub(/^ {8}/, '')
     end
 
-    before do
-      expect(compiler).to receive(:build_reps).once
-      expect(Nanoc::CLI::CommandRunner).to receive(:find_site_dir).and_return(Dir.getwd)
-    end
-
     it 'writes item and layout rules to stdout' do
+      expect(runner).to receive(:load_site).and_return(site)
+      expect(compiler).to receive(:build_reps).once
       expect { subject }.to output(expected_out).to_stdout
     end
 
-    it 'writes status informaion to stderr' do
+    it 'writes status information to stderr' do
       expect { subject }.to output("Loading site… done\n").to_stderr
     end
   end

--- a/test/cli/commands/test_info.rb
+++ b/test/cli/commands/test_info.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require 'helper'
-
-class Nanoc::CLI::Commands::InfoTest < Nanoc::TestCase
-  def test_run
-    Nanoc::CLI.run %w[info]
-  end
-end


### PR DESCRIPTION
The mutable state introduced by letting `#load_site` set the `@site` ivar is troubling (see #1211 for a case where I was bitten by this).

This PR lets `#load_site` return the new site, rather than set `@site`. I’ve opted to let the command runners assign the return value of `#load_site` to `@site`, which, even though not perfect, is more reasonable.