### PR TITLE
Let #breadcrumbs_trail always find closest parent

### DIFF
--- a/nanoc/lib/nanoc/helpers/breadcrumbs.rb
+++ b/nanoc/lib/nanoc/helpers/breadcrumbs.rb
@@ -3,6 +3,34 @@
 module Nanoc::Helpers
   # @see http://nanoc.ws/doc/reference/helpers/#breadcrumbs
   module Breadcrumbs
+    # @api private
+    module Int
+      # e.g. unfold(10.class, &:superclass)
+      # => [Integer, Numeric, Object, BasicObject]
+      def self.unfold(obj, &blk)
+        acc = [obj]
+
+        res = yield(obj)
+        if res
+          acc + unfold(res, &blk)
+        else
+          acc
+        end
+      end
+
+      # e.g. patterns_for_prefix('/foo/1.0')
+      # => ['/foo/1.0.*', '/foo/1.*']
+      def self.patterns_for_prefix(prefix)
+        prefixes =
+          unfold(prefix) do |old_prefix|
+            new_prefix = Nanoc::Identifier.new(old_prefix).without_ext
+            new_prefix == old_prefix ? nil : new_prefix
+          end
+
+        prefixes.map { |pr| pr + '.*' }
+      end
+    end
+
     # @return [Array]
     def breadcrumbs_trail
       # e.g. ['', '/foo', '/foo/bar']
@@ -18,7 +46,8 @@ module Nanoc::Helpers
             if pr == ''
               @items['/index.*']
             else
-              @items[Nanoc::Identifier.new(pr).without_ext + '.*']
+              prefix_patterns = Int.patterns_for_prefix(pr)
+              prefix_patterns.lazy.map { |pat| @items[pat] }.find(&:itself)
             end
           end
       end

--- a/nanoc/spec/nanoc/helpers/breadcrumbs_spec.rb
+++ b/nanoc/spec/nanoc/helpers/breadcrumbs_spec.rb
@@ -130,6 +130,52 @@ describe Nanoc::Helpers::Breadcrumbs, helper: true do
           expect(subject).to eql([ctx.items['/index.md'], nil, ctx.items['/foo/index.md']])
         end
       end
+
+      context 'item with version number component in path' do
+        before do
+          ctx.create_item('grandchild', {}, Nanoc::Identifier.new('/1.5/stuff.md'))
+          ctx.create_item('child0', {}, Nanoc::Identifier.new('/1.4.md'))
+          ctx.create_item('child1', {}, Nanoc::Identifier.new('/1.5.md'))
+          ctx.create_item('child2', {}, Nanoc::Identifier.new('/1.6.md'))
+          ctx.create_item('root', {}, Nanoc::Identifier.new('/index.md'))
+
+          ctx.item = ctx.items['/1.5/stuff.md']
+        end
+
+        it 'picks the closest parent' do
+          expect(subject)
+            .to eql(
+              [
+                ctx.items['/index.md'],
+                ctx.items['/1.5.md'],
+                ctx.items['/1.5/stuff.md'],
+              ],
+            )
+        end
+      end
+
+      context 'item with multiple extensions in path' do
+        before do
+          ctx.create_item('grandchild', {}, Nanoc::Identifier.new('/foo/stuff.md'))
+          ctx.create_item('child0', {}, Nanoc::Identifier.new('/foo.md.erb'))
+          ctx.create_item('child1', {}, Nanoc::Identifier.new('/foo.md'))
+          ctx.create_item('child2', {}, Nanoc::Identifier.new('/foo.erb'))
+          ctx.create_item('root', {}, Nanoc::Identifier.new('/index.md'))
+
+          ctx.item = ctx.items['/foo/stuff.md']
+        end
+
+        it 'picks the closest parent' do
+          expect(subject)
+            .to eql(
+              [
+                ctx.items['/index.md'],
+                ctx.items['/foo.md.erb'],
+                ctx.items['/foo/stuff.md'],
+              ],
+            )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #1278.

`#breadcrumbs_trail` already supported cases like these:

```
/index.md
/foo.md.erb
/foo/stuff.html

# trail = [/index.md, /foo.md.erb, /foo/stuff.html]
```

but now it will also support

```
/index.md
/1.2.erb
/1.2/stuff.html

# trail = [/index.md, /1.2.erb, /1.2/stuff.html]
```