### PR TITLE
Make Filter#depend_on work even when no reps are present

### DIFF
--- a/nanoc/lib/nanoc/base/services/filter.rb
+++ b/nanoc/lib/nanoc/base/services/filter.rb
@@ -228,6 +228,7 @@ module Nanoc
     # @return [void]
     def depend_on(items)
       items.flat_map(&:reps).flat_map(&:raw_path)
+      items.each(&:raw_filename)
     end
   end
 end


### PR DESCRIPTION
`Filter#depend_on` does nothing when passed an item with no reps.

This change makes it depend at least on the raw content.