### PR TITLE
Aggregate compile listener

### DIFF
--- a/lib/nanoc/cli.rb
+++ b/lib/nanoc/cli.rb
@@ -26,6 +26,7 @@ require_relative 'cli/commands/compile_listeners/debug_printer'
 require_relative 'cli/commands/compile_listeners/diff_generator'
 require_relative 'cli/commands/compile_listeners/file_action_printer'
 require_relative 'cli/commands/compile_listeners/timing_recorder'
+require_relative 'cli/commands/compile_listeners/aggregate'
 
 # @api private
 module Nanoc::CLI

--- a/lib/nanoc/cli/commands/compile.rb
+++ b/lib/nanoc/cli/commands/compile.rb
@@ -11,11 +11,6 @@ module Nanoc::CLI::Commands
   class Compile < ::Nanoc::CLI::CommandRunner
     attr_accessor :listener_classes
 
-    def initialize(options, arguments, command)
-      super
-      @listener_classes = default_listener_classes
-    end
-
     def run
       time_before = Time.now
 
@@ -23,56 +18,18 @@ module Nanoc::CLI::Commands
 
       puts 'Compiling site…'
       compiler = Nanoc::Int::Compiler.new_for(@site)
-      run_listeners_while(compiler) do
+      listener = Nanoc::CLI::Commands::CompileListeners::Aggregate.new(
+        command_runner: self,
+        site: @site,
+        compiler: compiler,
+      )
+      listener.run_while do
         compiler.run_until_end
       end
 
       time_after = Time.now
       puts
       puts "Site compiled in #{format('%.2f', time_after - time_before)}s."
-    end
-
-    protected
-
-    def default_listener_classes
-      [
-        Nanoc::CLI::Commands::CompileListeners::DiffGenerator,
-        Nanoc::CLI::Commands::CompileListeners::DebugPrinter,
-        Nanoc::CLI::Commands::CompileListeners::TimingRecorder,
-        Nanoc::CLI::Commands::CompileListeners::FileActionPrinter,
-      ]
-    end
-
-    def setup_listeners(compiler)
-      reps = reps_for(compiler)
-
-      @listeners =
-        @listener_classes
-        .select { |klass| klass.enable_for?(self, @site) }
-        .map    { |klass| klass.new(reps: reps) }
-
-      @listeners.each(&:start_safely)
-    end
-
-    def listeners
-      @listeners
-    end
-
-    def run_listeners_while(compiler)
-      setup_listeners(compiler)
-      yield
-    ensure
-      teardown_listeners
-    end
-
-    def teardown_listeners
-      return unless @listeners
-      @listeners.reverse_each(&:stop_safely)
-    end
-
-    def reps_for(compiler)
-      res = compiler.run_until_reps_built
-      res.fetch(:reps)
     end
   end
 end

--- a/lib/nanoc/cli/commands/compile_listeners/abstract.rb
+++ b/lib/nanoc/cli/commands/compile_listeners/abstract.rb
@@ -8,11 +8,20 @@ module Nanoc::CLI::Commands::CompileListeners
       true
     end
 
+    # @abstract
     def start
       raise NotImplementedError, "Subclasses of #{self.class} must implement #start"
     end
 
+    # @abstract
     def stop; end
+
+    def run_while
+      start
+      yield
+    ensure
+      stop
+    end
 
     def start_safely
       start

--- a/lib/nanoc/cli/commands/compile_listeners/aggregate.rb
+++ b/lib/nanoc/cli/commands/compile_listeners/aggregate.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Nanoc::CLI::Commands::CompileListeners
+  class Aggregate < Abstract
+    def initialize(command_runner:, site:, compiler:)
+      @site = site
+      @compiler = compiler
+      @command_runner = command_runner
+
+      @listener_classes = self.class.default_listener_classes
+    end
+
+    def start
+      setup_listeners
+    end
+
+    def stop
+      teardown_listeners
+    end
+
+    def self.default_listener_classes
+      [
+        Nanoc::CLI::Commands::CompileListeners::DiffGenerator,
+        Nanoc::CLI::Commands::CompileListeners::DebugPrinter,
+        Nanoc::CLI::Commands::CompileListeners::TimingRecorder,
+        Nanoc::CLI::Commands::CompileListeners::FileActionPrinter,
+      ]
+    end
+
+    protected
+
+    def setup_listeners
+      res = @compiler.run_until_reps_built
+      reps = res.fetch(:reps)
+
+      @listeners =
+        @listener_classes
+        .select { |klass| klass.enable_for?(@command_runner, @site) }
+        .map    { |klass| klass.new(reps: reps) }
+
+      @listeners.each(&:start_safely)
+    end
+
+    def teardown_listeners
+      return unless @listeners
+      @listeners.reverse_each(&:stop_safely)
+    end
+  end
+end

--- a/spec/nanoc/cli/commands/compile_spec.rb
+++ b/spec/nanoc/cli/commands/compile_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+describe Nanoc::CLI::Commands::Compile, site: true, stdio: true do
+  describe '#run' do
+    example do
+      test_listener_class = Class.new(::Nanoc::CLI::Commands::CompileListeners::Abstract) do
+        def start
+          @started = true
+        end
+
+        def stop
+          @stopped = true
+        end
+
+        def started?
+          @started
+        end
+
+        def stopped?
+          @stopped
+        end
+      end
+
+      expect(Nanoc::CLI::Commands::CompileListeners::Aggregate)
+        .to receive(:default_listener_classes)
+        .and_return([test_listener_class])
+
+      listener = test_listener_class.new
+
+      expect(test_listener_class)
+        .to receive(:new)
+        .and_return(listener)
+
+      options = {}
+      arguments = []
+      cmd = nil
+      cmd_runner = Nanoc::CLI::Commands::Compile.new(options, arguments, cmd)
+
+      cmd_runner.run
+
+      expect(listener).to be_started
+      expect(listener).to be_stopped
+    end
+  end
+end

--- a/test/cli/commands/test_compile.rb
+++ b/test/cli/commands/test_compile.rb
@@ -129,41 +129,6 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
     end
   end
 
-  def test_setup_and_teardown_listeners
-    with_site do
-      test_listener_class = Class.new(::Nanoc::CLI::Commands::CompileListeners::Abstract) do
-        def start
-          @started = true
-        end
-
-        def stop
-          @stopped = true
-        end
-
-        def started?
-          @started
-        end
-
-        def stopped?
-          @stopped
-        end
-      end
-
-      options = {}
-      arguments = []
-      cmd = nil
-      cmd_runner = Nanoc::CLI::Commands::Compile.new(options, arguments, cmd)
-      cmd_runner.listener_classes = [test_listener_class]
-
-      cmd_runner.run
-
-      listeners = cmd_runner.send(:listeners)
-      assert listeners.size == 1
-      assert listeners.first.started?
-      assert listeners.first.stopped?
-    end
-  end
-
   def test_file_action_printer_normal
     # Create data
     item = Nanoc::Int::Item.new('content', {}, '/a')


### PR DESCRIPTION
This moves all the setup w.r.t. compile listeners into a new `Aggregate` listener class (actually `Nanoc::CLI::Commands::CompileListeners::Aggregate` — which I think is far too long of a name).

The upcoming `live` command will be able to use this!