### PR TITLE
Let check command run deploy checks by default

### DIFF
--- a/nanoc/lib/nanoc/cli/commands/check.rb
+++ b/nanoc/lib/nanoc/cli/commands/check.rb
@@ -3,17 +3,16 @@
 usage 'check [options] [names]'
 summary 'run issue checks'
 description "
-Run issue checks on the current site. If the `--all` option is passed, all available issue checks will be run. If the `--deploy` option is passed, the issue checks marked for deployment will be run.
+Run issue checks on the current site. If the `--all` option is passed, all available issue checks will be run. By default, the issue checks marked for deployment will be run.
 "
 
 flag :a, :all,    'run all checks'
 flag :L, :list,   'list all checks'
-flag :d, :deploy, 'run checks for deployment'
+flag :d, :deploy, '(deprecated)'
 
 module Nanoc::CLI::Commands
   class Check < ::Nanoc::CLI::CommandRunner
     def run
-      validate_options_and_arguments
       site = load_site
 
       runner = Nanoc::Checking::Runner.new(site)
@@ -28,23 +27,14 @@ module Nanoc::CLI::Commands
           runner.run_all
         elsif options[:deploy]
           runner.run_for_deploy
-        else
+        elsif arguments.any?
           runner.run_specific(arguments)
+        else
+          runner.run_for_deploy
         end
 
       unless success
         raise Nanoc::Int::Errors::GenericTrivial, 'One or more checks failed'
-      end
-    end
-
-    protected
-
-    def validate_options_and_arguments
-      if arguments.empty? && !options[:all] && !options[:deploy] && !options[:list]
-        raise(
-          Nanoc::Int::Errors::GenericTrivial,
-          'nothing to do (pass either --all, --deploy or --list or a list of checks)',
-        )
       end
     end
   end

--- a/nanoc/spec/nanoc/cli/commands/check_spec.rb
+++ b/nanoc/spec/nanoc/cli/commands/check_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+describe Nanoc::CLI::Commands::Check, site: true, stdio: true do
+  describe '#run' do
+    before do
+      File.write('Checks', "deploy_check :stale\n")
+    end
+
+    context 'without options and arguments' do
+      subject { Nanoc::CLI.run(['check']) }
+
+      context 'no issues for any checks' do
+        it 'succeeds' do
+          subject
+        end
+      end
+
+      context 'issues for deploy check' do
+        before do
+          FileUtils.mkdir_p('output')
+          File.write('output/asdf.txt', 'staaale')
+        end
+
+        it 'fails' do
+          expect { subject }.to raise_error(Nanoc::Int::Errors::GenericTrivial, 'One or more checks failed')
+        end
+      end
+
+      context 'issues for non-deploy check' do
+        before do
+          FileUtils.mkdir_p('output')
+          File.write('output/asdf.txt', 'staaale')
+          File.write('Checks', '')
+        end
+
+        it 'succeeds' do
+          subject
+        end
+      end
+    end
+  end
+
+  describe 'help' do
+    subject { Nanoc::CLI.run(%w[help check]) }
+
+    it 'shows --deploy as deprecated' do
+      expect { subject }.to output(/--deploy.*\(deprecated\)/).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
Run deploy checks when invoking `nanoc check` without arguments or options.

This also deprecates the `--deploy` option for `nanoc check`, as it’s no longer needed.