### PR TITLE
Improve LoadError resolution

### DIFF
--- a/nanoc/lib/nanoc/cli/error_handler.rb
+++ b/nanoc/lib/nanoc/cli/error_handler.rb
@@ -63,9 +63,13 @@ module Nanoc::CLI
 
     def handle_error(error, exit_on_error:)
       if trivial?(error)
+        $stderr.puts
         $stderr.puts "Error: #{error.message}"
         resolution = resolution_for(error)
-        $stderr.puts resolution if resolution
+        if resolution
+          $stderr.puts
+          $stderr.puts resolution
+        end
       else
         print_error(error)
       end
@@ -227,7 +231,11 @@ module Nanoc::CLI
 
         if gem_name
           if using_bundler?
-            'Make sure the gem is added to Gemfile and run `bundle install`.'
+            <<~RES
+              1. Add `gem '#{gem_name}'` to your Gemfile
+              2. Run `bundle install`
+              3. Re-run this command
+            RES
           else
             "Install the '#{gem_name}' gem using `gem install #{gem_name}`."
           end

--- a/nanoc/spec/nanoc/cli/error_handler_spec.rb
+++ b/nanoc/spec/nanoc/cli/error_handler_spec.rb
@@ -147,11 +147,11 @@ describe Nanoc::CLI::ErrorHandler, stdio: true do
         end
 
         it 'prints summary' do
-          expect { subject }.to output("Error: asdf\n").to_stderr
+          expect { subject }.to output("\nError: asdf\n").to_stderr
         end
       end
 
-      context 'trivial error with resolution' do
+      context 'LoadError' do
         let(:error) do
           begin
             raise LoadError, 'cannot load such file -- nokogiri'
@@ -161,9 +161,12 @@ describe Nanoc::CLI::ErrorHandler, stdio: true do
         end
 
         it 'prints summary' do
-          expected_output = <<~OUT
+          expected_output = "\n" + <<~OUT
             Error: cannot load such file -- nokogiri
-            Make sure the gem is added to Gemfile and run `bundle install`.
+
+            1. Add `gem 'nokogiri'` to your Gemfile
+            2. Run `bundle install`
+            3. Re-run this command
           OUT
           expect { subject }.to output(expected_output).to_stderr
         end

--- a/nanoc/test/cli/test_error_handler.rb
+++ b/nanoc/test/cli/test_error_handler.rb
@@ -26,7 +26,7 @@ class Nanoc::CLI::ErrorHandlerTest < Nanoc::TestCase
       true
     end
     error = LoadError.new('no such file to load -- kramdown')
-    assert_match(/^Make sure the gem is added to Gemfile/, @handler.send(:resolution_for, error))
+    assert_match(/^1\. Add.*to your Gemfile/, @handler.send(:resolution_for, error))
   end
 
   def test_resolution_for_with_not_load_error
@@ -73,7 +73,7 @@ class Nanoc::CLI::ErrorHandlerTest < Nanoc::TestCase
       true
     end
     error = new_wrapped_error(LoadError.new('no such file to load -- kramdown'))
-    assert_match(/^Make sure the gem is added to Gemfile/, @handler.send(:resolution_for, error))
+    assert_match(/^1\. Add.*to your Gemfile/, @handler.send(:resolution_for, error))
   end
 
   def new_wrapped_error(wrapped)


### PR DESCRIPTION
Follow-up to #1274.

Before:

```
Error: cannot load such file -- nokogiri
Make sure the gem is added to Gemfile and run `bundle install`.
```

After:

```
Error: cannot load such file -- nokogiri

1. Add `gem 'nokogiri'` to your Gemfile
2. Run `bundle install`
3. Re-run this command
```