### PR TITLE
Revert "Remove ItemRepView#raw_path"

### DIFF
--- a/lib/nanoc/base/services/filter.rb
+++ b/lib/nanoc/base/services/filter.rb
@@ -210,14 +210,7 @@ module Nanoc
     #
     # @return [void]
     def depend_on(items)
-      reps = items.flat_map(&:reps).map(&:unwrap)
-      reps.each do |rep|
-        @item._context.dependency_tracker.bounce(rep.item, compiled_content: true)
-
-        unless rep.compiled?
-          Fiber.yield(Nanoc::Int::Errors::UnmetDependency.new(rep))
-        end
-      end
+      items.flat_map(&:reps).flat_map(&:raw_path)
     end
   end
 end

--- a/lib/nanoc/base/views/item_rep_view.rb
+++ b/lib/nanoc/base/views/item_rep_view.rb
@@ -75,6 +75,19 @@ module Nanoc
     end
 
     # @api private
+    def raw_path(snapshot: :last)
+      @context.dependency_tracker.bounce(unwrap.item, compiled_content: true)
+
+      res = @item_rep.raw_path(snapshot: snapshot)
+
+      unless @item_rep.compiled?
+        Fiber.yield(Nanoc::Int::Errors::UnmetDependency.new(@item_rep))
+      end
+
+      res
+    end
+
+    # @api private
     def binary?
       snapshot_def = unwrap.snapshot_defs.find { |sd| sd.name == :last }
       raise Nanoc::Int::Errors::NoSuchSnapshot.new(unwrap, :last) if snapshot_def.nil?

--- a/spec/nanoc/base/views/item_rep_view_spec.rb
+++ b/spec/nanoc/base/views/item_rep_view_spec.rb
@@ -287,6 +287,64 @@ describe Nanoc::ItemRepView do
     it { should eq('/about/') }
   end
 
+  describe '#raw_path' do
+    subject { Fiber.new { view.raw_path }.resume }
+
+    let(:view) { described_class.new(rep, view_context) }
+
+    let(:rep) do
+      Nanoc::Int::ItemRep.new(item, :default).tap do |ir|
+        ir.raw_paths = {
+          last: ['output/about/index.html'],
+        }
+      end
+    end
+
+    let(:item) do
+      Nanoc::Int::Item.new('content', {}, '/asdf.md')
+    end
+
+    context 'rep is not compiled' do
+      it 'creates a dependency' do
+        expect { subject }.to change { dependency_store.objects_causing_outdatedness_of(base_item) }.from([]).to([item])
+      end
+
+      it 'creates a dependency with the right props' do
+        subject
+        dep = dependency_store.dependencies_causing_outdatedness_of(base_item)[0]
+
+        expect(dep.props.compiled_content?).to eq(true)
+
+        expect(dep.props.raw_content?).to eq(false)
+        expect(dep.props.attributes?).to eq(false)
+        expect(dep.props.path?).to eq(false)
+      end
+
+      it { should be_a(Nanoc::Int::Errors::UnmetDependency) }
+    end
+
+    context 'rep is compiled' do
+      before { rep.compiled = true }
+
+      it 'creates a dependency' do
+        expect { subject }.to change { dependency_store.objects_causing_outdatedness_of(base_item) }.from([]).to([item])
+      end
+
+      it 'creates a dependency with the right props' do
+        subject
+        dep = dependency_store.dependencies_causing_outdatedness_of(base_item)[0]
+
+        expect(dep.props.compiled_content?).to eq(true)
+
+        expect(dep.props.raw_content?).to eq(false)
+        expect(dep.props.attributes?).to eq(false)
+        expect(dep.props.path?).to eq(false)
+      end
+
+      it { should eq('output/about/index.html') }
+    end
+  end
+
   describe '#binary?' do
     let(:item_rep) { Nanoc::Int::ItemRep.new(item, :jacques) }
     let(:item) { Nanoc::Int::Item.new('asdf', {}, '/foo') }

--- a/spec/nanoc/regressions/gh_1093_spec.rb
+++ b/spec/nanoc/regressions/gh_1093_spec.rb
@@ -2,7 +2,7 @@
 
 describe 'GH-1093', site: true, stdio: true do
   before do
-    File.write('content/index.html', '<%= @items["/z.dat"].reps.all? { |r| File.file?(r.unwrap.raw_path) } %>')
+    File.write('content/index.html', '<%= @items["/z.dat"].reps.all? { |r| File.file?(r.raw_path) } %>')
     File.write('content/z.dat', 'asdf')
 
     File.write('Rules', <<EOS)

--- a/spec/nanoc/regressions/gh_1097_spec.rb
+++ b/spec/nanoc/regressions/gh_1097_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe 'GH-1097', site: true, stdio: true do
+  before do
+    File.write('content/a.dat', 'foo')
+    File.write('content/index.html', '<%= @items.find_all("/*.dat").flat_map(&:reps).all? { |r| File.file?(r.raw_path) } %>')
+    File.write('content/z.dat', 'quux')
+
+    File.write('Rules', <<EOS)
+  compile '/**/*.html' do
+    filter :erb
+    write item.identifier.to_s
+  end
+
+  passthrough '/**/*.dat'
+EOS
+  end
+
+  it 'generates dependency on all reps' do
+    Nanoc::CLI.run(%w[compile])
+    expect(File.read('output/index.html')).to eql('true')
+  end
+end


### PR DESCRIPTION
Reverts nanoc/nanoc#1229.

`#raw_path` is part of an internal API, but needs to become public as it has some use cases (`#compiled_content` suffices, but not for binary item snapshot).