### PR TITLE
Remove useless #if_have calls

### DIFF
--- a/test/filters/colorize_syntax/test_coderay.rb
+++ b/test/filters/colorize_syntax/test_coderay.rb
@@ -7,7 +7,7 @@ class Nanoc::Filters::ColorizeSyntax::CoderayTest < Nanoc::TestCase
   CODERAY_POST = '</div></div>'
 
   def test_coderay_simple
-    if_have 'coderay', 'nokogiri' do
+    if_have 'nokogiri' do
       # Create filter
       filter = ::Nanoc::Filters::ColorizeSyntax.new
 
@@ -22,7 +22,7 @@ class Nanoc::Filters::ColorizeSyntax::CoderayTest < Nanoc::TestCase
   end
 
   def test_coderay_with_comment
-    if_have 'coderay', 'nokogiri' do
+    if_have 'nokogiri' do
       # Create filter
       filter = ::Nanoc::Filters::ColorizeSyntax.new
 
@@ -38,7 +38,7 @@ class Nanoc::Filters::ColorizeSyntax::CoderayTest < Nanoc::TestCase
   end
 
   def test_coderay_with_comment_in_middle
-    if_have 'coderay', 'nokogiri' do
+    if_have 'nokogiri' do
       # Create filter
       filter = ::Nanoc::Filters::ColorizeSyntax.new
 
@@ -55,7 +55,7 @@ class Nanoc::Filters::ColorizeSyntax::CoderayTest < Nanoc::TestCase
   end
 
   def test_coderay_with_comment_and_class
-    if_have 'coderay', 'nokogiri' do
+    if_have 'nokogiri' do
       # Create filter
       filter = ::Nanoc::Filters::ColorizeSyntax.new
 
@@ -72,7 +72,7 @@ class Nanoc::Filters::ColorizeSyntax::CoderayTest < Nanoc::TestCase
   end
 
   def test_coderay_with_more_classes
-    if_have 'coderay', 'nokogiri' do
+    if_have 'nokogiri' do
       # Create filter
       filter = ::Nanoc::Filters::ColorizeSyntax.new
 
@@ -87,7 +87,7 @@ class Nanoc::Filters::ColorizeSyntax::CoderayTest < Nanoc::TestCase
   end
 
   def test_colorize_syntax_with_unknown_syntax
-    if_have 'coderay', 'nokogiri' do
+    if_have 'nokogiri' do
       # Create filter
       filter = ::Nanoc::Filters::ColorizeSyntax.new
 
@@ -99,7 +99,7 @@ class Nanoc::Filters::ColorizeSyntax::CoderayTest < Nanoc::TestCase
   end
 
   def test_colorize_syntax_with_xml
-    if_have 'coderay', 'nokogiri' do
+    if_have 'nokogiri' do
       # Create filter
       filter = ::Nanoc::Filters::ColorizeSyntax.new
 
@@ -114,7 +114,7 @@ class Nanoc::Filters::ColorizeSyntax::CoderayTest < Nanoc::TestCase
   end
 
   def test_colorize_syntax_with_xhtml
-    if_have 'coderay', 'nokogiri' do
+    if_have 'nokogiri' do
       # Create filter
       filter = ::Nanoc::Filters::ColorizeSyntax.new
 
@@ -129,7 +129,7 @@ class Nanoc::Filters::ColorizeSyntax::CoderayTest < Nanoc::TestCase
   end
 
   def test_colorize_syntax_with_non_language_shebang_line
-    if_have 'coderay', 'nokogiri' do
+    if_have 'nokogiri' do
       # Create filter
       filter = ::Nanoc::Filters::ColorizeSyntax.new
 
@@ -158,7 +158,7 @@ EOS
   end
 
   def test_colorize_syntax_with_non_language_shebang_line_and_language_line
-    if_have 'coderay', 'nokogiri' do
+    if_have 'nokogiri' do
       # Create filter
       filter = ::Nanoc::Filters::ColorizeSyntax.new
 
@@ -186,7 +186,7 @@ EOS
   end
 
   def test_not_outside_pre
-    if_have 'coderay', 'nokogiri' do
+    if_have 'nokogiri' do
       # Create filter
       filter = ::Nanoc::Filters::ColorizeSyntax.new
 
@@ -201,7 +201,7 @@ EOS
   end
 
   def test_outside_pre
-    if_have 'coderay', 'nokogiri' do
+    if_have 'nokogiri' do
       # Create filter
       filter = ::Nanoc::Filters::ColorizeSyntax.new
 
@@ -216,7 +216,7 @@ EOS
   end
 
   def test_strip
-    if_have 'coderay', 'nokogiri' do
+    if_have 'nokogiri' do
       # Create filter
       filter = ::Nanoc::Filters::ColorizeSyntax.new
 

--- a/test/filters/test_bluecloth.rb
+++ b/test/filters/test_bluecloth.rb
@@ -4,13 +4,11 @@ require 'helper'
 
 class Nanoc::Filters::BlueClothTest < Nanoc::TestCase
   def test_filter
-    if_have 'bluecloth' do
-      # Create filter
-      filter = ::Nanoc::Filters::BlueCloth.new
+    # Create filter
+    filter = ::Nanoc::Filters::BlueCloth.new
 
-      # Run filter
-      result = filter.setup_and_run('> Quote')
-      assert_match %r{<blockquote>\s*<p>Quote</p>\s*</blockquote>}, result
-    end
+    # Run filter
+    result = filter.setup_and_run('> Quote')
+    assert_match %r{<blockquote>\s*<p>Quote</p>\s*</blockquote>}, result
   end
 end

--- a/test/filters/test_erubi.rb
+++ b/test/filters/test_erubi.rb
@@ -4,72 +4,60 @@ require 'helper'
 
 class Nanoc::Filters::ErubiTest < Nanoc::TestCase
   def test_filter_with_instance_variable
-    if_have 'erubi' do
-      # Create filter
-      filter = ::Nanoc::Filters::Erubi.new(location: 'a cheap motel')
+    # Create filter
+    filter = ::Nanoc::Filters::Erubi.new(location: 'a cheap motel')
 
-      # Run filter
-      result = filter.setup_and_run('<%= "I was hiding in #{@location}." %>') # rubocop:disable Lint/InterpolationCheck
-      assert_equal('I was hiding in a cheap motel.', result)
-    end
+    # Run filter
+    result = filter.setup_and_run('<%= "I was hiding in #{@location}." %>') # rubocop:disable Lint/InterpolationCheck
+    assert_equal('I was hiding in a cheap motel.', result)
   end
 
   def test_filter_with_instance_method
-    if_have 'erubi' do
-      # Create filter
-      filter = ::Nanoc::Filters::Erubi.new(location: 'a cheap motel')
+    # Create filter
+    filter = ::Nanoc::Filters::Erubi.new(location: 'a cheap motel')
 
-      # Run filter
-      result = filter.setup_and_run('<%= "I was hiding in #{location}." %>') # rubocop:disable Lint/InterpolationCheck
-      assert_equal('I was hiding in a cheap motel.', result)
-    end
+    # Run filter
+    result = filter.setup_and_run('<%= "I was hiding in #{location}." %>') # rubocop:disable Lint/InterpolationCheck
+    assert_equal('I was hiding in a cheap motel.', result)
   end
 
   def test_filter_error
-    if_have 'erubi' do
-      # Create filter
-      filter = ::Nanoc::Filters::Erubi.new
+    # Create filter
+    filter = ::Nanoc::Filters::Erubi.new
 
-      # Run filter
-      raised = false
-      begin
-        filter.setup_and_run('<%= this isn\'t really ruby so it\'ll break, muahaha %>')
-      rescue SyntaxError => e
-        assert_match 'syntax error', e.message
-        raised = true
-      end
-      assert raised
+    # Run filter
+    raised = false
+    begin
+      filter.setup_and_run('<%= this isn\'t really ruby so it\'ll break, muahaha %>')
+    rescue SyntaxError => e
+      assert_match 'syntax error', e.message
+      raised = true
     end
+    assert raised
   end
 
   def test_filter_with_yield
-    if_have 'erubi' do
-      # Create filter
-      filter = ::Nanoc::Filters::Erubi.new(content: 'a cheap motel')
+    # Create filter
+    filter = ::Nanoc::Filters::Erubi.new(content: 'a cheap motel')
 
-      # Run filter
-      result = filter.setup_and_run('<%= "I was hiding in #{yield}." %>') # rubocop:disable Lint/InterpolationCheck
-      assert_equal('I was hiding in a cheap motel.', result)
-    end
+    # Run filter
+    result = filter.setup_and_run('<%= "I was hiding in #{yield}." %>') # rubocop:disable Lint/InterpolationCheck
+    assert_equal('I was hiding in a cheap motel.', result)
   end
 
   def test_filter_with_yield_without_content
-    if_have 'erubi' do
-      # Create filter
-      filter = ::Nanoc::Filters::Erubi.new(location: 'a cheap motel')
+    # Create filter
+    filter = ::Nanoc::Filters::Erubi.new(location: 'a cheap motel')
 
-      # Run filter
-      assert_raises LocalJumpError do
-        filter.setup_and_run('<%= "I was hiding in #{yield}." %>') # rubocop:disable Lint/InterpolationCheck
-      end
+    # Run filter
+    assert_raises LocalJumpError do
+      filter.setup_and_run('<%= "I was hiding in #{yield}." %>') # rubocop:disable Lint/InterpolationCheck
     end
   end
 
   def test_filter_with_erbout
-    if_have 'erubi' do
-      filter = ::Nanoc::Filters::Erubi.new
-      result = filter.setup_and_run('stuff<% _erbout << _erbout %>')
-      assert_equal 'stuffstuff', result
-    end
+    filter = ::Nanoc::Filters::Erubi.new
+    result = filter.setup_and_run('stuff<% _erbout << _erbout %>')
+    assert_equal 'stuffstuff', result
   end
 end

--- a/test/filters/test_erubis.rb
+++ b/test/filters/test_erubis.rb
@@ -4,73 +4,61 @@ require 'helper'
 
 class Nanoc::Filters::ErubisTest < Nanoc::TestCase
   def test_filter_with_instance_variable
-    if_have 'erubis' do
-      # Create filter
-      filter = ::Nanoc::Filters::Erubis.new(location: 'a cheap motel')
+    # Create filter
+    filter = ::Nanoc::Filters::Erubis.new(location: 'a cheap motel')
 
-      # Run filter
-      result = filter.setup_and_run('<%= "I was hiding in #{@location}." %>') # rubocop:disable Lint/InterpolationCheck
-      assert_equal('I was hiding in a cheap motel.', result)
-    end
+    # Run filter
+    result = filter.setup_and_run('<%= "I was hiding in #{@location}." %>') # rubocop:disable Lint/InterpolationCheck
+    assert_equal('I was hiding in a cheap motel.', result)
   end
 
   def test_filter_with_instance_method
-    if_have 'erubis' do
-      # Create filter
-      filter = ::Nanoc::Filters::Erubis.new(location: 'a cheap motel')
+    # Create filter
+    filter = ::Nanoc::Filters::Erubis.new(location: 'a cheap motel')
 
-      # Run filter
-      result = filter.setup_and_run('<%= "I was hiding in #{location}." %>') # rubocop:disable Lint/InterpolationCheck
-      assert_equal('I was hiding in a cheap motel.', result)
-    end
+    # Run filter
+    result = filter.setup_and_run('<%= "I was hiding in #{location}." %>') # rubocop:disable Lint/InterpolationCheck
+    assert_equal('I was hiding in a cheap motel.', result)
   end
 
   def test_filter_error
-    if_have 'erubis' do
-      # Create filter
-      filter = ::Nanoc::Filters::Erubis.new
+    # Create filter
+    filter = ::Nanoc::Filters::Erubis.new
 
-      # Run filter
-      raised = false
-      begin
-        filter.setup_and_run('<%= this isn\'t really ruby so it\'ll break, muahaha %>')
-      rescue SyntaxError => e
-        e.message =~ /(.+?):\d+: /
-        assert_match '?', Regexp.last_match[1]
-        raised = true
-      end
-      assert raised
+    # Run filter
+    raised = false
+    begin
+      filter.setup_and_run('<%= this isn\'t really ruby so it\'ll break, muahaha %>')
+    rescue SyntaxError => e
+      e.message =~ /(.+?):\d+: /
+      assert_match '?', Regexp.last_match[1]
+      raised = true
     end
+    assert raised
   end
 
   def test_filter_with_yield
-    if_have 'erubis' do
-      # Create filter
-      filter = ::Nanoc::Filters::Erubis.new(content: 'a cheap motel')
+    # Create filter
+    filter = ::Nanoc::Filters::Erubis.new(content: 'a cheap motel')
 
-      # Run filter
-      result = filter.setup_and_run('<%= "I was hiding in #{yield}." %>') # rubocop:disable Lint/InterpolationCheck
-      assert_equal('I was hiding in a cheap motel.', result)
-    end
+    # Run filter
+    result = filter.setup_and_run('<%= "I was hiding in #{yield}." %>') # rubocop:disable Lint/InterpolationCheck
+    assert_equal('I was hiding in a cheap motel.', result)
   end
 
   def test_filter_with_yield_without_content
-    if_have 'erubis' do
-      # Create filter
-      filter = ::Nanoc::Filters::Erubis.new(location: 'a cheap motel')
+    # Create filter
+    filter = ::Nanoc::Filters::Erubis.new(location: 'a cheap motel')
 
-      # Run filter
-      assert_raises LocalJumpError do
-        filter.setup_and_run('<%= "I was hiding in #{yield}." %>') # rubocop:disable Lint/InterpolationCheck
-      end
+    # Run filter
+    assert_raises LocalJumpError do
+      filter.setup_and_run('<%= "I was hiding in #{yield}." %>') # rubocop:disable Lint/InterpolationCheck
     end
   end
 
   def test_filter_with_erbout
-    if_have 'erubis' do
-      filter = ::Nanoc::Filters::Erubis.new
-      result = filter.setup_and_run('stuff<% _erbout << _erbout %>')
-      assert_equal 'stuffstuff', result
-    end
+    filter = ::Nanoc::Filters::Erubis.new
+    result = filter.setup_and_run('stuff<% _erbout << _erbout %>')
+    assert_equal 'stuffstuff', result
   end
 end

--- a/test/filters/test_haml.rb
+++ b/test/filters/test_haml.rb
@@ -4,91 +4,79 @@ require 'helper'
 
 class Nanoc::Filters::HamlTest < Nanoc::TestCase
   def test_filter
-    if_have 'haml' do
-      # Create filter
-      filter = ::Nanoc::Filters::Haml.new(question: 'Is this the Payne residence?')
+    # Create filter
+    filter = ::Nanoc::Filters::Haml.new(question: 'Is this the Payne residence?')
 
-      # Run filter (no assigns)
-      result = filter.setup_and_run('%html')
-      assert_match(/<html>.*<\/html>/, result)
+    # Run filter (no assigns)
+    result = filter.setup_and_run('%html')
+    assert_match(/<html>.*<\/html>/, result)
 
-      # Run filter (assigns without @)
-      result = filter.setup_and_run('%p= question')
-      assert_equal("<p>Is this the Payne residence?</p>\n", result)
+    # Run filter (assigns without @)
+    result = filter.setup_and_run('%p= question')
+    assert_equal("<p>Is this the Payne residence?</p>\n", result)
 
-      # Run filter (assigns with @)
-      result = filter.setup_and_run('%p= @question')
-      assert_equal("<p>Is this the Payne residence?</p>\n", result)
-    end
+    # Run filter (assigns with @)
+    result = filter.setup_and_run('%p= @question')
+    assert_equal("<p>Is this the Payne residence?</p>\n", result)
   end
 
   def test_filter_with_params
-    if_have 'haml' do
-      # Create filter
-      filter = ::Nanoc::Filters::Haml.new(foo: 'bar')
+    # Create filter
+    filter = ::Nanoc::Filters::Haml.new(foo: 'bar')
 
-      # Check with HTML5
-      result = filter.setup_and_run('%img', format: :html5)
-      assert_match(/<img>/, result)
+    # Check with HTML5
+    result = filter.setup_and_run('%img', format: :html5)
+    assert_match(/<img>/, result)
 
-      # Check with XHTML
-      result = filter.setup_and_run('%img', format: :xhtml)
-      assert_match(/<img\s*\/>/, result)
-    end
+    # Check with XHTML
+    result = filter.setup_and_run('%img', format: :xhtml)
+    assert_match(/<img\s*\/>/, result)
   end
 
   def test_filter_error
-    if_have 'haml' do
-      # Create filter
-      filter = ::Nanoc::Filters::Haml.new(foo: 'bar')
+    # Create filter
+    filter = ::Nanoc::Filters::Haml.new(foo: 'bar')
 
-      # Run filter
-      raised = false
-      begin
-        filter.setup_and_run('%p= this isn\'t really ruby so it\'ll break, muahaha')
-      rescue SyntaxError, Haml::SyntaxError => e
-        e.message =~ /(.+?):\d+: /
-        assert_match '?', Regexp.last_match[1]
-        raised = true
-      end
-      assert raised
+    # Run filter
+    raised = false
+    begin
+      filter.setup_and_run('%p= this isn\'t really ruby so it\'ll break, muahaha')
+    rescue SyntaxError, Haml::SyntaxError => e
+      e.message =~ /(.+?):\d+: /
+      assert_match '?', Regexp.last_match[1]
+      raised = true
     end
+    assert raised
   end
 
   def test_filter_with_yield
-    if_have 'haml' do
-      # Create filter
-      filter = ::Nanoc::Filters::Haml.new(content: 'Is this the Payne residence?')
+    # Create filter
+    filter = ::Nanoc::Filters::Haml.new(content: 'Is this the Payne residence?')
 
-      # Run filter
-      result = filter.setup_and_run('%p= yield')
-      assert_equal("<p>Is this the Payne residence?</p>\n", result)
-    end
+    # Run filter
+    result = filter.setup_and_run('%p= yield')
+    assert_equal("<p>Is this the Payne residence?</p>\n", result)
   end
 
   def test_filter_with_yield_without_content
-    if_have 'haml' do
-      # Create filter
-      filter = ::Nanoc::Filters::Haml.new(location: 'Is this the Payne residence?')
+    # Create filter
+    filter = ::Nanoc::Filters::Haml.new(location: 'Is this the Payne residence?')
 
-      # Run filter
-      assert_raises LocalJumpError do
-        filter.setup_and_run('%p= yield')
-      end
+    # Run filter
+    assert_raises LocalJumpError do
+      filter.setup_and_run('%p= yield')
     end
   end
 
   def test_filter_with_proper_indentation
-    if_have 'haml' do
-      # Create file to include
-      File.open('stuff', 'w') do |io|
-        io.write("<pre>Max Payne\nMona Sax</pre>")
-      end
-
-      # Run filter
-      filter = ::Nanoc::Filters::Haml.new
-      result = filter.setup_and_run("%body\n  ~ File.read('stuff')")
-      assert_match(/Max Payne&#x000A;Mona Sax/, result)
+    # Create file to include
+    File.open('stuff', 'w') do |io|
+      io.write("<pre>Max Payne\nMona Sax</pre>")
     end
+
+    # Run filter
+    filter = ::Nanoc::Filters::Haml.new
+    result = filter.setup_and_run("%body\n  ~ File.read('stuff')")
+    assert_match(/Max Payne&#x000A;Mona Sax/, result)
   end
 end

--- a/test/filters/test_kramdown.rb
+++ b/test/filters/test_kramdown.rb
@@ -4,53 +4,47 @@ require 'helper'
 
 class Nanoc::Filters::KramdownTest < Nanoc::TestCase
   def test_filter
-    if_have 'kramdown' do
-      # Create filter
-      filter = ::Nanoc::Filters::Kramdown.new
+    # Create filter
+    filter = ::Nanoc::Filters::Kramdown.new
 
-      # Run filter
-      result = filter.setup_and_run('This is _so_ **cool**!')
-      assert_equal("<p>This is <em>so</em> <strong>cool</strong>!</p>\n", result)
-    end
+    # Run filter
+    result = filter.setup_and_run('This is _so_ **cool**!')
+    assert_equal("<p>This is <em>so</em> <strong>cool</strong>!</p>\n", result)
   end
 
   def test_warnings
-    if_have 'kramdown' do
-      # Create item
-      item = Nanoc::Int::Item.new('foo', {}, '/foo.md')
-      item_view = Nanoc::CompilationItemView.new(item, nil)
-      item_rep = Nanoc::Int::ItemRep.new(item, :default)
-      item_rep_view = Nanoc::CompilationItemRepView.new(item_rep, nil)
+    # Create item
+    item = Nanoc::Int::Item.new('foo', {}, '/foo.md')
+    item_view = Nanoc::CompilationItemView.new(item, nil)
+    item_rep = Nanoc::Int::ItemRep.new(item, :default)
+    item_rep_view = Nanoc::CompilationItemRepView.new(item_rep, nil)
 
-      # Create filter
-      filter = ::Nanoc::Filters::Kramdown.new(item: item_view, item_rep: item_rep_view)
+    # Create filter
+    filter = ::Nanoc::Filters::Kramdown.new(item: item_view, item_rep: item_rep_view)
 
-      # Run filter
-      io = capturing_stdio do
-        filter.setup_and_run('{:foo}this is bogus')
-      end
-      assert_empty io[:stdout]
-      assert_equal "kramdown warning(s) for #{item_rep_view.inspect}\n  Found span IAL after text - ignoring it\n", io[:stderr]
+    # Run filter
+    io = capturing_stdio do
+      filter.setup_and_run('{:foo}this is bogus')
     end
+    assert_empty io[:stdout]
+    assert_equal "kramdown warning(s) for #{item_rep_view.inspect}\n  Found span IAL after text - ignoring it\n", io[:stderr]
   end
 
   def test_warning_filters
-    if_have 'kramdown' do
-      # Create item
-      item = Nanoc::Int::Item.new('foo', {}, '/foo.md')
-      item_view = Nanoc::CompilationItemView.new(item, nil)
-      item_rep = Nanoc::Int::ItemRep.new(item, :default)
-      item_rep_view = Nanoc::CompilationItemRepView.new(item_rep, nil)
+    # Create item
+    item = Nanoc::Int::Item.new('foo', {}, '/foo.md')
+    item_view = Nanoc::CompilationItemView.new(item, nil)
+    item_rep = Nanoc::Int::ItemRep.new(item, :default)
+    item_rep_view = Nanoc::CompilationItemRepView.new(item_rep, nil)
 
-      # Create filter
-      filter = ::Nanoc::Filters::Kramdown.new(item: item_view, item_rep: item_rep_view)
+    # Create filter
+    filter = ::Nanoc::Filters::Kramdown.new(item: item_view, item_rep: item_rep_view)
 
-      # Run filter
-      io = capturing_stdio do
-        filter.setup_and_run("{:foo}this is bogus\n[foo]: http://foo.com\n", warning_filters: 'No link definition')
-      end
-      assert_empty io[:stdout]
-      assert_equal "kramdown warning(s) for #{item_rep_view.inspect}\n  Found span IAL after text - ignoring it\n", io[:stderr]
+    # Run filter
+    io = capturing_stdio do
+      filter.setup_and_run("{:foo}this is bogus\n[foo]: http://foo.com\n", warning_filters: 'No link definition')
     end
+    assert_empty io[:stdout]
+    assert_equal "kramdown warning(s) for #{item_rep_view.inspect}\n  Found span IAL after text - ignoring it\n", io[:stderr]
   end
 end

--- a/test/filters/test_markaby.rb
+++ b/test/filters/test_markaby.rb
@@ -4,13 +4,11 @@ require 'helper'
 
 class Nanoc::Filters::MarkabyTest < Nanoc::TestCase
   def test_filter
-    if_have 'markaby' do
-      # Create filter
-      filter = ::Nanoc::Filters::Markaby.new
+    # Create filter
+    filter = ::Nanoc::Filters::Markaby.new
 
-      # Run filter
-      result = filter.setup_and_run("html do\nend")
-      assert_equal('<html></html>', result)
-    end
+    # Run filter
+    result = filter.setup_and_run("html do\nend")
+    assert_equal('<html></html>', result)
   end
 end

--- a/test/filters/test_maruku.rb
+++ b/test/filters/test_maruku.rb
@@ -4,13 +4,11 @@ require 'helper'
 
 class Nanoc::Filters::MarukuTest < Nanoc::TestCase
   def test_filter
-    if_have 'maruku' do
-      # Create filter
-      filter = ::Nanoc::Filters::Maruku.new
+    # Create filter
+    filter = ::Nanoc::Filters::Maruku.new
 
-      # Run filter
-      result = filter.setup_and_run('This is _so_ *cool*!')
-      assert_equal('<p>This is <em>so</em> <em>cool</em>!</p>', result.strip)
-    end
+    # Run filter
+    result = filter.setup_and_run('This is _so_ *cool*!')
+    assert_equal('<p>This is <em>so</em> <em>cool</em>!</p>', result.strip)
   end
 end

--- a/test/filters/test_mustache.rb
+++ b/test/filters/test_mustache.rb
@@ -4,40 +4,36 @@ require 'helper'
 
 class Nanoc::Filters::MustacheTest < Nanoc::TestCase
   def test_filter
-    if_have 'mustache' do
-      # Create item
-      item = Nanoc::Int::Item.new(
-        'content',
-        { title: 'Max Payne', protagonist: 'Max Payne' },
-        '/games/max-payne',
-      )
+    # Create item
+    item = Nanoc::Int::Item.new(
+      'content',
+      { title: 'Max Payne', protagonist: 'Max Payne' },
+      '/games/max-payne',
+    )
 
-      # Create filter
-      filter = ::Nanoc::Filters::Mustache.new(item: item)
+    # Create filter
+    filter = ::Nanoc::Filters::Mustache.new(item: item)
 
-      # Run filter
-      result = filter.setup_and_run('The protagonist of {{title}} is {{protagonist}}.')
-      assert_equal('The protagonist of Max Payne is Max Payne.', result)
-    end
+    # Run filter
+    result = filter.setup_and_run('The protagonist of {{title}} is {{protagonist}}.')
+    assert_equal('The protagonist of Max Payne is Max Payne.', result)
   end
 
   def test_filter_with_yield
-    if_have 'mustache' do
-      # Create item
-      item = Nanoc::Int::Item.new(
-        'content',
-        { title: 'Max Payne', protagonist: 'Max Payne' },
-        '/games/max-payne',
-      )
+    # Create item
+    item = Nanoc::Int::Item.new(
+      'content',
+      { title: 'Max Payne', protagonist: 'Max Payne' },
+      '/games/max-payne',
+    )
 
-      # Create filter
-      filter = ::Nanoc::Filters::Mustache.new(
-        content: 'No Payne No Gayne', item: item,
-      )
+    # Create filter
+    filter = ::Nanoc::Filters::Mustache.new(
+      content: 'No Payne No Gayne', item: item,
+    )
 
-      # Run filter
-      result = filter.setup_and_run('Max says: {{yield}}.')
-      assert_equal('Max says: No Payne No Gayne.', result)
-    end
+    # Run filter
+    result = filter.setup_and_run('Max says: {{yield}}.')
+    assert_equal('Max says: No Payne No Gayne.', result)
   end
 end

--- a/test/filters/test_rainpress.rb
+++ b/test/filters/test_rainpress.rb
@@ -4,24 +4,20 @@ require 'helper'
 
 class Nanoc::Filters::RainpressTest < Nanoc::TestCase
   def test_filter
-    if_have 'rainpress' do
-      # Create filter
-      filter = ::Nanoc::Filters::Rainpress.new
+    # Create filter
+    filter = ::Nanoc::Filters::Rainpress.new
 
-      # Run filter
-      result = filter.setup_and_run('body { color: black; }')
-      assert_equal('body{color:#000}', result)
-    end
+    # Run filter
+    result = filter.setup_and_run('body { color: black; }')
+    assert_equal('body{color:#000}', result)
   end
 
   def test_filter_with_options
-    if_have 'rainpress' do
-      # Create filter
-      filter = ::Nanoc::Filters::Rainpress.new
+    # Create filter
+    filter = ::Nanoc::Filters::Rainpress.new
 
-      # Run filter
-      result = filter.setup_and_run('body { color: #aabbcc; }', colors: false)
-      assert_equal('body{color:#aabbcc}', result)
-    end
+    # Run filter
+    result = filter.setup_and_run('body { color: #aabbcc; }', colors: false)
+    assert_equal('body{color:#aabbcc}', result)
   end
 end

--- a/test/filters/test_redcarpet.rb
+++ b/test/filters/test_redcarpet.rb
@@ -2,110 +2,99 @@
 
 require 'helper'
 
+# TODO: Remove this once Redcarpet 1.x support is dropped
+require 'redcarpet'
+
 class Nanoc::Filters::RedcarpetTest < Nanoc::TestCase
   def test_find
-    if_have 'redcarpet' do
-      refute Nanoc::Filter.named(:redcarpet).nil?
-    end
+    refute Nanoc::Filter.named(:redcarpet).nil?
   end
 
   def test_filter
-    if_have 'redcarpet' do
-      # Create filter
-      filter = ::Nanoc::Filters::Redcarpet.new
+    # Create filter
+    filter = ::Nanoc::Filters::Redcarpet.new
 
-      # Run filter
-      result = filter.setup_and_run('> Quote')
-      assert_match(/<blockquote>\s*<p>Quote<\/p>\s*<\/blockquote>/, result)
-    end
+    # Run filter
+    result = filter.setup_and_run('> Quote')
+    assert_match(/<blockquote>\s*<p>Quote<\/p>\s*<\/blockquote>/, result)
   end
 
   def test_with_extensions
-    if_have 'redcarpet' do
-      # Create filter
-      filter = ::Nanoc::Filters::Redcarpet.new
+    # Create filter
+    filter = ::Nanoc::Filters::Redcarpet.new
 
-      # Run filter
-      if ::Redcarpet::VERSION > '2'
-        input           = 'this is ~~good~~ bad'
-        output_expected = /this is <del>good<\/del> bad/
-        output_actual   = filter.setup_and_run(input, options: { strikethrough: true })
-      else
-        input           = "The quotation 'marks' sure make this look sarcastic!"
-        output_expected = /The quotation &lsquo;marks&rsquo; sure make this look sarcastic!/
-        output_actual   = filter.setup_and_run(input, options: [:smart])
-      end
-      assert_match(output_expected, output_actual)
+    # Run filter
+    if ::Redcarpet::VERSION > '2'
+      input           = 'this is ~~good~~ bad'
+      output_expected = /this is <del>good<\/del> bad/
+      output_actual   = filter.setup_and_run(input, options: { strikethrough: true })
+    else
+      input           = "The quotation 'marks' sure make this look sarcastic!"
+      output_expected = /The quotation &lsquo;marks&rsquo; sure make this look sarcastic!/
+      output_actual   = filter.setup_and_run(input, options: [:smart])
     end
+    assert_match(output_expected, output_actual)
   end
 
   def test_html_by_default
-    if_have 'redcarpet' do
-      # Create filter
-      filter = ::Nanoc::Filters::Redcarpet.new
+    # Create filter
+    filter = ::Nanoc::Filters::Redcarpet.new
 
-      # Run filter
-      input           = "![Alt](/path/to/img 'Title')"
-      output_expected = %r{<img src="/path/to/img" alt="Alt" title="Title">}
-      output_actual   = filter.setup_and_run(input)
-      assert_match(output_expected, output_actual)
-    end
+    # Run filter
+    input           = "![Alt](/path/to/img 'Title')"
+    output_expected = %r{<img src="/path/to/img" alt="Alt" title="Title">}
+    output_actual   = filter.setup_and_run(input)
+    assert_match(output_expected, output_actual)
   end
 
   def test_xhtml_if_requested
-    if_have 'redcarpet' do
-      # Create filter
-      filter = ::Nanoc::Filters::Redcarpet.new
+    # Create filter
+    filter = ::Nanoc::Filters::Redcarpet.new
 
-      # Run filter
-      input           = "![Alt](/path/to/img 'Title')"
-      output_expected = %r{<img src="/path/to/img" alt="Alt" title="Title"/>}
-      output_actual =
-        if ::Redcarpet::VERSION > '2'
-          filter.setup_and_run(input, renderer_options: { xhtml: true })
-        else
-          filter.setup_and_run(input, options: [:xhtml])
-        end
-      assert_match(output_expected, output_actual)
-    end
+    # Run filter
+    input           = "![Alt](/path/to/img 'Title')"
+    output_expected = %r{<img src="/path/to/img" alt="Alt" title="Title"/>}
+    output_actual =
+      if ::Redcarpet::VERSION > '2'
+        filter.setup_and_run(input, renderer_options: { xhtml: true })
+      else
+        filter.setup_and_run(input, options: [:xhtml])
+      end
+    assert_match(output_expected, output_actual)
   end
 
   def test_html_toc
-    if_have 'redcarpet' do
-      unless ::Redcarpet::VERSION > '2'
-        skip 'Requires Redcarpet >= 2'
-      end
-
-      # Create filter
-      filter = ::Nanoc::Filters::Redcarpet.new
-
-      # Run filter
-      input = "# Heading 1\n## Heading 2\n"
-      output_actual = filter.run(input, renderer: Redcarpet::Render::HTML_TOC)
-
-      # Test
-      output_expected = %r{<ul>\n<li>\n<a href=\"#heading-1\">Heading 1</a>\n<ul>\n<li>\n<a href=\"#heading-2\">Heading 2</a>\n</li>\n</ul>\n</li>\n</ul>}
-      assert_match(output_expected, output_actual)
+    unless ::Redcarpet::VERSION > '2'
+      skip 'Requires Redcarpet >= 2'
     end
+
+    # Create filter
+    filter = ::Nanoc::Filters::Redcarpet.new
+
+    # Run filter
+    input = "# Heading 1\n## Heading 2\n"
+    output_actual = filter.run(input, renderer: Redcarpet::Render::HTML_TOC)
+
+    # Test
+    output_expected = %r{<ul>\n<li>\n<a href=\"#heading-1\">Heading 1</a>\n<ul>\n<li>\n<a href=\"#heading-2\">Heading 2</a>\n</li>\n</ul>\n</li>\n</ul>}
+    assert_match(output_expected, output_actual)
   end
 
   def test_toc_if_requested
-    if_have 'redcarpet' do
-      # Create filter
-      filter = ::Nanoc::Filters::Redcarpet.new
+    # Create filter
+    filter = ::Nanoc::Filters::Redcarpet.new
 
-      # Run filter
-      input = "A Title\n======"
-      if ::Redcarpet::VERSION > '2'
-        output_expected = %r{<ul>\n<li>\n<a href="#a-title">A Title</a>\n</li>\n</ul>\n<h1 id="a-title">A Title</h1>\n}
-        output_actual   = filter.setup_and_run(input, with_toc: true)
-      else
-        output_expected = %r{<h1>A Title</h1>\n}
-        output_actual   = filter.setup_and_run(input)
-      end
-
-      # Test
-      assert_match(output_expected, output_actual)
+    # Run filter
+    input = "A Title\n======"
+    if ::Redcarpet::VERSION > '2'
+      output_expected = %r{<ul>\n<li>\n<a href="#a-title">A Title</a>\n</li>\n</ul>\n<h1 id="a-title">A Title</h1>\n}
+      output_actual   = filter.setup_and_run(input, with_toc: true)
+    else
+      output_expected = %r{<h1>A Title</h1>\n}
+      output_actual   = filter.setup_and_run(input)
     end
+
+    # Test
+    assert_match(output_expected, output_actual)
   end
 end

--- a/test/filters/test_redcloth.rb
+++ b/test/filters/test_redcloth.rb
@@ -4,28 +4,24 @@ require 'helper'
 
 class Nanoc::Filters::RedClothTest < Nanoc::TestCase
   def test_filter
-    if_have 'redcloth' do
-      # Get filter
-      filter = ::Nanoc::Filters::RedCloth.new
+    # Get filter
+    filter = ::Nanoc::Filters::RedCloth.new
 
-      # Run filter
-      result = filter.setup_and_run('h1. Foo')
-      assert_equal('<h1>Foo</h1>', result)
-    end
+    # Run filter
+    result = filter.setup_and_run('h1. Foo')
+    assert_equal('<h1>Foo</h1>', result)
   end
 
   def test_filter_with_options
-    if_have 'redcloth' do
-      # Get filter
-      filter = ::Nanoc::Filters::RedCloth.new
+    # Get filter
+    filter = ::Nanoc::Filters::RedCloth.new
 
-      # Run filter without options
-      result = filter.setup_and_run('I am a member of SPECTRE.')
-      assert_equal('<p>I am a member of <span class="caps">SPECTRE</span>.</p>', result)
+    # Run filter without options
+    result = filter.setup_and_run('I am a member of SPECTRE.')
+    assert_equal('<p>I am a member of <span class="caps">SPECTRE</span>.</p>', result)
 
-      # Run filter with options
-      result = filter.setup_and_run('I am a member of SPECTRE.', no_span_caps: true)
-      assert_equal('<p>I am a member of SPECTRE.</p>', result)
-    end
+    # Run filter with options
+    result = filter.setup_and_run('I am a member of SPECTRE.', no_span_caps: true)
+    assert_equal('<p>I am a member of SPECTRE.</p>', result)
   end
 end

--- a/test/filters/test_rubypants.rb
+++ b/test/filters/test_rubypants.rb
@@ -4,13 +4,11 @@ require 'helper'
 
 class Nanoc::Filters::RubyPantsTest < Nanoc::TestCase
   def test_filter
-    if_have 'rubypants' do
-      # Get filter
-      filter = ::Nanoc::Filters::RubyPants.new
+    # Get filter
+    filter = ::Nanoc::Filters::RubyPants.new
 
-      # Run filter
-      result = filter.setup_and_run('Wait---what?')
-      assert_equal('Wait&#8212;what?', result)
-    end
+    # Run filter
+    result = filter.setup_and_run('Wait---what?')
+    assert_equal('Wait&#8212;what?', result)
   end
 end

--- a/test/filters/test_slim.rb
+++ b/test/filters/test_slim.rb
@@ -4,31 +4,27 @@ require 'helper'
 
 class Nanoc::Filters::SlimTest < Nanoc::TestCase
   def test_filter
-    if_have 'slim' do
-      # Create filter
-      filter = ::Nanoc::Filters::Slim.new(rabbit: 'The rabbit is on the branch.')
+    # Create filter
+    filter = ::Nanoc::Filters::Slim.new(rabbit: 'The rabbit is on the branch.')
 
-      # Run filter (no assigns)
-      result = filter.setup_and_run('html')
-      assert_match(/<html>.*<\/html>/, result)
+    # Run filter (no assigns)
+    result = filter.setup_and_run('html')
+    assert_match(/<html>.*<\/html>/, result)
 
-      # Run filter (assigns without @)
-      result = filter.setup_and_run('p = rabbit')
-      assert_equal('<p>The rabbit is on the branch.</p>', result)
+    # Run filter (assigns without @)
+    result = filter.setup_and_run('p = rabbit')
+    assert_equal('<p>The rabbit is on the branch.</p>', result)
 
-      # Run filter (assigns with @)
-      result = filter.setup_and_run('p = @rabbit')
-      assert_equal('<p>The rabbit is on the branch.</p>', result)
-    end
+    # Run filter (assigns with @)
+    result = filter.setup_and_run('p = @rabbit')
+    assert_equal('<p>The rabbit is on the branch.</p>', result)
   end
 
   def test_filter_with_yield
-    if_have 'slim' do
-      filter = ::Nanoc::Filters::Slim.new(content: 'The rabbit is on the branch.')
+    filter = ::Nanoc::Filters::Slim.new(content: 'The rabbit is on the branch.')
 
-      result = filter.setup_and_run('p = yield')
-      assert_equal('<p>The rabbit is on the branch.</p>', result)
-    end
+    result = filter.setup_and_run('p = yield')
+    assert_equal('<p>The rabbit is on the branch.</p>', result)
   end
 
   def new_view_context
@@ -44,16 +40,14 @@ class Nanoc::Filters::SlimTest < Nanoc::TestCase
   end
 
   def test_filter_slim_reports_filename
-    if_have 'slim' do
-      layout = Nanoc::Int::Layout.new('', {}, '/layout.slim')
-      layout = Nanoc::LayoutView.new(layout, new_view_context)
+    layout = Nanoc::Int::Layout.new('', {}, '/layout.slim')
+    layout = Nanoc::LayoutView.new(layout, new_view_context)
 
-      assigns = { layout: layout }
+    assigns = { layout: layout }
 
-      filter = ::Nanoc::Filters::Slim.new(assigns)
+    filter = ::Nanoc::Filters::Slim.new(assigns)
 
-      error = assert_raises(NameError) { filter.setup_and_run('deliberate=failure') }
-      assert_match(%r{^layout /layout.slim}, error.backtrace[1])
-    end
+    error = assert_raises(NameError) { filter.setup_and_run('deliberate=failure') }
+    assert_match(%r{^layout /layout.slim}, error.backtrace[1])
   end
 end

--- a/test/helpers/test_blogging.rb
+++ b/test/helpers/test_blogging.rb
@@ -47,638 +47,592 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
   end
 
   def test_atom_feed
-    if_have 'builder' do
-      # Create items
-      @items = [mock, mock_article, mock_article]
+    # Create items
+    @items = [mock, mock_article, mock_article]
 
-      # Create item 0
-      @items[0].stubs(:[]).with(:kind).returns('item')
+    # Create item 0
+    @items[0].stubs(:[]).with(:kind).returns('item')
 
-      # Create item 1
-      @items[1].stubs(:[]).with(:updated_at).returns(Date.today - 1)
-      @items[1].stubs(:[]).with(:kind).returns('article')
-      @items[1].stubs(:[]).with(:created_at).returns((Date.today - 2).to_s)
-      @items[1].stubs(:[]).with(:title).returns('Item One')
-      @items[1].stubs(:[]).with(:custom_path_in_feed).returns(nil)
-      @items[1].stubs(:[]).with(:custom_url_in_feed).returns(nil)
-      @items[1].stubs(:[]).with(:excerpt).returns(nil)
-      @items[1].stubs(:path).returns('/item1/')
-      @items[1].expects(:compiled_content).with(snapshot: :pre).returns('item 1 content')
+    # Create item 1
+    @items[1].stubs(:[]).with(:updated_at).returns(Date.today - 1)
+    @items[1].stubs(:[]).with(:kind).returns('article')
+    @items[1].stubs(:[]).with(:created_at).returns((Date.today - 2).to_s)
+    @items[1].stubs(:[]).with(:title).returns('Item One')
+    @items[1].stubs(:[]).with(:custom_path_in_feed).returns(nil)
+    @items[1].stubs(:[]).with(:custom_url_in_feed).returns(nil)
+    @items[1].stubs(:[]).with(:excerpt).returns(nil)
+    @items[1].stubs(:path).returns('/item1/')
+    @items[1].expects(:compiled_content).with(snapshot: :pre).returns('item 1 content')
 
-      # Create item 2
-      @items[2].expects(:compiled_content).with(snapshot: :pre).returns('item 2 content')
+    # Create item 2
+    @items[2].expects(:compiled_content).with(snapshot: :pre).returns('item 2 content')
 
-      # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
-      @config = Nanoc::ConfigView.new(config, @view_context)
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    @config = Nanoc::ConfigView.new(config, @view_context)
 
-      # Create feed item
-      @item = mock
-      @item.stubs(:[]).with(:title).returns('My Cool Blog')
-      @item.stubs(:[]).with(:author_name).returns('Denis Defreyne')
-      @item.stubs(:[]).with(:author_uri).returns('http://stoneship.org/')
-      @item.stubs(:[]).with(:feed_url).returns(nil)
-      @item.stubs(:path).returns('/journal/feed/')
+    # Create feed item
+    @item = mock
+    @item.stubs(:[]).with(:title).returns('My Cool Blog')
+    @item.stubs(:[]).with(:author_name).returns('Denis Defreyne')
+    @item.stubs(:[]).with(:author_uri).returns('http://stoneship.org/')
+    @item.stubs(:[]).with(:feed_url).returns(nil)
+    @item.stubs(:path).returns('/journal/feed/')
 
-      # Check
-      atom_feed
-    end
+    # Check
+    atom_feed
   end
 
   def test_atom_feed_with_times
-    if_have 'builder' do
-      # Create items
-      @items = [mock_item, mock_article, mock_article]
+    # Create items
+    @items = [mock_item, mock_article, mock_article]
 
-      # Create item 1
-      @items[1].stubs(:[]).with(:updated_at).returns(Time.now - 500)
-      @items[1].stubs(:[]).with(:created_at).returns(Time.now - 1000)
-      @items[1].expects(:compiled_content).returns('item 1 content')
+    # Create item 1
+    @items[1].stubs(:[]).with(:updated_at).returns(Time.now - 500)
+    @items[1].stubs(:[]).with(:created_at).returns(Time.now - 1000)
+    @items[1].expects(:compiled_content).returns('item 1 content')
 
-      # Create item 2
-      @items[2].stubs(:[]).with(:updated_at).returns(Time.now - 250)
-      @items[2].stubs(:[]).with(:created_at).returns(Time.now - 1200)
-      @items[2].expects(:compiled_content).returns('item 2 content')
+    # Create item 2
+    @items[2].stubs(:[]).with(:updated_at).returns(Time.now - 250)
+    @items[2].stubs(:[]).with(:created_at).returns(Time.now - 1200)
+    @items[2].expects(:compiled_content).returns('item 2 content')
 
-      # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
-      @config = Nanoc::ConfigView.new(config, @view_context)
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    @config = Nanoc::ConfigView.new(config, @view_context)
 
-      # Create feed item
-      @item = mock
-      @item.stubs(:[]).with(:title).returns('My Cool Blog')
-      @item.stubs(:[]).with(:author_name).returns('Denis Defreyne')
-      @item.stubs(:[]).with(:author_uri).returns('http://stoneship.org/')
-      @item.stubs(:[]).with(:feed_url).returns(nil)
-      @item.stubs(:path).returns('/journal/feed/')
+    # Create feed item
+    @item = mock
+    @item.stubs(:[]).with(:title).returns('My Cool Blog')
+    @item.stubs(:[]).with(:author_name).returns('Denis Defreyne')
+    @item.stubs(:[]).with(:author_uri).returns('http://stoneship.org/')
+    @item.stubs(:[]).with(:feed_url).returns(nil)
+    @item.stubs(:path).returns('/journal/feed/')
 
-      # Check
-      atom_feed
-    end
+    # Check
+    atom_feed
   end
 
   def test_atom_feed_updated_is_most_recent
-    if_have 'builder' do
-      # Create items
-      @items = [mock_item, mock_article, mock_article]
+    # Create items
+    @items = [mock_item, mock_article, mock_article]
 
-      # Create item 1
-      @items[1].stubs(:[]).with(:updated_at).returns(nil)
-      @items[1].stubs(:[]).with(:created_at).returns(Time.parse('2016-12-01 17:20:00 +00:00'))
-      @items[1].expects(:compiled_content).returns('item 1 content')
+    # Create item 1
+    @items[1].stubs(:[]).with(:updated_at).returns(nil)
+    @items[1].stubs(:[]).with(:created_at).returns(Time.parse('2016-12-01 17:20:00 +00:00'))
+    @items[1].expects(:compiled_content).returns('item 1 content')
 
-      # Create item 2
-      @items[2].stubs(:[]).with(:updated_at).returns(nil)
-      @items[2].stubs(:[]).with(:created_at).returns(Time.parse('2016-12-01 18:40:00 +00:00'))
-      @items[2].expects(:compiled_content).returns('item 2 content')
+    # Create item 2
+    @items[2].stubs(:[]).with(:updated_at).returns(nil)
+    @items[2].stubs(:[]).with(:created_at).returns(Time.parse('2016-12-01 18:40:00 +00:00'))
+    @items[2].expects(:compiled_content).returns('item 2 content')
 
-      # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
-      @config = Nanoc::ConfigView.new(config, @view_context)
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    @config = Nanoc::ConfigView.new(config, @view_context)
 
-      # Create feed item
-      @item = mock
-      @item.stubs(:[]).with(:title).returns('My Cool Blog')
-      @item.stubs(:[]).with(:author_name).returns('Denis Defreyne')
-      @item.stubs(:[]).with(:author_uri).returns('http://stoneship.org/')
-      @item.stubs(:[]).with(:feed_url).returns(nil)
-      @item.stubs(:path).returns('/journal/feed/')
+    # Create feed item
+    @item = mock
+    @item.stubs(:[]).with(:title).returns('My Cool Blog')
+    @item.stubs(:[]).with(:author_name).returns('Denis Defreyne')
+    @item.stubs(:[]).with(:author_uri).returns('http://stoneship.org/')
+    @item.stubs(:[]).with(:feed_url).returns(nil)
+    @item.stubs(:path).returns('/journal/feed/')
 
-      # Check
-      assert_match(%r{<title>My Cool Blog</title>\n  <updated>2016-12-01T18:40:00Z</updated>}, atom_feed)
-    end
+    # Check
+    assert_match(%r{<title>My Cool Blog</title>\n  <updated>2016-12-01T18:40:00Z</updated>}, atom_feed)
   end
 
   def test_atom_feed_updated_is_most_recent_updated_at
-    if_have 'builder' do
-      # Create items
-      @items = [mock_item, mock_article, mock_article]
+    # Create items
+    @items = [mock_item, mock_article, mock_article]
 
-      # Create item 1
-      @items[1].stubs(:[]).with(:updated_at).returns(Time.parse('2016-12-01 19:20:00 +00:00'))
-      @items[1].stubs(:[]).with(:created_at).returns(Time.parse('2016-12-01 17:20:00 +00:00'))
-      @items[1].expects(:compiled_content).returns('item 1 content')
+    # Create item 1
+    @items[1].stubs(:[]).with(:updated_at).returns(Time.parse('2016-12-01 19:20:00 +00:00'))
+    @items[1].stubs(:[]).with(:created_at).returns(Time.parse('2016-12-01 17:20:00 +00:00'))
+    @items[1].expects(:compiled_content).returns('item 1 content')
 
-      # Create item 2
-      @items[2].stubs(:[]).with(:updated_at).returns(Time.parse('2016-12-01 20:40:00 +00:00'))
-      @items[2].stubs(:[]).with(:created_at).returns(Time.parse('2016-12-01 18:40:00 +00:00'))
-      @items[2].expects(:compiled_content).returns('item 2 content')
+    # Create item 2
+    @items[2].stubs(:[]).with(:updated_at).returns(Time.parse('2016-12-01 20:40:00 +00:00'))
+    @items[2].stubs(:[]).with(:created_at).returns(Time.parse('2016-12-01 18:40:00 +00:00'))
+    @items[2].expects(:compiled_content).returns('item 2 content')
 
-      # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
-      @config = Nanoc::ConfigView.new(config, @view_context)
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    @config = Nanoc::ConfigView.new(config, @view_context)
 
-      # Create feed item
-      @item = mock
-      @item.stubs(:[]).with(:title).returns('My Cool Blog')
-      @item.stubs(:[]).with(:author_name).returns('Denis Defreyne')
-      @item.stubs(:[]).with(:author_uri).returns('http://stoneship.org/')
-      @item.stubs(:[]).with(:feed_url).returns(nil)
-      @item.stubs(:path).returns('/journal/feed/')
+    # Create feed item
+    @item = mock
+    @item.stubs(:[]).with(:title).returns('My Cool Blog')
+    @item.stubs(:[]).with(:author_name).returns('Denis Defreyne')
+    @item.stubs(:[]).with(:author_uri).returns('http://stoneship.org/')
+    @item.stubs(:[]).with(:feed_url).returns(nil)
+    @item.stubs(:path).returns('/journal/feed/')
 
-      # Check
-      assert_match(%r{<title>My Cool Blog</title>\n  <updated>2016-12-01T20:40:00Z</updated>}, atom_feed)
-    end
+    # Check
+    assert_match(%r{<title>My Cool Blog</title>\n  <updated>2016-12-01T20:40:00Z</updated>}, atom_feed)
   end
 
   def test_atom_feed_without_articles
-    if_have 'builder' do
-      # Mock items
-      @items = [mock_item, mock_item]
+    # Mock items
+    @items = [mock_item, mock_item]
 
-      # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
-      @config = Nanoc::ConfigView.new(config, @view_context)
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    @config = Nanoc::ConfigView.new(config, @view_context)
 
-      # Create feed item
-      @item = mock
-      @item.stubs(:[]).with(:title).returns('My Blog Or Something')
-      @item.stubs(:[]).with(:author_name).returns('J. Doe')
-      @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
+    # Create feed item
+    @item = mock
+    @item.stubs(:[]).with(:title).returns('My Blog Or Something')
+    @item.stubs(:[]).with(:author_name).returns('J. Doe')
+    @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
 
-      # Check
-      error = assert_raises(Nanoc::Int::Errors::GenericTrivial) do
-        atom_feed
-      end
-      assert_equal(
-        'Cannot build Atom feed: no articles',
-        error.message,
-      )
+    # Check
+    error = assert_raises(Nanoc::Int::Errors::GenericTrivial) do
+      atom_feed
     end
+    assert_equal(
+      'Cannot build Atom feed: no articles',
+      error.message,
+    )
   end
 
   def test_atom_feed_without_base_url
-    if_have 'builder' do
-      # Create items
-      @items = [mock_item, mock_article]
+    # Create items
+    @items = [mock_item, mock_article]
 
-      # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: nil })
-      @config = Nanoc::ConfigView.new(config, @view_context)
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: nil })
+    @config = Nanoc::ConfigView.new(config, @view_context)
 
-      # Create feed item
-      @item = mock
-      @item.stubs(:[]).with(:title).returns('My Blog Or Something')
-      @item.stubs(:[]).with(:author_name).returns('J. Doe')
-      @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
+    # Create feed item
+    @item = mock
+    @item.stubs(:[]).with(:title).returns('My Blog Or Something')
+    @item.stubs(:[]).with(:author_name).returns('J. Doe')
+    @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
 
-      # Check
-      error = assert_raises(Nanoc::Int::Errors::GenericTrivial) do
-        atom_feed
-      end
-      assert_equal(
-        'Cannot build Atom feed: site configuration has no base_url',
-        error.message,
-      )
+    # Check
+    error = assert_raises(Nanoc::Int::Errors::GenericTrivial) do
+      atom_feed
     end
+    assert_equal(
+      'Cannot build Atom feed: site configuration has no base_url',
+      error.message,
+    )
   end
 
   def test_atom_feed_without_title
-    if_have 'builder' do
-      # Create items
-      @items = [mock_item, mock_article]
+    # Create items
+    @items = [mock_item, mock_article]
 
-      # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
-      @config = Nanoc::ConfigView.new(config, @view_context)
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    @config = Nanoc::ConfigView.new(config, @view_context)
 
-      # Create feed item
-      @item = mock
-      @item.stubs(:[]).with(:title).returns(nil)
-      @item.stubs(:[]).with(:author_name).returns('J. Doe')
-      @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
+    # Create feed item
+    @item = mock
+    @item.stubs(:[]).with(:title).returns(nil)
+    @item.stubs(:[]).with(:author_name).returns('J. Doe')
+    @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
 
-      # Check
-      error = assert_raises(Nanoc::Int::Errors::GenericTrivial) do
-        atom_feed
-      end
-      assert_equal(
-        'Cannot build Atom feed: no title in params, item or site config',
-        error.message,
-      )
+    # Check
+    error = assert_raises(Nanoc::Int::Errors::GenericTrivial) do
+      atom_feed
     end
+    assert_equal(
+      'Cannot build Atom feed: no title in params, item or site config',
+      error.message,
+    )
   end
 
   def test_atom_feed_without_author_name
-    if_have 'builder' do
-      # Create items
-      @items = [mock_item, mock_article]
+    # Create items
+    @items = [mock_item, mock_article]
 
-      # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
-      @config = Nanoc::ConfigView.new(config, @view_context)
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    @config = Nanoc::ConfigView.new(config, @view_context)
 
-      # Create feed item
-      @item = mock
-      @item.stubs(:[]).with(:title).returns('My Blog Or Something')
-      @item.stubs(:[]).with(:author_name).returns(nil)
-      @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
+    # Create feed item
+    @item = mock
+    @item.stubs(:[]).with(:title).returns('My Blog Or Something')
+    @item.stubs(:[]).with(:author_name).returns(nil)
+    @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
 
-      # Check
-      error = assert_raises(Nanoc::Int::Errors::GenericTrivial) do
-        atom_feed
-      end
-      assert_equal(
-        'Cannot build Atom feed: no author_name in params, item or site config',
-        error.message,
-      )
+    # Check
+    error = assert_raises(Nanoc::Int::Errors::GenericTrivial) do
+      atom_feed
     end
+    assert_equal(
+      'Cannot build Atom feed: no author_name in params, item or site config',
+      error.message,
+    )
   end
 
   def test_atom_feed_with_author_name_and_uri_from_content_item
-    if_have 'builder' do
-      # Create items
-      @items = [mock_article]
+    # Create items
+    @items = [mock_article]
 
-      # Create item 1
-      @items[0].stubs(:[]).with(:author_name).returns('Don Alias')
-      @items[0].stubs(:[]).with(:author_uri).returns('http://don.example.com/')
-      @items[0].expects(:compiled_content).returns('item 1 content')
+    # Create item 1
+    @items[0].stubs(:[]).with(:author_name).returns('Don Alias')
+    @items[0].stubs(:[]).with(:author_uri).returns('http://don.example.com/')
+    @items[0].expects(:compiled_content).returns('item 1 content')
 
-      # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com/' })
-      @config = Nanoc::ConfigView.new(config, @view_context)
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com/' })
+    @config = Nanoc::ConfigView.new(config, @view_context)
 
-      # Create feed item
-      @item = mock
-      @item.stubs(:[]).with(:kind).returns(nil)
-      @item.stubs(:[]).with(:title).returns('My Cool Blog')
-      @item.stubs(:[]).with(:author_name).returns('Denis Defreyne')
-      @item.stubs(:[]).with(:author_uri).returns('http://stoneship.org/')
-      @item.stubs(:[]).with(:feed_url).returns(nil)
-      @item.stubs(:path).returns('/journal/feed/')
+    # Create feed item
+    @item = mock
+    @item.stubs(:[]).with(:kind).returns(nil)
+    @item.stubs(:[]).with(:title).returns('My Cool Blog')
+    @item.stubs(:[]).with(:author_name).returns('Denis Defreyne')
+    @item.stubs(:[]).with(:author_uri).returns('http://stoneship.org/')
+    @item.stubs(:[]).with(:feed_url).returns(nil)
+    @item.stubs(:path).returns('/journal/feed/')
 
-      # Check
-      # TODO: Use xpath matchers for more specific test
-      result = atom_feed
-      # Still should keep feed level author
-      assert_includes(result, '<name>Denis Defreyne</name>')
-      assert_includes(result, '<uri>http://stoneship.org/</uri>')
+    # Check
+    # TODO: Use xpath matchers for more specific test
+    result = atom_feed
+    # Still should keep feed level author
+    assert_includes(result, '<name>Denis Defreyne</name>')
+    assert_includes(result, '<uri>http://stoneship.org/</uri>')
 
-      # Overrides on specific items
-      assert_includes(result, '<name>Don Alias</name>')
-      assert_includes(result, '<uri>http://don.example.com/</uri>')
-    end
+    # Overrides on specific items
+    assert_includes(result, '<name>Don Alias</name>')
+    assert_includes(result, '<uri>http://don.example.com/</uri>')
   end
 
   def test_atom_feed_without_author_uri
-    if_have 'builder' do
-      # Create items
-      @items = [mock_item, mock_article]
+    # Create items
+    @items = [mock_item, mock_article]
 
-      # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
-      @config = Nanoc::ConfigView.new(config, @view_context)
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    @config = Nanoc::ConfigView.new(config, @view_context)
 
-      # Create feed item
-      @item = mock
-      @item.stubs(:[]).with(:title).returns('My Blog Or Something')
-      @item.stubs(:[]).with(:author_name).returns('J. Doe')
-      @item.stubs(:[]).with(:author_uri).returns(nil)
+    # Create feed item
+    @item = mock
+    @item.stubs(:[]).with(:title).returns('My Blog Or Something')
+    @item.stubs(:[]).with(:author_name).returns('J. Doe')
+    @item.stubs(:[]).with(:author_uri).returns(nil)
 
-      # Check
-      error = assert_raises(Nanoc::Int::Errors::GenericTrivial) do
-        atom_feed
-      end
-      assert_equal(
-        'Cannot build Atom feed: no author_uri in params, item or site config',
-        error.message,
-      )
+    # Check
+    error = assert_raises(Nanoc::Int::Errors::GenericTrivial) do
+      atom_feed
     end
+    assert_equal(
+      'Cannot build Atom feed: no author_uri in params, item or site config',
+      error.message,
+    )
   end
 
   def test_atom_feed_without_articles_created_at
-    if_have 'builder' do
-      # Create items
-      @items = [mock_item, mock_article, mock_article]
-      @items[1].stubs(:[]).with(:created_at).returns(Time.now.to_s)
-      @items[2].stubs(:[]).with(:created_at).returns(nil)
+    # Create items
+    @items = [mock_item, mock_article, mock_article]
+    @items[1].stubs(:[]).with(:created_at).returns(Time.now.to_s)
+    @items[2].stubs(:[]).with(:created_at).returns(nil)
 
-      # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
-      @config = Nanoc::ConfigView.new(config, @view_context)
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    @config = Nanoc::ConfigView.new(config, @view_context)
 
-      # Create feed item
-      @item = mock
-      @item.stubs(:[]).with(:title).returns('My Blog Or Something')
-      @item.stubs(:[]).with(:author_name).returns('J. Doe')
-      @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
+    # Create feed item
+    @item = mock
+    @item.stubs(:[]).with(:title).returns('My Blog Or Something')
+    @item.stubs(:[]).with(:author_name).returns('J. Doe')
+    @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
 
-      # Check
-      error = assert_raises(Nanoc::Int::Errors::GenericTrivial) do
-        atom_feed
-      end
-      assert_equal(
-        'Cannot build Atom feed: one or more articles lack created_at',
-        error.message,
-      )
+    # Check
+    error = assert_raises(Nanoc::Int::Errors::GenericTrivial) do
+      atom_feed
     end
+    assert_equal(
+      'Cannot build Atom feed: one or more articles lack created_at',
+      error.message,
+    )
   end
 
   def test_atom_feed_with_title_author_name_and_uri_as_params
-    if_have 'builder' do
-      # Create items
-      @items = [mock_item, mock_article]
-      @items[1].expects(:compiled_content).with(snapshot: :pre).returns('asdf')
+    # Create items
+    @items = [mock_item, mock_article]
+    @items[1].expects(:compiled_content).with(snapshot: :pre).returns('asdf')
 
-      # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
-      @config = Nanoc::ConfigView.new(config, @view_context)
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    @config = Nanoc::ConfigView.new(config, @view_context)
 
-      # Create feed item
-      @item = mock
-      @item.stubs(:[]).with(:title).returns(nil)
-      @item.stubs(:[]).with(:author_name).returns(nil)
-      @item.stubs(:[]).with(:author_uri).returns(nil)
-      @item.stubs(:[]).with(:[]).with(:feed_url).returns('http://example.com/feed')
+    # Create feed item
+    @item = mock
+    @item.stubs(:[]).with(:title).returns(nil)
+    @item.stubs(:[]).with(:author_name).returns(nil)
+    @item.stubs(:[]).with(:author_uri).returns(nil)
+    @item.stubs(:[]).with(:[]).with(:feed_url).returns('http://example.com/feed')
 
-      # Check
-      atom_feed(
-        author_name: 'Bob',
-        author_uri: 'http://example.com/~bob/',
-        title: 'My Blog Or Something',
-      )
-    end
+    # Check
+    atom_feed(
+      author_name: 'Bob',
+      author_uri: 'http://example.com/~bob/',
+      title: 'My Blog Or Something',
+    )
   end
 
   def test_atom_feed_with_title_author_name_and_uri_from_config
-    if_have 'builder' do
-      # Create items
-      @items = [mock_item, mock_article]
-      @items[1].expects(:compiled_content).with(snapshot: :pre).returns('asdf')
+    # Create items
+    @items = [mock_item, mock_article]
+    @items[1].expects(:compiled_content).with(snapshot: :pre).returns('asdf')
 
-      # Mock site
-      config_hash =
-        {
-          author_name: 'Bob',
-          author_uri: 'http://example.com/~bob/',
-          title: 'My Blog Or Something',
-          base_url: 'http://example.com',
-        }
-      config = Nanoc::Int::Configuration.new(hash: config_hash)
-      @config = Nanoc::ConfigView.new(config, @view_context)
+    # Mock site
+    config_hash =
+      {
+        author_name: 'Bob',
+        author_uri: 'http://example.com/~bob/',
+        title: 'My Blog Or Something',
+        base_url: 'http://example.com',
+      }
+    config = Nanoc::Int::Configuration.new(hash: config_hash)
+    @config = Nanoc::ConfigView.new(config, @view_context)
 
-      # Create feed item
-      @item = mock
-      @item.stubs(:[]).with(:title).returns(nil)
-      @item.stubs(:[]).with(:author_name).returns(nil)
-      @item.stubs(:[]).with(:author_uri).returns(nil)
-      @item.stubs(:[]).with(:[]).with(:feed_url).returns('http://example.com/feed')
+    # Create feed item
+    @item = mock
+    @item.stubs(:[]).with(:title).returns(nil)
+    @item.stubs(:[]).with(:author_name).returns(nil)
+    @item.stubs(:[]).with(:author_uri).returns(nil)
+    @item.stubs(:[]).with(:[]).with(:feed_url).returns('http://example.com/feed')
 
-      # Check
-      atom_feed
-    end
+    # Check
+    atom_feed
   end
 
   def test_atom_feed_with_articles_param
-    if_have 'builder' do
-      # Mock items
-      @items = [mock_article, mock_article]
+    # Mock items
+    @items = [mock_article, mock_article]
 
-      @items[0].expects(:compiled_content).never
-      @items[1].stubs(:[]).with(:title).returns('Item One')
-      @items[1].expects(:compiled_content).with(snapshot: :pre).returns('asdf')
+    @items[0].expects(:compiled_content).never
+    @items[1].stubs(:[]).with(:title).returns('Item One')
+    @items[1].expects(:compiled_content).with(snapshot: :pre).returns('asdf')
 
-      # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
-      @config = Nanoc::ConfigView.new(config, @view_context)
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    @config = Nanoc::ConfigView.new(config, @view_context)
 
-      # Create feed item
-      @item = mock
-      @item.stubs(:[]).with(:title).returns('My Blog Or Something')
-      @item.stubs(:[]).with(:author_name).returns('J. Doe')
-      @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
-      @item.stubs(:[]).with(:[]).with(:feed_url).returns('http://example.com/feed')
+    # Create feed item
+    @item = mock
+    @item.stubs(:[]).with(:title).returns('My Blog Or Something')
+    @item.stubs(:[]).with(:author_name).returns('J. Doe')
+    @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
+    @item.stubs(:[]).with(:[]).with(:feed_url).returns('http://example.com/feed')
 
-      # Check
-      atom_feed articles: [@items[1]]
-    end
+    # Check
+    atom_feed articles: [@items[1]]
   end
 
   def test_atom_feed_with_limit_param
-    if_have 'builder' do
-      # Mock articles
-      @items = [mock_article, mock_article]
-      @items.each_with_index do |article, i|
-        article.stubs(:[]).with(:title).returns("Article #{i}")
-        article.stubs(:[]).with(:created_at).returns(Time.now - i)
-      end
-
-      # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
-      @config = Nanoc::ConfigView.new(config, @view_context)
-
-      # Create feed item
-      @item = mock
-      @item.stubs(:[]).with(:title).returns('My Blog Or Something')
-      @item.stubs(:[]).with(:author_name).returns('J. Doe')
-      @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
-      @item.stubs(:[]).with(:feed_url).returns('http://example.com/feed')
-
-      # Check
-      result = atom_feed limit: 1, articles: @items
-      assert_match(
-        Regexp.new('Article 0', Regexp::MULTILINE),
-        result,
-      )
-      refute_match(
-        Regexp.new('Article 1', Regexp::MULTILINE),
-        result,
-      )
+    # Mock articles
+    @items = [mock_article, mock_article]
+    @items.each_with_index do |article, i|
+      article.stubs(:[]).with(:title).returns("Article #{i}")
+      article.stubs(:[]).with(:created_at).returns(Time.now - i)
     end
+
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    @config = Nanoc::ConfigView.new(config, @view_context)
+
+    # Create feed item
+    @item = mock
+    @item.stubs(:[]).with(:title).returns('My Blog Or Something')
+    @item.stubs(:[]).with(:author_name).returns('J. Doe')
+    @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
+    @item.stubs(:[]).with(:feed_url).returns('http://example.com/feed')
+
+    # Check
+    result = atom_feed limit: 1, articles: @items
+    assert_match(
+      Regexp.new('Article 0', Regexp::MULTILINE),
+      result,
+    )
+    refute_match(
+      Regexp.new('Article 1', Regexp::MULTILINE),
+      result,
+    )
   end
 
   def test_atom_feed_sorting
-    if_have 'builder' do
-      # Mock articles
-      @items = [mock_article, mock_article]
-      @items.each_with_index do |article, i|
-        article.stubs(:[]).with(:title).returns("Article #{i}")
-      end
-      @items[0].stubs(:[]).with(:created_at).returns('23-02-2009')
-      @items[1].stubs(:[]).with(:created_at).returns('22-03-2009')
-
-      # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
-      @config = Nanoc::ConfigView.new(config, @view_context)
-
-      # Create feed item
-      @item = mock
-      @item.stubs(:[]).with(:title).returns('My Blog Or Something')
-      @item.stubs(:[]).with(:author_name).returns('J. Doe')
-      @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
-      @item.stubs(:[]).with(:feed_url).returns('http://example.com/feed')
-
-      # Check
-      result = atom_feed
-      assert_match(
-        Regexp.new('Article 1.*Article 0', Regexp::MULTILINE),
-        result,
-      )
+    # Mock articles
+    @items = [mock_article, mock_article]
+    @items.each_with_index do |article, i|
+      article.stubs(:[]).with(:title).returns("Article #{i}")
     end
+    @items[0].stubs(:[]).with(:created_at).returns('23-02-2009')
+    @items[1].stubs(:[]).with(:created_at).returns('22-03-2009')
+
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    @config = Nanoc::ConfigView.new(config, @view_context)
+
+    # Create feed item
+    @item = mock
+    @item.stubs(:[]).with(:title).returns('My Blog Or Something')
+    @item.stubs(:[]).with(:author_name).returns('J. Doe')
+    @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
+    @item.stubs(:[]).with(:feed_url).returns('http://example.com/feed')
+
+    # Check
+    result = atom_feed
+    assert_match(
+      Regexp.new('Article 1.*Article 0', Regexp::MULTILINE),
+      result,
+    )
   end
 
   def test_atom_feed_preserve_order
-    if_have 'builder' do
-      # Mock articles
-      @items = [mock_article, mock_article]
-      @items.each_with_index do |article, i|
-        article.stubs(:[]).with(:title).returns("Article #{i}")
-      end
-      @items[0].stubs(:[]).with(:created_at).returns('01-01-2015')
-      @items[1].stubs(:[]).with(:created_at).returns('01-01-2014')
-
-      # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
-      @config = Nanoc::ConfigView.new(config, @view_context)
-
-      # Create feed item
-      @item = mock
-      @item.stubs(:[]).with(:title).returns('My Blog Or Something')
-      @item.stubs(:[]).with(:author_name).returns('J. Doe')
-      @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
-      @item.stubs(:[]).with(:feed_url).returns('http://example.com/feed')
-
-      # Check
-      result = atom_feed(preserve_order: true)
-      assert_match(
-        Regexp.new('Article 1.*Article 0', Regexp::MULTILINE),
-        result,
-      )
+    # Mock articles
+    @items = [mock_article, mock_article]
+    @items.each_with_index do |article, i|
+      article.stubs(:[]).with(:title).returns("Article #{i}")
     end
+    @items[0].stubs(:[]).with(:created_at).returns('01-01-2015')
+    @items[1].stubs(:[]).with(:created_at).returns('01-01-2014')
+
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    @config = Nanoc::ConfigView.new(config, @view_context)
+
+    # Create feed item
+    @item = mock
+    @item.stubs(:[]).with(:title).returns('My Blog Or Something')
+    @item.stubs(:[]).with(:author_name).returns('J. Doe')
+    @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
+    @item.stubs(:[]).with(:feed_url).returns('http://example.com/feed')
+
+    # Check
+    result = atom_feed(preserve_order: true)
+    assert_match(
+      Regexp.new('Article 1.*Article 0', Regexp::MULTILINE),
+      result,
+    )
   end
 
   def test_atom_feed_with_content_proc_param
-    if_have 'builder' do
-      # Mock article
-      @items = [mock_article]
+    # Mock article
+    @items = [mock_article]
 
-      # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
-      @config = Nanoc::ConfigView.new(config, @view_context)
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    @config = Nanoc::ConfigView.new(config, @view_context)
 
-      # Create feed item
-      @item = mock
-      @item.stubs(:[]).with(:title).returns('My Blog Or Something')
-      @item.stubs(:[]).with(:author_name).returns('J. Doe')
-      @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
-      @item.stubs(:[]).with(:feed_url).returns('http://example.com/feed')
+    # Create feed item
+    @item = mock
+    @item.stubs(:[]).with(:title).returns('My Blog Or Something')
+    @item.stubs(:[]).with(:author_name).returns('J. Doe')
+    @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
+    @item.stubs(:[]).with(:feed_url).returns('http://example.com/feed')
 
-      # Check
-      result = atom_feed content_proc: ->(_a) { 'foobar!' }
-      assert_match 'foobar!</content>', result
-    end
+    # Check
+    result = atom_feed content_proc: ->(_a) { 'foobar!' }
+    assert_match 'foobar!</content>', result
   end
 
   def test_atom_feed_with_excerpt_proc_param
-    if_have 'builder' do
-      # Mock article
-      @items = [mock_article]
+    # Mock article
+    @items = [mock_article]
 
-      # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
-      @config = Nanoc::ConfigView.new(config, @view_context)
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    @config = Nanoc::ConfigView.new(config, @view_context)
 
-      # Create feed item
-      @item = mock
-      @item.stubs(:[]).with(:title).returns('My Blog Or Something')
-      @item.stubs(:[]).with(:author_name).returns('J. Doe')
-      @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
-      @item.stubs(:[]).with(:[]).with(:feed_url).returns('http://example.com/feed')
+    # Create feed item
+    @item = mock
+    @item.stubs(:[]).with(:title).returns('My Blog Or Something')
+    @item.stubs(:[]).with(:author_name).returns('J. Doe')
+    @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
+    @item.stubs(:[]).with(:[]).with(:feed_url).returns('http://example.com/feed')
 
-      # Check
-      result = atom_feed excerpt_proc: ->(_a) { 'foobar!' }
-      assert_match 'foobar!</summary>', result
-    end
+    # Check
+    result = atom_feed excerpt_proc: ->(_a) { 'foobar!' }
+    assert_match 'foobar!</summary>', result
   end
 
   def test_atom_feed_with_icon_param
-    if_have 'builder' do
-      # Mock article
-      @items = [mock_article]
+    # Mock article
+    @items = [mock_article]
 
-      # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
-      @config = Nanoc::ConfigView.new(config, @view_context)
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    @config = Nanoc::ConfigView.new(config, @view_context)
 
-      # Create feed item
-      @item = mock
-      @item.stubs(:[]).with(:title).returns('My Blog Or Something')
-      @item.stubs(:[]).with(:author_name).returns('J. Doe')
-      @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
-      @item.stubs(:[]).with(:feed_url).returns('http://example.com/feed')
+    # Create feed item
+    @item = mock
+    @item.stubs(:[]).with(:title).returns('My Blog Or Something')
+    @item.stubs(:[]).with(:author_name).returns('J. Doe')
+    @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
+    @item.stubs(:[]).with(:feed_url).returns('http://example.com/feed')
 
-      # Check
-      result = atom_feed icon: 'http://example.com/icon.png'
-      assert_match '<icon>http://example.com/icon.png</icon>', result
-    end
+    # Check
+    result = atom_feed icon: 'http://example.com/icon.png'
+    assert_match '<icon>http://example.com/icon.png</icon>', result
   end
 
   def test_atom_feed_with_logo_param
-    if_have 'builder' do
-      # Mock article
-      @items = [mock_article]
+    # Mock article
+    @items = [mock_article]
 
-      # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
-      @config = Nanoc::ConfigView.new(config, @view_context)
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    @config = Nanoc::ConfigView.new(config, @view_context)
 
-      # Create feed item
-      @item = mock
-      @item.stubs(:[]).with(:title).returns('My Blog Or Something')
-      @item.stubs(:[]).with(:author_name).returns('J. Doe')
-      @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
-      @item.stubs(:[]).with(:feed_url).returns('http://example.com/feed')
+    # Create feed item
+    @item = mock
+    @item.stubs(:[]).with(:title).returns('My Blog Or Something')
+    @item.stubs(:[]).with(:author_name).returns('J. Doe')
+    @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
+    @item.stubs(:[]).with(:feed_url).returns('http://example.com/feed')
 
-      # Check
-      result = atom_feed logo: 'http://example.com/logo.png'
-      assert_match '<logo>http://example.com/logo.png</logo>', result
-    end
+    # Check
+    result = atom_feed logo: 'http://example.com/logo.png'
+    assert_match '<logo>http://example.com/logo.png</logo>', result
   end
 
   def test_atom_feed_with_xml_base
-    if_have 'builder' do
-      # Mock article
-      @items = [mock_article]
+    # Mock article
+    @items = [mock_article]
 
-      # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
-      @config = Nanoc::ConfigView.new(config, @view_context)
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    @config = Nanoc::ConfigView.new(config, @view_context)
 
-      # Create feed item
-      @item = mock
-      @item.stubs(:[]).with(:title).returns('My Blog Or Something')
-      @item.stubs(:[]).with(:author_name).returns('J. Doe')
-      @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
-      @item.stubs(:[]).with(:feed_url).returns('http://example.com/feed')
+    # Create feed item
+    @item = mock
+    @item.stubs(:[]).with(:title).returns('My Blog Or Something')
+    @item.stubs(:[]).with(:author_name).returns('J. Doe')
+    @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
+    @item.stubs(:[]).with(:feed_url).returns('http://example.com/feed')
 
-      # Check
-      result = atom_feed
-      assert_match 'xml:base="http://example.com/"', result
-    end
+    # Check
+    result = atom_feed
+    assert_match 'xml:base="http://example.com/"', result
   end
 
   def test_atom_feed_with_item_without_path
-    if_have 'builder' do
-      # Create items
-      @items = [mock_article]
-      @items[0].stubs(:path).returns(nil)
+    # Create items
+    @items = [mock_article]
+    @items[0].stubs(:path).returns(nil)
 
-      # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
-      @config = Nanoc::ConfigView.new(config, @view_context)
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    @config = Nanoc::ConfigView.new(config, @view_context)
 
-      # Create feed item
-      @item = mock
-      @item.stubs(:identifier).returns('/feed/')
-      @item.stubs(:[]).with(:title).returns('My Cool Blog')
-      @item.stubs(:[]).with(:author_name).returns('Denis Defreyne')
-      @item.stubs(:[]).with(:author_uri).returns('http://stoneship.org/')
-      @item.stubs(:[]).with(:feed_url).returns(nil)
-      @item.stubs(:path).returns('/journal/feed/')
+    # Create feed item
+    @item = mock
+    @item.stubs(:identifier).returns('/feed/')
+    @item.stubs(:[]).with(:title).returns('My Cool Blog')
+    @item.stubs(:[]).with(:author_name).returns('Denis Defreyne')
+    @item.stubs(:[]).with(:author_uri).returns('http://stoneship.org/')
+    @item.stubs(:[]).with(:feed_url).returns(nil)
+    @item.stubs(:path).returns('/journal/feed/')
 
-      # Check
-      atom_feed
-    end
+    # Check
+    atom_feed
   end
 end

--- a/test/helpers/test_xml_sitemap.rb
+++ b/test/helpers/test_xml_sitemap.rb
@@ -30,7 +30,7 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
   end
 
   def test_xml_sitemap
-    if_have 'builder', 'nokogiri' do
+    if_have 'nokogiri' do
       # Create items
       items = []
 
@@ -95,7 +95,7 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
   end
 
   def test_sitemap_with_items_as_param
-    if_have 'builder', 'nokogiri' do
+    if_have 'nokogiri' do
       # Create items
       items = []
       items << nil
@@ -134,7 +134,7 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
   end
 
   def test_filter
-    if_have 'builder', 'nokogiri' do
+    if_have 'nokogiri' do
       # Create items
       item = Nanoc::CompilationItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/item-one'), @view_context)
       @items = Nanoc::Int::ItemCollection.new({}, [item])
@@ -165,7 +165,7 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
   end
 
   def test_sorted
-    if_have 'builder', 'nokogiri' do
+    if_have 'nokogiri' do
       # Create items
       items = []
       item = Nanoc::CompilationItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/george'), @view_context)
@@ -208,7 +208,7 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
   end
 
   def test_url_escape
-    if_have 'builder', 'nokogiri' do
+    if_have 'nokogiri' do
       # Create items
       item = Nanoc::CompilationItemView.new(Nanoc::Int::Item.new('some content 1', {}, '/george'), @view_context)
       @items = Nanoc::Int::ItemCollection.new({}, [item])


### PR DESCRIPTION
Don’t use `#if_have` for dependencies that _will_ work (i.e. have no non-Ruby dependencies).