### PR TITLE
Let `nanoc live` live-reload by default

### DIFF
--- a/nanoc-live/lib/nanoc/live/commands/live.rb
+++ b/nanoc-live/lib/nanoc/live/commands/live.rb
@@ -11,7 +11,6 @@ EOS
 required :H, :handler, 'specify the handler to use (webrick/mongrel/...)'
 required :o, :host,    'specify the host to listen on (default: 127.0.0.1)'
 required :p, :port,    'specify the port to listen on (default: 3000)'
-flag :L, :'live-reload', 'reload on changes'
 
 module Nanoc::Live::Commands
   class Live < ::Nanoc::CLI::CommandRunner
@@ -20,7 +19,8 @@ module Nanoc::Live::Commands
 
       Thread.new do
         Thread.current.abort_on_exception = true
-        Nanoc::CLI::Commands::View.new(options, [], self).run
+        view_options = options.merge('live-reload': true)
+        Nanoc::CLI::Commands::View.new(view_options, [], self).run
       end
 
       Nanoc::Live::LiveRecompiler.new(command_runner: self).run

--- a/nanoc-live/spec/nanoc/live/commands/live_spec.rb
+++ b/nanoc-live/spec/nanoc/live/commands/live_spec.rb
@@ -42,7 +42,10 @@ describe Nanoc::Live::Commands::Live, site: true, stdio: true do
     end
   end
 
-  it 'receives websocket connections' do
-    # TODO
+  it 'listens for websocket connections' do
+    run_cmd do
+      socket = TCPSocket.new('localhost', 35_729)
+      expect(socket).not_to be_closed
+    end
   end
 end


### PR DESCRIPTION
`nanoc live` should use `--live-reload` by default. Otherwise, it’s not really live.