### PR TITLE
Add title_proc parameter to blogging helper.

### DIFF
--- a/nanoc/lib/nanoc/helpers/blogging.rb
+++ b/nanoc/lib/nanoc/helpers/blogging.rb
@@ -36,6 +36,7 @@ module Nanoc::Helpers
       attr_accessor :preserve_order
       attr_accessor :content_proc
       attr_accessor :excerpt_proc
+      attr_accessor :title_proc
       attr_accessor :title
       attr_accessor :author_name
       attr_accessor :author_uri
@@ -147,7 +148,7 @@ module Nanoc::Helpers
         xml.entry do
           # Add primary attributes
           xml.id atom_tag_for(article)
-          xml.title article[:title], type: 'html'
+          xml.title title_proc.call(article), type: 'html'
 
           # Add dates
           xml.published attribute_to_time(article[:created_at]).__nanoc_to_iso8601_time
@@ -177,6 +178,7 @@ module Nanoc::Helpers
     # @option params [Boolean] :preserve_order
     # @option params [Proc] :content_proc
     # @option params [Proc] :excerpt_proc
+    # @option params [Proc] :title_proc
     # @option params [String] :alt_link
     # @option params [String] :id
     # @option params [String] :title
@@ -200,6 +202,7 @@ module Nanoc::Helpers
       builder.preserve_order    = params.fetch(:preserve_order, false)
       builder.content_proc      = params[:content_proc] || ->(a) { a.compiled_content(snapshot: :pre) }
       builder.excerpt_proc      = params[:excerpt_proc] || ->(a) { a[:excerpt] }
+      builder.title_proc        = params[:title_proc] || ->(a) { a[:title] }
       builder.title             = params[:title] || @item[:title] || @config[:title]
       builder.author_name       = params[:author_name] || @item[:author_name] || @config[:author_name]
       builder.author_uri        = params[:author_uri] || @item[:author_uri] || @config[:author_uri]


### PR DESCRIPTION
title_proc can be used to transform the title of each item in an Atom feed, like content_proc or excerpt_proc do for content or excerpt.

Closes nanoc/features#42

### To do

* [ ] Add / expand tests.
* [ ] Add documentation.

Signed-off-by: Thomas Hochstein <thh@inter.net>