### PR TITLE
Raise proper error when filter returns nil

### DIFF
--- a/nanoc/lib/nanoc/base/errors.rb
+++ b/nanoc/lib/nanoc/base/errors.rb
@@ -224,6 +224,18 @@ module Nanoc::Int
       end
     end
 
+    class OutputNotWrittenError < ::Nanoc::Error
+      def initialize(filter_name, output_filename)
+        super("The #{filter_name.inspect} filter did not write anything to the required output file, #{output_filename}.")
+      end
+    end
+
+    class FilterReturnedNil < ::Nanoc::Error
+      def initialize(filter_name)
+        super("The #{filter_name.inspect} filter returned nil, but is required to return a String.")
+      end
+    end
+
     class InternalInconsistency < Generic
     end
   end

--- a/nanoc/lib/nanoc/base/services/executor.rb
+++ b/nanoc/lib/nanoc/base/services/executor.rb
@@ -3,12 +3,6 @@
 module Nanoc
   module Int
     class Executor
-      class OutputNotWrittenError < ::Nanoc::Error
-        def initialize(filter_name, output_filename)
-          super("The #{filter_name.inspect} filter did not write anything to the required output file, #{output_filename}.")
-        end
-      end
-
       def initialize(rep, compilation_context, dependency_tracker)
         @rep = rep
         @compilation_context = compilation_context
@@ -35,11 +29,6 @@ module Nanoc
 
           # Store
           @compilation_context.snapshot_repo.set(@rep, :last, last)
-
-          # Check whether file was written
-          if filter.class.to_binary? && !File.file?(filter.output_filename)
-            raise OutputNotWrittenError.new(filter_name, filter.output_filename)
-          end
         ensure
           Nanoc::Int::NotificationCenter.post(:filtering_ended, @rep, filter_name)
         end

--- a/nanoc/spec/nanoc/base/services/executor_spec.rb
+++ b/nanoc/spec/nanoc/base/services/executor_spec.rb
@@ -335,7 +335,7 @@ describe Nanoc::Int::Executor do
 
       example do
         expect { executor.filter(:whatever) }
-          .to raise_error(Nanoc::Int::Executor::OutputNotWrittenError)
+          .to raise_error(Nanoc::Int::Errors::OutputNotWrittenError)
       end
     end
 

--- a/nanoc/spec/nanoc/regressions/gh_1323_spec.rb
+++ b/nanoc/spec/nanoc/regressions/gh_1323_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe 'GH-1323', site: true, stdio: true do
+  before do
+    File.write('content/stuff.html', 'stuff')
+
+    File.write('lib/stuff.rb', <<~EOS)
+      Nanoc::Filter.define(:filter_gh1323) do |content, params = {}|
+        nil
+      end
+    EOS
+
+    File.write('Rules', <<~EOS)
+      compile '/**/*' do
+        filter :filter_gh1323
+      end
+    EOS
+  end
+
+  example do
+    expect { Nanoc::CLI.run(%w[compile]) }
+      .to raise_error { |e| e.unwrap.is_a?(Nanoc::Int::Errors::FilterReturnedNil) }
+  end
+end


### PR DESCRIPTION
Fixes #1323.

After release: 

* Document `FilterReturnedNil` error on the Nanoc web site