### PR TITLE
Time load stores

### DIFF
--- a/nanoc/lib/nanoc/base/services/compiler/stages/load_stores.rb
+++ b/nanoc/lib/nanoc/base/services/compiler/stages/load_stores.rb
@@ -14,11 +14,19 @@ module Nanoc::Int::Compiler::Stages
 
     contract C::None => C::Any
     def run
-      @checksum_store.load
-      @compiled_content_cache.load
-      @dependency_store.load
-      @action_sequence_store.load
-      @outdatedness_store.load
+      load_store(@checksum_store)
+      load_store(@compiled_content_cache)
+      load_store(@dependency_store)
+      load_store(@action_sequence_store)
+      load_store(@outdatedness_store)
+    end
+
+    contract Nanoc::Int::Store => C::Any
+    def load_store(store)
+      Nanoc::Int::NotificationCenter.post(:load_store_started, store.class)
+      store.load
+    ensure
+      Nanoc::Int::NotificationCenter.post(:load_store_ended, store.class)
     end
   end
 end

--- a/nanoc/spec/nanoc/cli/commands/compile/timing_recorder_spec.rb
+++ b/nanoc/spec/nanoc/cli/commands/compile/timing_recorder_spec.rb
@@ -263,6 +263,16 @@ describe Nanoc::CLI::Commands::CompileListeners::TimingRecorder, stdio: true do
     expect(listener.outdatedness_rules_summary.get('CodeSnippetsModified').count).to eq(2.00)
   end
 
+  it 'prints load store durations' do
+    Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 0))
+    Nanoc::Int::NotificationCenter.post(:load_store_started, Nanoc::Int::ChecksumStore)
+    Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
+    Nanoc::Int::NotificationCenter.post(:load_store_ended, Nanoc::Int::ChecksumStore)
+
+    expect { listener.stop }
+      .to output(/^\s*Nanoc::Int::ChecksumStore │ 1\.00s$/).to_stdout
+  end
+
   it 'skips printing empty metrics' do
     expect { listener.stop }
       .not_to output(/filters|phases|stages/).to_stdout


### PR DESCRIPTION
Running `compile` with `-VV` shows e.g.

```
                     load_stores │   tot
─────────────────────────────────┼──────
       Nanoc::Int::ChecksumStore │ 0.00s
Nanoc::Int::CompiledContentCache │ 0.01s
     Nanoc::Int::DependencyStore │ 0.01s
 Nanoc::Int::ActionSequenceStore │ 0.00s
   Nanoc::Int::OutdatednessStore │ 0.00s
```