### PR TITLE
Add .tex to text_extensions

### DIFF
--- a/nanoc/lib/nanoc/base/entities/configuration.rb
+++ b/nanoc/lib/nanoc/base/entities/configuration.rb
@@ -24,7 +24,7 @@ module Nanoc::Int
     # that lacks some options, the default value will be taken from
     # `DEFAULT_CONFIG`.
     DEFAULT_CONFIG = {
-      text_extensions: %w[adoc asciidoc atom css erb haml htm html js less markdown md php rb sass scss txt xhtml xml coffee hb handlebars mustache ms slim rdoc].sort,
+      text_extensions: %w[adoc asciidoc atom css erb haml htm html js less markdown md php rb sass scss tex txt xhtml xml coffee hb handlebars mustache ms slim rdoc].sort,
       lib_dirs: %w[lib],
       commands_dirs: %w[commands],
       output_dir: 'output',


### PR DESCRIPTION
I added `.tex` to the list of `text_extensions`. Useful when creating a LaTeX layout (I stumbled upon this when creating a [latexmk filter](https://github.com/rien/nanoc-latexmk) for nanoc).
