### PR TITLE
Ensure breadcrumb trail always ends in item itself

### DIFF
--- a/nanoc/lib/nanoc/helpers/breadcrumbs.rb
+++ b/nanoc/lib/nanoc/helpers/breadcrumbs.rb
@@ -33,6 +33,34 @@ module Nanoc::Helpers
 
     # @return [Array]
     def breadcrumbs_trail
+      # The design of this function is a little complicated.
+      #
+      # We can’t use #parent_of from the ChildParent helper, because the
+      # breadcrumb trail can have gaps. For example, the breadcrumbs trail for
+      # /software/oink.md might be /index.md -> nil -> /software/oink.md if
+      # there is no item matching /software.* or /software/index.*.
+      #
+      # What this function does instead is something more complicated:
+      #
+      # 1.  It creates an ordered prefix list, based on the identifier of the
+      #     item to create a breadcrumbs trail for. For example,
+      #     /software/oink.md might have the prefix list
+      #     ['', '/software', '/software/oink.md'].
+      #
+      # 2.  For each of the elements in that list, it will create a list of
+      #     patterns could match zero or more items. For example, the element
+      #     '/software' would correspond to the pattern '/software.*'.
+      #
+      # 3.  For each of the elements in that list, and for each pattern for that
+      #     element, it will find any matching element. For example, the
+      #     pattern '/software.*' (coming from the prefix /software) would match
+      #     the item /software.md.
+      #
+      # 4.  Return the list of items, with the last element replaced by the item
+      #     for which the breadcrumb is generated for -- while ancestral items
+      #     in the breadcrumbs trail can have a bit of ambiguity, the item for
+      #     which to generate the breadcrumbs trail is fixed.
+
       # e.g. ['', '/foo', '/foo/bar']
       components = item.identifier.components
       prefixes = components.inject(['']) { |acc, elem| acc + [acc.last + '/' + elem] }

--- a/nanoc/lib/nanoc/helpers/breadcrumbs.rb
+++ b/nanoc/lib/nanoc/helpers/breadcrumbs.rb
@@ -40,9 +40,9 @@ module Nanoc::Helpers
       if @item.identifier.legacy?
         prefixes.map { |pr| @items[Nanoc::Identifier.new('/' + pr, type: :legacy)] }
       else
-        prefixes
-          .reject { |pr| pr =~ /^\/index\./ }
-          .map do |pr|
+        ancestral_prefixes = prefixes.reject { |pr| pr =~ /^\/index\./ }[0..-2]
+        ancestral_items =
+          ancestral_prefixes.map do |pr|
             if pr == ''
               @items['/index.*']
             else
@@ -50,6 +50,7 @@ module Nanoc::Helpers
               prefix_patterns.lazy.map { |pat| @items[pat] }.find(&:itself)
             end
           end
+        ancestral_items + [item]
       end
     end
   end

--- a/nanoc/spec/nanoc/helpers/breadcrumbs_spec.rb
+++ b/nanoc/spec/nanoc/helpers/breadcrumbs_spec.rb
@@ -176,6 +176,29 @@ describe Nanoc::Helpers::Breadcrumbs, helper: true do
             )
         end
       end
+
+      context 'child with multiple extensions' do
+        before do
+          ctx.create_item('grandchild1', {}, Nanoc::Identifier.new('/foo/stuff.zip'))
+          ctx.create_item('grandchild2', {}, Nanoc::Identifier.new('/foo/stuff.md'))
+          ctx.create_item('grandchild3', {}, Nanoc::Identifier.new('/foo/stuff.png'))
+          ctx.create_item('child', {}, Nanoc::Identifier.new('/foo.md'))
+          ctx.create_item('root', {}, Nanoc::Identifier.new('/index.md'))
+
+          ctx.item = ctx.items['/foo/stuff.md']
+        end
+
+        it 'picks the best parent' do
+          expect(subject)
+            .to eql(
+              [
+                ctx.items['/index.md'],
+                ctx.items['/foo.md'],
+                ctx.items['/foo/stuff.md'],
+              ],
+            )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Detailed description

The items in the path are up for interpretation (but not too much — see below), but the one at the very end, the item for which the breadcrumb is generated, definitely not.

As it stands right now, `#breadcrumbs_trail` makes a decision which parent to use. This might not be the right thing to do; when there is ambiguity, it might make more sense to raise an error instead. Perhaps it needs a `strict: false` (default `true`) option?

### To do

* [x] Tests

### Related issues

Fixes #1366.