### PR TITLE
Also consider .xhtml and .html in checks

### DIFF
--- a/nanoc/lib/nanoc/checking/check.rb
+++ b/nanoc/lib/nanoc/checking/check.rb
@@ -61,7 +61,7 @@ module Nanoc::Checking
 
     # @private
     def output_html_filenames
-      output_filenames.select { |f| File.extname(f) == '.html' }
+      output_filenames.select { |f| File.extname(f) =~ /\A\.x?html?\z/ }
     end
   end
 end

--- a/nanoc/lib/nanoc/checking/check.rb
+++ b/nanoc/lib/nanoc/checking/check.rb
@@ -58,5 +58,10 @@ module Nanoc::Checking
     def add_issue(desc, subject: nil)
       @issues << Issue.new(desc, subject, self.class)
     end
+
+    # @private
+    def output_html_filenames
+      output_filenames.select { |f| File.extname(f) == '.html' }
+    end
   end
 end

--- a/nanoc/lib/nanoc/checking/checks/external_links.rb
+++ b/nanoc/lib/nanoc/checking/checks/external_links.rb
@@ -10,7 +10,7 @@ module ::Nanoc::Checking::Checks
     def run
       # Find all broken external hrefs
       # TODO: de-duplicate this (duplicated in internal links check)
-      filenames = output_filenames.select { |f| File.extname(f) == '.html' && !excluded_file?(f) }
+      filenames = output_html_filenames.reject { |f| excluded_file?(f) }
       hrefs_with_filenames = ::Nanoc::Extra::LinkCollector.new(filenames, :external).filenames_per_href
       results = select_invalid(hrefs_with_filenames.keys)
 

--- a/nanoc/lib/nanoc/checking/checks/internal_links.rb
+++ b/nanoc/lib/nanoc/checking/checks/internal_links.rb
@@ -15,7 +15,7 @@ module Nanoc::Checking::Checks
     # @return [void]
     def run
       # TODO: de-duplicate this (duplicated in external links check)
-      filenames = output_filenames.select { |f| File.extname(f) == '.html' }
+      filenames = output_html_filenames
       hrefs_with_filenames = ::Nanoc::Extra::LinkCollector.new(filenames, :internal).filenames_per_href
       resource_uris_with_filenames = ::Nanoc::Extra::LinkCollector.new(filenames, :internal).filenames_per_resource_uri
 

--- a/nanoc/lib/nanoc/checking/checks/mixed_content.rb
+++ b/nanoc/lib/nanoc/checking/checks/mixed_content.rb
@@ -11,7 +11,7 @@ module Nanoc::Checking::Checks
     PROTOCOL_PATTERN = /^(\w+):\/\//
 
     def run
-      filenames = output_filenames.select { |f| File.extname(f) == '.html' }
+      filenames = output_html_filenames
       resource_uris_with_filenames = ::Nanoc::Extra::LinkCollector.new(filenames).filenames_per_resource_uri
 
       resource_uris_with_filenames.each_pair do |uri, fns|

--- a/nanoc/spec/nanoc/checking/check_spec.rb
+++ b/nanoc/spec/nanoc/checking/check_spec.rb
@@ -53,4 +53,31 @@ describe Nanoc::Checking::Check do
       expect(described_class.named(:asdfaskjlfdalhsgdjf)).to be_nil
     end
   end
+
+  describe '#output_html_filenames' do
+    let(:check) do
+      described_class.new(output_filenames: output_filenames)
+    end
+
+    let(:output_filenames) do
+      [
+        'output/foo.html',
+        'output/foo.htm',
+        'output/foo.xhtml',
+        'output/foo.txt',
+        'output/foo.htmlx',
+        'output/foo.yhtml',
+      ]
+    end
+
+    subject { check.output_html_filenames }
+
+    it { is_expected.to include('output/foo.html') }
+    it { is_expected.to include('output/foo.htm') }
+    it { is_expected.to include('output/foo.xhtml') }
+
+    it { is_expected.not_to include('output/foo.txt') }
+    it { is_expected.not_to include('output/foo.htmlx') }
+    it { is_expected.not_to include('output/foo.yhtml') }
+  end
 end

--- a/nanoc/spec/nanoc/regressions/gh_1328_spec.rb
+++ b/nanoc/spec/nanoc/regressions/gh_1328_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+describe 'GH-1328', site: true, stdio: true do
+  before do
+    FileUtils.mkdir_p('content')
+    File.write('content/foo.md', <<~EOS)
+      <html>
+        <head>
+          <title>hi</title>
+        </head>
+        <body>
+          <a href="/b0rk">bork bork</a>
+        </body>
+      </html>
+    EOS
+
+    File.write('Rules', <<~EOS)
+      compile '/*' do
+        write ext: 'html'
+        write ext: 'htm'
+        write ext: 'xhtml'
+      end
+    EOS
+  end
+
+  before do
+    Nanoc::CLI.run([])
+  end
+
+  it 'fails check for foo.html' do
+    expect { Nanoc::CLI.run(%w[check ilinks]) }
+      .to raise_error(Nanoc::Int::Errors::GenericTrivial, 'One or more checks failed')
+      .and output(%r{output/foo\.html:}).to_stdout
+  end
+
+  it 'fails check for foo.xhtml' do
+    expect { Nanoc::CLI.run(%w[check ilinks]) }
+      .to raise_error(Nanoc::Int::Errors::GenericTrivial, 'One or more checks failed')
+      .and output(%r{output/foo\.xhtml:}).to_stdout
+  end
+
+  it 'fails check for foo.htm' do
+    expect { Nanoc::CLI.run(%w[check ilinks]) }
+      .to raise_error(Nanoc::Int::Errors::GenericTrivial, 'One or more checks failed')
+      .and output(%r{output/foo\.htm:}).to_stdout
+  end
+end


### PR DESCRIPTION
Fixes #1328.

I’m unsure whether or not it makes sense to configure the list of HTML extensions. There are no commonly-used extensions other than `html`, `htm`, and `xhtml`. (Wikipedia also lists `.xht`, but I have never seen that one in the wild.)