### PR TITLE
Add dir to configuration

### DIFF
--- a/nanoc/lib/nanoc/base/contracts_support.rb
+++ b/nanoc/lib/nanoc/base/contracts_support.rb
@@ -73,7 +73,7 @@ module Nanoc::Int
 
       class AbsolutePathString < AbstractContract
         def self.valid?(val)
-          Pathname.new(val).absolute?
+          val.is_a?(String) && Pathname.new(val).absolute?
         end
       end
 

--- a/nanoc/lib/nanoc/base/repos/config_loader.rb
+++ b/nanoc/lib/nanoc/base/repos/config_loader.rb
@@ -46,7 +46,10 @@ module Nanoc::Int
       # Read
       config =
         apply_parent_config(
-          Nanoc::Int::Configuration.new(hash: load_file(filename)),
+          Nanoc::Int::Configuration.new(
+            hash: load_file(filename),
+            dir: File.dirname(filename),
+          ),
           [filename],
         ).with_defaults
 
@@ -82,7 +85,7 @@ module Nanoc::Int
       end
 
       # Load
-      parent_config = Nanoc::Int::Configuration.new(hash: load_file(parent_path))
+      parent_config = Nanoc::Int::Configuration.new(hash: load_file(parent_path), dir: config.dir)
       full_parent_config = apply_parent_config(parent_config, processed_paths + [parent_path])
       full_parent_config.merge(config.without(:parent_config_file))
     end

--- a/nanoc/lib/nanoc/base/repos/site_loader.rb
+++ b/nanoc/lib/nanoc/base/repos/site_loader.rb
@@ -3,11 +3,13 @@
 module Nanoc::Int
   class SiteLoader
     def new_empty
-      site_from_config(Nanoc::Int::Configuration.new.with_defaults)
+      # FIXME: don’t depend on working directory
+      site_from_config(Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults)
     end
 
     def new_with_config(hash)
-      site_from_config(Nanoc::Int::Configuration.new(hash: hash).with_defaults)
+      # FIXME: don’t depend on working directory
+      site_from_config(Nanoc::Int::Configuration.new(hash: hash, dir: Dir.getwd).with_defaults)
     end
 
     def new_from_cwd

--- a/nanoc/lib/nanoc/spec.rb
+++ b/nanoc/lib/nanoc/spec.rb
@@ -58,7 +58,7 @@ module Nanoc
 
         @erbout = +''
         @action_sequence = {}
-        @config = Nanoc::Int::Configuration.new.with_defaults
+        @config = Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults
         @reps = Nanoc::Int::ItemRepRepo.new
         @items = Nanoc::Int::ItemCollection.new(@config)
         @layouts = Nanoc::Int::LayoutCollection.new(@config)

--- a/nanoc/spec/nanoc/base/checksummer_spec.rb
+++ b/nanoc/spec/nanoc/base/checksummer_spec.rb
@@ -178,7 +178,7 @@ describe Nanoc::Int::Checksummer do
   end
 
   context 'Nanoc::Int::Configuration' do
-    let(:obj) { Nanoc::Int::Configuration.new(hash: { 'foo' => 'bar' }) }
+    let(:obj) { Nanoc::Int::Configuration.new(dir: Dir.getwd, hash: { 'foo' => 'bar' }) }
     it { is_expected.to eql('Nanoc::Int::Configuration<Symbol<foo>=String<bar>,>') }
   end
 
@@ -296,7 +296,7 @@ describe Nanoc::Int::Checksummer do
 
   context 'Nanoc::ConfigView' do
     let(:obj) { Nanoc::ConfigView.new(config, nil) }
-    let(:config) { Nanoc::Int::Configuration.new(hash: { 'foo' => 'bar' }) }
+    let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd, hash: { 'foo' => 'bar' }) }
 
     it { is_expected.to eql('Nanoc::ConfigView<Nanoc::Int::Configuration<Symbol<foo>=String<bar>,>>') }
   end
@@ -304,7 +304,7 @@ describe Nanoc::Int::Checksummer do
   context 'Nanoc::ItemCollectionWithRepsView' do
     let(:obj) { Nanoc::ItemCollectionWithRepsView.new(wrapped, nil) }
 
-    let(:config) { Nanoc::Int::Configuration.new(hash: { 'foo' => 'bar' }) }
+    let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd, hash: { 'foo' => 'bar' }) }
 
     let(:wrapped) do
       Nanoc::Int::ItemCollection.new(
@@ -322,7 +322,7 @@ describe Nanoc::Int::Checksummer do
   context 'Nanoc::ItemCollectionWithoutRepsView' do
     let(:obj) { Nanoc::ItemCollectionWithoutRepsView.new(wrapped, nil) }
 
-    let(:config) { Nanoc::Int::Configuration.new(hash: { 'foo' => 'bar' }) }
+    let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd, hash: { 'foo' => 'bar' }) }
 
     let(:wrapped) do
       Nanoc::Int::ItemCollection.new(
@@ -351,7 +351,7 @@ describe Nanoc::Int::Checksummer do
       )
     end
 
-    let(:config) { Nanoc::Int::Configuration.new(hash: { 'foo' => 'bar' }) }
+    let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd, hash: { 'foo' => 'bar' }) }
     let(:code_snippets) { [Nanoc::Int::CodeSnippet.new('asdf', '/bob.rb')] }
     let(:items) { Nanoc::Int::ItemCollection.new(config, [item]) }
     let(:layouts) { [Nanoc::Int::Layout.new('asdf', {}, '/foo.md')] }

--- a/nanoc/spec/nanoc/base/compiler_spec.rb
+++ b/nanoc/spec/nanoc/base/compiler_spec.rb
@@ -39,7 +39,7 @@ describe Nanoc::Int::Compiler do
     )
   end
 
-  let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+  let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
   let(:code_snippets) { [] }
 
   let(:items) do

--- a/nanoc/spec/nanoc/base/entities/configuration_spec.rb
+++ b/nanoc/spec/nanoc/base/entities/configuration_spec.rb
@@ -2,7 +2,7 @@
 
 describe Nanoc::Int::Configuration do
   let(:hash) { { foo: 'bar' } }
-  let(:config) { described_class.new(hash: hash) }
+  let(:config) { described_class.new(hash: hash, dir: Dir.getwd) }
 
   describe '#key?' do
     subject { config.key?(key) }
@@ -28,7 +28,7 @@ describe Nanoc::Int::Configuration do
     end
 
     context 'env' do
-      let(:config) { described_class.new(hash: hash, env_name: 'giraffes') }
+      let(:config) { described_class.new(hash: hash, dir: Dir.getwd, env_name: 'giraffes') }
 
       it 'retains the env name' do
         expect(subject.env_name).to eql('giraffes')
@@ -89,8 +89,8 @@ describe Nanoc::Int::Configuration do
   describe '#merge' do
     let(:hash1) { { foo: { bar: 'baz', baz: ['biz'] } } }
     let(:hash2) { { foo: { bar: :boz, biz: 'buz' } } }
-    let(:config1) { described_class.new(hash: hash1) }
-    let(:config2) { described_class.new(hash: hash2) }
+    let(:config1) { described_class.new(hash: hash1, dir: Dir.getwd) }
+    let(:config2) { described_class.new(hash: hash2, dir: Dir.getwd) }
 
     subject { config1.merge(config2).to_h }
 
@@ -101,7 +101,7 @@ describe Nanoc::Int::Configuration do
 
   context 'with environments defined' do
     let(:hash) { { foo: 'bar', environments: { test: { foo: 'test-bar' }, default: { foo: 'default-bar' } } } }
-    let(:config) { described_class.new(hash: hash, env_name: env_name).with_environment }
+    let(:config) { described_class.new(hash: hash, dir: Dir.getwd, env_name: env_name).with_environment }
 
     subject { config }
 

--- a/nanoc/spec/nanoc/base/entities/identifiable_collection_spec.rb
+++ b/nanoc/spec/nanoc/base/entities/identifiable_collection_spec.rb
@@ -4,7 +4,7 @@ describe Nanoc::Int::IdentifiableCollection do
   shared_examples 'a generic identifiable collection' do
     subject(:identifiable_collection) { described_class.new(config, objects) }
 
-    let(:config) { Nanoc::Int::Configuration.new }
+    let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd) }
     let(:objects) { [] }
 
     describe '#reject' do
@@ -28,7 +28,7 @@ describe Nanoc::Int::IdentifiableCollection do
       end
 
       context 'string pattern style is glob' do
-        let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+        let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
 
         it 'handles glob' do
           expect(identifiable_collection['/on*']).to equal(objects[0])
@@ -37,7 +37,7 @@ describe Nanoc::Int::IdentifiableCollection do
       end
 
       context 'string pattern style is glob' do
-        let(:config) { Nanoc::Int::Configuration.new }
+        let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd) }
 
         it 'does not handle glob' do
           expect(identifiable_collection['/on*']).to be_nil

--- a/nanoc/spec/nanoc/base/entities/site_spec.rb
+++ b/nanoc/spec/nanoc/base/entities/site_spec.rb
@@ -11,7 +11,7 @@ describe Nanoc::Int::Site do
     end
 
     let(:config) do
-      Nanoc::Int::Configuration.new.with_defaults
+      Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults
     end
 
     let(:code_snippets) do

--- a/nanoc/spec/nanoc/base/filter_spec.rb
+++ b/nanoc/spec/nanoc/base/filter_spec.rb
@@ -181,7 +181,7 @@ describe Nanoc::Filter do
     let(:empty_items) { Nanoc::Int::ItemCollection.new(config) }
     let(:empty_layouts) { Nanoc::Int::LayoutCollection.new(config) }
 
-    let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+    let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
 
     let(:reps) { Nanoc::Int::ItemRepRepo.new }
 

--- a/nanoc/spec/nanoc/base/repos/checksum_store_spec.rb
+++ b/nanoc/spec/nanoc/base/repos/checksum_store_spec.rb
@@ -3,7 +3,7 @@
 describe Nanoc::Int::ChecksumStore do
   let(:store) { described_class.new(config: config, objects: objects) }
 
-  let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+  let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
 
   let(:objects) { [item, code_snippet] }
 

--- a/nanoc/spec/nanoc/base/repos/compiled_content_cache_spec.rb
+++ b/nanoc/spec/nanoc/base/repos/compiled_content_cache_spec.rb
@@ -13,7 +13,7 @@ describe Nanoc::Int::CompiledContentCache do
 
   let(:content) { Nanoc::Int::Content.create('omg') }
 
-  let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+  let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
 
   it 'has no content by default' do
     expect(cache[item_rep]).to be_nil

--- a/nanoc/spec/nanoc/base/repos/config_loader_spec.rb
+++ b/nanoc/spec/nanoc/base/repos/config_loader_spec.rb
@@ -186,7 +186,7 @@ describe Nanoc::Int::ConfigLoader do
   describe '#apply_parent_config' do
     subject { loader.apply_parent_config(config, processed_paths) }
 
-    let(:config) { Nanoc::Int::Configuration.new(hash: { foo: 'bar' }) }
+    let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd, hash: { foo: 'bar' }) }
 
     let(:processed_paths) { ['nanoc.yaml'] }
 
@@ -198,7 +198,7 @@ describe Nanoc::Int::ConfigLoader do
 
     context 'parent config file is set' do
       let(:config) do
-        Nanoc::Int::Configuration.new(hash: { parent_config_file: 'foo.yaml', foo: 'bar' })
+        Nanoc::Int::Configuration.new(dir: Dir.getwd, hash: { parent_config_file: 'foo.yaml', foo: 'bar' })
       end
 
       context 'parent config file is not present' do

--- a/nanoc/spec/nanoc/base/repos/dependency_store_spec.rb
+++ b/nanoc/spec/nanoc/base/repos/dependency_store_spec.rb
@@ -12,7 +12,7 @@ describe Nanoc::Int::DependencyStore do
 
   let(:items) { Nanoc::Int::ItemCollection.new(config, [item_a, item_b, item_c]) }
   let(:layouts) { Nanoc::Int::LayoutCollection.new(config, [layout_a, layout_b]) }
-  let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+  let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
 
   it 'is empty by default' do
     expect(store.objects_causing_outdatedness_of(item_a)).to be_empty

--- a/nanoc/spec/nanoc/base/repos/outdatedness_store_spec.rb
+++ b/nanoc/spec/nanoc/base/repos/outdatedness_store_spec.rb
@@ -6,7 +6,7 @@ describe Nanoc::Int::OutdatednessStore do
   let(:item) { Nanoc::Int::Item.new('foo', {}, '/foo.md') }
   let(:rep) { Nanoc::Int::ItemRep.new(item, :foo) }
 
-  let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+  let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
   let(:items) { [] }
   let(:layouts) { [] }
   let(:code_snippets) { [] }

--- a/nanoc/spec/nanoc/base/repos/site_loader_spec.rb
+++ b/nanoc/spec/nanoc/base/repos/site_loader_spec.rb
@@ -217,7 +217,7 @@ describe Nanoc::Int::SiteLoader do
   describe '#code_snippets_from_config' do
     subject { loader.send(:code_snippets_from_config, config) }
 
-    let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+    let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
 
     before { FileUtils.mkdir_p('lib') }
 

--- a/nanoc/spec/nanoc/base/repos/store_spec.rb
+++ b/nanoc/spec/nanoc/base/repos/store_spec.rb
@@ -19,7 +19,7 @@ describe Nanoc::Int::Store do
       let(:hash_output_production) { gen_hash('output-production') }
 
       context 'no env specified' do
-        let(:config) { Nanoc::Int::Configuration.new(hash: config_hash).with_defaults.with_environment }
+        let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd, hash: config_hash).with_defaults.with_environment }
 
         context 'output dir is unspecified' do
           let(:config_hash) { {} }
@@ -43,7 +43,7 @@ describe Nanoc::Int::Store do
       end
 
       context 'env specified' do
-        let(:config) { Nanoc::Int::Configuration.new(env_name: 'staging', hash: config_hash).with_defaults.with_environment }
+        let(:config) { Nanoc::Int::Configuration.new(env_name: 'staging', dir: Dir.getwd, hash: config_hash).with_defaults.with_environment }
 
         context 'output dir is unspecified' do
           let(:config_hash) { {} }

--- a/nanoc/spec/nanoc/base/services/compiler/phases/cache_spec.rb
+++ b/nanoc/spec/nanoc/base/services/compiler/phases/cache_spec.rb
@@ -32,7 +32,7 @@ describe Nanoc::Int::Compiler::Phases::Cache do
   let(:item) { Nanoc::Int::Item.new('item content', {}, '/donkey.md') }
   let(:rep) { Nanoc::Int::ItemRep.new(item, :latex) }
 
-  let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+  let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
 
   describe '#run' do
     subject { phase.call(rep, is_outdated: is_outdated) }

--- a/nanoc/spec/nanoc/base/services/compiler/stages/calculate_checksums_spec.rb
+++ b/nanoc/spec/nanoc/base/services/compiler/stages/calculate_checksums_spec.rb
@@ -6,7 +6,7 @@ describe Nanoc::Int::Compiler::Stages::CalculateChecksums do
   end
 
   let(:config) do
-    Nanoc::Int::Configuration.new.with_defaults
+    Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults
   end
 
   let(:code_snippets) do

--- a/nanoc/spec/nanoc/base/services/compiler/stages/cleanup_spec.rb
+++ b/nanoc/spec/nanoc/base/services/compiler/stages/cleanup_spec.rb
@@ -4,7 +4,7 @@ describe Nanoc::Int::Compiler::Stages::Cleanup do
   let(:stage) { described_class.new(config.output_dirs) }
 
   let(:config) do
-    Nanoc::Int::Configuration.new.with_defaults
+    Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults
   end
 
   describe '#run' do

--- a/nanoc/spec/nanoc/base/services/compiler/stages/compile_reps_spec.rb
+++ b/nanoc/spec/nanoc/base/services/compiler/stages/compile_reps_spec.rb
@@ -45,7 +45,7 @@ describe Nanoc::Int::Compiler::Stages::CompileReps do
     )
   end
 
-  let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+  let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
   let(:code_snippets) { [] }
 
   let(:layouts) do

--- a/nanoc/spec/nanoc/base/services/compiler/stages/determine_outdatedness_spec.rb
+++ b/nanoc/spec/nanoc/base/services/compiler/stages/determine_outdatedness_spec.rb
@@ -21,7 +21,7 @@ describe Nanoc::Int::Compiler::Stages::DetermineOutdatedness do
     Nanoc::Int::OutdatednessStore.new(config: config)
   end
 
-  let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+  let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
   let(:code_snippets) { [] }
 
   describe '#run' do

--- a/nanoc/spec/nanoc/base/services/compiler/stages/preprocess_spec.rb
+++ b/nanoc/spec/nanoc/base/services/compiler/stages/preprocess_spec.rb
@@ -23,7 +23,7 @@ describe Nanoc::Int::Compiler::Stages::Preprocess do
   end
 
   let(:data_source) { Nanoc::Int::InMemDataSource.new(items, layouts) }
-  let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+  let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
   let(:items) { Nanoc::Int::ItemCollection.new(config) }
   let(:layouts) { Nanoc::Int::LayoutCollection.new(config) }
 

--- a/nanoc/spec/nanoc/base/services/dependency_tracker_spec.rb
+++ b/nanoc/spec/nanoc/base/services/dependency_tracker_spec.rb
@@ -12,7 +12,7 @@ describe Nanoc::Int::DependencyTracker do
   let(:empty_items) { Nanoc::Int::ItemCollection.new(config) }
   let(:empty_layouts) { Nanoc::Int::LayoutCollection.new(config) }
 
-  let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+  let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
 
   shared_examples 'a null dependency tracker' do
     let(:tracker) { Nanoc::Int::DependencyTracker::Null.new }

--- a/nanoc/spec/nanoc/base/services/item_rep_router_spec.rb
+++ b/nanoc/spec/nanoc/base/services/item_rep_router_spec.rb
@@ -6,7 +6,7 @@ describe(Nanoc::Int::ItemRepRouter) do
   let(:reps) { double(:reps) }
   let(:action_provider) { double(:action_provider) }
   let(:site) { double(:site, config: config) }
-  let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+  let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
 
   describe '#run' do
     subject { item_rep_router.run }

--- a/nanoc/spec/nanoc/base/services/outdatedness_checker_spec.rb
+++ b/nanoc/spec/nanoc/base/services/outdatedness_checker_spec.rb
@@ -74,7 +74,7 @@ describe Nanoc::Int::OutdatednessChecker do
 
     let(:checksum_store) { Nanoc::Int::ChecksumStore.new(config: config, objects: items.to_a + layouts.to_a) }
 
-    let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+    let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
 
     before do
       checksum_store.add(item)
@@ -182,7 +182,7 @@ describe Nanoc::Int::OutdatednessChecker do
     let(:other_item) { Nanoc::Int::Item.new('other stuff', {}, '/other.md') }
     let(:other_item_rep) { Nanoc::Int::ItemRep.new(other_item, :default) }
 
-    let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+    let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
 
     let(:items) { Nanoc::Int::ItemCollection.new(config, [item, other_item]) }
 

--- a/nanoc/spec/nanoc/base/services/outdatedness_rules_spec.rb
+++ b/nanoc/spec/nanoc/base/services/outdatedness_rules_spec.rb
@@ -22,7 +22,7 @@ describe Nanoc::Int::OutdatednessRules do
     let(:item) { Nanoc::Int::Item.new('stuff', {}, '/foo.md') }
     let(:layout) { Nanoc::Int::Layout.new('layoutz', {}, '/page.erb') }
 
-    let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+    let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
     let(:code_snippets) { [] }
     let(:objects) { [config] + code_snippets + [item] }
 

--- a/nanoc/spec/nanoc/base/services/pruner_spec.rb
+++ b/nanoc/spec/nanoc/base/services/pruner_spec.rb
@@ -3,7 +3,7 @@
 describe Nanoc::Pruner, stdio: true do
   subject(:pruner) { described_class.new(config, reps, dry_run: dry_run, exclude: exclude) }
 
-  let(:config) { Nanoc::Int::Configuration.new({}).with_defaults }
+  let(:config) { Nanoc::Int::Configuration.new(hash: {}, dir: Dir.getwd).with_defaults }
   let(:dry_run) { false }
   let(:exclude) { [] }
 

--- a/nanoc/spec/nanoc/base/views/compilation_item_rep_view_spec.rb
+++ b/nanoc/spec/nanoc/base/views/compilation_item_rep_view_spec.rb
@@ -27,7 +27,7 @@ describe Nanoc::CompilationItemRepView do
   let(:empty_items) { Nanoc::Int::ItemCollection.new(config) }
   let(:empty_layouts) { Nanoc::Int::LayoutCollection.new(config) }
 
-  let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+  let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
 
   before do
     dependency_tracker.enter(base_item)

--- a/nanoc/spec/nanoc/base/views/config_view_spec.rb
+++ b/nanoc/spec/nanoc/base/views/config_view_spec.rb
@@ -2,7 +2,7 @@
 
 describe Nanoc::ConfigView do
   let(:config) do
-    Nanoc::Int::Configuration.new(hash: hash)
+    Nanoc::Int::Configuration.new(dir: Dir.getwd, hash: hash)
   end
 
   let(:hash) { { amount: 9000, animal: 'donkey', foo: { bar: :baz } } }

--- a/nanoc/spec/nanoc/base/views/item_view_spec.rb
+++ b/nanoc/spec/nanoc/base/views/item_view_spec.rb
@@ -29,7 +29,7 @@ describe Nanoc::CompilationItemView do
   let(:empty_items) { Nanoc::Int::ItemCollection.new(config) }
   let(:empty_layouts) { Nanoc::Int::LayoutCollection.new(config) }
 
-  let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+  let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
 
   before do
     dependency_tracker.enter(base_item)

--- a/nanoc/spec/nanoc/base/views/post_compile_item_rep_view_spec.rb
+++ b/nanoc/spec/nanoc/base/views/post_compile_item_rep_view_spec.rb
@@ -23,7 +23,7 @@ describe Nanoc::PostCompileItemRepView do
 
   let(:reps) { double(:reps) }
   let(:items) { Nanoc::Int::ItemCollection.new(config) }
-  let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+  let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
   let(:dependency_tracker) { Nanoc::Int::DependencyTracker.new(double(:dependency_store)) }
   let(:compilation_context) { double(:compilation_context, compiled_content_cache: compiled_content_cache) }
   let(:snapshot_repo) { double(:snapshot_repo) }

--- a/nanoc/spec/nanoc/base/views/support/document_view_examples.rb
+++ b/nanoc/spec/nanoc/base/views/support/document_view_examples.rb
@@ -20,7 +20,7 @@ shared_examples 'a document view' do
   let(:empty_items) { Nanoc::Int::ItemCollection.new(config) }
   let(:empty_layouts) { Nanoc::Int::LayoutCollection.new(config) }
 
-  let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+  let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
 
   before do
     dependency_tracker.enter(base_item)

--- a/nanoc/spec/nanoc/base/views/support/item_rep_view_examples.rb
+++ b/nanoc/spec/nanoc/base/views/support/item_rep_view_examples.rb
@@ -23,7 +23,7 @@ shared_examples 'an item rep view' do
   let(:empty_items) { Nanoc::Int::ItemCollection.new(config) }
   let(:empty_layouts) { Nanoc::Int::LayoutCollection.new(config) }
 
-  let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+  let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
 
   before do
     dependency_tracker.enter(base_item)

--- a/nanoc/spec/nanoc/base/views/support/mutable_document_view_examples.rb
+++ b/nanoc/spec/nanoc/base/views/support/mutable_document_view_examples.rb
@@ -15,7 +15,7 @@ shared_examples 'a mutable document view' do
 
   let(:dependency_tracker) { Nanoc::Int::DependencyTracker.new(double(:dependency_store)) }
   let(:snapshot_repo) { double(:snapshot_repo) }
-  let(:config) { Nanoc::Int::Configuration.new }
+  let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd) }
 
   describe '#raw_content=' do
     let(:document) { entity_class.new('content', {}, '/asdf') }

--- a/nanoc/spec/nanoc/checking/check_spec.rb
+++ b/nanoc/spec/nanoc/checking/check_spec.rb
@@ -22,7 +22,7 @@ describe Nanoc::Checking::Check do
       )
     end
 
-    let(:config)        { Nanoc::Int::Configuration.new.with_defaults }
+    let(:config)        { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
     let(:code_snippets) { [] }
     let(:items)         { Nanoc::Int::ItemCollection.new(config, []) }
     let(:layouts)       { Nanoc::Int::LayoutCollection.new(config, []) }

--- a/nanoc/spec/nanoc/checking/checks/external_links_spec.rb
+++ b/nanoc/spec/nanoc/checking/checks/external_links_spec.rb
@@ -17,7 +17,7 @@ describe ::Nanoc::Checking::Checks::ExternalLinks do
     )
   end
 
-  let(:config)        { Nanoc::Int::Configuration.new.with_defaults }
+  let(:config)        { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
   let(:code_snippets) { [] }
   let(:items)         { Nanoc::Int::ItemCollection.new(config, []) }
   let(:layouts)       { Nanoc::Int::LayoutCollection.new(config, []) }

--- a/nanoc/spec/nanoc/cli/commands/compile/diff_generator_spec.rb
+++ b/nanoc/spec/nanoc/cli/commands/compile/diff_generator_spec.rb
@@ -18,7 +18,7 @@ describe Nanoc::CLI::Commands::CompileListeners::DiffGenerator do
       )
     end
 
-    let(:config) { Nanoc::Int::Configuration.new(hash: config_hash).with_defaults }
+    let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd, hash: config_hash).with_defaults }
     let(:items) { [] }
     let(:layouts) { [] }
     let(:code_snippets) { [] }

--- a/nanoc/spec/nanoc/cli/commands/show_data_spec.rb
+++ b/nanoc/spec/nanoc/cli/commands/show_data_spec.rb
@@ -27,7 +27,7 @@ describe Nanoc::CLI::Commands::ShowData, stdio: true do
     let(:item_dog)   { Nanoc::Int::Item.new('About My Dog', {}, '/dog.md') }
     let(:item_other) { Nanoc::Int::Item.new('Raw Data', {}, '/other.dat') }
 
-    let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+    let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
 
     let(:dependency_store) do
       Nanoc::Int::DependencyStore.new(items, layouts, config)
@@ -194,7 +194,7 @@ describe Nanoc::CLI::Commands::ShowData, stdio: true do
     let(:arguments) { [] }
     let(:command) { double(:command) }
 
-    let(:config) { Nanoc::Int::Configuration.new }
+    let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd) }
 
     let(:items) do
       Nanoc::Int::ItemCollection.new(
@@ -276,7 +276,7 @@ describe Nanoc::CLI::Commands::ShowData, stdio: true do
     let(:arguments) { [] }
     let(:command) { double(:command) }
 
-    let(:config) { Nanoc::Int::Configuration.new }
+    let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd) }
 
     let(:layouts) do
       Nanoc::Int::LayoutCollection.new(config, [layout])

--- a/nanoc/spec/nanoc/cli/commands/show_rules_spec.rb
+++ b/nanoc/spec/nanoc/cli/commands/show_rules_spec.rb
@@ -56,7 +56,7 @@ describe Nanoc::CLI::Commands::ShowRules, stdio: true, site: true do
       )
     end
 
-    let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+    let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
 
     let(:action_provider) { double(:action_provider, rules_collection: rules_collection) }
     let(:compiler) { double(:compiler) }

--- a/nanoc/spec/nanoc/data_sources/filesystem/parser_spec.rb
+++ b/nanoc/spec/nanoc/data_sources/filesystem/parser_spec.rb
@@ -4,7 +4,7 @@ describe Nanoc::DataSources::Filesystem::Parser do
   subject(:parser) { described_class.new(config: config) }
 
   let(:config) do
-    Nanoc::Int::Configuration.new.with_defaults
+    Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults
   end
 
   describe '#call' do

--- a/nanoc/spec/nanoc/filters/sass_spec.rb
+++ b/nanoc/spec/nanoc/filters/sass_spec.rb
@@ -80,7 +80,7 @@ describe Nanoc::Filters::Sass do
     let(:empty_items) { Nanoc::Int::ItemCollection.new(config) }
     let(:empty_layouts) { Nanoc::Int::LayoutCollection.new(config) }
 
-    let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+    let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
 
     before do
       FileUtils.mkdir_p(File.dirname(item.attributes[:content_filename]))

--- a/nanoc/spec/nanoc/rule_dsl/action_sequence_calculator_spec.rb
+++ b/nanoc/spec/nanoc/rule_dsl/action_sequence_calculator_spec.rb
@@ -7,7 +7,7 @@ describe(Nanoc::RuleDSL::ActionSequenceCalculator) do
 
   let(:rules_collection) { Nanoc::RuleDSL::RulesCollection.new }
 
-  let(:config) { Nanoc::Int::Configuration.new.with_defaults }
+  let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults }
   let(:items) { Nanoc::Int::ItemCollection.new(config) }
   let(:layouts) { Nanoc::Int::LayoutCollection.new(config) }
 

--- a/nanoc/spec/nanoc/rule_dsl/rule_context_spec.rb
+++ b/nanoc/spec/nanoc/rule_dsl/rule_context_spec.rb
@@ -3,7 +3,7 @@
 shared_examples 'a rule context' do
   let(:item_identifier) { Nanoc::Identifier.new('/foo.md') }
   let(:item) { Nanoc::Int::Item.new('content', {}, item_identifier) }
-  let(:config) { Nanoc::Int::Configuration.new }
+  let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd) }
   let(:items) { Nanoc::Int::ItemCollection.new(config) }
   let(:layouts) { Nanoc::Int::LayoutCollection.new(config) }
 
@@ -147,7 +147,7 @@ describe(Nanoc::RuleDSL::RoutingRuleContext) do
   let(:item_identifier) { Nanoc::Identifier.new('/foo.md') }
   let(:item) { Nanoc::Int::Item.new('content', {}, item_identifier) }
   let(:rep) { Nanoc::Int::ItemRep.new(item, :default) }
-  let(:config) { Nanoc::Int::Configuration.new }
+  let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd) }
   let(:items) { Nanoc::Int::ItemCollection.new(config) }
 
   let(:site) do
@@ -173,7 +173,7 @@ describe(Nanoc::RuleDSL::CompilationRuleContext) do
   let(:item_identifier) { Nanoc::Identifier.new('/foo.md') }
   let(:item) { Nanoc::Int::Item.new('content', {}, item_identifier) }
   let(:rep) { Nanoc::Int::ItemRep.new(item, :default) }
-  let(:config) { Nanoc::Int::Configuration.new }
+  let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd) }
   let(:items) { Nanoc::Int::ItemCollection.new(config) }
   let(:layouts) { Nanoc::Int::LayoutCollection.new(config) }
 

--- a/nanoc/spec/nanoc/rule_dsl/rule_spec.rb
+++ b/nanoc/spec/nanoc/rule_dsl/rule_spec.rb
@@ -56,7 +56,7 @@ shared_examples 'Rule#apply_to' do
 
   let(:site) { Nanoc::Int::Site.new(config: config, data_source: data_source, code_snippets: []) }
   let(:data_source) { Nanoc::Int::InMemDataSource.new(items, layouts) }
-  let(:config) { Nanoc::Int::Configuration.new }
+  let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd) }
   let(:view_context) { Nanoc::ViewContextForPreCompilation.new(items: items) }
   let(:items) { Nanoc::Int::ItemCollection.new(config, []) }
   let(:layouts) { Nanoc::Int::LayoutCollection.new(config, []) }

--- a/nanoc/test/filters/test_slim.rb
+++ b/nanoc/test/filters/test_slim.rb
@@ -28,7 +28,7 @@ class Nanoc::Filters::SlimTest < Nanoc::TestCase
   end
 
   def new_view_context
-    config = Nanoc::Int::Configuration.new
+    config = Nanoc::Int::Configuration.new(dir: Dir.getwd)
 
     Nanoc::ViewContextForCompilation.new(
       reps:                Nanoc::Int::ItemRepRepo.new,

--- a/nanoc/test/filters/test_xsl.rb
+++ b/nanoc/test/filters/test_xsl.rb
@@ -88,7 +88,7 @@ class Nanoc::Filters::XSLTest < Nanoc::TestCase
   def setup
     super
 
-    config = Nanoc::Int::Configuration.new.with_defaults
+    config = Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults
     items = Nanoc::Int::ItemCollection.new(config)
     layouts = Nanoc::Int::LayoutCollection.new(config)
 
@@ -101,7 +101,7 @@ class Nanoc::Filters::XSLTest < Nanoc::TestCase
   end
 
   def new_view_context
-    config = Nanoc::Int::Configuration.new.with_defaults
+    config = Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults
 
     Nanoc::ViewContextForCompilation.new(
       reps:                Nanoc::Int::ItemRepRepo.new,

--- a/nanoc/test/helpers/test_blogging.rb
+++ b/nanoc/test/helpers/test_blogging.rb
@@ -31,7 +31,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
   def setup
     super
 
-    config = Nanoc::Int::Configuration.new.with_defaults
+    config = Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults
     items = Nanoc::Int::ItemCollection.new(config)
     layouts = Nanoc::Int::LayoutCollection.new(config)
     dep_store = Nanoc::Int::DependencyStore.new(items, layouts, config)
@@ -68,7 +68,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     @items[2].expects(:compiled_content).with(snapshot: :pre).returns('item 2 content')
 
     # Mock site
-    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
     @config = Nanoc::ConfigView.new(config, @view_context)
 
     # Create feed item
@@ -98,7 +98,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     @items[2].expects(:compiled_content).returns('item 2 content')
 
     # Mock site
-    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
     @config = Nanoc::ConfigView.new(config, @view_context)
 
     # Create feed item
@@ -128,7 +128,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     @items[2].expects(:compiled_content).returns('item 2 content')
 
     # Mock site
-    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
     @config = Nanoc::ConfigView.new(config, @view_context)
 
     # Create feed item
@@ -158,7 +158,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     @items[2].expects(:compiled_content).returns('item 2 content')
 
     # Mock site
-    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
     @config = Nanoc::ConfigView.new(config, @view_context)
 
     # Create feed item
@@ -178,7 +178,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     @items = [mock_item, mock_item]
 
     # Mock site
-    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
     @config = Nanoc::ConfigView.new(config, @view_context)
 
     # Create feed item
@@ -202,7 +202,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     @items = [mock_item, mock_article]
 
     # Mock site
-    config = Nanoc::Int::Configuration.new(hash: { base_url: nil })
+    config = Nanoc::Int::Configuration.new(hash: { base_url: nil }, dir: Dir.getwd)
     @config = Nanoc::ConfigView.new(config, @view_context)
 
     # Create feed item
@@ -226,7 +226,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     @items = [mock_item, mock_article]
 
     # Mock site
-    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
     @config = Nanoc::ConfigView.new(config, @view_context)
 
     # Create feed item
@@ -250,7 +250,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     @items = [mock_item, mock_article]
 
     # Mock site
-    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
     @config = Nanoc::ConfigView.new(config, @view_context)
 
     # Create feed item
@@ -279,7 +279,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     @items[0].expects(:compiled_content).returns('item 1 content')
 
     # Mock site
-    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com/' })
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com/' }, dir: Dir.getwd)
     @config = Nanoc::ConfigView.new(config, @view_context)
 
     # Create feed item
@@ -308,7 +308,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     @items = [mock_item, mock_article]
 
     # Mock site
-    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
     @config = Nanoc::ConfigView.new(config, @view_context)
 
     # Create feed item
@@ -334,7 +334,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     @items[2].stubs(:[]).with(:created_at).returns(nil)
 
     # Mock site
-    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
     @config = Nanoc::ConfigView.new(config, @view_context)
 
     # Create feed item
@@ -359,7 +359,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     @items[1].expects(:compiled_content).with(snapshot: :pre).returns('asdf')
 
     # Mock site
-    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
     @config = Nanoc::ConfigView.new(config, @view_context)
 
     # Create feed item
@@ -390,7 +390,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
         title: 'My Blog Or Something',
         base_url: 'http://example.com',
       }
-    config = Nanoc::Int::Configuration.new(hash: config_hash)
+    config = Nanoc::Int::Configuration.new(hash: config_hash, dir: Dir.getwd)
     @config = Nanoc::ConfigView.new(config, @view_context)
 
     # Create feed item
@@ -413,7 +413,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     @items[1].expects(:compiled_content).with(snapshot: :pre).returns('asdf')
 
     # Mock site
-    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
     @config = Nanoc::ConfigView.new(config, @view_context)
 
     # Create feed item
@@ -436,7 +436,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     end
 
     # Mock site
-    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
     @config = Nanoc::ConfigView.new(config, @view_context)
 
     # Create feed item
@@ -468,7 +468,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     @items[1].stubs(:[]).with(:created_at).returns('22-03-2009')
 
     # Mock site
-    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
     @config = Nanoc::ConfigView.new(config, @view_context)
 
     # Create feed item
@@ -496,7 +496,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     @items[1].stubs(:[]).with(:created_at).returns('01-01-2014')
 
     # Mock site
-    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
     @config = Nanoc::ConfigView.new(config, @view_context)
 
     # Create feed item
@@ -519,7 +519,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     @items = [mock_article]
 
     # Mock site
-    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
     @config = Nanoc::ConfigView.new(config, @view_context)
 
     # Create feed item
@@ -539,7 +539,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     @items = [mock_article]
 
     # Mock site
-    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
     @config = Nanoc::ConfigView.new(config, @view_context)
 
     # Create feed item
@@ -559,7 +559,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     @items = [mock_article]
 
     # Mock site
-    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
     @config = Nanoc::ConfigView.new(config, @view_context)
 
     # Create feed item
@@ -579,7 +579,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     @items = [mock_article]
 
     # Mock site
-    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
     @config = Nanoc::ConfigView.new(config, @view_context)
 
     # Create feed item
@@ -599,7 +599,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     @items = [mock_article]
 
     # Mock site
-    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
     @config = Nanoc::ConfigView.new(config, @view_context)
 
     # Create feed item
@@ -620,7 +620,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     @items[0].stubs(:path).returns(nil)
 
     # Mock site
-    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+    config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
     @config = Nanoc::ConfigView.new(config, @view_context)
 
     # Create feed item
@@ -643,7 +643,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items[0].stubs(:path).returns(nil)
 
       # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
       @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
@@ -670,7 +670,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items[0].stubs(:path).returns(nil)
 
       # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
       @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
@@ -697,7 +697,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items[0].stubs(:path).returns(nil)
 
       # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
       @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item
@@ -724,7 +724,7 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
       @items[0].stubs(:path).returns(nil)
 
       # Mock site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
       @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Create feed item

--- a/nanoc/test/helpers/test_capturing.rb
+++ b/nanoc/test/helpers/test_capturing.rb
@@ -12,7 +12,7 @@ class Nanoc::Helpers::CapturingTest < Nanoc::TestCase
   end
 
   def view_context_for(item)
-    config = Nanoc::Int::Configuration.new
+    config = Nanoc::Int::Configuration.new(dir: Dir.getwd)
 
     Nanoc::ViewContextForCompilation.new(
       reps:                item_rep_repo_for(item),
@@ -85,7 +85,7 @@ class Nanoc::Helpers::CapturingTest < Nanoc::TestCase
     item = Nanoc::Int::Item.new('content', {}, '/asdf')
     view_context = view_context_for(item)
     @item = Nanoc::CompilationItemView.new(item, view_context_for(item))
-    @config = Nanoc::ConfigView.new(Nanoc::Int::Configuration.new, view_context)
+    @config = Nanoc::ConfigView.new(Nanoc::Int::Configuration.new(dir: Dir.getwd), view_context)
 
     result = ::ERB.new(content).result(binding)
 

--- a/nanoc/test/helpers/test_xml_sitemap.rb
+++ b/nanoc/test/helpers/test_xml_sitemap.rb
@@ -8,7 +8,7 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
   def setup
     super
 
-    config = Nanoc::Int::Configuration.new.with_defaults
+    config = Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults
     items = Nanoc::Int::ItemCollection.new(config)
     layouts = Nanoc::Int::LayoutCollection.new(config)
     dep_store = Nanoc::Int::DependencyStore.new(items, layouts, config)
@@ -63,7 +63,7 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
       @item = Nanoc::CompilationItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap'), @view_context)
 
       # Create site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
       @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Build sitemap
@@ -110,7 +110,7 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
       @item = Nanoc::Int::Item.new('sitemap content', {}, '/sitemap')
 
       # Create site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
       @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Build sitemap
@@ -145,7 +145,7 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
       @item = Nanoc::CompilationItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap'), @view_context)
 
       # Create site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
       @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Build sitemap
@@ -186,7 +186,7 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
       @item = Nanoc::CompilationItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap'), @view_context)
 
       # Create site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
       @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Build sitemap
@@ -218,7 +218,7 @@ class Nanoc::Helpers::XMLSitemapTest < Nanoc::TestCase
       @item = Nanoc::CompilationItemView.new(Nanoc::Int::Item.new('sitemap content', {}, '/sitemap'), @view_context)
 
       # Create site
-      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' })
+      config = Nanoc::Int::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
       @config = Nanoc::ConfigView.new(config, @view_context)
 
       # Build sitemap


### PR DESCRIPTION
This explicitly adds the site directory to the configuration, and removes the dependency from the output path onto the current working directory.

This is one step towards making Nanoc not depend on the current working directory, and will hopefully help towards fixing #1338.