### PR TITLE
Make sh an alias for shell

### DIFF
--- a/nanoc/lib/nanoc/cli/commands/shell.rb
+++ b/nanoc/lib/nanoc/cli/commands/shell.rb
@@ -2,7 +2,7 @@
 
 usage 'shell'
 summary 'open a shell on the Nanoc environment'
-aliases 'console'
+aliases 'console', 'sh'
 description "
 Open an IRB shell on a context that contains @items, @layouts, and @config.
 "

--- a/nanoc/spec/nanoc/cli/commands/shell_spec.rb
+++ b/nanoc/spec/nanoc/cli/commands/shell_spec.rb
@@ -27,6 +27,24 @@ describe Nanoc::CLI::Commands::Shell, site: true, stdio: true do
       Nanoc::CLI.run(['shell'])
     end
 
+    it 'can be invoked as sh' do
+      expect_any_instance_of(Nanoc::Int::Context).to receive(:pry) do |ctx|
+        expect(ctx.items.size).to eq(1)
+        expect(ctx.items.to_a[0].unwrap.content.string).to eq('Hello!')
+      end
+
+      Nanoc::CLI.run(['sh'])
+    end
+
+    it 'can be invoked as console' do
+      expect_any_instance_of(Nanoc::Int::Context).to receive(:pry) do |ctx|
+        expect(ctx.items.size).to eq(1)
+        expect(ctx.items.to_a[0].unwrap.content.string).to eq('Hello!')
+      end
+
+      Nanoc::CLI.run(['console'])
+    end
+
     it 'will preprocess if requested' do
       expect_any_instance_of(Nanoc::Int::Context).to receive(:pry) do |ctx|
         expect(ctx.items.size).to eq(1)


### PR DESCRIPTION
`nanoc shell` can now be invoked as `nanoc sh` (previously, it was an ambiguous command).