### PR TITLE
Add Identifier#match?

### DIFF
--- a/nanoc/lib/nanoc/base/entities/identifier.rb
+++ b/nanoc/lib/nanoc/base/entities/identifier.rb
@@ -101,6 +101,11 @@ module Nanoc
       Nanoc::Int::Pattern.from(other).match?(to_s) ? 0 : nil
     end
 
+    contract C::Any => C::Bool
+    def match?(other)
+      Nanoc::Int::Pattern.from(other).match?(to_s)
+    end
+
     contract C::Any => C::Num
     def <=>(other)
       to_s <=> other.to_s

--- a/nanoc/spec/nanoc/base/entities/identifier_spec.rb
+++ b/nanoc/spec/nanoc/base/entities/identifier_spec.rb
@@ -249,6 +249,40 @@ describe Nanoc::Identifier do
     end
   end
 
+  describe '#match?' do
+    let(:identifier) { described_class.new('/foo/bar') }
+
+    subject { identifier.match?(pat) }
+
+    context 'given a regex' do
+      context 'matching regex' do
+        let(:pat) { %r{\A/foo/bar} }
+        it { is_expected.to be(true) }
+        example { expect { subject }.not_to change { Regexp.last_match } }
+      end
+
+      context 'non-matching regex' do
+        let(:pat) { %r{\A/qux/monkey} }
+        it { is_expected.to be(false) }
+        example { expect { subject }.not_to change { Regexp.last_match } }
+      end
+    end
+
+    context 'given a string' do
+      context 'matching string' do
+        let(:pat) { '/foo/*' }
+        it { is_expected.to be(true) }
+        example { expect { subject }.not_to change { Regexp.last_match } }
+      end
+
+      context 'non-matching string' do
+        let(:pat) { '/qux/*' }
+        it { is_expected.to be(false) }
+        example { expect { subject }.not_to change { Regexp.last_match } }
+      end
+    end
+  end
+
   describe '#<=>' do
     let(:identifier) { described_class.new('/foo/bar') }
 


### PR DESCRIPTION
Rubocop suggests changing `x =~ /foo/` to `x.match?(/foo/)`, but that fails when `x` is an identifier rather than a string.