### PR TITLE
Read checks from config too

### DIFF
--- a/nanoc/lib/nanoc/checking/loader.rb
+++ b/nanoc/lib/nanoc/checking/loader.rb
@@ -5,18 +5,30 @@ module Nanoc::Checking
   class Loader
     CHECKS_FILENAMES = ['Checks', 'Checks.rb', 'checks', 'checks.rb'].freeze
 
+    def initialize(config:)
+      @config = config
+    end
+
     def run
       dsl
     end
 
     def deploy_checks
-      dsl.deploy_checks
+      (deploy_checks_from_dsl + deploy_checks_from_config).uniq
     end
 
     private
 
     def dsl_present?
       checks_filename && File.file?(checks_filename)
+    end
+
+    def deploy_checks_from_dsl
+      dsl.deploy_checks
+    end
+
+    def deploy_checks_from_config
+      @config.fetch(:checking, {}).fetch(:deploy_checks, []).map(&:to_sym)
     end
 
     def dsl

--- a/nanoc/lib/nanoc/checking/runner.rb
+++ b/nanoc/lib/nanoc/checking/runner.rb
@@ -54,7 +54,7 @@ module Nanoc::Checking
     private
 
     def loader
-      @loader ||= Nanoc::Checking::Loader.new
+      @loader ||= Nanoc::Checking::Loader.new(config: @site.config)
     end
 
     def load_all

--- a/nanoc/spec/nanoc/checking/runner_spec.rb
+++ b/nanoc/spec/nanoc/checking/runner_spec.rb
@@ -9,23 +9,107 @@ describe Nanoc::Checking::Runner, site: true do
     subject { runner.any_deploy_checks? }
 
     context 'no DSL' do
-      it { is_expected.to be(false) }
+      context 'no deploy checks defined in config' do
+        it { is_expected.to be(false) }
+      end
+
+      context 'deploy checks defined in config' do
+        before do
+          File.write('nanoc.yaml', "checking:\n  deploy_checks:\n    - elinks")
+        end
+
+        it { is_expected.to be(true) }
+      end
     end
 
-    context 'DSL defined, but no deploy checks' do
+    context 'DSL without deploy checks defined' do
       before do
         File.write('Checks', '')
       end
 
-      it { is_expected.to be(false) }
+      context 'no deploy checks defined in config' do
+        it { is_expected.to be(false) }
+      end
+
+      context 'deploy checks defined in config' do
+        before do
+          File.write('nanoc.yaml', "checking:\n  deploy_checks:\n    - elinks")
+        end
+
+        it { is_expected.to be(true) }
+      end
     end
 
-    context 'DSL defined, with deploy checks' do
+    context 'DSL with deploy checks defined' do
       before do
         File.write('Checks', 'deploy_check :ilinks')
       end
 
-      it { is_expected.to be(true) }
+      context 'no deploy checks defined in config' do
+        it { is_expected.to be(true) }
+      end
+
+      context 'deploy checks defined in config' do
+        before do
+          File.write('nanoc.yaml', "checking:\n  deploy_checks:\n    - elinks")
+        end
+
+        it { is_expected.to be(true) }
+      end
+    end
+  end
+
+  describe '#deploy_checks' do
+    subject { runner.send(:deploy_checks) }
+
+    context 'no DSL' do
+      context 'no deploy checks defined in config' do
+        it { is_expected.to be_empty }
+      end
+
+      context 'deploy checks defined in config' do
+        before do
+          File.write('nanoc.yaml', "checking:\n  deploy_checks:\n    - elinks")
+        end
+
+        it { is_expected.to match_array([:elinks]) }
+      end
+    end
+
+    context 'DSL without deploy checks defined' do
+      before do
+        File.write('Checks', '')
+      end
+
+      context 'no deploy checks defined in config' do
+        it { is_expected.to be_empty }
+      end
+
+      context 'deploy checks defined in config' do
+        before do
+          File.write('nanoc.yaml', "checking:\n  deploy_checks:\n    - elinks")
+        end
+
+        it { is_expected.to match_array([:elinks]) }
+      end
+    end
+
+    context 'DSL with deploy checks defined' do
+      before do
+        File.write('Checks', 'deploy_check :ilinks')
+      end
+
+      context 'no deploy checks defined in config' do
+        it { is_expected.to match_array([:ilinks]) }
+      end
+
+      context 'deploy checks defined in config' do
+        before do
+          File.write('nanoc.yaml', "checking:\n  deploy_checks:\n    - elinks")
+        end
+
+        it { is_expected.to match_array(%i[ilinks elinks]) }
+      end
     end
   end
 


### PR DESCRIPTION
This allows defining deploy checks in the configuration file, rather than the Checks file:

```yaml
checking:
  deploy_checks:
    - internal_links
    - spelling
```

See nanoc/features#27.