### PR TITLE
Remove routing rules from default site

### DIFF
--- a/nanoc/lib/nanoc/cli/commands/create-site.rb
+++ b/nanoc/lib/nanoc/cli/commands/create-site.rb
@@ -113,8 +113,14 @@ EOS
     DEFAULT_RULES = <<~EOS unless defined? DEFAULT_RULES
       #!/usr/bin/env ruby
 
+      compile '/index.html' do
+        layout '/default.*'
+        write '/index.html'
+      end
+
       compile '/**/*.html' do
         layout '/default.*'
+        write item.identifier.without_ext + '/index.html'
       end
 
       # This is an example rule that matches Markdown (.md) files, and filters them
@@ -124,15 +130,8 @@ EOS
       #compile '/**/*.md' do
       #  filter :kramdown
       #  layout '/default.*'
+      #  write item.identifier.without_ext + '/index.html'
       #end
-
-      route '/**/*.{html,md}' do
-        if item.identifier =~ '/index.*'
-          '/index.html'
-        else
-          item.identifier.without_ext + '/index.html'
-        end
-      end
 
       compile '/**/*' do
         write item.identifier.to_s


### PR DESCRIPTION
This changes the default site to only have compilation and layouting rules — no more routing rules.

Compilation rules with write calls are preferred over compilation rules and routing rules. They make the rules more easy to follow.