### PR TITLE
Refactor: Remove non-useful SiteLoader methods

### DIFF
--- a/nanoc/lib/nanoc/base/repos/site_loader.rb
+++ b/nanoc/lib/nanoc/base/repos/site_loader.rb
@@ -7,11 +7,6 @@ module Nanoc::Int
       site_from_config(Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults)
     end
 
-    def new_with_config(hash)
-      # FIXME: don’t depend on working directory
-      site_from_config(Nanoc::Int::Configuration.new(hash: hash, dir: Dir.getwd).with_defaults)
-    end
-
     def new_from_cwd
       site_from_config(Nanoc::Int::ConfigLoader.new.new_from_cwd)
     end

--- a/nanoc/lib/nanoc/base/repos/site_loader.rb
+++ b/nanoc/lib/nanoc/base/repos/site_loader.rb
@@ -2,11 +2,6 @@
 
 module Nanoc::Int
   class SiteLoader
-    def new_empty
-      # FIXME: don’t depend on working directory
-      site_from_config(Nanoc::Int::Configuration.new(dir: Dir.getwd).with_defaults)
-    end
-
     def new_from_cwd
       site_from_config(Nanoc::Int::ConfigLoader.new.new_from_cwd)
     end

--- a/nanoc/spec/nanoc/base/repos/site_loader_spec.rb
+++ b/nanoc/spec/nanoc/base/repos/site_loader_spec.rb
@@ -3,27 +3,6 @@
 describe Nanoc::Int::SiteLoader do
   let(:loader) { described_class.new }
 
-  describe '#new_empty' do
-    subject { loader.new_empty }
-
-    it 'has the default configuration' do
-      expect(subject.config).to be_a(Nanoc::Int::Configuration)
-      expect(subject.config[:index_filenames]).to eq(['index.html'])
-    end
-
-    it 'has no code snippets' do
-      expect(subject.code_snippets).to be_empty
-    end
-
-    it 'has no items' do
-      expect(subject.items).to be_empty
-    end
-
-    it 'has no layouts' do
-      expect(subject.layouts).to be_empty
-    end
-  end
-
   describe '#new_from_cwd' do
     subject { loader.new_from_cwd }
 

--- a/nanoc/spec/nanoc/base/repos/site_loader_spec.rb
+++ b/nanoc/spec/nanoc/base/repos/site_loader_spec.rb
@@ -24,30 +24,6 @@ describe Nanoc::Int::SiteLoader do
     end
   end
 
-  describe '#new_with_config' do
-    subject { loader.new_with_config(arg) }
-
-    let(:arg) { { foo: 'bar' } }
-
-    it 'has a slightly modified configuration' do
-      expect(subject.config).to be_a(Nanoc::Int::Configuration)
-      expect(subject.config[:index_filenames]).to eq(['index.html'])
-      expect(subject.config[:foo]).to eq('bar')
-    end
-
-    it 'has no code snippets' do
-      expect(subject.code_snippets).to be_empty
-    end
-
-    it 'has no items' do
-      expect(subject.items).to be_empty
-    end
-
-    it 'has no layouts' do
-      expect(subject.layouts).to be_empty
-    end
-  end
-
   describe '#new_from_cwd' do
     subject { loader.new_from_cwd }
 

--- a/nanoc/spec/nanoc/data_sources/filesystem_spec.rb
+++ b/nanoc/spec/nanoc/data_sources/filesystem_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-describe Nanoc::DataSources::Filesystem do
+describe Nanoc::DataSources::Filesystem, site: true do
   let(:data_source) { Nanoc::DataSources::Filesystem.new(site.config, nil, nil, params) }
   let(:params) { {} }
-  let(:site) { Nanoc::Int::SiteLoader.new.new_empty }
+  let(:site) { Nanoc::Int::SiteLoader.new.new_from_cwd }
 
   before { Timecop.freeze(now) }
   after { Timecop.return }

--- a/nanoc/test/base/test_site.rb
+++ b/nanoc/test/base/test_site.rb
@@ -21,13 +21,9 @@ class Nanoc::Int::SiteTest < Nanoc::TestCase
     assert_equal Dir.getwd + '/public_html', site.config.output_dir
   end
 
-  def test_initialize_with_config_hash
-    site = Nanoc::Int::SiteLoader.new.new_with_config(foo: 'bar')
-    assert_equal 'bar', site.config[:foo]
-  end
-
   def test_initialize_with_incomplete_data_source_config
-    site = Nanoc::Int::SiteLoader.new.new_with_config(data_sources: [{ items_root: '/bar/' }])
+    File.open('nanoc.yaml', 'w') { |io| io.write('data_sources: [{ items_root: "/bar/" }]') }
+    site = Nanoc::Int::SiteLoader.new.new_from_cwd
     assert_equal('filesystem', site.config[:data_sources][0][:type])
     assert_equal('/bar/', site.config[:data_sources][0][:items_root])
     assert_equal('/',     site.config[:data_sources][0][:layouts_root])

--- a/nanoc/test/data_sources/test_filesystem.rb
+++ b/nanoc/test/data_sources/test_filesystem.rb
@@ -4,14 +4,9 @@ require 'helper'
 
 class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
   def new_data_source(params = nil)
-    # Mock site
-    site = Nanoc::Int::SiteLoader.new.new_empty
-
-    # Create data source
-    data_source = Nanoc::DataSources::Filesystem.new(site.config, nil, nil, params)
-
-    # Done
-    data_source
+    with_site do |site|
+      Nanoc::DataSources::Filesystem.new(site.config, nil, nil, params)
+    end
   end
 
   def test_load_objects

--- a/nanoc/test/helper.rb
+++ b/nanoc/test/helper.rb
@@ -110,7 +110,8 @@ module Nanoc::TestHelpers
 
     # Yield site
     FileUtils.cd(site_name) do
-      yield Nanoc::Int::SiteLoader.new.new_from_cwd
+      site = Nanoc::Int::SiteLoader.new.new_from_cwd
+      return yield(site)
     end
   end
 


### PR DESCRIPTION
This removes

* `SiteLoader.new_empty`
* `SiteLoader.new_with_config`

… as both are not particularly useful.