### PR TITLE
Do not report thread exceptions

### DIFF
--- a/nanoc-live/lib/nanoc/live/commands/live.rb
+++ b/nanoc-live/lib/nanoc/live/commands/live.rb
@@ -19,6 +19,10 @@ module Nanoc::Live::Commands
 
       Thread.new do
         Thread.current.abort_on_exception = true
+        if Thread.current.respond_to?(:report_on_exception)
+          Thread.current.report_on_exception = false
+        end
+
         view_options = options.merge('live-reload': true)
         Nanoc::CLI::Commands::View.new(view_options, [], self).run
       end


### PR DESCRIPTION
This fixes an obscure problem where `nanoc-live` would appear to successfully exit, but one thread would remain behind and keep soaking up memory and CPU time in trying to do garbage collection, in order to be able to print an apparently very large string.

This only affects Ruby 2.5, as older versions of Ruby either don’t have `report_on_exception`, or have it set to `false` by default.

Sample:

```
    2591 Thread_1639960: live.rb:20
    + 2591 thread_start  (in libsystem_pthread.dylib) + 13  [0x7fff7ccb5c5d]
    +   2591 _pthread_start  (in libsystem_pthread.dylib) + 377  [0x7fff7ccb656d]
    +     2591 _pthread_body  (in libsystem_pthread.dylib) + 340  [0x7fff7ccb66c1]
    +       2591 thread_start_func_1  (in libruby.2.5.dylib) + 69  [0x10a81c481]
    +         2591 thread_start_func_2  (in libruby.2.5.dylib) + 369  [0x10a81c5fb]
    +           2591 rb_write_error_str  (in libruby.2.5.dylib) + 69  [0x10a7634fd]
    +             2591 rb_funcallv  (in libruby.2.5.dylib) + 49  [0x10a83e3c1]
    +               2591 rb_call0  (in libruby.2.5.dylib) + 151  [0x10a84d87f]
    +                 2591 vm_call0_body  (in libruby.2.5.dylib) + 895  [0x10a84d2a7]
    +                   2591 vm_exec  (in libruby.2.5.dylib) + 142  [0x10a843beb]
    +                     2591 vm_exec_core  (in libruby.2.5.dylib) + 9450  [0x10a837607]
    +                       2591 vm_call_cfunc  (in libruby.2.5.dylib) + 280  [0x10a8475ca]
    +                         2591 io_write  (in libruby.2.5.dylib) + 282  [0x10a7703b3]
    +                           2591 rb_sys_fail_path_in  (in libruby.2.5.dylib) + 47  [0x10a741725]
    +                             2591 rb_syserr_fail_path_in  (in libruby.2.5.dylib) + 86  [0x10a74177b]
    +                               2591 rb_class_new_instance  (in libruby.2.5.dylib) + 67  [0x10a79145d]
    +                                 2591 rb_funcallv  (in libruby.2.5.dylib) + 49  [0x10a83e3c1]
    +                                   2591 rb_call0  (in libruby.2.5.dylib) + 151  [0x10a84d87f]
    +                                     2591 vm_call0_body  (in libruby.2.5.dylib) + 577  [0x10a84d169]
    +                                       2591 syserr_initialize  (in libruby.2.5.dylib) + 581  [0x10a740d71]
    +                                         2591 rb_str_catf  (in libruby.2.5.dylib) + 124  [0x10a7f2170]
    +                                           2591 rb_str_vcatf  (in libruby.2.5.dylib) + 173  [0x10a7f5977]
    +                                             2591 BSD_vfprintf  (in libruby.2.5.dylib) + 8234  [0x10a7f478b]
    +                                               2591 ruby__sfvwrite  (in libruby.2.5.dylib) + 171  [0x10a7f245b]
    +                                                 2591 rb_str_resize  (in libruby.2.5.dylib) + 501  [0x10a8007f9]
    +                                                   2591 str_make_independent_expand  (in libruby.2.5.dylib) + 85  [0x10a7ff5da]
    +                                                     2591 objspace_xmalloc0  (in libruby.2.5.dylib) + 129  [0x10a7538ae]
    +                                                       2540 gc_start  (in libruby.2.5.dylib) + 1800  [0x10a7572a6]
    +                                                       ! 1824 backtrace_mark  (in libruby.2.5.dylib) + 14,18,...  [0x10a850330,0x10a850334,...]
    +                                                       ! 675 gc_mark_children  (in libruby.2.5.dylib) + 20,1273,...  [0x10a752d67,0x10a75324c,...]
    +                                                       ! 23 backtrace_mark  (in libruby.2.5.dylib) + 54  [0x10a850358]
    +                                                       ! : 15 gc_mark_ptr  (in libruby.2.5.dylib) + 84,48,...  [0x10a758f78,0x10a758f54,...]
    +                                                       ! : 6 rb_gc_mark  (in libruby.2.5.dylib) + 0,37,...  [0x10a75022a,0x10a75024f,...]
    +                                                       ! : 2 gc_mark_ptr  (in libruby.2.5.dylib) + 36  [0x10a758f48]
    +                                                       ! :   2 rgengc_check_relation  (in libruby.2.5.dylib) + 4,12  [0x10a758fc7,0x10a758fcf]
    +                                                       ! 12 gc_mark_children  (in libruby.2.5.dylib) + 345  [0x10a752eac]
    +                                                       ! : 8 gc_mark_ptr  (in libruby.2.5.dylib) + 6,84,...  [0x10a758f2a,0x10a758f78,...]
    +                                                       ! : 4 gc_mark_ptr  (in libruby.2.5.dylib) + 36  [0x10a758f48]
    +                                                       ! :   4 rgengc_check_relation  (in libruby.2.5.dylib) + 0,1  [0x10a758fc3,0x10a758fc4]
    +                                                       ! 3 backtrace_mark  (in libruby.2.5.dylib) + 75  [0x10a85036d]
    +                                                       ! : 3 rb_gc_mark  (in libruby.2.5.dylib) + 47,14  [0x10a750259,0x10a750238]
    +                                                       ! 3 rb_gc_mark  (in libruby.2.5.dylib) + 1,11,...  [0x10a75022b,0x10a750235,...]
    +                                                       50 gc_start  (in libruby.2.5.dylib) + 1700,1804,...  [0x10a757242,0x10a7572aa,...]
    +                                                       1 gc_mark_children  (in libruby.2.5.dylib) + 1624  [0x10a7533ab]
```