### PR TITLE
Do not remove output dir when pruning

### DIFF
--- a/lib/nanoc/base/services/pruner.rb
+++ b/lib/nanoc/base/services/pruner.rb
@@ -80,6 +80,8 @@ module Nanoc
       present_files = []
       present_dirs = []
 
+      expanded_dir = File.expand_path(dir)
+
       Find.find(dir) do |f|
         basename = File.basename(f)
 
@@ -91,7 +93,7 @@ module Nanoc
         when 'directory'
           if exclude?(basename)
             Find.prune
-          else
+          elsif expanded_dir != File.expand_path(f)
             present_dirs << f
           end
         end

--- a/spec/nanoc/base/services/pruner_spec.rb
+++ b/spec/nanoc/base/services/pruner_spec.rb
@@ -62,7 +62,6 @@ describe Nanoc::Pruner do
 
       it 'returns all directories' do
         dirs = [
-          'output/',
           'output/projects',
           'output/.git',
         ]
@@ -84,7 +83,6 @@ describe Nanoc::Pruner do
 
       it 'returns all directories' do
         dirs = [
-          'output/',
           'output/projects',
         ]
         expect(subject[1]).to match_array(dirs)
@@ -105,7 +103,6 @@ describe Nanoc::Pruner do
 
       it 'returns all directories' do
         dirs = [
-          'output/',
           'output/projects',
           'output/.git',
         ]


### PR DESCRIPTION
The output dir itself is definitely still useful, so don’t prune it.