### PR TITLE
Improve flexibility of Atom feed generator

### DIFF
--- a/nanoc/lib/nanoc/helpers/blogging.rb
+++ b/nanoc/lib/nanoc/helpers/blogging.rb
@@ -29,6 +29,8 @@ module Nanoc::Helpers
 
       attr_accessor :config
 
+      attr_accessor :alt_link
+      attr_accessor :id
       attr_accessor :limit
       attr_accessor :relevant_articles
       attr_accessor :preserve_order
@@ -110,14 +112,14 @@ module Nanoc::Helpers
         xml.instruct!
         xml.feed(xmlns: 'http://www.w3.org/2005/Atom', 'xml:base' => root_url) do
           # Add primary attributes
-          xml.id root_url
+          xml.id(id || root_url)
           xml.title title
 
           # Add date
           xml.updated(updated.__nanoc_to_iso8601_time)
 
           # Add links
-          xml.link(rel: 'alternate', href: root_url)
+          xml.link(rel: 'alternate', href: (alt_link || root_url))
           xml.link(rel: 'self',      href: feed_url)
 
           # Add author information
@@ -175,6 +177,8 @@ module Nanoc::Helpers
     # @option params [Boolean] :preserve_order
     # @option params [Proc] :content_proc
     # @option params [Proc] :excerpt_proc
+    # @option params [String] :alt_link
+    # @option params [String] :id
     # @option params [String] :title
     # @option params [String] :author_name
     # @option params [String] :author_uri
@@ -189,6 +193,8 @@ module Nanoc::Helpers
       builder = AtomFeedBuilder.new(@config, @item)
 
       # Fill builder
+      builder.alt_link          = params[:alt_link]
+      builder.id                = params[:id]
       builder.limit             = params[:limit] || 5
       builder.relevant_articles = params[:articles] || articles || []
       builder.preserve_order    = params.fetch(:preserve_order, false)

--- a/nanoc/test/helpers/test_blogging.rb
+++ b/nanoc/test/helpers/test_blogging.rb
@@ -635,4 +635,104 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     # Check
     atom_feed
   end
+
+  def test_atom_feed_without_id
+    # Create items
+    @items = [mock_article]
+    @items[0].stubs(:path).returns(nil)
+
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    @config = Nanoc::ConfigView.new(config, @view_context)
+
+    # Create feed item
+    @item = mock
+    @item.stubs(:identifier).returns('/feed/')
+    @item.stubs(:[]).with(:title).returns('My Cool Blog')
+    @item.stubs(:[]).with(:author_name).returns('Denis Defreyne')
+    @item.stubs(:[]).with(:author_uri).returns('http://stoneship.org/')
+    @item.stubs(:[]).with(:feed_url).returns(nil)
+    @item.stubs(:path).returns('/journal/feed/')
+
+    # Check
+    doc = Nokogiri::XML(atom_feed)
+    id_elements = doc.xpath('/atom:feed/atom:id', atom: 'http://www.w3.org/2005/Atom')
+    assert_equal 1, id_elements.size
+    assert_equal 'http://example.com/', id_elements[0].inner_text
+  end
+
+  def test_atom_feed_with_id
+    # Create items
+    @items = [mock_article]
+    @items[0].stubs(:path).returns(nil)
+
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    @config = Nanoc::ConfigView.new(config, @view_context)
+
+    # Create feed item
+    @item = mock
+    @item.stubs(:identifier).returns('/feed/')
+    @item.stubs(:[]).with(:title).returns('My Cool Blog')
+    @item.stubs(:[]).with(:author_name).returns('Denis Defreyne')
+    @item.stubs(:[]).with(:author_uri).returns('http://stoneship.org/')
+    @item.stubs(:[]).with(:feed_url).returns(nil)
+    @item.stubs(:path).returns('/journal/feed/')
+
+    # Check
+    doc = Nokogiri::XML(atom_feed(id: 'tag:foo,bar'))
+    id_elements = doc.xpath('/atom:feed/atom:id', atom: 'http://www.w3.org/2005/Atom')
+    assert_equal 1, id_elements.size
+    assert_equal 'tag:foo,bar', id_elements[0].inner_text
+  end
+
+  def test_atom_feed_without_alt_link
+    # Create items
+    @items = [mock_article]
+    @items[0].stubs(:path).returns(nil)
+
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    @config = Nanoc::ConfigView.new(config, @view_context)
+
+    # Create feed item
+    @item = mock
+    @item.stubs(:identifier).returns('/feed/')
+    @item.stubs(:[]).with(:title).returns('My Cool Blog')
+    @item.stubs(:[]).with(:author_name).returns('Denis Defreyne')
+    @item.stubs(:[]).with(:author_uri).returns('http://stoneship.org/')
+    @item.stubs(:[]).with(:feed_url).returns(nil)
+    @item.stubs(:path).returns('/journal/feed/')
+
+    # Check
+    doc = Nokogiri::XML(atom_feed)
+    elements = doc.xpath('/atom:feed/atom:link[@rel=\'alternate\']', atom: 'http://www.w3.org/2005/Atom')
+    assert_equal 1, elements.size
+    assert_equal 'http://example.com/', elements[0].attribute('href').inner_text
+  end
+
+  def test_atom_feed_with_alt_link
+    # Create items
+    @items = [mock_article]
+    @items[0].stubs(:path).returns(nil)
+
+    # Mock site
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    @config = Nanoc::ConfigView.new(config, @view_context)
+
+    # Create feed item
+    @item = mock
+    @item.stubs(:identifier).returns('/feed/')
+    @item.stubs(:[]).with(:title).returns('My Cool Blog')
+    @item.stubs(:[]).with(:author_name).returns('Denis Defreyne')
+    @item.stubs(:[]).with(:author_uri).returns('http://stoneship.org/')
+    @item.stubs(:[]).with(:feed_url).returns(nil)
+    @item.stubs(:path).returns('/journal/feed/')
+
+    # Check
+    doc = Nokogiri::XML(atom_feed(alt_link: '/blog/'))
+    elements = doc.xpath('/atom:feed/atom:link[@rel=\'alternate\']', atom: 'http://www.w3.org/2005/Atom')
+    assert_equal 1, elements.size
+    assert_equal '/blog/', elements[0].attribute('href').inner_text
+  end
 end


### PR DESCRIPTION
Allow overriding `<id>` and `<link rel="alternate">` elements.

### Detailed description

Adds two new parameters, `:alt_link` and `:id`, to the `atom_feed` method. These allow the overriding of the `<id>` and `<link rel="alternate">` elements of the generated Atom feed.

Overriding these can result in greater compatibility and also allow for the possibility of multiple feeds per site.

I have manually tested that if you don't supply these new parameters, you get the same output as before. As mentioned in the comments on #1300, I think there's a separate issue that the default for `:alt_link` should probably be something like `"/"` instead of the base URL, but that seems like a separate issue to this enhancement.

### To do

(Include the to-do list for this PR to be finished here.)

* [ ] Tests
* [ ] Documentation
* [ ] Feature flags
* [ ] …

### Related issues

Would address #1300.