### PR TITLE
Reverse stack trace

### DIFF
--- a/lib/nanoc/base/feature.rb
+++ b/lib/nanoc/base/feature.rb
@@ -92,3 +92,4 @@ module Nanoc
 end
 
 Nanoc::Feature.define('live_cmd', version: '4.8')
+Nanoc::Feature.define('sensible_stack_traces', version: '4.8')

--- a/lib/nanoc/cli/stack_trace_writer.rb
+++ b/lib/nanoc/cli/stack_trace_writer.rb
@@ -3,11 +3,22 @@
 module Nanoc::CLI
   # @api private
   class StackTraceWriter
-    def initialize(stream)
+    def initialize(stream, forwards:)
       @stream = stream
+      @forwards = forwards
     end
 
     def write(error, verbose:)
+      if @forwards
+        write_forwards(error, verbose: verbose)
+      else
+        write_backwards(error, verbose: verbose)
+      end
+    end
+
+    private
+
+    def write_backwards(error, verbose:)
       count = verbose ? -1 : 10
 
       error.backtrace[0...count].each_with_index do |item, index|
@@ -16,6 +27,23 @@ module Nanoc::CLI
 
       if !verbose && error.backtrace.size > count
         @stream.puts "  ... #{error.backtrace.size - count} lines omitted (see crash.log for details)"
+      end
+    end
+
+    def write_forwards(error, verbose:)
+      count = 10
+      backtrace = verbose ? error.backtrace : error.backtrace.take(count)
+
+      if !verbose && error.backtrace.size > count
+        @stream.puts "  ... #{error.backtrace.size - count} lines omitted (see crash.log for details)"
+      end
+
+      backtrace.each_with_index.to_a.reverse.each do |(item, index)|
+        if index.zero?
+          @stream.puts "  #{item}"
+        else
+          @stream.puts "  #{index}. from #{item}"
+        end
       end
     end
   end

--- a/spec/nanoc/cli/error_handler_spec.rb
+++ b/spec/nanoc/cli/error_handler_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+describe Nanoc::CLI::ErrorHandler do
+  subject(:error_handler) { described_class.new }
+
+  describe '#forwards_stack_trace?' do
+    subject { error_handler.forwards_stack_trace? }
+
+    context 'feature enabled' do
+      around do |ex|
+        Nanoc::Feature.enable(Nanoc::Feature::SENSIBLE_STACK_TRACES) do
+          ex.run
+        end
+      end
+
+      context 'Ruby 2.4' do
+        it { is_expected.to be(true) }
+      end
+
+      context 'Ruby 2.5' do
+        it { is_expected.to be(true) }
+      end
+    end
+
+    context 'feature not enabled' do
+      context 'Ruby 2.4' do
+        before do
+          expect(error_handler).to receive(:ruby_version).and_return('2.4.2')
+        end
+
+        it { is_expected.to be(false) }
+      end
+
+      context 'Ruby 2.5' do
+        before do
+          expect(error_handler).to receive(:ruby_version).and_return('2.5.0')
+        end
+
+        it { is_expected.to be(true) }
+      end
+    end
+  end
+end

--- a/spec/nanoc/cli/stack_trace_writer_spec.rb
+++ b/spec/nanoc/cli/stack_trace_writer_spec.rb
@@ -1,82 +1,156 @@
 # frozen_string_literal: true
 
 describe Nanoc::CLI::StackTraceWriter do
-  let(:exception) do
-    backtrace_generator = lambda do |af|
-      if af.zero?
-        raise 'finally!'
-      else
-        backtrace_generator.call(af - 1)
+  subject(:writer) do
+    described_class.new(io, forwards: forwards)
+  end
+
+  let(:io) { StringIO.new }
+  let(:forwards) { true }
+
+  describe '#write' do
+    let(:exception) do
+      backtrace_generator = lambda do |af|
+        if af.zero?
+          raise 'finally!'
+        else
+          backtrace_generator.call(af - 1)
+        end
+      end
+
+      begin
+        backtrace_generator.call(3)
+      rescue => e
+        return e
       end
     end
 
-    begin
-      backtrace_generator.call(3)
-    rescue => e
-      return e
-    end
-  end
+    subject { writer.write(exception, verbose: verbose) }
 
-  subject { described_class.new(io).write(exception, verbose: verbose) }
-
-  let(:io) { StringIO.new }
-  let(:verbose) { false }
-
-  context 'verbose' do
-    let(:verbose) { true }
-
-    it 'starts with zero' do
-      expect { subject }
-        .to change { io.string }
-        .from('')
-        .to(start_with('  0. '))
-    end
-
-    it 'has more recent stack frames at the top' do
-      expect { subject }
-        .to change { io.string }
-        .from('')
-        .to(match(%r{^  0\. /.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d+.*$\n  1\. /.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d}m))
-    end
-
-    it 'has more than 10 stack frames' do
-      expect { subject }
-        .to change { io.string }
-        .from('')
-        .to(match(%r{^  11\. }))
-    end
-
-    it 'does not contain a see-more explanation' do
-      subject
-      expect(io.string).not_to match(/crash\.log/)
-    end
-  end
-
-  context 'not verbose' do
     let(:verbose) { false }
 
-    it 'starts with zero' do
-      expect { subject }
-        .to change { io.string }
-        .from('')
-        .to(start_with('  0. '))
+    context 'backwards' do
+      let(:forwards) { false }
+
+      context 'verbose' do
+        let(:verbose) { true }
+
+        it 'starts with zero' do
+          expect { subject }
+            .to change { io.string }
+            .from('')
+            .to(start_with('  0. '))
+        end
+
+        it 'has more recent stack frames at the top' do
+          expect { subject }
+            .to change { io.string }
+            .from('')
+            .to(match(%r{^  0\. /.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d+.*$\n  1\. /.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d}m))
+        end
+
+        it 'has more than 10 stack frames' do
+          expect { subject }
+            .to change { io.string }
+            .from('')
+            .to(match(%r{^  11\. }))
+        end
+
+        it 'does not contain a see-more explanation' do
+          subject
+          expect(io.string).not_to match(/crash\.log/)
+        end
+      end
+
+      context 'not verbose' do
+        let(:verbose) { false }
+
+        it 'starts with zero' do
+          expect { subject }
+            .to change { io.string }
+            .from('')
+            .to(start_with('  0. '))
+        end
+
+        it 'has more recent stack frames at the top' do
+          expect { subject }
+            .to change { io.string }
+            .from('')
+            .to(match(%r{^  0\. /.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d+.*$\n  1\. /.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d}m))
+        end
+
+        it 'has not more than 10 stack frames' do
+          subject
+          expect(io.string).not_to match(/^  11\. /)
+        end
+
+        it 'does not contain a see-more explanation' do
+          subject
+          expect(io.string).to include(" lines omitted (see crash.log for details)\n")
+        end
+      end
     end
 
-    it 'has more recent stack frames at the top' do
-      expect { subject }
-        .to change { io.string }
-        .from('')
-        .to(match(%r{^  0\. /.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d+.*$\n  1\. /.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d}m))
-    end
+    context 'forwards' do
+      let(:forwards) { true }
 
-    it 'has not more than 10 stack frames' do
-      subject
-      expect(io.string).not_to match(/^  11\. /)
-    end
+      context 'verbose' do
+        let(:verbose) { true }
 
-    it 'does not contain a see-more explanation' do
-      subject
-      expect(io.string).to include(" lines omitted (see crash.log for details)\n")
+        it 'ends with most recent line' do
+          expect { subject }
+            .to change { io.string }
+            .from('')
+            .to(match(%r{^  1\. from /.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d+.*$\n  /.+/spec/nanoc/cli}m))
+        end
+
+        it 'has more recent stack frames at the bottom' do
+          expect { subject }
+            .to change { io.string }
+            .from('')
+            .to(match(%r{^  2\. from /.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d+.*$\n  1\. from /.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d}m))
+        end
+
+        it 'has more than 10 stack frames' do
+          expect { subject }
+            .to change { io.string }
+            .from('')
+            .to(match(%r{^  11\. from }))
+        end
+
+        it 'does not contain a see-more explanation' do
+          subject
+          expect(io.string).not_to match(/crash\.log/)
+        end
+      end
+
+      context 'not verbose' do
+        let(:verbose) { false }
+
+        it 'ends with most recent line' do
+          expect { subject }
+            .to change { io.string }
+            .from('')
+            .to(match(%r{^  1\. from /.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d+.*$\n  /.+/spec/nanoc/cli}m))
+        end
+
+        it 'has more recent stack frames at the top' do
+          expect { subject }
+            .to change { io.string }
+            .from('')
+            .to(match(%r{^  2\. from /.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d+.*$\n  1\. from /.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d}m))
+        end
+
+        it 'has not more than 10 stack frames' do
+          subject
+          expect(io.string).not_to match(/^  11\. from /)
+        end
+
+        it 'does not contain a see-more explanation' do
+          subject
+          expect(io.string).to include(" lines omitted (see crash.log for details)\n")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This reverses the stack trace, to be in line with Ruby 2.5.

This change is **experimental**, because Ruby 2.5’s reversed stack trace is also experimental. These new stack traces will be used on Ruby 2.5 or when the new `sensible_stack_traces` feature is enabled.

* * *

**Regular stack trace (old):**

<img width="1280" alt="screen shot 2017-10-23 at 15 46 35" src="https://user-images.githubusercontent.com/6269/31892471-643d005e-b809-11e7-8f09-9d9c50095b1d.png">

* * *

**Reversed stack trace (new):**

<img width="1280" alt="screen shot 2017-10-23 at 15 46 19" src="https://user-images.githubusercontent.com/6269/31892481-6a9d90bc-b809-11e7-9a54-6145d84f2b22.png">
