### PR TITLE
Limit fog's dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,8 @@ group :plugins do
   gem 'compass'
   gem 'erubi'
   gem 'erubis'
-  gem 'fog'
+  gem 'fog-aws'
+  gem 'fog-local'
   gem 'haml'
   gem 'handlebars', platforms: :ruby
   gem 'kramdown'

--- a/lib/nanoc/deploying/deployers/fog.rb
+++ b/lib/nanoc/deploying/deployers/fog.rb
@@ -82,7 +82,8 @@ module Nanoc::Deploying::Deployers
 
     # @see Nanoc::Deploying::Deployer#run
     def run
-      require 'fog'
+      require 'fog/core'
+      require 'fog/aws'
 
       src      = File.expand_path(source_path)
       bucket   = config[:bucket] || config[:bucket_name]

--- a/lib/nanoc/deploying/deployers/fog.rb
+++ b/lib/nanoc/deploying/deployers/fog.rb
@@ -83,7 +83,6 @@ module Nanoc::Deploying::Deployers
     # @see Nanoc::Deploying::Deployer#run
     def run
       require 'fog/core'
-      require 'fog/aws'
 
       src      = File.expand_path(source_path)
       bucket   = config[:bucket] || config[:bucket_name]
@@ -126,6 +125,9 @@ module Nanoc::Deploying::Deployers
     end
 
     def connect
+      ::Fog::Storage.new(config_for_fog)
+    rescue ArgumentError
+      require "fog/#{config[:provider]}"
       ::Fog::Storage.new(config_for_fog)
     end
 


### PR DESCRIPTION
`require 'fog'` loads all providers. This patch limits fog and aws only.

### Detailed description

fog has a ton of dependencies. (see below)
I think the deploy script does not need them.
We can use `'fog/core'` and `'fog/aws'` instead of just `'fog'`.

```
Using fog-aliyun 0.2.0
Using fog-brightbox 0.13.0
Using fog-dnsimple 1.0.0
Using fog-joyent 0.0.1
Using fog-openstack 0.1.21
Using fog-profitbricks 4.0.0
Using fog-sakuracloud 1.7.5
Using fog-serverlove 0.1.2
Using fog-softlayer 1.1.4
Using fog-storm_on_demand 0.1.1
Using fog-atmos 0.1.0
Using fog-cloudatcost 0.1.2
Using fog-digitalocean 0.3.0
Using fog-dynect 0.0.3
Using fog-ecloud 0.3.0
Using fog-google 0.1.0
Using fog-internet-archive 0.0.1
Using fog-powerdns 0.1.1
Using fog-rackspace 0.1.5
Using fog-radosgw 0.0.5
Using fog-riakcs 0.1.0
Using fog-terremark 0.1.0
Using fog-voxel 0.1.0
Using fog-xenserver 0.3.0
Using fog-vsphere 1.13.1
Using rest-client 2.0.2
Using rbovirt 0.1.4
Using fog-ovirt 0.1.0
Using fog 1.42.0
```

### To do

* [ ] Tests
* [ ] Documentation
* [ ] Feature flags
