### PR TITLE
Retain cached compiled content for items created in preprocessor

### DIFF
--- a/nanoc/lib/nanoc/base.rb
+++ b/nanoc/lib/nanoc/base.rb
@@ -9,6 +9,7 @@ require_relative 'base/contracts_support'
 require_relative 'base/error'
 require_relative 'base/errors'
 require_relative 'base/changes_stream'
+require_relative 'base/assertions'
 
 require_relative 'base/entities'
 require_relative 'base/feature'

--- a/nanoc/lib/nanoc/base/assertions.rb
+++ b/nanoc/lib/nanoc/base/assertions.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Nanoc
+  module Assertions
+    class AssertionFailure < Nanoc::Int::Errors::InternalInconsistency
+    end
+
+    module Mixin
+      def assert(assertion)
+        return unless Nanoc::Int::ContractsSupport.enabled?
+
+        unless assertion.call
+          raise AssertionFailure, "assertion failed: #{assertion.class}"
+        end
+      end
+    end
+
+    class Base
+      def call
+        raise NotImplementedError
+      end
+    end
+
+    class AllItemRepsHaveCompiledContent < Nanoc::Assertions::Base
+      def initialize(compiled_content_cache:, item_reps:)
+        @compiled_content_cache = compiled_content_cache
+        @item_reps = item_reps
+      end
+
+      def call
+        @item_reps.all? do |rep|
+          @compiled_content_cache[rep]
+        end
+      end
+    end
+  end
+end

--- a/nanoc/lib/nanoc/base/contracts_support.rb
+++ b/nanoc/lib/nanoc/base/contracts_support.rb
@@ -35,10 +35,6 @@ module Nanoc::Int
       def contract(*args); end
     end
 
-    module DisabledContractsMethods
-      def assert(&block); end
-    end
-
     module EnabledContracts
       class AbstractContract
         def self.[](*vals)
@@ -79,14 +75,6 @@ module Nanoc::Int
       end
     end
 
-    module EnabledContractsMethods
-      def assert(&block)
-        val = yield
-        return if val
-        raise Nanoc::Int::Errors::InternalInconsistency, "assertion failure: #{val.inspect} (#{block.source_location.join(':')})"
-      end
-    end
-
     def self.setup_once
       @_contracts_support__setup ||= false
       return @_contracts_support__should_enable if @_contracts_support__setup
@@ -111,6 +99,10 @@ module Nanoc::Int
       @_contracts_support__should_enable
     end
 
+    def self.enabled?
+      setup_once
+    end
+
     def self.included(base)
       should_enable = setup_once
 
@@ -118,12 +110,10 @@ module Nanoc::Int
         unless base.include?(::Contracts::Core)
           base.include(::Contracts::Core)
           base.extend(EnabledContracts)
-          base.include(EnabledContractsMethods)
           base.const_set('C', ::Contracts)
         end
       else
         base.extend(DisabledContracts)
-        base.include(DisabledContractsMethods)
         base.const_set('C', DisabledContracts)
       end
     end

--- a/nanoc/lib/nanoc/base/services/compiler_loader.rb
+++ b/nanoc/lib/nanoc/base/services/compiler_loader.rb
@@ -20,10 +20,7 @@ module Nanoc::Int
         Nanoc::Int::OutdatednessStore.new(config: site.config)
 
       compiled_content_cache =
-        Nanoc::Int::CompiledContentCache.new(
-          config: site.config,
-          items: site.items,
-        )
+        Nanoc::Int::CompiledContentCache.new(config: site.config)
 
       params = {
         compiled_content_cache: compiled_content_cache,

--- a/nanoc/nanoc.manifest
+++ b/nanoc/nanoc.manifest
@@ -6,6 +6,7 @@ bin/nanoc
 
 lib/nanoc.rb
 lib/nanoc/base.rb
+lib/nanoc/base/assertions.rb
 lib/nanoc/base/changes_stream.rb
 lib/nanoc/base/contracts_support.rb
 lib/nanoc/base/core_ext.rb

--- a/nanoc/spec/nanoc/base/compiler_spec.rb
+++ b/nanoc/spec/nanoc/base/compiler_spec.rb
@@ -22,10 +22,7 @@ describe Nanoc::Int::Compiler do
   let(:action_provider) { double(:action_provider) }
 
   let(:compiled_content_cache) do
-    Nanoc::Int::CompiledContentCache.new(
-      config: config,
-      items: items,
-    )
+    Nanoc::Int::CompiledContentCache.new(config: config)
   end
 
   let(:rep) { Nanoc::Int::ItemRep.new(item, :default) }

--- a/nanoc/spec/nanoc/base/repos/compiled_content_cache_spec.rb
+++ b/nanoc/spec/nanoc/base/repos/compiled_content_cache_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Nanoc::Int::CompiledContentCache do
-  let(:cache) { described_class.new(items: items, config: config) }
+  let(:cache) { described_class.new(config: config) }
 
   let(:items) { [item] }
 
@@ -49,6 +49,16 @@ describe Nanoc::Int::CompiledContentCache do
       before do
         cache.store
         cache.load
+      end
+
+      it 'has content' do
+        expect(cache[other_item_rep][:last].string).to eql('omg')
+      end
+    end
+
+    context 'after pruning' do
+      before do
+        cache.prune(items: items)
       end
 
       it 'has no content' do

--- a/nanoc/spec/nanoc/base/services/compiler/phases/cache_spec.rb
+++ b/nanoc/spec/nanoc/base/services/compiler/phases/cache_spec.rb
@@ -10,7 +10,7 @@ describe Nanoc::Int::Compiler::Phases::Cache do
   end
 
   let(:compiled_content_cache) do
-    Nanoc::Int::CompiledContentCache.new(items: [item], config: config)
+    Nanoc::Int::CompiledContentCache.new(config: config)
   end
 
   let(:snapshot_repo) { Nanoc::Int::SnapshotRepo.new }

--- a/nanoc/spec/nanoc/base/services/compiler/stages/compile_reps_spec.rb
+++ b/nanoc/spec/nanoc/base/services/compiler/stages/compile_reps_spec.rb
@@ -25,7 +25,7 @@ describe Nanoc::Int::Compiler::Stages::CompileReps do
   let(:action_provider) { double(:action_provider) }
   let(:action_sequences) { double(:action_sequences) }
   let(:reps) { Nanoc::Int::ItemRepRepo.new }
-  let(:compiled_content_cache) { Nanoc::Int::CompiledContentCache.new(items: items, config: config) }
+  let(:compiled_content_cache) { Nanoc::Int::CompiledContentCache.new(config: config) }
   let(:snapshot_repo) { Nanoc::Int::SnapshotRepo.new }
 
   let(:outdatedness_store) { Nanoc::Int::OutdatednessStore.new(config: config) }
@@ -93,6 +93,12 @@ describe Nanoc::Int::Compiler::Stages::CompileReps do
     end
 
     context 'rep not in outdatedness store' do
+      before do
+        # Needed for consistency
+        compiled_content_cache[rep] = { last: Nanoc::Int::TextualContent.new('asdf') }
+        compiled_content_cache[other_rep] = { last: Nanoc::Int::TextualContent.new('asdf') }
+      end
+
       it 'keeps the item rep out of the outdatedness store' do
         expect(outdatedness_store.include?(rep)).not_to be
         expect { subject }.not_to change { outdatedness_store.include?(rep) }
@@ -101,6 +107,11 @@ describe Nanoc::Int::Compiler::Stages::CompileReps do
 
     context 'rep in outdatedness store' do
       before { outdatedness_store.add(rep) }
+
+      before do
+        # Needed for consistency
+        compiled_content_cache[other_rep] = { last: Nanoc::Int::TextualContent.new('asdf') }
+      end
 
       it 'compiles individual reps' do
         expect { subject }.to change { snapshot_repo.get(rep, :last) }

--- a/nanoc/spec/nanoc/base/views/post_compile_item_rep_view_spec.rb
+++ b/nanoc/spec/nanoc/base/views/post_compile_item_rep_view_spec.rb
@@ -37,7 +37,7 @@ describe Nanoc::PostCompileItemRepView do
   end
 
   let(:compiled_content_cache) do
-    Nanoc::Int::CompiledContentCache.new(items: items, config: config).tap do |ccc|
+    Nanoc::Int::CompiledContentCache.new(config: config).tap do |ccc|
       ccc[item_rep] = snapshot_contents
     end
   end

--- a/nanoc/spec/nanoc/regressions/gh_1342_spec.rb
+++ b/nanoc/spec/nanoc/regressions/gh_1342_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe 'GH-1342', site: true, stdio: true do
+  before do
+    File.write('Rules', <<~EOS)
+      preprocess do
+        items.create('<%= "hi!" %>', {}, '/hello.html')
+      end
+
+      compile '/*' do
+        filter :erb
+        write ext: 'html'
+      end
+
+      postprocess do
+        @items.each(&:compiled_content)
+      end
+    EOS
+  end
+
+  example do
+    Nanoc::CLI.run([])
+    Nanoc::CLI.run([])
+  end
+end


### PR DESCRIPTION
Potential fix for #1342.

The compiled content cache is loaded before preprocessing, and during loading it throws away all data about items it does not know about — therefore also the items that are not yet created. The compiled content cache is now pruned before storing, rather than at load time.

This PR also adds an assertion system to verify assumptions at runtime. It is disabled by default, but will be enabled if the `contracts` gem is loaded.

* [x] High-level regression test