### PR TITLE
Refactor: Support multiple compilers

### DIFF
--- a/lib/nanoc/base/entities/site.rb
+++ b/lib/nanoc/base/entities/site.rb
@@ -23,7 +23,7 @@ module Nanoc::Int
 
     contract C::None => self
     def compile
-      Nanoc::Int::Compiler.new_for(self).run_all
+      Nanoc::Int::Compiler.new_for(self).run_until_end
       self
     end
 

--- a/lib/nanoc/base/entities/site.rb
+++ b/lib/nanoc/base/entities/site.rb
@@ -8,7 +8,6 @@ module Nanoc::Int
     attr_reader :code_snippets
     attr_reader :config
     attr_accessor :data_source
-    attr_writer :compiler
 
     contract C::KeywordArgs[config: Nanoc::Int::Configuration, code_snippets: C::IterOf[Nanoc::Int::CodeSnippet], data_source: C::Maybe[C::Named['Nanoc::DataSource']]] => C::Any
     def initialize(config:, code_snippets:, data_source:)
@@ -24,13 +23,8 @@ module Nanoc::Int
 
     contract C::None => self
     def compile
-      compiler.run_all
+      Nanoc::Int::Compiler.new_for(self).run_all
       self
-    end
-
-    contract C::None => C::Named['Nanoc::Int::Compiler']
-    def compiler
-      @compiler ||= Nanoc::Int::Compiler.new_for(self)
     end
 
     def mark_as_preprocessed

--- a/lib/nanoc/base/entities/site.rb
+++ b/lib/nanoc/base/entities/site.rb
@@ -16,6 +16,8 @@ module Nanoc::Int
       @code_snippets = code_snippets
       @data_source = data_source
 
+      @preprocessed = false
+
       ensure_identifier_uniqueness(@data_source.items, 'item')
       ensure_identifier_uniqueness(@data_source.layouts, 'layout')
     end
@@ -28,7 +30,15 @@ module Nanoc::Int
 
     contract C::None => C::Named['Nanoc::Int::Compiler']
     def compiler
-      @compiler ||= Nanoc::Int::CompilerLoader.new.load(self)
+      @compiler ||= Nanoc::Int::Compiler.new_for(self)
+    end
+
+    def mark_as_preprocessed
+      @preprocessed = true
+    end
+
+    def preprocessed?
+      @preprocessed
     end
 
     def items

--- a/lib/nanoc/base/services/compiler.rb
+++ b/lib/nanoc/base/services/compiler.rb
@@ -17,6 +17,11 @@ module Nanoc::Int
       @snapshot_repo = Nanoc::Int::SnapshotRepo.new
     end
 
+    contract Nanoc::Int::Site => Nanoc::Int::Compiler
+    def self.new_for(site)
+      Nanoc::Int::CompilerLoader.new.load(site)
+    end
+
     def run_until_preprocessed
       @_res_preprocessed ||= begin
         run_stage(preprocess_stage)
@@ -73,7 +78,7 @@ module Nanoc::Int
       run_stage(prune_stage(reps))
       run_stage(compile_reps_stage(action_sequences, reps))
       run_stage(store_post_compilation_state_stage)
-      run_stage(postprocess_stage(reps))
+      run_stage(postprocess_stage(reps), self)
     ensure
       run_stage(cleanup_stage)
     end

--- a/lib/nanoc/base/services/compiler.rb
+++ b/lib/nanoc/base/services/compiler.rb
@@ -66,7 +66,7 @@ module Nanoc::Int
       end
     end
 
-    def run_all
+    def run_until_end
       res = run_until_precompiled
       action_sequences = res.fetch(:action_sequences)
       reps = res.fetch(:reps)

--- a/lib/nanoc/base/services/compiler/stages/postprocess.rb
+++ b/lib/nanoc/base/services/compiler/stages/postprocess.rb
@@ -10,9 +10,9 @@ module Nanoc::Int::Compiler::Stages
       @reps = reps
     end
 
-    contract C::None => C::Any
-    def run
-      @action_provider.postprocess(@site, @reps)
+    contract Nanoc::Int::Compiler => C::Any
+    def run(compiler)
+      @action_provider.postprocess(@site, compiler, @reps)
     end
   end
 end

--- a/lib/nanoc/base/services/compiler/stages/preprocess.rb
+++ b/lib/nanoc/base/services/compiler/stages/preprocess.rb
@@ -10,6 +10,8 @@ module Nanoc::Int::Compiler::Stages
     end
 
     def run
+      return if @site.preprocessed?
+
       if @action_provider.need_preprocessing?
         @site.data_source = Nanoc::Int::InMemDataSource.new(@site.items, @site.layouts)
         @action_provider.preprocess(@site)
@@ -19,6 +21,7 @@ module Nanoc::Int::Compiler::Stages
         @checksum_store.objects = @site.items.to_a + @site.layouts.to_a + @site.code_snippets + [@site.config]
       end
 
+      @site.mark_as_preprocessed
       @site.freeze
     end
   end

--- a/lib/nanoc/checking/check.rb
+++ b/lib/nanoc/checking/check.rb
@@ -22,9 +22,10 @@ module Nanoc::Checking
       output_filenames = Dir[output_dir + '/**/*'].select { |f| File.file?(f) }
 
       # FIXME: ugly
-      res = site.compiler.run_until_reps_built
+      compiler = Nanoc::Int::Compiler.new_for(site)
+      res = compiler.run_until_reps_built
       reps = res.fetch(:reps)
-      compilation_context = site.compiler.compilation_context(reps: reps)
+      compilation_context = compiler.compilation_context(reps: reps)
       view_context = compilation_context.create_view_context(Nanoc::Int::DependencyTracker::Null.new)
 
       context = {

--- a/lib/nanoc/checking/runner.rb
+++ b/lib/nanoc/checking/runner.rb
@@ -111,7 +111,7 @@ module Nanoc::Checking
       return [] if classes.empty?
 
       # TODO: remove me
-      @site.compiler.run_until_reps_built
+      Nanoc::Int::Compiler.new_for(@site).run_until_reps_built
 
       checks = []
       issues = Set.new

--- a/lib/nanoc/cli/command_runner.rb
+++ b/lib/nanoc/cli/command_runner.rb
@@ -50,20 +50,14 @@ module Nanoc::CLI
     # Asserts that the current working directory contains a site and loads the site into memory.
     #
     # @return [void]
-    def load_site(preprocess: false)
+    def load_site
       self.class.enter_site_dir
 
       $stderr.print 'Loading site… '
       $stderr.flush
-
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
 
-      if preprocess
-        site.compiler.run_until_preprocessed
-      end
-
       $stderr.puts 'done'
-
       site
     end
 

--- a/lib/nanoc/cli/commands/check.rb
+++ b/lib/nanoc/cli/commands/check.rb
@@ -14,10 +14,9 @@ module Nanoc::CLI::Commands
   class Check < ::Nanoc::CLI::CommandRunner
     def run
       validate_options_and_arguments
-      @site = load_site
-      @site.compiler.run_until_preprocessed
+      site = load_site
 
-      runner = Nanoc::Checking::Runner.new(@site)
+      runner = Nanoc::Checking::Runner.new(site)
 
       if options[:list]
         runner.list_checks

--- a/lib/nanoc/cli/commands/check.rb
+++ b/lib/nanoc/cli/commands/check.rb
@@ -14,7 +14,8 @@ module Nanoc::CLI::Commands
   class Check < ::Nanoc::CLI::CommandRunner
     def run
       validate_options_and_arguments
-      @site = load_site(preprocess: true)
+      @site = load_site
+      @site.compiler.run_until_preprocessed
 
       runner = Nanoc::Checking::Runner.new(@site)
 

--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -24,7 +24,7 @@ module Nanoc::CLI::Commands
       puts 'Compiling site…'
       compiler = Nanoc::Int::Compiler.new_for(@site)
       run_listeners_while(compiler) do
-        compiler.run_all
+        compiler.run_until_end
       end
 
       time_after = Time.now

--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -22,8 +22,9 @@ module Nanoc::CLI::Commands
       @site = load_site
 
       puts 'Compiling site…'
-      run_listeners_while do
-        @site.compile
+      compiler = Nanoc::Int::Compiler.new_for(@site)
+      run_listeners_while(compiler) do
+        compiler.run_all
       end
 
       time_after = Time.now
@@ -42,7 +43,9 @@ module Nanoc::CLI::Commands
       ]
     end
 
-    def setup_listeners
+    def setup_listeners(compiler)
+      reps = reps_for(compiler)
+
       @listeners =
         @listener_classes
         .select { |klass| klass.enable_for?(self, @site) }
@@ -55,8 +58,8 @@ module Nanoc::CLI::Commands
       @listeners
     end
 
-    def run_listeners_while
-      setup_listeners
+    def run_listeners_while(compiler)
+      setup_listeners(compiler)
       yield
     ensure
       teardown_listeners
@@ -67,11 +70,9 @@ module Nanoc::CLI::Commands
       @listeners.reverse_each(&:stop_safely)
     end
 
-    def reps
-      @_reps ||= begin
-        res = @site.compiler.run_until_reps_built
-        res.fetch(:reps)
-      end
+    def reps_for(compiler)
+      res = compiler.run_until_reps_built
+      res.fetch(:reps)
     end
   end
 end

--- a/lib/nanoc/cli/commands/deploy.rb
+++ b/lib/nanoc/cli/commands/deploy.rb
@@ -16,7 +16,7 @@ module Nanoc::CLI::Commands
   class Deploy < ::Nanoc::CLI::CommandRunner
     def run
       @site = load_site
-      @site.compiler.run_until_preprocessed
+      Nanoc::Int::Compiler.new_for(@site).run_until_preprocessed
 
       if options[:'list-deployers']
         list_deployers

--- a/lib/nanoc/cli/commands/deploy.rb
+++ b/lib/nanoc/cli/commands/deploy.rb
@@ -15,7 +15,8 @@ option :n, :'dry-run',      'show what would be deployed'
 module Nanoc::CLI::Commands
   class Deploy < ::Nanoc::CLI::CommandRunner
     def run
-      @site = load_site(preprocess: true)
+      @site = load_site
+      @site.compiler.run_until_preprocessed
 
       if options[:'list-deployers']
         list_deployers

--- a/lib/nanoc/cli/commands/prune.rb
+++ b/lib/nanoc/cli/commands/prune.rb
@@ -18,7 +18,7 @@ module Nanoc::CLI::Commands
   class Prune < ::Nanoc::CLI::CommandRunner
     def run
       @site = load_site
-      res = @site.compiler.run_until_reps_built
+      res = Nanoc::Int::Compiler.new_for(@site).run_until_reps_built
       reps = res.fetch(:reps)
 
       if options.key?(:yes)

--- a/lib/nanoc/cli/commands/shell.rb
+++ b/lib/nanoc/cli/commands/shell.rb
@@ -14,7 +14,7 @@ module Nanoc::CLI::Commands
       require 'pry'
 
       @site = load_site
-      @site.compiler.run_until_preprocessed if options[:preprocess]
+      Nanoc::Int::Compiler.new_for(@site).run_until_preprocessed if options[:preprocess]
 
       Nanoc::Int::Context.new(env).pry
     end

--- a/lib/nanoc/cli/commands/shell.rb
+++ b/lib/nanoc/cli/commands/shell.rb
@@ -13,7 +13,8 @@ module Nanoc::CLI::Commands
     def run
       require 'pry'
 
-      @site = load_site(preprocess: options[:preprocess])
+      @site = load_site
+      @site.compiler.run_until_preprocessed if options[:preprocess]
 
       Nanoc::Int::Context.new(env).pry
     end

--- a/lib/nanoc/cli/commands/show-data.rb
+++ b/lib/nanoc/cli/commands/show-data.rb
@@ -12,7 +12,7 @@ module Nanoc::CLI::Commands
   class ShowData < ::Nanoc::CLI::CommandRunner
     def run
       site = load_site
-      res = site.compiler.run_until_precompiled
+      res = Nanoc::Int::Compiler.new_for(site).run_until_precompiled
 
       items                = site.items
       layouts              = site.layouts

--- a/lib/nanoc/cli/commands/show-rules.rb
+++ b/lib/nanoc/cli/commands/show-rules.rb
@@ -12,7 +12,7 @@ module Nanoc::CLI::Commands
     def run
       site = load_site
 
-      res = site.compiler.run_until_reps_built
+      res = Nanoc::Int::Compiler.new_for(site).run_until_reps_built
       reps = res.fetch(:reps)
 
       action_provider = Nanoc::Int::ActionProvider.named(:rule_dsl).for(site)

--- a/lib/nanoc/rule_dsl/action_provider.rb
+++ b/lib/nanoc/rule_dsl/action_provider.rb
@@ -53,10 +53,10 @@ module Nanoc::RuleDSL
         Nanoc::Int::InMemDataSource.new(ctx.items.unwrap, ctx.layouts.unwrap)
     end
 
-    def postprocess(site, reps)
+    def postprocess(site, compiler, reps)
       dependency_tracker = Nanoc::Int::DependencyTracker::Null.new
 
-      res = site.compiler.run_until_reps_built
+      res = compiler.run_until_reps_built
       reps = res.fetch(:reps)
 
       view_context =
@@ -64,7 +64,7 @@ module Nanoc::RuleDSL
           reps: reps,
           items: site.items,
           dependency_tracker: dependency_tracker,
-          compilation_context: site.compiler.compilation_context(reps: reps),
+          compilation_context: compiler.compilation_context(reps: reps),
           snapshot_repo: nil,
         )
       ctx = new_postprocessor_context(site, view_context)

--- a/lib/nanoc/spec.rb
+++ b/lib/nanoc/spec.rb
@@ -179,15 +179,12 @@ module Nanoc
       end
 
       def site
-        @_site ||= begin
-          site = Nanoc::Int::Site.new(
+        @_site ||=
+          Nanoc::Int::Site.new(
             config: @config,
             code_snippets: [],
             data_source: Nanoc::Int::InMemDataSource.new(@items, @layouts),
           )
-          site.compiler = new_compiler_for(site)
-          site
-        end
       end
 
       def assigns

--- a/spec/nanoc/base/services/compiler/stages/preprocess_spec.rb
+++ b/spec/nanoc/base/services/compiler/stages/preprocess_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+describe Nanoc::Int::Compiler::Stages::Preprocess do
+  let(:stage) do
+    described_class.new(
+      action_provider: action_provider,
+      site: site,
+      dependency_store: dependency_store,
+      checksum_store: checksum_store,
+    )
+  end
+
+  let(:action_provider) do
+    double(:action_provider)
+  end
+
+  let(:site) do
+    Nanoc::Int::Site.new(
+      config: config,
+      code_snippets: [],
+      data_source: data_source,
+    )
+  end
+
+  let(:data_source) { Nanoc::Int::InMemDataSource.new(items, layouts) }
+  let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+  let(:items) { Nanoc::Int::ItemCollection.new(config) }
+  let(:layouts) { Nanoc::Int::LayoutCollection.new(config) }
+
+  let(:dependency_store) do
+    Nanoc::Int::DependencyStore.new(items, layouts, config, site: site)
+  end
+
+  let(:checksum_store) do
+    Nanoc::Int::ChecksumStore.new(site: site, objects: items.to_a + layouts.to_a)
+  end
+
+  describe '#run' do
+    subject { stage.run }
+
+    context 'no preprocessing needed' do
+      before do
+        expect(action_provider).to receive(:need_preprocessing?).and_return(false)
+      end
+
+      it 'marks the site as preprocessed' do
+        expect { subject }
+          .to change { site.preprocessed? }
+          .from(false)
+          .to(true)
+      end
+
+      it 'freezes the site' do
+        subject
+      end
+    end
+
+    context 'preprocessing needed' do
+      let(:new_item) { Nanoc::Int::Item.new('new item', {}, '/new.md') }
+      let(:new_layout) { Nanoc::Int::Layout.new('new layout', {}, '/new.md') }
+
+      before do
+        expect(action_provider).to receive(:need_preprocessing?).and_return(true)
+
+        expect(action_provider).to receive(:preprocess) do |site|
+          site.data_source =
+            Nanoc::Int::InMemDataSource.new(
+              Nanoc::Int::ItemCollection.new(config, [new_item]),
+              Nanoc::Int::LayoutCollection.new(config, [new_layout]),
+            )
+        end
+      end
+
+      it 'marks the site as preprocessed' do
+        expect { subject }
+          .to change { site.preprocessed? }
+          .from(false)
+          .to(true)
+      end
+
+      it 'freezes the site' do
+        expect { subject }
+          .to change { site.config.frozen? }
+          .from(false)
+          .to(true)
+      end
+
+      it 'sets items on dependency store' do
+        expect { subject }
+          .to change { dependency_store.items.to_a }
+          .from([])
+          .to([new_item])
+      end
+
+      it 'sets layouts on dependency store' do
+        expect { subject }
+          .to change { dependency_store.layouts.to_a }
+          .from([])
+          .to([new_layout])
+      end
+
+      it 'sets data on checksum store' do
+        expect { subject }
+          .to change { checksum_store.objects.to_a }
+          .from([])
+          .to(match_array([new_item, new_layout, config]))
+      end
+    end
+  end
+end

--- a/spec/nanoc/cli/commands/show_rules_spec.rb
+++ b/spec/nanoc/cli/commands/show_rules_spec.rb
@@ -105,6 +105,7 @@ describe Nanoc::CLI::Commands::ShowRules, stdio: true, site: true do
 
     it 'writes item and layout rules to stdout' do
       expect(runner).to receive(:load_site).and_return(site)
+      expect(Nanoc::Int::Compiler).to receive(:new_for).with(site).and_return(compiler)
       expect(compiler).to receive(:run_until_reps_built).and_return(reps: reps)
       expect(Nanoc::RuleDSL::ActionProvider).to receive(:for).with(site).and_return(action_provider)
       expect { subject }.to output(expected_out).to_stdout

--- a/spec/nanoc/regressions/gh_776_spec.rb
+++ b/spec/nanoc/regressions/gh_776_spec.rb
@@ -30,7 +30,7 @@ EOS
 
   context 'with pruning' do
     before do
-      res = site.compiler.run_until_reps_built
+      res = Nanoc::Int::Compiler.new_for(site).run_until_reps_built
       Nanoc::Pruner.new(site.config, res.fetch(:reps)).run
     end
 


### PR DESCRIPTION
This PR makes it possible to have multiple Compiler instances for the same site.

This makes the code cleaner (Site does not need to know about Compiler anymore), but also brings Nanoc closer to being able to listen to changes and compile the same site over and over again, as changes are coming in.

Note that the effects of compilers can still interfere with each other; don’t run two compilers at the same time.

* [x] Store preprocessedness on site
* [x] Remove `preprocess` option from `#load_site`
* [x] Remove `Site#compiler`