### PR TITLE
Allow creation of Pattern from Symbol

### DIFF
--- a/lib/nanoc/base/entities/pattern.rb
+++ b/lib/nanoc/base/entities/pattern.rb
@@ -14,6 +14,8 @@ module Nanoc::Int
         Nanoc::Int::StringPattern.new(obj)
       when Regexp
         Nanoc::Int::RegexpPattern.new(obj)
+      when Symbol
+        Nanoc::Int::StringPattern.new(obj.to_s)
       else
         raise ArgumentError, "Do not know how to convert `#{obj.inspect}` into a Nanoc::Pattern"
       end

--- a/spec/nanoc/base/entities/pattern_spec.rb
+++ b/spec/nanoc/base/entities/pattern_spec.rb
@@ -21,6 +21,12 @@ describe Nanoc::Int::Pattern do
       expect(pattern.match?('/foo/xyz/bar.html')).to eql(false)
     end
 
+    it 'converts from symbol' do
+      pattern = described_class.from(:'/foo/x[ab]z/bar.*')
+      expect(pattern.match?('/foo/xaz/bar.html')).to eql(true)
+      expect(pattern.match?('/foo/xyz/bar.html')).to eql(false)
+    end
+
     it 'errors on other inputs' do
       expect { described_class.from(123) }.to raise_error(ArgumentError)
     end


### PR DESCRIPTION
A little addition to allow the creation of patterns from symbols, which allows you to write
```
@items[i]
```
where `i` is a `Symbol` instead of having to mess with `#to_s()` at the call site