### PR TITLE
Stabilise nanoc-live specs on Travis CI

### DIFF
--- a/nanoc-live/lib/nanoc/live/live_recompiler.rb
+++ b/nanoc-live/lib/nanoc/live/live_recompiler.rb
@@ -37,6 +37,7 @@ module Nanoc::Live
         y << quit
       end
 
+      puts 'Listening for site changes…'
       SlowEnumeratorTools.merge([parent_enum, changes_enum]).each do |e|
         break if quit.equal?(e)
 
@@ -64,7 +65,9 @@ module Nanoc::Live
       fork { run_child(pipe_write, pipe_read) { |s| yield(s) } }
       pipe_read.close
 
-      gen_lib_changes.each do |_e|
+      changes = gen_lib_changes
+      puts 'Listening for lib/ changes…'
+      changes.each do |_e|
         # stop child
         pipe_write.write('q')
         pipe_write.close

--- a/nanoc/spec/nanoc/cli/commands/view_spec.rb
+++ b/nanoc/spec/nanoc/cli/commands/view_spec.rb
@@ -11,11 +11,13 @@ describe Nanoc::CLI::Commands::View, site: true, stdio: true do
       20.times do |i|
         begin
           Net::HTTP.get('127.0.0.1', '/', 50_385)
+          break
         rescue Errno::ECONNREFUSED, Errno::ECONNRESET
           sleep(0.1 * 1.1**i)
           next
         end
-        break
+
+        raise 'Server did not start up in time'
       end
 
       yield


### PR DESCRIPTION
The `live` command specs are flaky. This PR changes the implementation of the specs to be more robust.