### PR TITLE
Handle invalid URI components

### DIFF
--- a/nanoc/lib/nanoc/checking/checks/external_links.rb
+++ b/nanoc/lib/nanoc/checking/checks/external_links.rb
@@ -45,7 +45,7 @@ module ::Nanoc::Checking::Checks
       url = nil
       begin
         url = URI.parse(href)
-      rescue URI::InvalidURIError
+      rescue URI::Error
         return Result.new(href, 'invalid URI')
       end
 

--- a/nanoc/spec/nanoc/checking/checks/external_links_spec.rb
+++ b/nanoc/spec/nanoc/checking/checks/external_links_spec.rb
@@ -98,4 +98,21 @@ describe ::Nanoc::Checking::Checks::ExternalLinks do
         .to eq('broken reference to http://example.com/x: redirection without a target location')
     end
   end
+
+  context 'invalid URL component' do
+    let(:check) do
+      Nanoc::Checking::Checks::ExternalLinks.create(site)
+    end
+
+    before do
+      File.write('output/hi.html', '<a href="mailto:lol">stuff</a>')
+    end
+
+    it 'has issues' do
+      check.run
+      expect(check.issues.size).to eq(1)
+      expect(check.issues.first.description)
+        .to eq('broken reference to mailto:lol: invalid URI')
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1299.

### Detailed description

Links with invalid URIs, e.g. `<a href="mailto:lol">stuff</a>`, will now create a proper issue.
