### PR TITLE
Refactor ViewContext

### DIFF
--- a/lib/nanoc/base/services/compilation_context.rb
+++ b/lib/nanoc/base/services/compilation_context.rb
@@ -23,7 +23,7 @@ module Nanoc::Int
     end
 
     def create_view_context(dependency_tracker)
-      Nanoc::ViewContext.new(
+      Nanoc::ViewContextForCompilation.new(
         reps: @reps,
         items: @site.items,
         dependency_tracker: dependency_tracker,

--- a/lib/nanoc/base/views.rb
+++ b/lib/nanoc/base/views.rb
@@ -6,6 +6,7 @@ require_relative 'views/mixins/with_reps_view_mixin'
 
 require_relative 'views/view_context_for_compilation'
 require_relative 'views/view_context_for_pre_compilation'
+require_relative 'views/view_context_for_shell'
 
 require_relative 'views/view'
 require_relative 'views/config_view'

--- a/lib/nanoc/base/views.rb
+++ b/lib/nanoc/base/views.rb
@@ -5,6 +5,7 @@ require_relative 'views/mixins/mutable_document_view_mixin'
 require_relative 'views/mixins/with_reps_view_mixin'
 
 require_relative 'views/view_context_for_compilation'
+require_relative 'views/view_context_for_pre_compilation'
 
 require_relative 'views/view'
 require_relative 'views/config_view'

--- a/lib/nanoc/base/views.rb
+++ b/lib/nanoc/base/views.rb
@@ -4,9 +4,9 @@ require_relative 'views/mixins/document_view_mixin'
 require_relative 'views/mixins/mutable_document_view_mixin'
 require_relative 'views/mixins/with_reps_view_mixin'
 
-require_relative 'views/view'
-require_relative 'views/view_context'
+require_relative 'views/view_context_for_compilation'
 
+require_relative 'views/view'
 require_relative 'views/config_view'
 require_relative 'views/identifiable_collection_view'
 require_relative 'views/item_without_reps_view'

--- a/lib/nanoc/base/views/view_context.rb
+++ b/lib/nanoc/base/views/view_context.rb
@@ -3,12 +3,21 @@
 module Nanoc
   # @api private
   class ViewContext
+    include Nanoc::Int::ContractsSupport
+
     attr_reader :reps
     attr_reader :items
     attr_reader :dependency_tracker
     attr_reader :compilation_context
     attr_reader :snapshot_repo
 
+    contract C::KeywordArgs[
+      reps: Nanoc::Int::ItemRepRepo,
+      items: Nanoc::Int::IdentifiableCollection,
+      dependency_tracker: C::Any,
+      compilation_context: C::Any,
+      snapshot_repo: C::Any,
+    ] => C::Any
     def initialize(reps:, items:, dependency_tracker:, compilation_context:, snapshot_repo:)
       @reps = reps
       @items = items

--- a/lib/nanoc/base/views/view_context_for_compilation.rb
+++ b/lib/nanoc/base/views/view_context_for_compilation.rb
@@ -2,7 +2,7 @@
 
 module Nanoc
   # @api private
-  class ViewContext
+  class ViewContextForCompilation
     include Nanoc::Int::ContractsSupport
 
     attr_reader :reps

--- a/lib/nanoc/base/views/view_context_for_pre_compilation.rb
+++ b/lib/nanoc/base/views/view_context_for_pre_compilation.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Nanoc
+  # @api private
+  class ViewContextForPreCompilation
+    include Nanoc::Int::ContractsSupport
+
+    attr_reader :items
+    attr_reader :dependency_tracker
+
+    contract C::KeywordArgs[items: Nanoc::Int::IdentifiableCollection] => C::Any
+    def initialize(items:)
+      @items = items
+
+      @dependency_tracker = Nanoc::Int::DependencyTracker::Null.new
+    end
+  end
+end

--- a/lib/nanoc/base/views/view_context_for_shell.rb
+++ b/lib/nanoc/base/views/view_context_for_shell.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Nanoc
+  # @api private
+  class ViewContextForShell
+    include Nanoc::Int::ContractsSupport
+
+    attr_reader :items
+    attr_reader :reps
+    attr_reader :dependency_tracker
+
+    contract C::KeywordArgs[
+      items: Nanoc::Int::IdentifiableCollection,
+      reps: Nanoc::Int::ItemRepRepo,
+    ] => C::Any
+    def initialize(items:, reps:)
+      @items = items
+      @reps = reps
+
+      @dependency_tracker = Nanoc::Int::DependencyTracker::Null.new
+    end
+  end
+end

--- a/lib/nanoc/cli/commands/shell.rb
+++ b/lib/nanoc/cli/commands/shell.rb
@@ -31,7 +31,7 @@ module Nanoc::CLI::Commands
     end
 
     def self.view_context_for(site)
-      Nanoc::ViewContext.new(
+      Nanoc::ViewContextForCompilation.new(
         reps: reps_for(site),
         items: site.items,
         dependency_tracker: Nanoc::Int::DependencyTracker::Null.new,

--- a/lib/nanoc/cli/commands/shell.rb
+++ b/lib/nanoc/cli/commands/shell.rb
@@ -31,12 +31,9 @@ module Nanoc::CLI::Commands
     end
 
     def self.view_context_for(site)
-      Nanoc::ViewContextForCompilation.new(
-        reps: reps_for(site),
+      Nanoc::ViewContextForShell.new(
         items: site.items,
-        dependency_tracker: Nanoc::Int::DependencyTracker::Null.new,
-        compilation_context: nil,
-        snapshot_repo: nil,
+        reps: reps_for(site),
       )
     end
 

--- a/lib/nanoc/rule_dsl/action_provider.rb
+++ b/lib/nanoc/rule_dsl/action_provider.rb
@@ -77,13 +77,14 @@ module Nanoc::RuleDSL
     # @api private
     def new_preprocessor_context(site)
       dependency_tracker = Nanoc::Int::DependencyTracker::Null.new
+      config = Nanoc::Int::Configuration.new
       view_context =
         Nanoc::ViewContext.new(
-          reps: nil,
-          items: nil,
-          dependency_tracker: dependency_tracker,
-          compilation_context: nil,
-          snapshot_repo: nil,
+          reps: Nanoc::Int::ItemRepRepo.new,             # FIXME: nonsensical
+          items: Nanoc::Int::ItemCollection.new(config), # FIXME: nonsensical
+          dependency_tracker: dependency_tracker,        # FIXME: nonsensical
+          compilation_context: nil,                      # FIXME: nonsensical
+          snapshot_repo: nil,                            # FIXME: nonsensical
         )
 
       Nanoc::Int::Context.new(

--- a/lib/nanoc/rule_dsl/action_provider.rb
+++ b/lib/nanoc/rule_dsl/action_provider.rb
@@ -60,7 +60,7 @@ module Nanoc::RuleDSL
       reps = res.fetch(:reps)
 
       view_context =
-        Nanoc::ViewContext.new(
+        Nanoc::ViewContextForCompilation.new(
           reps: reps,
           items: site.items,
           dependency_tracker: dependency_tracker,
@@ -79,7 +79,7 @@ module Nanoc::RuleDSL
       dependency_tracker = Nanoc::Int::DependencyTracker::Null.new
       config = Nanoc::Int::Configuration.new
       view_context =
-        Nanoc::ViewContext.new(
+        Nanoc::ViewContextForCompilation.new(
           reps: Nanoc::Int::ItemRepRepo.new,             # FIXME: nonsensical
           items: Nanoc::Int::ItemCollection.new(config), # FIXME: nonsensical
           dependency_tracker: dependency_tracker,        # FIXME: nonsensical

--- a/lib/nanoc/rule_dsl/action_provider.rb
+++ b/lib/nanoc/rule_dsl/action_provider.rb
@@ -76,16 +76,8 @@ module Nanoc::RuleDSL
 
     # @api private
     def new_preprocessor_context(site)
-      dependency_tracker = Nanoc::Int::DependencyTracker::Null.new
-      config = Nanoc::Int::Configuration.new
       view_context =
-        Nanoc::ViewContextForCompilation.new(
-          reps: Nanoc::Int::ItemRepRepo.new,             # FIXME: nonsensical
-          items: Nanoc::Int::ItemCollection.new(config), # FIXME: nonsensical
-          dependency_tracker: dependency_tracker,        # FIXME: nonsensical
-          compilation_context: nil,                      # FIXME: nonsensical
-          snapshot_repo: nil,                            # FIXME: nonsensical
-        )
+        Nanoc::ViewContextForPreCompilation.new(items: site.items)
 
       Nanoc::Int::Context.new(
         config: Nanoc::MutableConfigView.new(site.config, view_context),

--- a/lib/nanoc/rule_dsl/action_sequence_calculator.rb
+++ b/lib/nanoc/rule_dsl/action_sequence_calculator.rb
@@ -57,9 +57,14 @@ module Nanoc::RuleDSL
     end
 
     def new_action_sequence_for_rep(rep)
-      dependency_tracker = Nanoc::Int::DependencyTracker::Null.new
-      reps = Nanoc::Int::ItemRepRepo.new
-      view_context = @site.compiler.compilation_context(reps: reps).create_view_context(dependency_tracker)
+      view_context =
+        Nanoc::ViewContext.new(
+          reps: Nanoc::Int::ItemRepRepo.new,
+          items: @site.items,
+          dependency_tracker: Nanoc::Int::DependencyTracker::Null.new,
+          compilation_context: :__invalid__compilation_context,
+          snapshot_repo: :__invalid__snapshot_repo,
+        )
 
       executor = Nanoc::RuleDSL::RecordingExecutor.new(rep)
       rule = @rules_collection.compilation_rule_for(rep)
@@ -134,7 +139,15 @@ module Nanoc::RuleDSL
       return nil if routing_rule.nil?
 
       dependency_tracker = Nanoc::Int::DependencyTracker::Null.new
-      view_context = Nanoc::ViewContext.new(reps: nil, items: nil, dependency_tracker: dependency_tracker, compilation_context: nil, snapshot_repo: nil)
+      config = Nanoc::Int::Configuration.new
+      view_context = Nanoc::ViewContext.new(
+        reps:                Nanoc::Int::ItemRepRepo.new,            # FIXME: nonsensical
+        items:               Nanoc::Int::ItemCollection.new(config), # FIXME: nonsensical
+        dependency_tracker:  dependency_tracker,                     # FIXME: nonsensical
+        compilation_context: nil,                                    # FIXME: nonsensical
+        snapshot_repo:       nil,                                    # FIXME: nonsensical
+      )
+
       basic_path = routing_rule.apply_to(rep, executor: nil, site: @site, view_context: view_context)
       if basic_path && !basic_path.start_with?('/')
         raise PathWithoutInitialSlashError.new(rep, basic_path)

--- a/lib/nanoc/rule_dsl/action_sequence_calculator.rb
+++ b/lib/nanoc/rule_dsl/action_sequence_calculator.rb
@@ -58,7 +58,7 @@ module Nanoc::RuleDSL
 
     def new_action_sequence_for_rep(rep)
       view_context =
-        Nanoc::ViewContext.new(
+        Nanoc::ViewContextForCompilation.new(
           reps: Nanoc::Int::ItemRepRepo.new,
           items: @site.items,
           dependency_tracker: Nanoc::Int::DependencyTracker::Null.new,
@@ -140,7 +140,7 @@ module Nanoc::RuleDSL
 
       dependency_tracker = Nanoc::Int::DependencyTracker::Null.new
       config = Nanoc::Int::Configuration.new
-      view_context = Nanoc::ViewContext.new(
+      view_context = Nanoc::ViewContextForCompilation.new(
         reps:                Nanoc::Int::ItemRepRepo.new,            # FIXME: nonsensical
         items:               Nanoc::Int::ItemCollection.new(config), # FIXME: nonsensical
         dependency_tracker:  dependency_tracker,                     # FIXME: nonsensical

--- a/lib/nanoc/rule_dsl/action_sequence_calculator.rb
+++ b/lib/nanoc/rule_dsl/action_sequence_calculator.rb
@@ -58,13 +58,7 @@ module Nanoc::RuleDSL
 
     def new_action_sequence_for_rep(rep)
       view_context =
-        Nanoc::ViewContextForCompilation.new(
-          reps: Nanoc::Int::ItemRepRepo.new,
-          items: @site.items,
-          dependency_tracker: Nanoc::Int::DependencyTracker::Null.new,
-          compilation_context: :__invalid__compilation_context,
-          snapshot_repo: :__invalid__snapshot_repo,
-        )
+        Nanoc::ViewContextForPreCompilation.new(items: @site.items)
 
       executor = Nanoc::RuleDSL::RecordingExecutor.new(rep)
       rule = @rules_collection.compilation_rule_for(rep)
@@ -138,20 +132,21 @@ module Nanoc::RuleDSL
       routing_rule = routing_rules[snapshot_name]
       return nil if routing_rule.nil?
 
-      dependency_tracker = Nanoc::Int::DependencyTracker::Null.new
-      config = Nanoc::Int::Configuration.new
-      view_context = Nanoc::ViewContextForCompilation.new(
-        reps:                Nanoc::Int::ItemRepRepo.new,            # FIXME: nonsensical
-        items:               Nanoc::Int::ItemCollection.new(config), # FIXME: nonsensical
-        dependency_tracker:  dependency_tracker,                     # FIXME: nonsensical
-        compilation_context: nil,                                    # FIXME: nonsensical
-        snapshot_repo:       nil,                                    # FIXME: nonsensical
-      )
+      view_context =
+        Nanoc::ViewContextForPreCompilation.new(items: @site.items)
 
-      basic_path = routing_rule.apply_to(rep, executor: nil, site: @site, view_context: view_context)
+      basic_path =
+        routing_rule.apply_to(
+          rep,
+          executor: nil,
+          site: @site,
+          view_context: view_context,
+        )
+
       if basic_path && !basic_path.start_with?('/')
         raise PathWithoutInitialSlashError.new(rep, basic_path)
       end
+
       basic_path
     end
   end

--- a/lib/nanoc/rule_dsl/rule.rb
+++ b/lib/nanoc/rule_dsl/rule.rb
@@ -49,7 +49,7 @@ module Nanoc::RuleDSL
     # @param [Nanoc::Int::ItemRep] rep
     # @param [Nanoc::Int::Site] site
     # @param [Nanoc::Int::Executor, Nanoc::RuleDSL::RecordingExecutor] executor
-    # @param [Nanoc::ViewContext] view_context
+    # @param [Nanoc::ViewContextForCompilation] view_context
     #
     # @return [void]
     def apply_to(rep, site:, executor:, view_context:)

--- a/lib/nanoc/rule_dsl/rule_context.rb
+++ b/lib/nanoc/rule_dsl/rule_context.rb
@@ -10,7 +10,7 @@ module Nanoc::RuleDSL
     # @param [Nanoc::Int::ItemRep] rep
     # @param [Nanoc::Int::Site] site
     # @param [Nanoc::Int::Executor, Nanoc::RuleDSL::RecordingExecutor] executor
-    # @param [Nanoc::ViewContext] view_context
+    # @param [Nanoc::ViewContextForCompilation] view_context
     def initialize(rep:, site:, executor:, view_context:)
       @_executor = executor
 

--- a/lib/nanoc/spec.rb
+++ b/lib/nanoc/spec.rb
@@ -141,7 +141,7 @@ module Nanoc
             snapshot_repo:          @snapshot_repo,
           )
 
-        Nanoc::ViewContext.new(
+        Nanoc::ViewContextForCompilation.new(
           reps:                @reps,
           items:               @items,
           dependency_tracker:  @dependency_tracker,

--- a/spec/nanoc/base/filter_spec.rb
+++ b/spec/nanoc/base/filter_spec.rb
@@ -87,15 +87,16 @@ describe Nanoc::Filter do
 
     let(:view_context) do
       Nanoc::ViewContext.new(
-        reps: reps,
-        items: double(:items),
-        dependency_tracker: dependency_tracker,
+        reps:                reps,
+        items:               Nanoc::Int::ItemCollection.new(config),
+        dependency_tracker:  dependency_tracker,
         compilation_context: double(:compilation_context),
-        snapshot_repo: double(:snapshot_repo),
+        snapshot_repo:       double(:snapshot_repo),
       )
     end
 
     let(:dependency_tracker) { double(:dependency_tracker) }
+    let(:config) { Nanoc::Int::Configuration.new }
 
     let(:reps) { Nanoc::Int::ItemRepRepo.new }
 

--- a/spec/nanoc/base/filter_spec.rb
+++ b/spec/nanoc/base/filter_spec.rb
@@ -86,7 +86,7 @@ describe Nanoc::Filter do
     let(:rep) { Nanoc::Int::ItemRep.new(item, :default) }
 
     let(:view_context) do
-      Nanoc::ViewContext.new(
+      Nanoc::ViewContextForCompilation.new(
         reps:                reps,
         items:               Nanoc::Int::ItemCollection.new(config),
         dependency_tracker:  dependency_tracker,

--- a/spec/nanoc/base/services/executor_spec.rb
+++ b/spec/nanoc/base/services/executor_spec.rb
@@ -401,11 +401,11 @@ describe Nanoc::Int::Executor do
 
     let(:view_context) do
       Nanoc::ViewContext.new(
-        reps: double(:reps),
-        items: double(:items),
-        dependency_tracker: dependency_tracker,
+        reps:                Nanoc::Int::ItemRepRepo.new,
+        items:               Nanoc::Int::ItemCollection.new(config),
+        dependency_tracker:  dependency_tracker,
         compilation_context: double(:compilation_context),
-        snapshot_repo: snapshot_repo,
+        snapshot_repo:       snapshot_repo,
       )
     end
 

--- a/spec/nanoc/base/services/executor_spec.rb
+++ b/spec/nanoc/base/services/executor_spec.rb
@@ -400,7 +400,7 @@ describe Nanoc::Int::Executor do
     end
 
     let(:view_context) do
-      Nanoc::ViewContext.new(
+      Nanoc::ViewContextForCompilation.new(
         reps:                Nanoc::Int::ItemRepRepo.new,
         items:               Nanoc::Int::ItemCollection.new(config),
         dependency_tracker:  dependency_tracker,

--- a/spec/nanoc/base/views/config_view_spec.rb
+++ b/spec/nanoc/base/views/config_view_spec.rb
@@ -10,7 +10,7 @@ describe Nanoc::ConfigView do
   let(:view) { described_class.new(config, view_context) }
 
   let(:view_context) do
-    Nanoc::ViewContext.new(
+    Nanoc::ViewContextForCompilation.new(
       reps:                Nanoc::Int::ItemRepRepo.new,
       items:               Nanoc::Int::ItemCollection.new(config),
       dependency_tracker:  dependency_tracker,

--- a/spec/nanoc/base/views/config_view_spec.rb
+++ b/spec/nanoc/base/views/config_view_spec.rb
@@ -11,11 +11,11 @@ describe Nanoc::ConfigView do
 
   let(:view_context) do
     Nanoc::ViewContext.new(
-      reps: double(:reps),
-      items: double(:items),
-      dependency_tracker: dependency_tracker,
+      reps:                Nanoc::Int::ItemRepRepo.new,
+      items:               Nanoc::Int::ItemCollection.new(config),
+      dependency_tracker:  dependency_tracker,
       compilation_context: double(:compilation_context),
-      snapshot_repo: double(:snapshot_repo),
+      snapshot_repo:       double(:snapshot_repo),
     )
   end
 

--- a/spec/nanoc/base/views/document_view_spec.rb
+++ b/spec/nanoc/base/views/document_view_spec.rb
@@ -4,7 +4,7 @@ shared_examples 'a document view' do
   let(:view) { described_class.new(document, view_context) }
 
   let(:view_context) do
-    Nanoc::ViewContext.new(
+    Nanoc::ViewContextForCompilation.new(
       reps:                Nanoc::Int::ItemRepRepo.new,
       items:               Nanoc::Int::ItemCollection.new(config),
       dependency_tracker:  dependency_tracker,

--- a/spec/nanoc/base/views/document_view_spec.rb
+++ b/spec/nanoc/base/views/document_view_spec.rb
@@ -5,11 +5,11 @@ shared_examples 'a document view' do
 
   let(:view_context) do
     Nanoc::ViewContext.new(
-      reps: double(:reps),
-      items: double(:items),
-      dependency_tracker: dependency_tracker,
+      reps:                Nanoc::Int::ItemRepRepo.new,
+      items:               Nanoc::Int::ItemCollection.new(config),
+      dependency_tracker:  dependency_tracker,
       compilation_context: double(:compilation_context),
-      snapshot_repo: double(:snapshot_repo),
+      snapshot_repo:       double(:snapshot_repo),
     )
   end
 

--- a/spec/nanoc/base/views/identifiable_collection_view_spec.rb
+++ b/spec/nanoc/base/views/identifiable_collection_view_spec.rb
@@ -6,8 +6,8 @@ shared_examples 'an identifiable collection' do
 
   let(:view_context) do
     Nanoc::ViewContext.new(
-      reps:                double(:__reps),
-      items:               double(:__items),
+      reps:                Nanoc::Int::ItemRepRepo.new,
+      items:               Nanoc::Int::ItemCollection.new(config),
       dependency_tracker:  dependency_tracker,
       compilation_context: double(:__compilation_context),
       snapshot_repo:       double(:__snapshot_repo),

--- a/spec/nanoc/base/views/identifiable_collection_view_spec.rb
+++ b/spec/nanoc/base/views/identifiable_collection_view_spec.rb
@@ -5,7 +5,7 @@ shared_examples 'an identifiable collection' do
   let(:view) { described_class.new(wrapped, view_context) }
 
   let(:view_context) do
-    Nanoc::ViewContext.new(
+    Nanoc::ViewContextForCompilation.new(
       reps:                Nanoc::Int::ItemRepRepo.new,
       items:               Nanoc::Int::ItemCollection.new(config),
       dependency_tracker:  dependency_tracker,

--- a/spec/nanoc/base/views/item_rep_view_spec.rb
+++ b/spec/nanoc/base/views/item_rep_view_spec.rb
@@ -3,16 +3,14 @@
 describe Nanoc::ItemRepView do
   let(:view_context) do
     Nanoc::ViewContext.new(
-      reps: reps,
-      items: items,
-      dependency_tracker: dependency_tracker,
+      reps:                Nanoc::Int::ItemRepRepo.new,
+      items:               Nanoc::Int::ItemCollection.new(config),
+      dependency_tracker:  dependency_tracker,
       compilation_context: compilation_context,
-      snapshot_repo: snapshot_repo,
+      snapshot_repo:       snapshot_repo,
     )
   end
 
-  let(:reps) { double(:reps) }
-  let(:items) { double(:items) }
   let(:compilation_context) { double(:compilation_context) }
   let(:snapshot_repo) { Nanoc::Int::SnapshotRepo.new }
 

--- a/spec/nanoc/base/views/item_rep_view_spec.rb
+++ b/spec/nanoc/base/views/item_rep_view_spec.rb
@@ -2,7 +2,7 @@
 
 describe Nanoc::ItemRepView do
   let(:view_context) do
-    Nanoc::ViewContext.new(
+    Nanoc::ViewContextForCompilation.new(
       reps:                Nanoc::Int::ItemRepRepo.new,
       items:               Nanoc::Int::ItemCollection.new(config),
       dependency_tracker:  dependency_tracker,

--- a/spec/nanoc/base/views/item_view_spec.rb
+++ b/spec/nanoc/base/views/item_view_spec.rb
@@ -6,7 +6,7 @@ describe Nanoc::ItemWithRepsView do
   it_behaves_like 'a document view'
 
   let(:view_context) do
-    Nanoc::ViewContext.new(
+    Nanoc::ViewContextForCompilation.new(
       reps: reps,
       items: items,
       dependency_tracker: dependency_tracker,

--- a/spec/nanoc/base/views/item_view_spec.rb
+++ b/spec/nanoc/base/views/item_view_spec.rb
@@ -15,8 +15,8 @@ describe Nanoc::ItemWithRepsView do
     )
   end
 
-  let(:reps) { [] }
-  let(:items) { [] }
+  let(:reps) { Nanoc::Int::ItemRepRepo.new }
+  let(:items) { Nanoc::Int::ItemCollection.new(config) }
   let(:dependency_tracker) { Nanoc::Int::DependencyTracker.new(dependency_store) }
   let(:dependency_store) { Nanoc::Int::DependencyStore.new(empty_items, empty_layouts, config) }
   let(:compilation_context) { double(:compilation_context) }

--- a/spec/nanoc/base/views/mutable_document_view_spec.rb
+++ b/spec/nanoc/base/views/mutable_document_view_spec.rb
@@ -5,16 +5,17 @@ shared_examples 'a mutable document view' do
 
   let(:view_context) do
     Nanoc::ViewContext.new(
-      reps: double(:reps),
-      items: double(:items),
-      dependency_tracker: dependency_tracker,
+      reps:                Nanoc::Int::ItemRepRepo.new,
+      items:               Nanoc::Int::ItemCollection.new(config),
+      dependency_tracker:  dependency_tracker,
       compilation_context: double(:compilation_context),
-      snapshot_repo: snapshot_repo,
+      snapshot_repo:       snapshot_repo,
     )
   end
 
   let(:dependency_tracker) { Nanoc::Int::DependencyTracker.new(double(:dependency_store)) }
   let(:snapshot_repo) { double(:snapshot_repo) }
+  let(:config) { Nanoc::Int::Configuration.new }
 
   describe '#raw_content=' do
     let(:document) { entity_class.new('content', {}, '/asdf') }

--- a/spec/nanoc/base/views/mutable_document_view_spec.rb
+++ b/spec/nanoc/base/views/mutable_document_view_spec.rb
@@ -4,7 +4,7 @@ shared_examples 'a mutable document view' do
   let(:view) { described_class.new(document, view_context) }
 
   let(:view_context) do
-    Nanoc::ViewContext.new(
+    Nanoc::ViewContextForCompilation.new(
       reps:                Nanoc::Int::ItemRepRepo.new,
       items:               Nanoc::Int::ItemCollection.new(config),
       dependency_tracker:  dependency_tracker,

--- a/spec/nanoc/base/views/post_compile_item_rep_view_spec.rb
+++ b/spec/nanoc/base/views/post_compile_item_rep_view_spec.rb
@@ -7,8 +7,8 @@ describe Nanoc::PostCompileItemRepView do
 
   let(:view_context) do
     Nanoc::ViewContext.new(
-      reps: reps,
-      items: items,
+      reps:                Nanoc::Int::ItemRepRepo.new,
+      items:               Nanoc::Int::ItemCollection.new(config),
       dependency_tracker: dependency_tracker,
       compilation_context: compilation_context,
       snapshot_repo: snapshot_repo,

--- a/spec/nanoc/base/views/post_compile_item_rep_view_spec.rb
+++ b/spec/nanoc/base/views/post_compile_item_rep_view_spec.rb
@@ -6,7 +6,7 @@ describe Nanoc::PostCompileItemRepView do
   let(:view) { described_class.new(item_rep, view_context) }
 
   let(:view_context) do
-    Nanoc::ViewContext.new(
+    Nanoc::ViewContextForCompilation.new(
       reps:                Nanoc::Int::ItemRepRepo.new,
       items:               Nanoc::Int::ItemCollection.new(config),
       dependency_tracker: dependency_tracker,

--- a/spec/nanoc/rule_dsl/action_sequence_calculator_spec.rb
+++ b/spec/nanoc/rule_dsl/action_sequence_calculator_spec.rb
@@ -18,14 +18,7 @@ describe(Nanoc::RuleDSL::ActionSequenceCalculator) do
       let(:config) { Nanoc::Int::Configuration.new.with_defaults }
       let(:items) { Nanoc::Int::ItemCollection.new(config) }
       let(:layouts) { Nanoc::Int::LayoutCollection.new(config) }
-      let(:site) { double(:site, items: items, layouts: layouts, config: config, compiler: compiler) }
-      let(:compiler) { double(:compiler, compilation_context: compilation_context) }
-      let(:compilation_context) { double(:compilation_context) }
-      let(:view_context) { double(:view_context) }
-
-      before do
-        expect(compilation_context).to receive(:create_view_context).and_return(view_context)
-      end
+      let(:site) { double(:site, items: items, layouts: layouts, config: config) }
 
       context 'no rules exist' do
         it 'raises error' do

--- a/spec/nanoc/rule_dsl/rule_context_spec.rb
+++ b/spec/nanoc/rule_dsl/rule_context_spec.rb
@@ -16,7 +16,17 @@ describe(Nanoc::RuleDSL::RuleContext) do
   let(:executor) { double(:executor) }
   let(:reps) { double(:reps) }
   let(:compilation_context) { double(:compilation_context) }
-  let(:view_context) { Nanoc::ViewContext.new(reps: reps, items: items, dependency_tracker: dependency_tracker, compilation_context: compilation_context, snapshot_repo: snapshot_repo) }
+
+  let(:view_context) do
+    Nanoc::ViewContext.new(
+      reps:                Nanoc::Int::ItemRepRepo.new,
+      items:               items,
+      dependency_tracker:  dependency_tracker,
+      compilation_context: compilation_context,
+      snapshot_repo:       snapshot_repo,
+    )
+  end
+
   let(:dependency_tracker) { double(:dependency_tracker) }
   let(:snapshot_repo) { double(:snapshot_repo) }
 

--- a/spec/nanoc/rule_dsl/rule_context_spec.rb
+++ b/spec/nanoc/rule_dsl/rule_context_spec.rb
@@ -18,7 +18,7 @@ describe(Nanoc::RuleDSL::RuleContext) do
   let(:compilation_context) { double(:compilation_context) }
 
   let(:view_context) do
-    Nanoc::ViewContext.new(
+    Nanoc::ViewContextForCompilation.new(
       reps:                Nanoc::Int::ItemRepRepo.new,
       items:               items,
       dependency_tracker:  dependency_tracker,

--- a/test/filters/test_slim.rb
+++ b/test/filters/test_slim.rb
@@ -34,7 +34,7 @@ class Nanoc::Filters::SlimTest < Nanoc::TestCase
   def new_view_context
     config = Nanoc::Int::Configuration.new
 
-    Nanoc::ViewContext.new(
+    Nanoc::ViewContextForCompilation.new(
       reps:                Nanoc::Int::ItemRepRepo.new,
       items:               Nanoc::Int::ItemCollection.new(config),
       dependency_tracker:  :__irrelevant_dependency_tracker,

--- a/test/filters/test_slim.rb
+++ b/test/filters/test_slim.rb
@@ -32,12 +32,14 @@ class Nanoc::Filters::SlimTest < Nanoc::TestCase
   end
 
   def new_view_context
+    config = Nanoc::Int::Configuration.new
+
     Nanoc::ViewContext.new(
-      reps: :__irrelevat_reps,
-      items: :__irrelevat_items,
-      dependency_tracker: :__irrelevant_dependency_tracker,
+      reps:                Nanoc::Int::ItemRepRepo.new,
+      items:               Nanoc::Int::ItemCollection.new(config),
+      dependency_tracker:  :__irrelevant_dependency_tracker,
       compilation_context: :__irrelevat_compiler,
-      snapshot_repo: :__irrelevant_snapshot_repo,
+      snapshot_repo:       :__irrelevant_snapshot_repo,
     )
   end
 

--- a/test/filters/test_xsl.rb
+++ b/test/filters/test_xsl.rb
@@ -101,12 +101,14 @@ EOS
   end
 
   def new_view_context
+    config = Nanoc::Int::Configuration.new
+
     Nanoc::ViewContext.new(
-      reps: :__irrelevat_reps,
-      items: :__irrelevat_items,
-      dependency_tracker: @dependency_tracker,
+      reps:                Nanoc::Int::ItemRepRepo.new,
+      items:               Nanoc::Int::ItemCollection.new(config),
+      dependency_tracker:  @dependency_tracker,
       compilation_context: :__irrelevat_compiler,
-      snapshot_repo: :__irrelevant_snapshot_repo,
+      snapshot_repo:       :__irrelevant_snapshot_repo,
     )
   end
 

--- a/test/filters/test_xsl.rb
+++ b/test/filters/test_xsl.rb
@@ -103,7 +103,7 @@ EOS
   def new_view_context
     config = Nanoc::Int::Configuration.new
 
-    Nanoc::ViewContext.new(
+    Nanoc::ViewContextForCompilation.new(
       reps:                Nanoc::Int::ItemRepRepo.new,
       items:               Nanoc::Int::ItemCollection.new(config),
       dependency_tracker:  @dependency_tracker,

--- a/test/helpers/test_blogging.rb
+++ b/test/helpers/test_blogging.rb
@@ -38,11 +38,11 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     dependency_tracker = Nanoc::Int::DependencyTracker.new(dep_store)
 
     @view_context = Nanoc::ViewContext.new(
-      reps: :__irrelevant__,
-      items: nil,
-      dependency_tracker: dependency_tracker,
+      reps:                Nanoc::Int::ItemRepRepo.new,
+      items:               Nanoc::Int::ItemCollection.new(config),
+      dependency_tracker:  dependency_tracker,
       compilation_context: :__irrelevant__,
-      snapshot_repo: :__irrelevant_snapshot_repo,
+      snapshot_repo:       :__irrelevant_snapshot_repo,
     )
   end
 

--- a/test/helpers/test_blogging.rb
+++ b/test/helpers/test_blogging.rb
@@ -37,7 +37,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     dep_store = Nanoc::Int::DependencyStore.new(items, layouts, config)
     dependency_tracker = Nanoc::Int::DependencyTracker.new(dep_store)
 
-    @view_context = Nanoc::ViewContext.new(
+    @view_context = Nanoc::ViewContextForCompilation.new(
       reps:                Nanoc::Int::ItemRepRepo.new,
       items:               Nanoc::Int::ItemCollection.new(config),
       dependency_tracker:  dependency_tracker,

--- a/test/helpers/test_capturing.rb
+++ b/test/helpers/test_capturing.rb
@@ -12,12 +12,14 @@ class Nanoc::Helpers::CapturingTest < Nanoc::TestCase
   end
 
   def view_context_for(item)
+    config = Nanoc::Int::Configuration.new
+
     Nanoc::ViewContext.new(
-      reps: item_rep_repo_for(item),
-      items: :__irrelevant__,
-      dependency_tracker: :__irrelevant__,
+      reps:                item_rep_repo_for(item),
+      items:               Nanoc::Int::ItemCollection.new(config),
+      dependency_tracker:  :__irrelevant__,
       compilation_context: :__irrelevant__,
-      snapshot_repo: snapshot_repo,
+      snapshot_repo:       snapshot_repo,
     )
   end
 

--- a/test/helpers/test_capturing.rb
+++ b/test/helpers/test_capturing.rb
@@ -14,7 +14,7 @@ class Nanoc::Helpers::CapturingTest < Nanoc::TestCase
   def view_context_for(item)
     config = Nanoc::Int::Configuration.new
 
-    Nanoc::ViewContext.new(
+    Nanoc::ViewContextForCompilation.new(
       reps:                item_rep_repo_for(item),
       items:               Nanoc::Int::ItemCollection.new(config),
       dependency_tracker:  :__irrelevant__,

--- a/test/helpers/test_xml_sitemap.rb
+++ b/test/helpers/test_xml_sitemap.rb
@@ -15,7 +15,7 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
     dependency_tracker = Nanoc::Int::DependencyTracker.new(dep_store)
 
     @reps = Nanoc::Int::ItemRepRepo.new
-    @view_context = Nanoc::ViewContext.new(
+    @view_context = Nanoc::ViewContextForCompilation.new(
       reps:                @reps,
       items:               Nanoc::Int::ItemCollection.new(config),
       dependency_tracker:  dependency_tracker,

--- a/test/helpers/test_xml_sitemap.rb
+++ b/test/helpers/test_xml_sitemap.rb
@@ -16,11 +16,11 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
 
     @reps = Nanoc::Int::ItemRepRepo.new
     @view_context = Nanoc::ViewContext.new(
-      reps: @reps,
-      items: nil,
-      dependency_tracker: dependency_tracker,
+      reps:                @reps,
+      items:               Nanoc::Int::ItemCollection.new(config),
+      dependency_tracker:  dependency_tracker,
       compilation_context: :__irrelevant__,
-      snapshot_repo: :__irrelevant_snapshot_repo,
+      snapshot_repo:       :__irrelevant_snapshot_repo,
     )
 
     @items = nil


### PR DESCRIPTION
* Add contracts
* Split up
  * `ViewContextForCompilation`
  * `ViewContextForPreCompilation`
  * `ViewContextForShell`
* Construct manually instead of going through compilation context (reduces hidden complexity)

This will meant to get rid of nonsensical view context constructions (e.g. weirdly requiring a dependency tracker and an item rep repo when preprocessing).