### PR TITLE
Really ignore output_dir when checking for excludes in pruner

### DIFF
--- a/nanoc/spec/nanoc/regressions/gh_1313_spec.rb
+++ b/nanoc/spec/nanoc/regressions/gh_1313_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe 'GH-1313', site: true, stdio: true do
+  before do
+    File.write('nanoc.yaml', <<~CONFIG)
+      output_dir: build/bin/web/bin
+      prune:
+        auto_prune: true
+        exclude:
+          - bin
+    CONFIG
+  end
+
+  before do
+    FileUtils.mkdir_p('build/bin/web/bin')
+    File.write('build/bin/web/bin/should-be-pruned', 'asdf')
+  end
+
+  example do
+    expect { Nanoc::CLI.run(%w[compile]) }
+      .to change { File.file?('build/bin/web/bin/should-be-pruned') }
+      .from(true)
+      .to(false)
+  end
+end


### PR DESCRIPTION
Fixes #1313.

* [x] Increase test coverage

Also see #1317, which didn’t properly fix this issue.