### PR TITLE
Make raw paths absolute

### DIFF
--- a/nanoc/lib/nanoc/base/assertions.rb
+++ b/nanoc/lib/nanoc/base/assertions.rb
@@ -33,5 +33,15 @@ module Nanoc
         end
       end
     end
+
+    class PathIsAbsolute < Nanoc::Assertions::Base
+      def initialize(path:)
+        @path = path
+      end
+
+      def call
+        Pathname.new(@path).absolute?
+      end
+    end
   end
 end

--- a/nanoc/lib/nanoc/base/contracts_support.rb
+++ b/nanoc/lib/nanoc/base/contracts_support.rb
@@ -31,6 +31,7 @@ module Nanoc::Int
       Named       = Ignorer.instance
       IterOf      = Ignorer.instance
       HashOf      = Ignorer.instance
+      AbsolutePathString = Ignorer.instance
 
       def contract(*args); end
     end
@@ -70,6 +71,12 @@ module Nanoc::Int
         end
       end
 
+      class AbsolutePathString < AbstractContract
+        def self.valid?(val)
+          Pathname.new(val).absolute?
+        end
+      end
+
       def contract(*args)
         Contract(*args)
       end
@@ -95,6 +102,7 @@ module Nanoc::Int
         # FIXME: ugly
         ::Contracts.const_set('Named', EnabledContracts::Named)
         ::Contracts.const_set('IterOf', EnabledContracts::IterOf)
+        ::Contracts.const_set('AbsolutePathString', EnabledContracts::AbsolutePathString)
       end
 
       @_contracts_support__should_enable

--- a/nanoc/lib/nanoc/base/entities/configuration.rb
+++ b/nanoc/lib/nanoc/base/entities/configuration.rb
@@ -151,7 +151,7 @@ module Nanoc::Int
 
     contract C::None => String
     def output_dir
-      self[:output_dir]
+      make_absolute(self[:output_dir]).freeze
     end
 
     contract C::None => Symbol
@@ -162,7 +162,7 @@ module Nanoc::Int
     contract C::None => C::IterOf[String]
     def output_dirs
       envs = @wrapped.fetch(ENVIRONMENTS_CONFIG_KEY, {})
-      res = [output_dir] + envs.values.map { |v| v[:output_dir] }
+      res = [output_dir] + envs.values.map { |v| make_absolute(v[:output_dir]) }
       res.uniq.compact
     end
 
@@ -178,6 +178,11 @@ module Nanoc::Int
     end
 
     private
+
+    def make_absolute(path)
+      # FIXME: don’t depend on working directory
+      path && File.absolute_path(path, Dir.getwd).encode('UTF-8')
+    end
 
     def merge_recursively(config1, config2)
       config1.merge(config2) do |_, value1, value2|

--- a/nanoc/lib/nanoc/base/entities/item_rep.rb
+++ b/nanoc/lib/nanoc/base/entities/item_rep.rb
@@ -44,7 +44,7 @@ module Nanoc::Int
       @modified = false
     end
 
-    contract C::HashOf[Symbol => C::IterOf[String]] => C::HashOf[Symbol => C::IterOf[String]]
+    contract C::HashOf[Symbol => C::IterOf[C::AbsolutePathString]] => C::HashOf[Symbol => C::IterOf[C::AbsolutePathString]]
     def raw_paths=(val)
       @raw_paths = val
     end

--- a/nanoc/lib/nanoc/base/repos/store.rb
+++ b/nanoc/lib/nanoc/base/repos/store.rb
@@ -42,6 +42,7 @@ module Nanoc::Int
     # @api private
     contract C::KeywordArgs[config: Nanoc::Int::Configuration, store_name: String] => String
     def self.tmp_path_for(store_name:, config:)
+      # FIXME: make absolute
       File.join(tmp_path_prefix(config.output_dir), store_name)
     end
 

--- a/nanoc/lib/nanoc/base/services/item_rep_router.rb
+++ b/nanoc/lib/nanoc/base/services/item_rep_router.rb
@@ -75,7 +75,7 @@ module Nanoc::Int
 
       # Assign
       snapshot_names.each do |snapshot_name|
-        rep.raw_paths[snapshot_name] = paths.map { |path| @site.config[:output_dir] + path }
+        rep.raw_paths[snapshot_name] = paths.map { |path| @site.config.output_dir + path }
         rep.paths[snapshot_name] = paths.map { |path| strip_index_filename(path) }
       end
     end

--- a/nanoc/lib/nanoc/base/services/item_rep_writer.rb
+++ b/nanoc/lib/nanoc/base/services/item_rep_writer.rb
@@ -3,6 +3,9 @@
 module Nanoc::Int
   # @api private
   class ItemRepWriter
+    include Nanoc::Int::ContractsSupport
+    include Nanoc::Assertions::Mixin
+
     TMP_TEXT_ITEMS_DIR = 'text_items'
 
     def write_all(item_rep, snapshot_repo)
@@ -20,6 +23,8 @@ module Nanoc::Int
     end
 
     def write_single(item_rep, snapshot_repo, snapshot_name, raw_path, written_paths)
+      assert Nanoc::Assertions::PathIsAbsolute.new(path: raw_path)
+
       # Don’t write twice
       # TODO: test written_paths behavior
       return if written_paths.include?(raw_path)

--- a/nanoc/lib/nanoc/base/services/pruner.rb
+++ b/nanoc/lib/nanoc/base/services/pruner.rb
@@ -25,10 +25,10 @@ module Nanoc
     end
 
     def run
-      return unless File.directory?(@config[:output_dir])
+      return unless File.directory?(@config.output_dir)
 
       compiled_files = @reps.flat_map { |r| r.raw_paths.values.flatten }.compact
-      present_files, present_dirs = files_and_dirs_in(@config[:output_dir] + '/')
+      present_files, present_dirs = files_and_dirs_in(@config.output_dir + '/')
 
       remove_stray_files(present_files, compiled_files)
       remove_empty_directories(present_dirs)
@@ -42,8 +42,8 @@ module Nanoc
 
     contract String => String
     def strip_output_dir(filename)
-      if filename.start_with?(@config[:output_dir])
-        filename[@config[:output_dir].size..-1]
+      if filename.start_with?(@config.output_dir)
+        filename[@config.output_dir.size..-1]
       else
         filename
       end

--- a/nanoc/lib/nanoc/base/views/config_view.rb
+++ b/nanoc/lib/nanoc/base/views/config_view.rb
@@ -16,6 +16,11 @@ module Nanoc
       @config
     end
 
+    # @api private
+    def output_dir
+      @config.output_dir
+    end
+
     # @see Hash#fetch
     def fetch(key, fallback = NONE, &_block)
       @context.dependency_tracker.bounce(_unwrap, attributes: [key])

--- a/nanoc/lib/nanoc/checking/check.rb
+++ b/nanoc/lib/nanoc/checking/check.rb
@@ -22,7 +22,7 @@ module Nanoc::Checking
     end
 
     def self.create(site)
-      output_dir = site.config[:output_dir]
+      output_dir = site.config.output_dir
       unless File.exist?(output_dir)
         raise Nanoc::Checking::OutputDirNotFoundError.new(output_dir)
       end
@@ -57,6 +57,12 @@ module Nanoc::Checking
     end
 
     def add_issue(desc, subject: nil)
+      # Simplify subject
+      # FIXME: do not depend on working directory
+      if subject&.start_with?(Dir.getwd)
+        subject = subject[(Dir.getwd.size + 1)..subject.size]
+      end
+
       @issues << Issue.new(desc, subject, self.class)
     end
 

--- a/nanoc/lib/nanoc/checking/checks/internal_links.rb
+++ b/nanoc/lib/nanoc/checking/checks/internal_links.rb
@@ -56,7 +56,7 @@ module Nanoc::Checking::Checks
       # Make absolute
       path =
         if path[0, 1] == '/'
-          @config[:output_dir] + path
+          @config.output_dir + path
         else
           ::File.expand_path(path, ::File.dirname(origin))
         end
@@ -82,7 +82,10 @@ module Nanoc::Checking::Checks
     end
 
     def excluded_origin?(origin, config)
-      relative_origin = origin[@config[:output_dir].size..-1]
+      # FIXME: do not depend on current working directory
+      origin = File.absolute_path(origin)
+
+      relative_origin = origin[@config.output_dir.size..-1]
       excludes = config.fetch(:exclude_origins, [])
       excludes.any? { |pattern| Regexp.new(pattern).match(relative_origin) }
     end

--- a/nanoc/lib/nanoc/checking/checks/w3c_validator.rb
+++ b/nanoc/lib/nanoc/checking/checks/w3c_validator.rb
@@ -7,7 +7,7 @@ module ::Nanoc::Checking::Checks
       require 'w3c_validators'
       require 'resolv-replace'
 
-      Dir[@config[:output_dir] + '/**/*.' + extension].each do |filename|
+      Dir[@config.output_dir + '/**/*.' + extension].each do |filename|
         results = validator_class.new.validate_file(filename)
         lines = File.readlines(filename)
         results.errors.each do |e|

--- a/nanoc/lib/nanoc/cli/commands/compile_listeners/diff_generator.rb
+++ b/nanoc/lib/nanoc/cli/commands/compile_listeners/diff_generator.rb
@@ -51,6 +51,12 @@ module Nanoc::CLI::Commands::CompileListeners
       return if old_content == new_content
 
       @diff_threads << Thread.new do
+        # Simplify path
+        # FIXME: do not depend on working directory
+        if path.start_with?(Dir.getwd)
+          path = path[(Dir.getwd.size + 1)..path.size]
+        end
+
         # Generate diff
         diff = diff_strings(old_content, new_content)
         diff.sub!(/^--- .*/,    '--- ' + path)

--- a/nanoc/lib/nanoc/cli/commands/compile_listeners/file_action_printer.rb
+++ b/nanoc/lib/nanoc/cli/commands/compile_listeners/file_action_printer.rb
@@ -48,6 +48,12 @@ module Nanoc::CLI::Commands::CompileListeners
           elsif is_modified then :high
           else :low
           end
+
+        # FIXME: do not depend on working directory
+        if path.start_with?(Dir.getwd)
+          path = path[(Dir.getwd.size + 1)..path.size]
+        end
+
         log(level, action, path, duration)
       end
     end

--- a/nanoc/lib/nanoc/cli/commands/deploy.rb
+++ b/nanoc/lib/nanoc/cli/commands/deploy.rb
@@ -81,7 +81,7 @@ module Nanoc::CLI::Commands
 
     def deployer_for(config)
       deployer_class_for_config(config).new(
-        @site.config[:output_dir],
+        @site.config.output_dir,
         config,
         dry_run: options[:'dry-run'],
       )

--- a/nanoc/lib/nanoc/cli/commands/view.rb
+++ b/nanoc/lib/nanoc/cli/commands/view.rb
@@ -24,11 +24,11 @@ module Nanoc::CLI::Commands
       config = Nanoc::Int::ConfigLoader.new.new_from_cwd
 
       # Create output dir so that viewer/watcher doesn’t explode.
-      FileUtils.mkdir_p(config[:output_dir])
+      FileUtils.mkdir_p(config.output_dir)
 
       server =
         Adsf::Server.new(
-          root: File.absolute_path(config[:output_dir]),
+          root: File.absolute_path(config.output_dir),
           live: options[:'live-reload'],
           index_filenames: config[:index_filenames],
           host: options.fetch(:host),

--- a/nanoc/spec/nanoc/base/entities/configuration_spec.rb
+++ b/nanoc/spec/nanoc/base/entities/configuration_spec.rb
@@ -41,12 +41,12 @@ describe Nanoc::Int::Configuration do
 
     context 'not explicitly defined' do
       let(:hash) { { foo: 'bar' } }
-      it { is_expected.to eql('output') }
+      it { is_expected.to eql(Dir.getwd + '/output') }
     end
 
     context 'explicitly defined, top-level' do
       let(:hash) { { foo: 'bar', output_dir: 'build' } }
-      it { is_expected.to eql('build') }
+      it { is_expected.to eql(Dir.getwd + '/build') }
     end
   end
 
@@ -72,8 +72,8 @@ describe Nanoc::Int::Configuration do
     end
 
     it 'contains both top-level and default output dir' do
-      expect(subject).to include('output_toplevel')
-      expect(subject).to include('output_default')
+      expect(subject).to include(Dir.getwd + '/output_toplevel')
+      expect(subject).to include(Dir.getwd + '/output_default')
     end
 
     it 'does not contain nil' do
@@ -81,8 +81,8 @@ describe Nanoc::Int::Configuration do
     end
 
     it 'contains all other output dirs' do
-      expect(subject).to include('output_staging')
-      expect(subject).to include('output_prod')
+      expect(subject).to include(Dir.getwd + '/output_staging')
+      expect(subject).to include(Dir.getwd + '/output_prod')
     end
   end
 

--- a/nanoc/spec/nanoc/base/entities/site_spec.rb
+++ b/nanoc/spec/nanoc/base/entities/site_spec.rb
@@ -50,7 +50,7 @@ describe Nanoc::Int::Site do
     end
 
     it 'freezes the configuration contents' do
-      expect(site.config[:output_dir]).to be_frozen
+      expect(site.config.output_dir).to be_frozen
     end
 
     it 'freezes items collection' do

--- a/nanoc/spec/nanoc/base/item_rep_writer_spec.rb
+++ b/nanoc/spec/nanoc/base/item_rep_writer_spec.rb
@@ -2,7 +2,7 @@
 
 describe Nanoc::Int::ItemRepWriter do
   describe '#write' do
-    let(:raw_path) { 'output/blah.dat' }
+    let(:raw_path) { Dir.getwd + '/output/blah.dat' }
 
     let(:item) { Nanoc::Int::Item.new(orig_content, {}, '/foo') }
 
@@ -56,9 +56,9 @@ describe Nanoc::Int::ItemRepWriter do
 
       it 'copies contents' do
         expect(Nanoc::Int::NotificationCenter).to receive(:post)
-          .with(:rep_write_started, item_rep, 'output/blah.dat')
+          .with(:rep_write_started, item_rep, Dir.getwd + '/output/blah.dat')
         expect(Nanoc::Int::NotificationCenter).to receive(:post)
-          .with(:rep_write_ended, item_rep, true, 'output/blah.dat', true, true)
+          .with(:rep_write_ended, item_rep, true, Dir.getwd + '/output/blah.dat', true, true)
 
         subject
 
@@ -108,9 +108,9 @@ describe Nanoc::Int::ItemRepWriter do
 
       it 'writes' do
         expect(Nanoc::Int::NotificationCenter).to receive(:post)
-          .with(:rep_write_started, item_rep, 'output/blah.dat')
+          .with(:rep_write_started, item_rep, Dir.getwd + '/output/blah.dat')
         expect(Nanoc::Int::NotificationCenter).to receive(:post)
-          .with(:rep_write_ended, item_rep, false, 'output/blah.dat', true, true)
+          .with(:rep_write_ended, item_rep, false, Dir.getwd + '/output/blah.dat', true, true)
 
         subject
 

--- a/nanoc/spec/nanoc/base/repos/store_spec.rb
+++ b/nanoc/spec/nanoc/base/repos/store_spec.rb
@@ -9,41 +9,60 @@ describe Nanoc::Int::Store do
       let(:items) { [] }
       let(:layouts) { [] }
 
+      def gen_hash(path)
+        Digest::SHA1.hexdigest(File.absolute_path(path))[0..12]
+      end
+
+      let(:hash_output) { gen_hash('output') }
+      let(:hash_output_default) { gen_hash('output-default') }
+      let(:hash_output_staging) { gen_hash('output-staging') }
+      let(:hash_output_production) { gen_hash('output-production') }
+
       context 'no env specified' do
         let(:config) { Nanoc::Int::Configuration.new(hash: config_hash).with_defaults.with_environment }
 
+        context 'output dir is unspecified' do
+          let(:config_hash) { {} }
+          it { is_expected.to eql("tmp/nanoc/#{hash_output}/giraffes") }
+        end
+
         context 'output dir at root is specified' do
           let(:config_hash) { { output_dir: 'output-default' } }
-          it { is_expected.to eql('tmp/nanoc/b592240c777c6/giraffes') }
+          it { is_expected.to eql("tmp/nanoc/#{hash_output_default}/giraffes") }
         end
 
         context 'output dir in default env is specified' do
           let(:config_hash) { { environments: { default: { output_dir: 'output-default' } } } }
-          it { is_expected.to eql('tmp/nanoc/b592240c777c6/giraffes') }
+          it { is_expected.to eql("tmp/nanoc/#{hash_output_default}/giraffes") }
         end
 
         context 'output dir in other env is specified' do
           let(:config_hash) { { environments: { production: { output_dir: 'output-production' } } } }
-          it { is_expected.to eql('tmp/nanoc/1029d67644815/giraffes') }
+          it { is_expected.to eql("tmp/nanoc/#{hash_output}/giraffes") }
         end
       end
 
       context 'env specified' do
         let(:config) { Nanoc::Int::Configuration.new(env_name: 'staging', hash: config_hash).with_defaults.with_environment }
 
+        context 'output dir is unspecified' do
+          let(:config_hash) { {} }
+          it { is_expected.to eql("tmp/nanoc/#{hash_output}/giraffes") }
+        end
+
         context 'output dir at root is specified' do
           let(:config_hash) { { output_dir: 'output-default' } }
-          it { is_expected.to eql('tmp/nanoc/b592240c777c6/giraffes') }
+          it { is_expected.to eql("tmp/nanoc/#{hash_output_default}/giraffes") }
         end
 
         context 'output dir in given env is specified' do
           let(:config_hash) { { environments: { staging: { output_dir: 'output-staging' } } } }
-          it { is_expected.to eql('tmp/nanoc/9d274da4d73ba/giraffes') }
+          it { is_expected.to eql("tmp/nanoc/#{hash_output_staging}/giraffes") }
         end
 
         context 'output dir in other env is specified' do
           let(:config_hash) { { environments: { production: { output_dir: 'output-production' } } } }
-          it { is_expected.to eql('tmp/nanoc/1029d67644815/giraffes') }
+          it { is_expected.to eql("tmp/nanoc/#{hash_output}/giraffes") }
         end
       end
     end

--- a/nanoc/spec/nanoc/base/services/compiler/stages/cleanup_spec.rb
+++ b/nanoc/spec/nanoc/base/services/compiler/stages/cleanup_spec.rb
@@ -10,6 +10,10 @@ describe Nanoc::Int::Compiler::Stages::Cleanup do
   describe '#run' do
     subject { stage.run }
 
+    def gen_hash(path)
+      Digest::SHA1.hexdigest(File.absolute_path(path))[0..12]
+    end
+
     it 'removes temporary binary items' do
       a = Nanoc::Int::TempFilenameFactory.instance.create(Nanoc::Filter::TMP_BINARY_ITEMS_DIR)
       File.write(a, 'hello there')
@@ -75,14 +79,18 @@ describe Nanoc::Int::Compiler::Stages::Cleanup do
     end
 
     it 'removes stores for unused output paths' do
-      FileUtils.mkdir_p('tmp/nanoc/2f0692fb1a1d')
-      FileUtils.mkdir_p('tmp/nanoc/1a2195bfef6c')
-      FileUtils.mkdir_p('tmp/nanoc/1029d67644815')
+      default_dir = "tmp/nanoc/#{gen_hash(Dir.getwd + '/output')}"
+      prod_dir = "tmp/nanoc/#{gen_hash(Dir.getwd + '/output_production')}"
+      staging_dir = "tmp/nanoc/#{gen_hash(Dir.getwd + '/output_staging')}"
+
+      FileUtils.mkdir_p(default_dir)
+      FileUtils.mkdir_p(prod_dir)
+      FileUtils.mkdir_p(staging_dir)
 
       expect { subject }
         .to change { Dir.glob('tmp/nanoc/*').sort }
-        .from(['tmp/nanoc/1029d67644815', 'tmp/nanoc/1a2195bfef6c', 'tmp/nanoc/2f0692fb1a1d'])
-        .to(['tmp/nanoc/1029d67644815'])
+        .from([default_dir, prod_dir, staging_dir].sort)
+        .to([default_dir])
     end
   end
 end

--- a/nanoc/spec/nanoc/base/services/executor_spec.rb
+++ b/nanoc/spec/nanoc/base/services/executor_spec.rb
@@ -618,7 +618,7 @@ describe Nanoc::Int::Executor do
 
       context 'raw path' do
         before do
-          rep.raw_paths = { something: ['output/donkey.md'] }
+          rep.raw_paths = { something: [Dir.getwd + '/output/donkey.md'] }
         end
 
         it 'does not write' do

--- a/nanoc/spec/nanoc/base/services/item_rep_router_spec.rb
+++ b/nanoc/spec/nanoc/base/services/item_rep_router_spec.rb
@@ -56,10 +56,10 @@ describe(Nanoc::Int::ItemRepRouter) do
 
       subject
 
-      expect(reps[0].raw_paths).to eql(last: ['output/foo/index.html'])
+      expect(reps[0].raw_paths).to eql(last: [Dir.getwd + '/output/foo/index.html'])
       expect(reps[0].paths).to eql(last: ['/foo/'])
 
-      expect(reps[1].raw_paths).to eql(last: ['output/foo.csv'])
+      expect(reps[1].raw_paths).to eql(last: [Dir.getwd + '/output/foo.csv'])
       expect(reps[1].paths).to eql(last: ['/foo.csv'])
     end
 
@@ -71,10 +71,10 @@ describe(Nanoc::Int::ItemRepRouter) do
 
       subject
 
-      expect(reps[0].raw_paths).to eql(last: ['output/foo/index.html'])
+      expect(reps[0].raw_paths).to eql(last: [Dir.getwd + '/output/foo/index.html'])
       expect(reps[0].paths).to eql(last: ['/foo/'])
 
-      expect(reps[1].raw_paths).to eql(last: ['output/foo.csv'])
+      expect(reps[1].raw_paths).to eql(last: [Dir.getwd + '/output/foo.csv'])
       expect(reps[1].paths).to eql(last: ['/foo.csv'])
     end
   end
@@ -111,7 +111,7 @@ describe(Nanoc::Int::ItemRepRouter) do
         context 'single path' do
           it 'sets the raw path' do
             subject
-            expect(rep.raw_paths).to eql(foo: ['output/foo/index.html'])
+            expect(rep.raw_paths).to eql(foo: [Dir.getwd + '/output/foo/index.html'])
           end
 
           it 'sets the path' do
@@ -143,7 +143,7 @@ describe(Nanoc::Int::ItemRepRouter) do
 
             it 'sets the raw path as UTF-8' do
               subject
-              expect(rep.raw_paths).to eql(foo: ['output/foo/index.html'])
+              expect(rep.raw_paths).to eql(foo: [Dir.getwd + '/output/foo/index.html'])
               expect(rep.raw_paths[:foo].first.encoding.to_s).to eql('UTF-8')
             end
           end
@@ -154,7 +154,7 @@ describe(Nanoc::Int::ItemRepRouter) do
 
           it 'sets the raw paths' do
             subject
-            expect(rep.raw_paths).to eql(foo: ['output/foo/index.html', 'output/bar/index.html'])
+            expect(rep.raw_paths).to eql(foo: [Dir.getwd + '/output/foo/index.html', Dir.getwd + '/output/bar/index.html'])
           end
 
           it 'sets the paths' do

--- a/nanoc/spec/nanoc/base/services/outdatedness_rules_spec.rb
+++ b/nanoc/spec/nanoc/base/services/outdatedness_rules_spec.rb
@@ -95,7 +95,7 @@ describe Nanoc::Int::OutdatednessRules do
       end
 
       context 'path for last snapshot' do
-        let(:path) { 'foo.txt' }
+        let(:path) { Dir.getwd + '/foo.txt' }
 
         before { item_rep.raw_paths = { last: [path] } }
 
@@ -110,7 +110,7 @@ describe Nanoc::Int::OutdatednessRules do
       end
 
       context 'path for other snapshot' do
-        let(:path) { 'foo.txt' }
+        let(:path) { Dir.getwd + '/foo.txt' }
 
         before { item_rep.raw_paths = { donkey: [path] } }
 

--- a/nanoc/spec/nanoc/base/services/pruner_spec.rb
+++ b/nanoc/spec/nanoc/base/services/pruner_spec.rb
@@ -10,11 +10,11 @@ describe Nanoc::Pruner, stdio: true do
   let(:reps) do
     Nanoc::Int::ItemRepRepo.new.tap do |reps|
       reps << Nanoc::Int::ItemRep.new(item, :default).tap do |rep|
-        rep.raw_paths = { last: ['output/asdf.html'] }
+        rep.raw_paths = { last: [Dir.getwd + '/output/asdf.html'] }
       end
 
       reps << Nanoc::Int::ItemRep.new(item, :text).tap do |rep|
-        rep.raw_paths = { last: ['output/asdf.txt'] }
+        rep.raw_paths = { last: [Dir.getwd + '/output/asdf.txt'] }
       end
     end
   end
@@ -28,7 +28,7 @@ describe Nanoc::Pruner, stdio: true do
   describe '#filename_excluded?' do
     subject { pruner.filename_excluded?(filename) }
 
-    let(:filename) { 'output/foo/bar.html' }
+    let(:filename) { Dir.getwd + '/output/foo/bar.html' }
 
     context 'nothing excluded' do
       it { is_expected.to be(false) }
@@ -68,15 +68,15 @@ describe Nanoc::Pruner, stdio: true do
       let(:reps) do
         Nanoc::Int::ItemRepRepo.new.tap do |reps|
           reps << Nanoc::Int::ItemRep.new(item, :a).tap do |rep|
-            rep.raw_paths = { last: ['output/foo.html'] }
+            rep.raw_paths = { last: [Dir.getwd + '/output/foo.html'] }
           end
 
           reps << Nanoc::Int::ItemRep.new(item, :b).tap do |rep|
-            rep.raw_paths = { last: ['output/bar.html'] }
+            rep.raw_paths = { last: [Dir.getwd + '/output/bar.html'] }
           end
 
           reps << Nanoc::Int::ItemRep.new(item, :c).tap do |rep|
-            rep.raw_paths = { last: ['output/foo/bar.html'] }
+            rep.raw_paths = { last: [Dir.getwd + '/output/foo/bar.html'] }
           end
         end
       end

--- a/nanoc/spec/nanoc/base/views/compilation_item_rep_view_spec.rb
+++ b/nanoc/spec/nanoc/base/views/compilation_item_rep_view_spec.rb
@@ -41,7 +41,7 @@ describe Nanoc::CompilationItemRepView do
     let(:rep) do
       Nanoc::Int::ItemRep.new(item, :default).tap do |ir|
         ir.raw_paths = {
-          last: ['output/about/index.html'],
+          last: [Dir.getwd + '/output/about/index.html'],
         }
       end
     end
@@ -99,7 +99,7 @@ describe Nanoc::CompilationItemRepView do
           expect(dep.props.path?).to eq(false)
         end
 
-        it { should eq('output/about/index.html') }
+        it { should eq(Dir.getwd + '/output/about/index.html') }
       end
     end
   end

--- a/nanoc/spec/nanoc/base/views/post_compile_item_rep_view_spec.rb
+++ b/nanoc/spec/nanoc/base/views/post_compile_item_rep_view_spec.rb
@@ -56,15 +56,15 @@ describe Nanoc::PostCompileItemRepView do
 
       context 'path for default snapshot specified' do
         before do
-          item_rep.raw_paths = { last: ['output/about/index.html'] }
+          item_rep.raw_paths = { last: [Dir.getwd + '/output/about/index.html'] }
         end
 
-        it { is_expected.to eql('output/about/index.html') }
+        it { is_expected.to eql(Dir.getwd + '/output/about/index.html') }
       end
 
       context 'path specified, but not for default snapshot' do
         before do
-          item_rep.raw_paths = { pre: ['output/about/index.html'] }
+          item_rep.raw_paths = { pre: [Dir.getwd + '/output/about/index.html'] }
         end
 
         it { is_expected.to be_nil }
@@ -84,15 +84,15 @@ describe Nanoc::PostCompileItemRepView do
 
       context 'path for default snapshot specified' do
         before do
-          item_rep.raw_paths = { special: ['output/about/index.html'] }
+          item_rep.raw_paths = { special: [Dir.getwd + '/output/about/index.html'] }
         end
 
-        it { is_expected.to eql('output/about/index.html') }
+        it { is_expected.to eql(Dir.getwd + '/output/about/index.html') }
       end
 
       context 'path specified, but not for default snapshot' do
         before do
-          item_rep.raw_paths = { pre: ['output/about/index.html'] }
+          item_rep.raw_paths = { pre: [Dir.getwd + '/output/about/index.html'] }
         end
 
         it { is_expected.to be_nil }

--- a/nanoc/test/base/test_site.rb
+++ b/nanoc/test/base/test_site.rb
@@ -12,13 +12,13 @@ class Nanoc::Int::SiteTest < Nanoc::TestCase
   def test_initialize_with_dir_with_config_yaml
     File.open('config.yaml', 'w') { |io| io.write('output_dir: public_html') }
     site = Nanoc::Int::SiteLoader.new.new_from_cwd
-    assert_equal 'public_html', site.config[:output_dir]
+    assert_equal Dir.getwd + '/public_html', site.config.output_dir
   end
 
   def test_initialize_with_dir_with_nanoc_yaml
     File.open('nanoc.yaml', 'w') { |io| io.write('output_dir: public_html') }
     site = Nanoc::Int::SiteLoader.new.new_from_cwd
-    assert_equal 'public_html', site.config[:output_dir]
+    assert_equal Dir.getwd + '/public_html', site.config.output_dir
   end
 
   def test_initialize_with_config_hash
@@ -64,7 +64,7 @@ class Nanoc::Int::SiteTest < Nanoc::TestCase
     assert_nil site.config[:parent_config_file]
     assert site.config[:enable_output_diff]
     assert_equal 'bar', site.config[:foo]
-    assert_equal 'public_html', site.config[:output_dir]
+    assert_equal Dir.getwd + '/public_html', site.config.output_dir
   end
 
   def test_initialize_with_missing_parent_config_file

--- a/nanoc/test/checking/test_check.rb
+++ b/nanoc/test/checking/test_check.rb
@@ -7,7 +7,7 @@ class Nanoc::Checking::CheckTest < Nanoc::TestCase
     with_site do |site|
       File.open('output/foo.html', 'w') { |io| io.write 'hello' }
       check = Nanoc::Checking::Check.create(site)
-      assert_equal ['output/foo.html'], check.output_filenames
+      assert_equal [Dir.getwd + '/output/foo.html'], check.output_filenames
     end
   end
 


### PR DESCRIPTION
This makes all raw paths absolute. The dependency on the current working directory still exists, but will be removed in the future. The dependency on the current working directory is much more explicit now, which should help in preventing issues where the current working directory might change during compilation.

This will likely help with #1338.