### PR TITLE
Upgrade Cri to 2.12 and use its param support

### DIFF
--- a/nanoc/lib/nanoc/cli/commands/create-site.rb
+++ b/nanoc/lib/nanoc/cli/commands/create-site.rb
@@ -5,6 +5,7 @@ aliases :create_site, :cs
 summary 'create a site'
 description 'Create a new site at the given path. The site will use the `filesystem` data source.'
 flag nil, :force, 'force creation of new site'
+param :path
 
 module Nanoc::CLI::Commands
   class CreateSite < ::Nanoc::CLI::CommandRunner
@@ -215,11 +216,7 @@ module Nanoc::CLI::Commands
     EOS
 
     def run
-      # Extract arguments
-      if arguments.length != 1
-        raise Nanoc::Int::Errors::GenericTrivial, "usage: #{command.usage}"
-      end
-      path = arguments[0]
+      path = arguments[:path]
 
       # Check whether site exists
       if File.exist?(path) && (!File.directory?(path) || !(Dir.entries(path) - %w[. ..]).empty?) && !options[:force]

--- a/nanoc/nanoc.gemspec
+++ b/nanoc/nanoc.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '~> 2.3'
 
   s.add_runtime_dependency('addressable', '~> 2.5')
-  s.add_runtime_dependency('cri', '~> 2.11')
+  s.add_runtime_dependency('cri', '~> 2.12')
   s.add_runtime_dependency('ddmemoize', '~> 1.0')
   s.add_runtime_dependency('ddmetrics', '~> 1.0')
   s.add_runtime_dependency('ddplugin', '~> 1.0')

--- a/nanoc/spec/nanoc/cli_spec.rb
+++ b/nanoc/spec/nanoc/cli_spec.rb
@@ -24,7 +24,7 @@ describe Nanoc::CLI do
 
   def short_options_for_command(command)
     ancestors = ancestors_of_command(command)
-    ancestors.flat_map { |a| a.option_definitions.to_a.map { |od| od[:short] } }.compact
+    ancestors.flat_map { |a| a.option_definitions.to_a.map(&:short) }.compact
   end
 
   it 'has no commands that have conflicting options' do


### PR DESCRIPTION
This upgrades Cri in order to make use of the new `#param` support.