### PR TITLE
Print “cached” rather than “identical” when appropriate

### DIFF
--- a/lib/nanoc/cli/commands/compile_listeners/file_action_printer.rb
+++ b/lib/nanoc/cli/commands/compile_listeners/file_action_printer.rb
@@ -20,6 +20,11 @@ module Nanoc::CLI::Commands::CompileListeners
         @acc_durations[rep] += Time.now - @start_times[rep]
       end
 
+      cached_reps = Set.new
+      Nanoc::Int::NotificationCenter.on(:cached_content_used, self) do |rep|
+        cached_reps << rep
+      end
+
       Nanoc::Int::NotificationCenter.on(:rep_written, self) do |rep, _binary, path, is_created, is_modified|
         @acc_durations[rep] += Time.now - @start_times[rep]
         duration = @acc_durations[rep]
@@ -27,6 +32,7 @@ module Nanoc::CLI::Commands::CompileListeners
         action =
           if is_created then :create
           elsif is_modified then :update
+          elsif cached_reps.include?(rep) then :cached
           else :identical
           end
         level =

--- a/lib/nanoc/cli/logger.rb
+++ b/lib/nanoc/cli/logger.rb
@@ -8,12 +8,13 @@ module Nanoc::CLI
   #
   # @api private
   class Logger
-    # Maps actions (`:create`, `:update`, `:identical`, `:skip` and `:delete`)
+    # Maps actions (`:create`, `:update`, `:identical`, `:cached`, `:skip` and `:delete`)
     # onto their ANSI color codes.
     ACTION_COLORS = {
       create: "\e[32m", # green
       update: "\e[33m", # yellow
       identical: '',    # (nothing)
+      cached: '',       # (nothing)
       skip: '',         # (nothing)
       delete: "\e[31m"  # red
     }.freeze
@@ -35,7 +36,7 @@ module Nanoc::CLI
     #
     # @param [:high, :low] level The importance of this action
     #
-    # @param [:create, :update, :identical, :skip, :delete] action The kind of file action
+    # @param [:create, :update, :identical, :cached, :skip, :delete] action The kind of file action
     #
     # @param [String] name The name of the file the action was performed on
     #

--- a/spec/nanoc/cli/commands/compile/file_action_printer_spec.rb
+++ b/spec/nanoc/cli/commands/compile/file_action_printer_spec.rb
@@ -60,9 +60,26 @@ describe Nanoc::CLI::Commands::CompileListeners::FileActionPrinter, stdio: true 
     before { listener.start }
     before { Nanoc::CLI::Logger.instance.level = :high }
 
-    it 'prints skipped (uncompiled) reps' do
+    it 'does not print skipped (uncompiled) reps' do
       expect { listener.stop }
         .not_to output(/skip/).to_stdout
+    end
+
+    it 'prints nothing' do
+      Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
+      Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
+
+      expect { Nanoc::Int::NotificationCenter.post(:rep_written, rep, false, '/foo.html', false, false) }
+        .not_to output(/identical/).to_stdout
+    end
+
+    it 'prints nothing' do
+      Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
+      Nanoc::Int::NotificationCenter.post(:cached_content_used, rep)
+      Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
+
+      expect { Nanoc::Int::NotificationCenter.post(:rep_written, rep, false, '/foo.html', false, false) }
+        .not_to output(/cached/).to_stdout
     end
   end
 
@@ -70,9 +87,26 @@ describe Nanoc::CLI::Commands::CompileListeners::FileActionPrinter, stdio: true 
     before { listener.start }
     before { Nanoc::CLI::Logger.instance.level = :low }
 
-    it 'prints nothing' do
+    it 'prints skipped (uncompiled) reps' do
       expect { listener.stop }
         .to output(/skip.*\/hi\.html/).to_stdout
+    end
+
+    it 'prints “identical” if not cached' do
+      Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
+      Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
+
+      expect { Nanoc::Int::NotificationCenter.post(:rep_written, rep, false, '/foo.html', false, false) }
+        .to output(/identical/).to_stdout
+    end
+
+    it 'prints “cached” if cached' do
+      Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
+      Nanoc::Int::NotificationCenter.post(:cached_content_used, rep)
+      Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
+
+      expect { Nanoc::Int::NotificationCenter.post(:rep_written, rep, false, '/foo.html', false, false) }
+        .to output(/cached/).to_stdout
     end
   end
 end


### PR DESCRIPTION
This will let Nanoc print `cached` instead of `identical` when the compiled content of an item can be reused:

<img width="720" alt="screen shot 2017-09-07 at 11 49 44" src="https://user-images.githubusercontent.com/6269/30157470-b0381040-93c2-11e7-9b61-c1d02f15082d.png">

Fixes nanoc/features#12.