### PR TITLE
Reduce async write queue size

### DIFF
--- a/nanoc/lib/nanoc/base/services/compiler/phases/write.rb
+++ b/nanoc/lib/nanoc/base/services/compiler/phases/write.rb
@@ -42,7 +42,7 @@ module Nanoc::Int::Compiler::Phases
       end
     end
 
-    QUEUE_SIZE = 1000
+    QUEUE_SIZE = 40
     WORKER_POOL_SIZE = 5
 
     def initialize(snapshot_repo:, wrapped:)


### PR DESCRIPTION
This speeds up the writing phase.

By reducing the queue size, the queue fill up more quickly, which will cause the compilation thread to be suspended more quickly, giving implicit priority to the writer threads.

I’ve measured a ~10% speedup as a result of this change.