### PR TITLE
Add regression test for #1338

### DIFF
--- a/nanoc/spec/nanoc/regressions/gh_1338_spec.rb
+++ b/nanoc/spec/nanoc/regressions/gh_1338_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe 'GH-1338', site: true, stdio: true do
+  before do
+    File.write('lib/default.rb', <<~EOS)
+      Nanoc::Filter.define(:gh_1338) do |content, params = {}|
+        Dir.chdir('..')
+        content.upcase
+      end
+    EOS
+
+    File.write('Rules', <<~EOS)
+      compile '/*' do
+        filter :gh_1338
+        write ext: 'html'
+      end
+    EOS
+
+    File.write('content/foo.txt', 'stuff')
+  end
+
+  example do
+    Nanoc::CLI.run([])
+  end
+end


### PR DESCRIPTION
This adds an explicit test for #1338.

I am not 100% sure whether #1338 is indeed caused by the working directory changing, but if it does, at least now Nanoc keeps working fine.