### PR TITLE
Raise when meta-file cannot be unambiguously associated

### DIFF
--- a/nanoc/lib/nanoc/base/errors.rb
+++ b/nanoc/lib/nanoc/base/errors.rb
@@ -236,6 +236,12 @@ module Nanoc::Int
       end
     end
 
+    class AmbiguousMetadataAssociation < Generic
+      def initialize(content_filenames, meta_filename)
+        super("There are multiple content files (#{content_filenames.join(', ')}) that could match the file containing metadata (#{meta_filename}).")
+      end
+    end
+
     class InternalInconsistency < Generic
     end
   end

--- a/nanoc/lib/nanoc/data_sources/filesystem/parser.rb
+++ b/nanoc/lib/nanoc/data_sources/filesystem/parser.rb
@@ -70,6 +70,11 @@ class Nanoc::DataSources::Filesystem
       meta
     end
 
+    def frontmatter?(filename)
+      data = Tools.read_file(filename, config: @config)
+      /\A#{SEPARATOR}\s*$/.match?(data)
+    end
+
     def verify_meta(meta, filename)
       return if meta.is_a?(Hash)
 


### PR DESCRIPTION
Fixes #1369.

### Detailed description

In the case where there is on meta-file, and

* … two or more content files, all without inline metadata: raise error
* … two or more content files, all with inline metadata: raise error
* … exactly one content file without inline metadata: use attributes from the meta-file

### To do

(Include the to-do list for this PR to be finished here.)

* [x] Tests
* [ ] Documentation
* [x] Refactoring (but maybe later)

### Related issues

#1369
