### PR TITLE
Improve test/spec Windows compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,11 +54,11 @@ group :plugins do
   gem 'nokogiri', '~> 1.6'
   gem 'nokogumbo', '~> 1.4', platforms: :ruby
   gem 'pandoc-ruby'
-  gem 'pygments.rb', '~> 1.1', '>= 1.1.1', platforms: %i[ruby mswin]
+  gem 'pygments.rb', '~> 1.1', '>= 1.1.1', platforms: :ruby
   gem 'rack'
   gem 'rainpress'
-  gem 'rdiscount', '~> 2.2', platforms: %i[ruby mswin]
-  gem 'redcarpet', '~> 3.0', platforms: %i[ruby mswin]
+  gem 'rdiscount', '~> 2.2', platforms: :ruby
+  gem 'redcarpet', '~> 3.0', platforms: :ruby
   gem 'RedCloth', platforms: :ruby
   gem 'rouge', '~> 3.0'
   gem 'rubypants'

--- a/common/spec/spec_helper_foot.rb
+++ b/common/spec/spec_helper_foot.rb
@@ -60,6 +60,10 @@ RSpec.configure do |c|
 
     File.write('Rules', 'passthrough "/**/*"')
   end
+
+  c.before(:each, fork: true) do
+    skip 'fork() is not supported on Windows' if Nanoc.on_windows?
+  end
 end
 
 RSpec::Matchers.define_negated_matcher :not_match, :match

--- a/nanoc-live/spec/nanoc/live/commands/live_spec.rb
+++ b/nanoc-live/spec/nanoc/live/commands/live_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Nanoc::Live::Commands::Live, site: true, stdio: true do
+describe Nanoc::Live::Commands::Live, site: true, stdio: true, fork: true do
   def run_cmd
     pipe_stdout_read, pipe_stdout_write = IO.pipe
     pid = fork do

--- a/nanoc-live/spec/nanoc/live/live_recompiler_spec.rb
+++ b/nanoc-live/spec/nanoc/live/live_recompiler_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Nanoc::Live::LiveRecompiler, site: true, stdio: true do
+describe Nanoc::Live::LiveRecompiler, site: true, stdio: true, fork: true do
   before do
     Nanoc::CLI::ErrorHandler.enable
   end

--- a/nanoc/lib/nanoc/spec.rb
+++ b/nanoc/lib/nanoc/spec.rb
@@ -25,6 +25,12 @@ module Nanoc
         skip "Could not find external command \"#{cmd}\"" unless command?(cmd)
       end
 
+      def skip_unless_gem_available(gem)
+        require gem
+      rescue LoadError
+        skip "Could not load gem \"#{gem}\""
+      end
+
       def sleep_until(max: 3.0)
         start = Time.now
         loop do

--- a/nanoc/spec/nanoc/base/checksummer_spec.rb
+++ b/nanoc/spec/nanoc/base/checksummer_spec.rb
@@ -395,7 +395,7 @@ describe Nanoc::Int::Checksummer do
 
     before { require 'sass' }
 
-    it { is_expected.to eql('Sass::Importers::Filesystem<root=/foo>') }
+    it { is_expected.to match(%r{\ASass::Importers::Filesystem<root=(C:)?/foo>\z}) }
   end
 
   context 'other marshal-able classes' do

--- a/nanoc/spec/nanoc/base/services/executor_spec.rb
+++ b/nanoc/spec/nanoc/base/services/executor_spec.rb
@@ -127,7 +127,7 @@ describe Nanoc::Int::Executor do
         expect { subject }
           .to change { snapshot_repo.get(rep, :last) }
           .from(some_binary_content('Foo Data'))
-          .to(some_binary_content(/\ACompiled data for \/.*\/foo.dat\z/))
+          .to(some_binary_content(/\ACompiled data for (C:)?\/.*\/foo.dat\z/))
       end
 
       it 'does not set :pre in repo' do
@@ -144,7 +144,7 @@ describe Nanoc::Int::Executor do
         expect { subject }
           .to change { File.read(snapshot_repo.get(rep, :last).filename) }
           .from('Foo Data')
-          .to(/\ACompiled data for \/.*\/foo.dat\z/)
+          .to(/\ACompiled data for (C:)?\/.*\/foo.dat\z/)
       end
 
       it 'returns frozen data' do
@@ -194,7 +194,7 @@ describe Nanoc::Int::Executor do
         expect { subject }
           .to change { snapshot_repo.get(rep, :last) }
           .from(some_binary_content('Foo Data'))
-          .to(some_textual_content(/\ACompiled data for \/.*\/foo.dat\z/))
+          .to(some_textual_content(/\ACompiled data for (C:)?\/.*\/foo.dat\z/))
       end
 
       it 'does not set :pre in repo' do
@@ -211,7 +211,7 @@ describe Nanoc::Int::Executor do
         expect { subject }
           .to change { snapshot_repo.get(rep, :last) }
           .from(some_binary_content('Foo Data'))
-          .to(some_textual_content(/\ACompiled data for \/.*\/foo.dat\z/))
+          .to(some_textual_content(/\ACompiled data for (C:)?\/.*\/foo.dat\z/))
       end
     end
 

--- a/nanoc/spec/nanoc/base/services/temp_filename_factory_spec.rb
+++ b/nanoc/spec/nanoc/base/services/temp_filename_factory_spec.rb
@@ -16,7 +16,7 @@ describe Nanoc::Int::TempFilenameFactory do
     it 'returns absolute paths' do
       path = subject.create(prefix)
 
-      expect(path).to match(/\A\//)
+      expect(path).to match(/\A(C:)?\//)
     end
 
     it 'creates the containing directory' do

--- a/nanoc/spec/nanoc/cli/commands/compile_spec.rb
+++ b/nanoc/spec/nanoc/cli/commands/compile_spec.rb
@@ -42,45 +42,47 @@ describe Nanoc::CLI::Commands::Compile, site: true, stdio: true do
       expect(listener).to be_stopped
     end
 
-    it 'watches with --watch' do
-      pipe_stdout_read, pipe_stdout_write = IO.pipe
-      pid = fork do
-        trap(:INT) { exit(0) }
+    describe '--watch', fork: true do
+      it 'watches with --watch' do
+        pipe_stdout_read, pipe_stdout_write = IO.pipe
+        pid = fork do
+          trap(:INT) { exit(0) }
 
-        pipe_stdout_read.close
-        $stdout = pipe_stdout_write
+          pipe_stdout_read.close
+          $stdout = pipe_stdout_write
 
-        # TODO: Use Nanoc::CLI.run instead (when --watch is no longer experimental)
-        options = { watch: true }
-        arguments = []
-        cmd = nil
-        cmd_runner = Nanoc::CLI::Commands::Compile.new(options, arguments, cmd)
-        cmd_runner.run
-      end
-      pipe_stdout_write.close
-
-      # Wait until ready
-      Timeout.timeout(5) do
-        progress = 0
-        pipe_stdout_read.each_line do |line|
-          progress += 1 if line.start_with?('Listening for lib/ changes')
-          progress += 1 if line.start_with?('Listening for site changes')
-          break if progress == 2
+          # TODO: Use Nanoc::CLI.run instead (when --watch is no longer experimental)
+          options = { watch: true }
+          arguments = []
+          cmd = nil
+          cmd_runner = Nanoc::CLI::Commands::Compile.new(options, arguments, cmd)
+          cmd_runner.run
         end
+        pipe_stdout_write.close
+
+        # Wait until ready
+        Timeout.timeout(5) do
+          progress = 0
+          pipe_stdout_read.each_line do |line|
+            progress += 1 if line.start_with?('Listening for lib/ changes')
+            progress += 1 if line.start_with?('Listening for site changes')
+            break if progress == 2
+          end
+        end
+        sleep 0.5 # Still needs time to warm up…
+
+        File.write('content/lol.html', 'hej')
+        sleep_until { File.file?('output/lol.html') }
+        expect(File.read('output/lol.html')).to eq('hej')
+
+        sleep 1.0 # HFS+ mtime resolution is 1s
+        File.write('content/lol.html', 'bye')
+        sleep_until { File.read('output/lol.html') == 'bye' }
+
+        # Stop
+        Process.kill('INT', pid)
+        Process.waitpid(pid)
       end
-      sleep 0.5 # Still needs time to warm up…
-
-      File.write('content/lol.html', 'hej')
-      sleep_until { File.file?('output/lol.html') }
-      expect(File.read('output/lol.html')).to eq('hej')
-
-      sleep 1.0 # HFS+ mtime resolution is 1s
-      File.write('content/lol.html', 'bye')
-      sleep_until { File.read('output/lol.html') == 'bye' }
-
-      # Stop
-      Process.kill('INT', pid)
-      Process.waitpid(pid)
     end
   end
 end

--- a/nanoc/spec/nanoc/cli/commands/deploy_spec.rb
+++ b/nanoc/spec/nanoc/cli/commands/deploy_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 describe Nanoc::CLI::Commands::Deploy, site: true, stdio: true do
+  before do
+    skip_unless_have_command 'rsync'
+  end
+
   describe '#run' do
     let(:config) { {} }
 

--- a/nanoc/spec/nanoc/cli/commands/view_spec.rb
+++ b/nanoc/spec/nanoc/cli/commands/view_spec.rb
@@ -2,7 +2,7 @@
 
 require 'net/http'
 
-describe Nanoc::CLI::Commands::View, site: true, stdio: true do
+describe Nanoc::CLI::Commands::View, site: true, stdio: true, fork: true do
   describe '#run' do
     def run_nanoc_cmd(cmd)
       pid = fork { Nanoc::CLI.run(cmd) }

--- a/nanoc/spec/nanoc/cli/stack_trace_writer_spec.rb
+++ b/nanoc/spec/nanoc/cli/stack_trace_writer_spec.rb
@@ -46,7 +46,7 @@ describe Nanoc::CLI::StackTraceWriter do
           expect { subject }
             .to change { io.string }
             .from('')
-            .to(match(%r{^  0\. /.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d+.*$\n  1\. /.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d}m))
+            .to(match(%r{^  0\. (C:)?/.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d+.*$\n  1\. (C:)?/.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d}m))
         end
 
         it 'has more than 10 stack frames' do
@@ -76,7 +76,7 @@ describe Nanoc::CLI::StackTraceWriter do
           expect { subject }
             .to change { io.string }
             .from('')
-            .to(match(%r{^  0\. /.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d+.*$\n  1\. /.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d}m))
+            .to(match(%r{^  0\. (C:)?/.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d+.*$\n  1\. (C:)?/.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d}m))
         end
 
         it 'has not more than 10 stack frames' do
@@ -101,14 +101,14 @@ describe Nanoc::CLI::StackTraceWriter do
           expect { subject }
             .to change { io.string }
             .from('')
-            .to(match(%r{^  1\. from /.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d+.*$\n  /.+/spec/nanoc/cli}m))
+            .to(match(%r{^  1\. from (C:)?/.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d+.*$\n  (C:)?/.+/spec/nanoc/cli}m))
         end
 
         it 'has more recent stack frames at the bottom' do
           expect { subject }
             .to change { io.string }
             .from('')
-            .to(match(%r{^  2\. from /.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d+.*$\n  1\. from /.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d}m))
+            .to(match(%r{^  2\. from (C:)?/.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d+.*$\n  1\. from (C:)?/.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d}m))
         end
 
         it 'has more than 10 stack frames' do
@@ -131,14 +131,14 @@ describe Nanoc::CLI::StackTraceWriter do
           expect { subject }
             .to change { io.string }
             .from('')
-            .to(match(%r{^  1\. from /.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d+.*$\n  /.+/spec/nanoc/cli}m))
+            .to(match(%r{^  1\. from (C:)?/.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d+.*$\n  (C:)?/.+/spec/nanoc/cli}m))
         end
 
         it 'has more recent stack frames at the top' do
           expect { subject }
             .to change { io.string }
             .from('')
-            .to(match(%r{^  2\. from /.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d+.*$\n  1\. from /.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d}m))
+            .to(match(%r{^  2\. from (C:)?/.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d+.*$\n  1\. from (C:)?/.+/spec/nanoc/cli/stack_trace_writer_spec\.rb:\d}m))
         end
 
         it 'has not more than 10 stack frames' do

--- a/nanoc/spec/nanoc/filters/less_spec.rb
+++ b/nanoc/spec/nanoc/filters/less_spec.rb
@@ -5,6 +5,10 @@ describe Nanoc::Filters::Less, site: true, stdio: true do
   # this :less filter, because of the way it handles fibers.
 
   before do
+    skip_unless_gem_available('less')
+  end
+
+  before do
     File.open('Rules', 'w') do |io|
       io.write "compile '/**/*.less' do\n"
       io.write "  filter :less\n"

--- a/nanoc/test/checking/test_dsl.rb
+++ b/nanoc/test/checking/test_dsl.rb
@@ -28,7 +28,7 @@ class Nanoc::Checking::DSLTest < Nanoc::TestCase
     with_site do |_site|
       File.write('Checks', '$stuff = __FILE__')
       Nanoc::Checking::DSL.from_file('Checks', enabled_checks: [])
-      assert($stuff.start_with?('/'))
+      assert(Pathname.new($stuff).absolute?)
     end
   end
 end

--- a/nanoc/test/deploying/test_rsync.rb
+++ b/nanoc/test/deploying/test_rsync.rb
@@ -3,6 +3,11 @@
 require 'helper'
 
 class Nanoc::Deploying::Deployers::RsyncTest < Nanoc::TestCase
+  def setup
+    super
+    skip_unless_have_command 'rsync'
+  end
+
   def test_run_without_dst
     # Create deployer
     rsync = Nanoc::Deploying::Deployers::Rsync.new(

--- a/nanoc/test/filters/colorize_syntax/test_common.rb
+++ b/nanoc/test/filters/colorize_syntax/test_common.rb
@@ -54,6 +54,8 @@ EOS
   end
 
   def test_full_page_html5
+    skip_unless_have 'nokogumbo'
+
     # Create filter
     filter = ::Nanoc::Filters::ColorizeSyntax.new
 

--- a/nanoc/test/filters/test_bluecloth.rb
+++ b/nanoc/test/filters/test_bluecloth.rb
@@ -4,6 +4,8 @@ require 'helper'
 
 class Nanoc::Filters::BlueClothTest < Nanoc::TestCase
   def test_filter
+    skip_unless_have 'bluecloth'
+
     # Create filter
     filter = ::Nanoc::Filters::BlueCloth.new
 

--- a/nanoc/test/filters/test_redcarpet.rb
+++ b/nanoc/test/filters/test_redcarpet.rb
@@ -2,8 +2,12 @@
 
 require 'helper'
 
-require 'redcarpet'
 class Nanoc::Filters::RedcarpetTest < Nanoc::TestCase
+  def setup
+    super
+    skip_unless_have 'redcarpet'
+  end
+
   def test_find
     refute Nanoc::Filter.named(:redcarpet).nil?
   end

--- a/nanoc/test/filters/test_redcloth.rb
+++ b/nanoc/test/filters/test_redcloth.rb
@@ -3,6 +3,11 @@
 require 'helper'
 
 class Nanoc::Filters::RedClothTest < Nanoc::TestCase
+  def setup
+    super
+    skip_unless_have 'redcloth'
+  end
+
   def test_filter
     # Get filter
     filter = ::Nanoc::Filters::RedCloth.new

--- a/nanoc/test/filters/test_relativize_paths.rb
+++ b/nanoc/test/filters/test_relativize_paths.rb
@@ -120,6 +120,8 @@ EOS
   end
 
   def test_filter_html5_with_boilerplate
+    skip_unless_have 'nokogumbo'
+
     # Create filter with mock item
     filter = Nanoc::Filters::RelativizePaths.new
 

--- a/nanoc/test/helper.rb
+++ b/nanoc/test/helper.rb
@@ -234,6 +234,10 @@ EOS
     skip 'Symlinks are not supported by Ruby on Windows' unless symlinks_supported?
   end
 
+  def skip_unless_have(*libs)
+    if_have(*libs) {}
+  end
+
   def root_dir
     File.absolute_path(__dir__ + '/..')
   end


### PR DESCRIPTION
This change is in preparation of running the build on AppVeyor (see #1325).

* [x] Skip gems with C extensions
* [x] Skip tests that use `fork()`
* [x] Handle absolute paths — handle optional `C:` prefix
* [x] Handle missing `rsync`