### PR TITLE
Add :save_with parameter to relativize_paths

### DIFF
--- a/lib/nanoc/filters/relativize_paths.rb
+++ b/lib/nanoc/filters/relativize_paths.rb
@@ -61,14 +61,15 @@ module Nanoc::Filters
     end
 
     def relativize_html_like(content, params)
-      selectors  = params.fetch(:select, SELECTORS)
-      namespaces = params.fetch(:namespaces, {})
-      type       = params.fetch(:type)
+      selectors             = params.fetch(:select, SELECTORS)
+      namespaces            = params.fetch(:namespaces, {})
+      type                  = params.fetch(:type)
+      nokogiri_save_options = params.fetch(:nokogiri_save_options, nil)
 
       parser = parser_for(type)
       content = fix_content(content, type)
 
-      nokogiri_process(content, selectors, namespaces, parser, type)
+      nokogiri_process(content, selectors, namespaces, parser, type, nokogiri_save_options)
     end
 
     def parser_for(type)
@@ -101,7 +102,7 @@ module Nanoc::Filters
       end
     end
 
-    def nokogiri_process(content, selectors, namespaces, klass, type)
+    def nokogiri_process(content, selectors, namespaces, klass, type, nokogiri_save_options = nil)
       # Ensure that all prefixes are strings
       namespaces = namespaces.reduce({}) { |new, (prefix, uri)| new.merge(prefix.to_s => uri) }
 
@@ -117,9 +118,9 @@ module Nanoc::Filters
 
       case type
       when :html5
-        doc.to_html
+        doc.to_html(save_with: nokogiri_save_options)
       else
-        doc.send("to_#{type}")
+        doc.send("to_#{type}", save_with: nokogiri_save_options)
       end
     end
 

--- a/test/filters/test_relativize_paths.rb
+++ b/test/filters/test_relativize_paths.rb
@@ -854,4 +854,34 @@ XML
     actual_content = filter.setup_and_run(raw_content, type: :html)
     assert_equal(expected_content, actual_content)
   end
+
+  def test_filter_nokogiri_save_with
+    if_have 'nokogiri' do
+      # Create filter with mock item
+      filter = Nanoc::Filters::RelativizePaths.new
+
+      # Mock item
+      filter.instance_eval do
+        @item_rep = Nanoc::Int::ItemRep.new(
+          Nanoc::Int::Item.new(
+            'content',
+            {},
+            '/foo/baz',
+          ),
+          :blah,
+        )
+        @item_rep.paths[:last] = ['/foo/baz/']
+      end
+
+      # Set content
+      raw_content = %(
+<td><span>some</span><span>moderately</span><span>long</span><span>content</span></td>
+)
+
+      # Test
+      nokogiri_save_options = Nokogiri::XML::Node::SaveOptions::DEFAULT_HTML & ~Nokogiri::XML::Node::SaveOptions::FORMAT
+      actual_content = filter.setup_and_run(raw_content.freeze, type: :html, nokogiri_save_options: nokogiri_save_options)
+      assert_equal(actual_content, raw_content)
+    end
+  end
 end


### PR DESCRIPTION
Sometimes, you don't Nokogiri to reformat the document. Typically when you plan to style elements with `white-space: pre;`.

This PR adds a `save_with` parameter to the `relativize_paths` filter to which one can pass e.g. `Nokogiri::XML::Node::SaveOptions::DEFAULT_HTML & ~Nokogiri::XML::Node::SaveOptions::FORMAT` which clears the formatting bit from the default save options.