### PR TITLE
Make *ItemView#raw_filename create dependency

### DIFF
--- a/nanoc/lib/nanoc/base/views/basic_item_view.rb
+++ b/nanoc/lib/nanoc/base/views/basic_item_view.rb
@@ -45,6 +45,7 @@ module Nanoc
 
     # @api private
     def raw_filename
+      @context.dependency_tracker.bounce(_unwrap, raw_content: true)
       _unwrap.content.filename
     end
   end

--- a/nanoc/spec/nanoc/base/views/item_view_spec.rb
+++ b/nanoc/spec/nanoc/base/views/item_view_spec.rb
@@ -362,7 +362,78 @@ describe Nanoc::CompilationItemView do
   end
 
   describe '#raw_filename' do
-    # TODO: implement
+    subject { view.raw_filename }
+
+    let(:item) do
+      Nanoc::Int::Item.new(content, { animal: 'donkey' }, '/foo')
+    end
+
+    let(:view) { described_class.new(item, view_context) }
+
+    context 'textual content with no raw filename' do
+      let(:content) { Nanoc::Int::TextualContent.new('asdf') }
+
+      it { is_expected.to be_nil }
+
+      it 'creates a dependency' do
+        expect { subject }.to change { dependency_store.objects_causing_outdatedness_of(base_item) }.from([]).to([item])
+      end
+
+      it 'creates a dependency with the right props' do
+        subject
+        dep = dependency_store.dependencies_causing_outdatedness_of(base_item)[0]
+
+        expect(dep.props.raw_content?).to eq(true)
+
+        expect(dep.props.attributes?).to eq(false)
+        expect(dep.props.compiled_content?).to eq(false)
+        expect(dep.props.path?).to eq(false)
+      end
+    end
+
+    context 'textual content with raw filename' do
+      let(:content) { Nanoc::Int::TextualContent.new('asdf', filename: filename) }
+      let(:filename) { '/tmp/lol.txt' }
+
+      it { is_expected.to eql('/tmp/lol.txt') }
+
+      it 'creates a dependency' do
+        expect { subject }.to change { dependency_store.objects_causing_outdatedness_of(base_item) }.from([]).to([item])
+      end
+
+      it 'creates a dependency with the right props' do
+        subject
+        dep = dependency_store.dependencies_causing_outdatedness_of(base_item)[0]
+
+        expect(dep.props.raw_content?).to eq(true)
+
+        expect(dep.props.attributes?).to eq(false)
+        expect(dep.props.compiled_content?).to eq(false)
+        expect(dep.props.path?).to eq(false)
+      end
+    end
+
+    context 'binary content' do
+      let(:content) { Nanoc::Int::BinaryContent.new(filename) }
+      let(:filename) { '/tmp/lol.txt' }
+
+      it { is_expected.to eql('/tmp/lol.txt') }
+
+      it 'creates a dependency' do
+        expect { subject }.to change { dependency_store.objects_causing_outdatedness_of(base_item) }.from([]).to([item])
+      end
+
+      it 'creates a dependency with the right props' do
+        subject
+        dep = dependency_store.dependencies_causing_outdatedness_of(base_item)[0]
+
+        expect(dep.props.raw_content?).to eq(true)
+
+        expect(dep.props.attributes?).to eq(false)
+        expect(dep.props.compiled_content?).to eq(false)
+        expect(dep.props.path?).to eq(false)
+      end
+    end
   end
 
   describe '#inspect' do

--- a/nanoc/spec/nanoc/filters/sass_spec.rb
+++ b/nanoc/spec/nanoc/filters/sass_spec.rb
@@ -48,9 +48,31 @@ describe Nanoc::Filters::Sass do
       )
     end
 
-    let(:item_view) { Nanoc::CompilationItemView.new(item, nil) }
+    let(:item_view) { Nanoc::CompilationItemView.new(item, view_context) }
 
     let(:item_views) { [item_view] }
+
+    let(:view_context) do
+      Nanoc::ViewContextForCompilation.new(
+        reps: reps,
+        items: items,
+        dependency_tracker: dependency_tracker,
+        compilation_context: compilation_context,
+        snapshot_repo: snapshot_repo,
+      )
+    end
+
+    let(:reps) { Nanoc::Int::ItemRepRepo.new }
+    let(:items) { Nanoc::Int::ItemCollection.new(config) }
+    let(:dependency_tracker) { Nanoc::Int::DependencyTracker.new(dependency_store) }
+    let(:dependency_store) { Nanoc::Int::DependencyStore.new(empty_items, empty_layouts, config) }
+    let(:compilation_context) { double(:compilation_context) }
+    let(:snapshot_repo) { Nanoc::Int::SnapshotRepo.new }
+
+    let(:empty_items) { Nanoc::Int::ItemCollection.new(config) }
+    let(:empty_layouts) { Nanoc::Int::LayoutCollection.new(config) }
+
+    let(:config) { Nanoc::Int::Configuration.new.with_defaults }
 
     before do
       FileUtils.mkdir_p(File.dirname(item.attributes[:content_filename]))

--- a/nanoc/test/filters/test_sass.rb
+++ b/nanoc/test/filters/test_sass.rb
@@ -289,6 +289,15 @@ class Nanoc::Filters::SassTest < Nanoc::TestCase
     FileUtils.mkdir_p('content')
     File.open('content/xyzzy.sass', 'w') { |io| io.write('p\n  color: green') }
 
+    config = Nanoc::Int::Configuration.new.with_defaults
+
+    empty_items = Nanoc::Int::ItemCollection.new(config)
+    empty_layouts = Nanoc::Int::LayoutCollection.new(config)
+
+    dependency_store = Nanoc::Int::DependencyStore.new(empty_items, empty_layouts, config)
+    dependency_tracker = Nanoc::Int::DependencyTracker.new(dependency_store)
+    view_context = OpenStruct.new(dependency_tracker: dependency_tracker)
+
     items = [
       Nanoc::CompilationItemView.new(
         Nanoc::Int::Item.new(
@@ -296,7 +305,7 @@ class Nanoc::Filters::SassTest < Nanoc::TestCase
           { content_filename: 'content/xyzzy.sass' },
           '/blah',
         ),
-        nil,
+        view_context,
       ),
     ]
     params = { item: items[0], items: items }.merge(params)


### PR DESCRIPTION
As the title says. `#raw_filename` should have created a dependency.