### PR TITLE
Experiment: Extract nanoc-live gem

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,0 @@
--r ./spec/spec_helper.rb
---format Fuubar
---color

--- a/.rspec-nanoc
+++ b/.rspec-nanoc
@@ -1,3 +1,0 @@
--r ./spec/spec_helper_nanoc.rb
---format Fuubar
---color

--- a/.rspec-nanoc
+++ b/.rspec-nanoc
@@ -1,0 +1,3 @@
+-r ./spec/spec_helper_nanoc.rb
+--format Fuubar
+--color

--- a/.rspec-nanoc-live
+++ b/.rspec-nanoc-live
@@ -1,0 +1,3 @@
+-r ./spec/spec_helper_nanoc_live.rb
+--format Fuubar
+--color

--- a/.rspec-nanoc-live
+++ b/.rspec-nanoc-live
@@ -1,3 +1,0 @@
--r ./spec/spec_helper_nanoc_live.rb
---format Fuubar
---color

--- a/.rspec.nanoc
+++ b/.rspec.nanoc
@@ -1,0 +1,5 @@
+--require ./spec/spec_helper_nanoc.rb
+--pattern spec/**/*_spec.rb
+--exclude-pattern spec/nanoc/live/**/*_spec.rb
+--format Fuubar
+--color

--- a/.rspec.nanoc-live
+++ b/.rspec.nanoc-live
@@ -1,0 +1,4 @@
+--require ./spec/spec_helper_nanoc_live.rb
+--pattern spec/nanoc/live/**/*_spec.rb
+--format Fuubar
+--color

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -86,6 +86,7 @@ Security/MarshalLoad:
 
 Security/Eval:
   Exclude:
+    - 'nanoc.gemspec'
     - 'test/**/*.rb'
     - 'spec/**/*.rb'
     - 'lib/nanoc/base/entities/code_snippet.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@
 
 source 'https://rubygems.org'
 
-gemspec
+gemspec name: 'nanoc'
+gemspec name: 'nanoc-live'
 
 group :devel do
   gem 'codecov', require: false

--- a/Rakefile
+++ b/Rakefile
@@ -5,9 +5,15 @@ require 'rspec/core/rake_task'
 require 'rake/testtask'
 require 'coveralls/rake/task'
 
-RuboCop::RakeTask.new(:rubocop)
+### coverage
 
 Coveralls::RakeTask.new
+
+### style
+
+RuboCop::RakeTask.new(:rubocop)
+
+### test
 
 Rake::TestTask.new(:test_all) do |t|
   t.test_files = Dir['test/**/test_*.rb']
@@ -15,11 +21,27 @@ Rake::TestTask.new(:test_all) do |t|
   t.verbose = false
 end
 
-RSpec::Core::RakeTask.new(:spec) do |t|
+### spec
+
+RSpec::Core::RakeTask.new(:spec_nanoc) do |t|
   t.verbose = false
+  t.rspec_opts =
+    '--options .rspec-nanoc ' \
+    '--exclude-pattern spec/nanoc/live/**/*_spec.rb'
 end
 
-task test: %i[spec test_all rubocop]
+RSpec::Core::RakeTask.new(:spec_nanoc_live) do |t|
+  t.verbose = false
+  t.rspec_opts = \
+    '--options .rspec-nanoc-live ' \
+    '--pattern spec/nanoc/live/**/*_spec.rb'
+end
+
+task spec: %i[spec_nanoc spec_nanoc_live]
+
+###
+
+task test: %i[spec spec_nanoc_live test_all rubocop]
 task test_ci: %i[test coveralls:push]
 
 task default: :test

--- a/Rakefile
+++ b/Rakefile
@@ -25,16 +25,12 @@ end
 
 RSpec::Core::RakeTask.new(:spec_nanoc) do |t|
   t.verbose = false
-  t.rspec_opts =
-    '--options .rspec-nanoc ' \
-    '--exclude-pattern spec/nanoc/live/**/*_spec.rb'
+  t.rspec_opts = '--options .rspec.nanoc'
 end
 
 RSpec::Core::RakeTask.new(:spec_nanoc_live) do |t|
   t.verbose = false
-  t.rspec_opts = \
-    '--options .rspec-nanoc-live ' \
-    '--pattern spec/nanoc/live/**/*_spec.rb'
+  t.rspec_opts = '--options .rspec.nanoc-live'
 end
 
 task spec: %i[spec_nanoc spec_nanoc_live]

--- a/lib/nanoc/cli.rb
+++ b/lib/nanoc/cli.rb
@@ -118,8 +118,6 @@ module Nanoc::CLI
 
       next if basename == 'nanoc'
 
-      next if basename == 'live' && !Nanoc::Feature.enabled?(Nanoc::Feature::LIVE_CMD)
-
       cmd = load_command_at(cmd_filename)
       add_command(cmd)
     end

--- a/lib/nanoc/extra.rb
+++ b/lib/nanoc/extra.rb
@@ -16,7 +16,6 @@ module Nanoc::Extra
 end
 
 require_relative 'extra/link_collector.rb'
-require_relative 'extra/live_recompiler'
 require_relative 'extra/piper'
 require_relative 'extra/jruby_nokogiri_warner'
 require_relative 'extra/core_ext'

--- a/lib/nanoc/live.rb
+++ b/lib/nanoc/live.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'nanoc'
+require 'nanoc/cli'
+
+module Nanoc
+  module Live
+  end
+end
+
+require_relative 'live/version'
+require_relative 'live/live_recompiler'
+
+Nanoc::CLI.after_setup do
+  cmd = Nanoc::CLI.load_command_at(__dir__ + '/live/command.rb', 'live')
+  Nanoc::CLI.root_command.add_command(cmd)
+end

--- a/lib/nanoc/live/command.rb
+++ b/lib/nanoc/live/command.rb
@@ -22,7 +22,7 @@ module Nanoc::CLI::Commands
         Nanoc::CLI::Commands::View.new(options, [], self).run
       end
 
-      Nanoc::Extra::LiveRecompiler.new(command_runner: self).run
+      Nanoc::Live::LiveRecompiler.new(command_runner: self).run
     end
   end
 end

--- a/lib/nanoc/live/live_recompiler.rb
+++ b/lib/nanoc/live/live_recompiler.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nanoc::Extra
+module Nanoc::Live
   class LiveRecompiler
     def initialize(command_runner:)
       @command_runner = command_runner

--- a/lib/nanoc/live/version.rb
+++ b/lib/nanoc/live/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Nanoc
+  module Live
+    VERSION = '0.0.1'
+  end
+end

--- a/nanoc-live.gemspec
+++ b/nanoc-live.gemspec
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative 'lib/nanoc/version'
+require_relative 'lib/nanoc/live/version'
+
+Gem::Specification.new do |s|
+  s.name        = 'nanoc-live'
+  s.version     = Nanoc::Live::VERSION
+  s.homepage    = 'http://nanoc.ws/'
+  s.summary     = 'Live command for Nanoc'
+
+  s.author  = 'Denis Defreyne'
+  s.email   = 'denis@stoneship.org'
+  s.license = 'MIT'
+
+  all_files = `git ls-files -z`.split("\x0")
+  s.files         = all_files.select { |fn| fn =~ %r{nanoc[_/-]live|spec_helper_common} }
+  s.require_paths = ['lib']
+
+  s.required_ruby_version = '>= 2.3.0'
+
+  s.add_runtime_dependency('listen', '~> 3.0')
+  s.add_runtime_dependency('slow_enumerator_tools', '~> 1.0')
+end

--- a/nanoc-live.manifest
+++ b/nanoc-live.manifest
@@ -1,0 +1,12 @@
+.rspec-nanoc-live
+nanoc-live.gemspec
+nanoc-live.manifest
+
+lib/nanoc/live.rb
+lib/nanoc/live/version.rb
+lib/nanoc/live/command.rb
+lib/nanoc/live/live_recompiler.rb
+
+spec/nanoc/live/live_recompiler_spec.rb
+spec/spec_helper_nanoc_live.rb
+spec/spec_helper_common.rb

--- a/nanoc.gemspec
+++ b/nanoc.gemspec
@@ -13,6 +13,9 @@ ignored_files = %w[
   Guardfile
 ]
 
+gemspecs = Dir['nanoc-*.gemspec'].map { |fn| eval(File.read(fn), binding, fn) }
+plugin_files = gemspecs.flat_map(&:files).uniq.reject { |fn| fn =~ /spec_helper_common/ }
+
 Gem::Specification.new do |s|
   s.name        = 'nanoc'
   s.version     = Nanoc::VERSION
@@ -24,7 +27,8 @@ Gem::Specification.new do |s|
   s.email   = 'denis@stoneship.org'
   s.license = 'MIT'
 
-  s.files = `git ls-files -z`.split("\x0") - ignored_files
+  all_files = `git ls-files -z`.split("\x0")
+  s.files = all_files - plugin_files - ignored_files
   s.executables        = ['nanoc']
   s.require_paths      = ['lib']
 

--- a/nanoc.manifest
+++ b/nanoc.manifest
@@ -1,4 +1,4 @@
-.rspec
+.rspec-nanoc
 .rubocop.yml
 Appraisals
 CODE_OF_CONDUCT.md
@@ -171,7 +171,6 @@ lib/nanoc/cli/commands/compile_listeners/timing_recorder.rb
 lib/nanoc/cli/commands/compile.rb
 lib/nanoc/cli/commands/create-site.rb
 lib/nanoc/cli/commands/deploy.rb
-lib/nanoc/cli/commands/live.rb
 lib/nanoc/cli/commands/nanoc.rb
 lib/nanoc/cli/commands/prune.rb
 lib/nanoc/cli/commands/shell.rb
@@ -202,7 +201,6 @@ lib/nanoc/extra/core_ext/pathname.rb
 lib/nanoc/extra/core_ext/time.rb
 lib/nanoc/extra/jruby_nokogiri_warner.rb
 lib/nanoc/extra/link_collector.rb
-lib/nanoc/extra/live_recompiler.rb
 lib/nanoc/extra/parallel_collection.rb
 lib/nanoc/extra/piper.rb
 lib/nanoc/filters.rb
@@ -374,7 +372,6 @@ spec/nanoc/cli/stream_cleaners/utf8_spec.rb
 spec/nanoc/data_sources/filesystem_spec.rb
 spec/nanoc/deploying/fog_spec.rb
 spec/nanoc/deploying/git_spec.rb
-spec/nanoc/extra/live_recompiler_spec.rb
 spec/nanoc/extra/parallel_collection_spec.rb
 spec/nanoc/filters/asciidoctor_spec.rb
 spec/nanoc/filters/colorize_syntax/rouge_spec.rb
@@ -463,7 +460,8 @@ spec/nanoc/telemetry/stopwatch_spec.rb
 spec/nanoc/telemetry/summary_spec.rb
 spec/nanoc/telemetry/table_spec.rb
 spec/regression_filenames_spec.rb
-spec/spec_helper.rb
+spec/spec_helper_nanoc.rb
+spec/spec_helper_common.rb
 
 test/base/test_compiler.rb
 test/base/test_dependency_tracker.rb

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -1,22 +1,36 @@
 # frozen_string_literal: true
 
 describe 'manifest', chdir: false do
+  let(:gem_names) do
+    Dir['*.gemspec'].map { |fn| fn.sub(/\.gemspec$/, '') }
+  end
+
   let(:manifest_lines) do
-    File.readlines('nanoc.manifest').map(&:chomp).reject(&:empty?)
+    gem_names.each_with_object({}) do |gem_name, memo|
+      raw_lines = File.readlines(gem_name + '.manifest')
+      memo[gem_name] = raw_lines.map(&:chomp).reject(&:empty?)
+    end
   end
 
   let(:gemspec_lines) do
-    gemspec = eval(File.read('nanoc.gemspec'), binding, 'nanoc.gemspec')
-    gemspec.files
+    gem_names.each_with_object({}) do |gem_name, memo|
+      gemspec_filename = gem_name + '.gemspec'
+      gemspec = eval(File.read(gemspec_filename), binding, gemspec_filename)
+      memo[gem_name] = gemspec.files
+    end
   end
 
   it 'contains all files in gemspec' do
-    missing_from_manifest = gemspec_lines - manifest_lines
-    expect(missing_from_manifest).to be_empty, "Found files that appear in the gemspec, but not in the manifest: #{missing_from_manifest.join(', ')}"
+    gem_names.each do |gem_name|
+      missing_from_manifest = gemspec_lines.fetch(gem_name) - manifest_lines.fetch(gem_name)
+      expect(missing_from_manifest).to be_empty, "Found files that appear in the gemspec, but not in the manifest: #{missing_from_manifest.join(', ')}"
+    end
   end
 
   it 'contains no files not in gemspec' do
-    extra_in_manifest = manifest_lines - gemspec_lines
-    expect(extra_in_manifest).to be_empty, "Found files that appear in the manifest, but not in the gemspec: #{extra_in_manifest.join(', ')}"
+    gem_names.each do |gem_name|
+      extra_in_manifest = manifest_lines.fetch(gem_name) - gemspec_lines.fetch(gem_name)
+      expect(extra_in_manifest).to be_empty, "Found files that appear in the manifest, but not in the gemspec: #{extra_in_manifest.join(', ')}"
+    end
   end
 end

--- a/spec/nanoc/live/live_recompiler_spec.rb
+++ b/spec/nanoc/live/live_recompiler_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Nanoc::Extra::LiveRecompiler, site: true, stdio: true do
+describe Nanoc::Live::LiveRecompiler, site: true, stdio: true do
   it 'detects content changes' do
     command = nil
     command_runner = Nanoc::CLI::CommandRunner.new({}, [], command)

--- a/spec/spec_helper_nanoc.rb
+++ b/spec/spec_helper_nanoc.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'simplecov'
+SimpleCov.start
+
+require 'codecov'
+SimpleCov.formatter = SimpleCov::Formatter::Codecov
+
+require 'nanoc'
+require 'nanoc/cli'
+
+require_relative 'spec_helper_common'

--- a/spec/spec_helper_nanoc_live.rb
+++ b/spec/spec_helper_nanoc_live.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'simplecov'
+SimpleCov.start
+
+require 'codecov'
+SimpleCov.formatter = SimpleCov::Formatter::Codecov
+
+require 'nanoc/live'
+
+require_relative 'spec_helper_common'


### PR DESCRIPTION
⚠️  **Experimental** ⚠️ 

This changes the `nanoc` repository to generate two gems:

* `nanoc`: as before
* `nanoc-live`: containing all files related to the `nanoc live` command

The `nanoc` gem will no longer contain files related to the `nanoc live` command. This is backwards-compatible, as there is no (non-experimental) `live` command in a released version of Nanoc yet.

This attempt (hopefully) paves the way to splitting out more parts of Nanoc.

## Advantages

Advantages over using a monolithic gem:

* The dependencies are specified explicitly. Adding the `nanoc-live` gem to a Gemfile pulls in all dependencies (`listen`, `notiffany`, …).

Advantages over splitting up into separate repositories:

* Everything is tested together. This eliminates the possibility of a change in a one gem causing another gem to break.

* All gems can share infrastructure, such as configuration files for RSpec, Travis CI, and Rubocop, as well as common code, such as custom RSpec matchers. 

* It is still possible to generate a single monolithic gem if needed. This would need a change in the `nanoc.gemspec` to not filter out plugin files, which is what currently happens.

## Open questions

*  **How will this affect Debian packaging?**

    One concern around splitting up Nanoc’s single gem into multiple gems was that it would make packaging for Debian (and potential other distros) harder, as getting multiple packages into a distro’s package repo is considerably harder than updating an existing package.

    With a little bit more work, it would still be possible to generate a package that contains everything. With this approach, the `nanoc` *gem* would not contain code related to `nanoc-live`, but the `nanoc` *package* would.

    @boutil Can you leave your thoughts on this approach?

*   **Is lock-step versioning the right approach?**

    * Do sub-gems need their own NEWS.md, or will only the main gem have a NEWS.md? How will GitHub release notes be handled when there are multiple NEWS.md files?

    * Do experimental new sub-gems still do lock-step versioning, or will they deviate from that approach while they’re experimental?

*   **How shall we select files to build the gem?**

    Currently, `fn.match?(%r{nanoc[/-]live})` is used to find all files to include in the `nanoc-live` gem. This means that the way the gem is built relies on a convention, which, even though it is pretty common in the Ruby world, might not be directly clear to others, e.g. new contributors/release managers.

*   **How can the tests be run independently from another?**

    It is not sufficient to run all tests at the same time. The specs for `nanoc` should be run independently from `nanoc-live`, and vice versa, to ensure that `nanoc-live` works by itself.

## To do

* [ ] update release script to support making multiple releases