### PR TITLE
Enable passing custom variables to the Haml filter

### DIFF
--- a/nanoc/lib/nanoc/filters/haml.rb
+++ b/nanoc/lib/nanoc/filters/haml.rb
@@ -16,13 +16,15 @@ module Nanoc::Filters
     def run(content, params = {})
       # Get options
       options = params.merge(filename: filename)
+      options.delete:(assigns)
 
       # Create context
       context = ::Nanoc::Int::Context.new(assigns)
+      locals = assigns.merge(params[:assigns] || {})
 
       # Get result
       proc = assigns[:content] ? -> { assigns[:content] } : nil
-      ::Haml::Engine.new(content, options).render(context, assigns, &proc)
+      ::Haml::Engine.new(content, options).render(context, locals, &proc)
     end
   end
 end


### PR DESCRIPTION
The Haml filter can now take custom local variables

### Detailed description

```ruby
compile "/**/index.html" do
  layout "/default.haml", assigns: {foo: "bar"}
  # Now, in the layout, one can use the "foo" variable whose value will be "bar"
  write item.identifier
end
```