### PR TITLE
Properly handle four dashes for separating metadata

### DIFF
--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -371,15 +371,17 @@ module Nanoc::DataSources
       ParseResult.new(content: content, attributes: meta, attributes_data: meta_raw)
     end
 
+    SEPARATOR = /(-{5}|-{3})/.source
+
     # @return [ParseResult]
     def parse_with_frontmatter(content_filename)
       data = read(content_filename)
 
-      if data !~ /\A(-{5}|-{3})\s*$/
+      if data !~ /\A#{SEPARATOR}\s*$/
         return ParseResult.new(content: data, attributes: {}, attributes_data: '')
       end
 
-      pieces = data.split(/^(-{5}|-{3})[ \t]*\r?\n?/, 3)
+      pieces = data.split(/^#{SEPARATOR}[ \t]*\r?\n?/, 3)
       if pieces.size < 4
         raise Errors::InvalidFormat.new(content_filename)
       end

--- a/lib/nanoc/data_sources/filesystem.rb
+++ b/lib/nanoc/data_sources/filesystem.rb
@@ -375,7 +375,7 @@ module Nanoc::DataSources
     def parse_with_frontmatter(content_filename)
       data = read(content_filename)
 
-      if data !~ /\A-{3,5}\s*$/
+      if data !~ /\A(-{5}|-{3})\s*$/
         return ParseResult.new(content: data, attributes: {}, attributes_data: '')
       end
 

--- a/test/data_sources/test_filesystem.rb
+++ b/test/data_sources/test_filesystem.rb
@@ -1004,6 +1004,22 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
     end
   end
 
+  def test_parse_internal_four_dashes
+    content = \
+      "----\n" \
+      "fav_animal: donkey\n" \
+      "----\n" \
+      "blah blah\n"
+
+    File.open('test.html', 'w') { |io| io.write(content) }
+
+    data_source = Nanoc::DataSources::Filesystem.new(nil, nil, nil, nil)
+
+    result = data_source.instance_eval { parse('test.html', nil) }
+    assert_equal({}, result.attributes)
+    assert_equal(content, result.content)
+  end
+
   def test_parse_external_bad_metadata
     File.open('test.html', 'w') { |io| io.write('blah blah') }
     File.open('test.yaml', 'w') { |io| io.write('Hello world!') }


### PR DESCRIPTION
Nanoc does not support four dashes to separate out metadata; it only supports either three or five.

Using four causes a weird error. This PR makes that weird error not happen.

Fixes #1222.