### PR TITLE
Add exclude: param to relativize_paths filter

### DIFF
--- a/nanoc/spec/nanoc/filters/relativize_paths_spec.rb
+++ b/nanoc/spec/nanoc/filters/relativize_paths_spec.rb
@@ -21,7 +21,7 @@ describe Nanoc::Filters::RelativizePaths do
     subject { filter.setup_and_run(content, params) }
 
     let(:content) do
-      '<a href="/foo">Foo</a>'
+      '<a href="/foo/bar">Foo</a>'
     end
 
     let(:params) do
@@ -30,26 +30,147 @@ describe Nanoc::Filters::RelativizePaths do
 
     context 'HTML' do
       let(:params) { { type: :html } }
-      it { is_expected.to eq('<a href="../foo">Foo</a>') }
+      it { is_expected.to eq('<a href="../foo/bar">Foo</a>') }
+
+      context 'full component excluded' do
+        let(:params) { { type: :html, exclude: '/foo' } }
+        it { is_expected.to eq('<a href="/foo/bar">Foo</a>') }
+      end
+
+      context 'full component excluded as list' do
+        let(:params) { { type: :html, exclude: ['/foo'] } }
+        it { is_expected.to eq('<a href="/foo/bar">Foo</a>') }
+      end
+
+      context 'partial component excluded' do
+        let(:params) { { type: :html, exclude: ['/fo'] } }
+        it { is_expected.to eq('<a href="../foo/bar">Foo</a>') }
+      end
+
+      context 'non-root component excluded' do
+        let(:params) { { type: :html, exclude: ['/bar'] } }
+        it { is_expected.to eq('<a href="../foo/bar">Foo</a>') }
+      end
+
+      context 'excluded with regexp' do
+        let(:params) { { type: :html, exclude: /ar/ } }
+        it { is_expected.to eq('<a href="/foo/bar">Foo</a>') }
+      end
+
+      context 'excluded with regexp list' do
+        let(:params) { { type: :html, exclude: [/ar/] } }
+        it { is_expected.to eq('<a href="/foo/bar">Foo</a>') }
+      end
     end
 
     context 'HTML5' do
       let(:params) { { type: :html5 } }
-      it { is_expected.to eq('<a href="../foo">Foo</a>') }
+      it { is_expected.to eq('<a href="../foo/bar">Foo</a>') }
+
+      context 'full component excluded' do
+        let(:params) { { type: :html5, exclude: '/foo' } }
+        it { is_expected.to eq('<a href="/foo/bar">Foo</a>') }
+      end
+
+      context 'full component excluded as list' do
+        let(:params) { { type: :html5, exclude: ['/foo'] } }
+        it { is_expected.to eq('<a href="/foo/bar">Foo</a>') }
+      end
+
+      context 'partial component excluded' do
+        let(:params) { { type: :html5, exclude: ['/fo'] } }
+        it { is_expected.to eq('<a href="../foo/bar">Foo</a>') }
+      end
+
+      context 'non-root component excluded' do
+        let(:params) { { type: :html5, exclude: ['/bar'] } }
+        it { is_expected.to eq('<a href="../foo/bar">Foo</a>') }
+      end
+
+      context 'excluded with regexp' do
+        let(:params) { { type: :html5, exclude: /ar/ } }
+        it { is_expected.to eq('<a href="/foo/bar">Foo</a>') }
+      end
+
+      context 'excluded with regexp list' do
+        let(:params) { { type: :html5, exclude: [/ar/] } }
+        it { is_expected.to eq('<a href="/foo/bar">Foo</a>') }
+      end
     end
 
     context 'XHTML' do
       let(:params) { { type: :xhtml } }
-      it { is_expected.to eq('<a href="../foo">Foo</a>') }
+      it { is_expected.to eq('<a href="../foo/bar">Foo</a>') }
+
+      context 'full component excluded' do
+        let(:params) { { type: :xhtml, exclude: '/foo' } }
+        it { is_expected.to eq('<a href="/foo/bar">Foo</a>') }
+      end
+
+      context 'full component excluded as list' do
+        let(:params) { { type: :xhtml, exclude: ['/foo'] } }
+        it { is_expected.to eq('<a href="/foo/bar">Foo</a>') }
+      end
+
+      context 'partial component excluded' do
+        let(:params) { { type: :xhtml, exclude: ['/fo'] } }
+        it { is_expected.to eq('<a href="../foo/bar">Foo</a>') }
+      end
+
+      context 'non-root component excluded' do
+        let(:params) { { type: :xhtml, exclude: ['/bar'] } }
+        it { is_expected.to eq('<a href="../foo/bar">Foo</a>') }
+      end
+
+      context 'excluded with regexp' do
+        let(:params) { { type: :xhtml, exclude: /ar/ } }
+        it { is_expected.to eq('<a href="/foo/bar">Foo</a>') }
+      end
+
+      context 'excluded with regexp list' do
+        let(:params) { { type: :xhtml, exclude: [/ar/] } }
+        it { is_expected.to eq('<a href="/foo/bar">Foo</a>') }
+      end
     end
 
     context 'CSS' do
       let(:params) { { type: :css } }
+
       let(:content) do
-        '.oink { background: url(/foo.png) }'
+        '.oink { background: url(/foo/bar.png) }'
       end
 
-      it { is_expected.to eq('.oink { background: url(../foo.png) }') }
+      it { is_expected.to eq('.oink { background: url(../foo/bar.png) }') }
+
+      context 'full component excluded' do
+        let(:params) { { type: :css, exclude: '/foo' } }
+        it { is_expected.to eq('.oink { background: url(/foo/bar.png) }') }
+      end
+
+      context 'full component excluded as list' do
+        let(:params) { { type: :css, exclude: ['/foo'] } }
+        it { is_expected.to eq('.oink { background: url(/foo/bar.png) }') }
+      end
+
+      context 'partial component excluded' do
+        let(:params) { { type: :css, exclude: ['/fo'] } }
+        it { is_expected.to eq('.oink { background: url(../foo/bar.png) }') }
+      end
+
+      context 'non-root component excluded' do
+        let(:params) { { type: :css, exclude: ['/bar'] } }
+        it { is_expected.to eq('.oink { background: url(../foo/bar.png) }') }
+      end
+
+      context 'excluded with regexp' do
+        let(:params) { { type: :css, exclude: /ar/ } }
+        it { is_expected.to eq('.oink { background: url(/foo/bar.png) }') }
+      end
+
+      context 'excluded with regexp list' do
+        let(:params) { { type: :css, exclude: [/ar/] } }
+        it { is_expected.to eq('.oink { background: url(/foo/bar.png) }') }
+      end
     end
   end
 end


### PR DESCRIPTION
Implements nanoc/features/issues/41.

### Detailed description

This allows specifying a list of excludes in the `relativize_paths` filter, e.g.

```ruby
# excludes /foo, /foo/bar, …
# does not exclude /fooooo, /qux/foo, /qux/foo/asdf, …
filter :relativize_paths, type: :html, exclude: '/foo'

# excludes /foo, /foo/asdf, /bar, /bar/asdf, …
# does not exclude /fooooo, /qux/foo, /qux/foo/asdf, /qux/bar, …
filter :relativize_paths, type: :html, exclude: ['/foo', '/bar']

# excludes /foo/bar, /bar, /archive, /blog/archive/something, …
filter :relativize_paths, type: :html, exclude: /ar/
```

It can be used in different ways:

* **string vs. regexp**: When given a regular expression, the path will not be relativized if the regular expression matches. When given a string, the path will not be relativized when the path starts with one or more components that matches the given string.

* **single object vs. array**: The parameter can be either a single string or regexp, or an array of them.

### To do

* [x] Exclude only when fully matching a path component
* [x] Allow specifying string instead of an array of strings
* [x] Allow specifying an (array of) regex instead of an (array of) strings

After merge, before release:

* Document