### PR TITLE
Make Write phase async

### DIFF
--- a/nanoc/lib/nanoc/base/services/compiler/phases/write.rb
+++ b/nanoc/lib/nanoc/base/services/compiler/phases/write.rb
@@ -37,7 +37,10 @@ module Nanoc::Int::Compiler::Phases
     contract Nanoc::Int::ItemRep, C::KeywordArgs[is_outdated: C::Bool], C::Func[C::None => C::Any] => C::Any
     def run(rep, is_outdated:) # rubocop:disable Lint/UnusedMethodArgument
       yield
+
       @queue_to_write << rep
+
+      Nanoc::Int::NotificationCenter.post(:rep_write_enqueued, rep)
     end
   end
 end

--- a/nanoc/lib/nanoc/base/services/compiler/phases/write.rb
+++ b/nanoc/lib/nanoc/base/services/compiler/phases/write.rb
@@ -8,13 +8,36 @@ module Nanoc::Int::Compiler::Phases
       super(wrapped: wrapped)
 
       @snapshot_repo = snapshot_repo
+
+      @queue_to_write = SizedQueue.new(1000)
+    end
+
+    def start
+      super
+
+      @thread = Thread.new do
+        Thread.current.abort_on_exception = true
+        Thread.current.priority = -1 # schedule I/O work ASAP
+
+        writer = Nanoc::Int::ItemRepWriter.new
+
+        while rep = @queue_to_write.pop # rubocop:disable Lint/AssignmentInCondition
+          writer.write_all(rep, @snapshot_repo)
+        end
+      end
+    end
+
+    def stop
+      super
+
+      @queue_to_write.close
+      @thread.join
     end
 
     contract Nanoc::Int::ItemRep, C::KeywordArgs[is_outdated: C::Bool], C::Func[C::None => C::Any] => C::Any
     def run(rep, is_outdated:) # rubocop:disable Lint/UnusedMethodArgument
       yield
-
-      Nanoc::Int::ItemRepWriter.new.write_all(rep, @snapshot_repo)
+      @queue_to_write << rep
     end
   end
 end

--- a/nanoc/lib/nanoc/base/views/compilation_item_rep_view.rb
+++ b/nanoc/lib/nanoc/base/views/compilation_item_rep_view.rb
@@ -23,6 +23,13 @@ module Nanoc
         Fiber.yield(Nanoc::Int::Errors::UnmetDependency.new(@item_rep))
       end
 
+      # Wait for file to exist
+      if res
+        start = Time.now
+        sleep 0.05 until File.file?(res) || Time.now - start > 1.0
+        raise Nanoc::Int::Errors::InternalInconsistency, "File did not apear in time: #{res}" unless File.file?(res)
+      end
+
       res
     end
 

--- a/nanoc/lib/nanoc/cli/commands/compile_listeners/file_action_printer.rb
+++ b/nanoc/lib/nanoc/cli/commands/compile_listeners/file_action_printer.rb
@@ -25,6 +25,14 @@ module Nanoc::CLI::Commands::CompileListeners
         cached_reps << rep
       end
 
+      Nanoc::Int::NotificationCenter.on(:rep_write_enqueued, self) do |rep|
+        @acc_durations[rep] += Time.now - @start_times[rep]
+      end
+
+      Nanoc::Int::NotificationCenter.on(:rep_write_started, self) do |rep, _raw_path|
+        @start_times[rep] = Time.now
+      end
+
       Nanoc::Int::NotificationCenter.on(:rep_write_ended, self) do |rep, _binary, path, is_created, is_modified|
         @acc_durations[rep] += Time.now - @start_times[rep]
         duration = @acc_durations[rep]
@@ -50,6 +58,8 @@ module Nanoc::CLI::Commands::CompileListeners
 
       Nanoc::Int::NotificationCenter.remove(:compilation_started, self)
       Nanoc::Int::NotificationCenter.remove(:compilation_suspended, self)
+      Nanoc::Int::NotificationCenter.remove(:rep_write_enqueued, self)
+      Nanoc::Int::NotificationCenter.remove(:rep_write_started, self)
       Nanoc::Int::NotificationCenter.remove(:rep_write_ended, self)
 
       @reps.reject(&:compiled?).each do |rep|

--- a/nanoc/spec/nanoc/base/views/compilation_item_rep_view_spec.rb
+++ b/nanoc/spec/nanoc/base/views/compilation_item_rep_view_spec.rb
@@ -72,22 +72,35 @@ describe Nanoc::CompilationItemRepView do
     context 'rep is compiled' do
       before { rep.compiled = true }
 
-      it 'creates a dependency' do
-        expect { subject }.to change { dependency_store.objects_causing_outdatedness_of(base_item) }.from([]).to([item])
+      context 'file does not exist' do
+        it 'raises' do
+          expect { subject }.to raise_error(Nanoc::Int::Errors::InternalInconsistency)
+        end
       end
 
-      it 'creates a dependency with the right props' do
-        subject
-        dep = dependency_store.dependencies_causing_outdatedness_of(base_item)[0]
+      context 'file exists' do
+        before do
+          FileUtils.mkdir_p('output/about')
+          File.write('output/about/index.html', 'hi!')
+        end
 
-        expect(dep.props.compiled_content?).to eq(true)
+        it 'creates a dependency' do
+          expect { subject }.to change { dependency_store.objects_causing_outdatedness_of(base_item) }.from([]).to([item])
+        end
 
-        expect(dep.props.raw_content?).to eq(false)
-        expect(dep.props.attributes?).to eq(false)
-        expect(dep.props.path?).to eq(false)
+        it 'creates a dependency with the right props' do
+          subject
+          dep = dependency_store.dependencies_causing_outdatedness_of(base_item)[0]
+
+          expect(dep.props.compiled_content?).to eq(true)
+
+          expect(dep.props.raw_content?).to eq(false)
+          expect(dep.props.attributes?).to eq(false)
+          expect(dep.props.path?).to eq(false)
+        end
+
+        it { should eq('output/about/index.html') }
       end
-
-      it { should eq('output/about/index.html') }
     end
   end
 

--- a/nanoc/spec/nanoc/cli/commands/compile/file_action_printer_spec.rb
+++ b/nanoc/spec/nanoc/cli/commands/compile/file_action_printer_spec.rb
@@ -56,6 +56,21 @@ describe Nanoc::CLI::Commands::CompileListeners::FileActionPrinter, stdio: true 
       .to output(/create.*\[4\.00s\]/).to_stdout
   end
 
+  it 'records from compilation_started over rep_write_{enqueued,started} to rep_write_ended' do
+    listener.start
+
+    Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 0))
+    Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
+    Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
+    Nanoc::Int::NotificationCenter.post(:rep_write_enqueued, rep)
+    Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 3))
+    Nanoc::Int::NotificationCenter.post(:rep_write_started, rep)
+    Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 6))
+
+    expect { Nanoc::Int::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', true, true) }
+      .to output(/create.*\[4\.00s\]/).to_stdout
+  end
+
   context 'log level = high' do
     before { listener.start }
     before { Nanoc::CLI::Logger.instance.level = :high }


### PR DESCRIPTION
This changes the `Write` phase to do writing in a background process, so that IO-intensive and CPU-intensive work can happen at the same time.

* [x] Let `#raw_path` block until file exists
* [x] Fix compilation duration for each item rep
  * Currently, it records/shows the duration between the start of the compilation and the moment where the file is written. This duration no longer makes sense because the writing happens asynchronously. The value that it currently prints gives a hint at how much the writing is running behind the compilation.

* * *

Here’s a before-and-after comparison of the GitLab CI docs (a fairly large site):

Before:

```
     phases │ count     min     .50     .90     .95     max      tot
────────────┼───────────────────────────────────────────────────────
      Write │  3209   0.00s   0.00s   0.01s   0.01s   0.18s   12.09s
```

```
Site compiled in 49.90s.
```

After:

```
     phases │ count     min     .50     .90     .95     max      tot
────────────┼───────────────────────────────────────────────────────
      Write │  3209   0.00s   0.00s   0.01s   0.01s   0.13s    7.17s
```

```
Site compiled in 39.90s.
```
  