### PR TITLE
Lazy-load Sass

### DIFF
--- a/nanoc/lib/nanoc/filters/sass.rb
+++ b/nanoc/lib/nanoc/filters/sass.rb
@@ -1,19 +1,9 @@
 # frozen_string_literal: true
 
 module Nanoc::Filters
-  Nanoc::Filter.define(:sass) do |content, params = {}|
-    include Sass
-    css(self, @item_rep, content, params)
-  end
+  module SassCommon
+    REQUIRES = %w[sass nanoc/filters/sass/importer nanoc/filters/sass/functions].freeze
 
-  Nanoc::Filter.define(:sass_sourcemap) do |content, params = {}|
-    include Sass
-    sourcemap(self, @item_rep, content, params)
-  end
-
-  require 'sass'
-
-  module Sass
     def css(filter, rep, content, params)
       css, = render(filter, rep, content, params)
       css
@@ -27,7 +17,7 @@ module Nanoc::Filters
     private
 
     def render(filter, rep, content, params = {})
-      importer = NanocSassImporter.new(filter)
+      importer = Nanoc::Filters::SassCommon::Importer.new(filter)
 
       options = params.merge(
         load_paths: [importer, *params[:load_paths]&.reject { |p| p.is_a?(String) && %r{^content/} =~ p }],
@@ -41,113 +31,27 @@ module Nanoc::Filters
       css, sourcemap = sourcemap_path ? engine.render_with_sourcemap(sourcemap_path) : engine.render
       [css, sourcemap&.to_json(css_uri: rep.path, type: rep.path.nil? ? :inline : :auto)]
     end
+  end
 
-    # @api private
-    class NanocSassImporter < ::Sass::Importers::Filesystem
-      attr_reader :filter
+  class SassFilter < Nanoc::Filter
+    identifier :sass
 
-      def initialize(filter)
-        @filter = filter
-        super('.')
-      end
+    include SassCommon
+    requires(*SassCommon::REQUIRES)
 
-      def find_relative(name, base_identifier, options)
-        base_raw_filename = filter.items[base_identifier].raw_filename
-
-        # we can't resolve a relative filename from an in-memory item
-        return unless base_raw_filename
-
-        raw_filename, syntax = ::Sass::Util.destructure(find_real_file(File.dirname(base_raw_filename), name, options))
-        return unless raw_filename
-
-        item = raw_filename_to_item(raw_filename)
-        # it doesn't make sense to import a file, from Nanoc's content if the corresponding item has been deleted
-        raise "unable to map #{raw_filename} to any item" if item.nil?
-
-        filter.depend_on([item])
-
-        options[:syntax] = syntax
-        options[:filename] = item.identifier.to_s
-        options[:importer] = self
-        ::Sass::Engine.new(item.raw_content, options)
-      end
-
-      def find(identifier, options)
-        items = filter.items.find_all(identifier)
-        return if items.empty?
-
-        content = if items.size == 1
-                    items.first.compiled_content
-                  else
-                    items.map { |item| %(@import "#{item.identifier}";) }.join("\n")
-                  end
-
-        options[:syntax] = :scss
-        options[:filename] = identifier.to_s
-        options[:importer] = self
-        ::Sass::Engine.new(content, options)
-      end
-
-      def key(identifier, _options)
-        [self.class.name + ':' + root, identifier.to_s]
-      end
-
-      def public_url(identifier, _sourcemap_directory)
-        path = filter.items[identifier].path
-        return path unless path.nil?
-
-        raw_filename = filter.items[identifier].raw_filename
-        return if raw_filename.nil?
-
-        ::Sass::Util.file_uri_from_path(raw_filename)
-      end
-
-      def to_s
-        'Nanoc Sass Importer'
-      end
-
-      def self.raw_filename_to_item_map_for_config(config, items)
-        @raw_filename_to_item_map ||= {}
-        @raw_filename_to_item_map[config.object_id] ||=
-          {}.tap do |map|
-            items.each do |item|
-              if item.raw_filename
-                path = Pathname.new(item.raw_filename).realpath.to_s
-                map[path] = item
-              end
-            end
-          end
-      end
-
-      def raw_filename_to_item(filename)
-        realpath = Pathname.new(filename).realpath.to_s
-
-        map = self.class.raw_filename_to_item_map_for_config(filter.config, filter.items)
-        map[realpath]
-      end
+    def run(content, params = {})
+      css(self, @item_rep, content, params)
     end
   end
 
-  module ::Sass::Script::Functions
-    def nanoc(string, params)
-      assert_type string, :String
-      assert_type params, :Hash
-      result = options[:importer].filter.instance_eval(string.value)
-      case result
-      when TrueClass, FalseClass
-        bool(result)
-      when Array
-        list(result, :comma)
-      when Hash
-        map(result)
-      when nil
-        null
-      when Numeric
-        number(result)
-      else
-        params['unquote'] ? unquoted_string(result) : quoted_string(result)
-      end
+  class SassSourcemapFilter < Nanoc::Filter
+    identifier :sass_sourcemap
+
+    include SassCommon
+    requires(*SassCommon::REQUIRES)
+
+    def run(content, params = {})
+      sourcemap(self, @item_rep, content, params)
     end
-    declare :nanoc, [:string], var_kwargs: true
   end
 end

--- a/nanoc/lib/nanoc/filters/sass/functions.rb
+++ b/nanoc/lib/nanoc/filters/sass/functions.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module ::Sass::Script::Functions
+  def nanoc(string, params)
+    assert_type string, :String
+    assert_type params, :Hash
+    result = options[:importer].filter.instance_eval(string.value)
+    case result
+    when TrueClass, FalseClass
+      bool(result)
+    when Array
+      list(result, :comma)
+    when Hash
+      map(result)
+    when nil
+      null
+    when Numeric
+      number(result)
+    else
+      params['unquote'] ? unquoted_string(result) : quoted_string(result)
+    end
+  end
+  declare :nanoc, [:string], var_kwargs: true
+end

--- a/nanoc/lib/nanoc/filters/sass/importer.rb
+++ b/nanoc/lib/nanoc/filters/sass/importer.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Nanoc::Filters::SassCommon
+  # @api private
+  class Importer < ::Sass::Importers::Filesystem
+    attr_reader :filter
+
+    def initialize(filter)
+      @filter = filter
+      super('.')
+    end
+
+    def find_relative(name, base_identifier, options)
+      base_raw_filename = filter.items[base_identifier].raw_filename
+
+      # we can't resolve a relative filename from an in-memory item
+      return unless base_raw_filename
+
+      raw_filename, syntax = ::Sass::Util.destructure(find_real_file(File.dirname(base_raw_filename), name, options))
+      return unless raw_filename
+
+      item = raw_filename_to_item(raw_filename)
+      # it doesn't make sense to import a file, from Nanoc's content if the corresponding item has been deleted
+      raise "unable to map #{raw_filename} to any item" if item.nil?
+
+      filter.depend_on([item])
+
+      options[:syntax] = syntax
+      options[:filename] = item.identifier.to_s
+      options[:importer] = self
+      ::Sass::Engine.new(item.raw_content, options)
+    end
+
+    def find(identifier, options)
+      items = filter.items.find_all(identifier)
+      return if items.empty?
+
+      content = if items.size == 1
+                  items.first.compiled_content
+                else
+                  items.map { |item| %(@import "#{item.identifier}";) }.join("\n")
+                end
+
+      options[:syntax] = :scss
+      options[:filename] = identifier.to_s
+      options[:importer] = self
+      ::Sass::Engine.new(content, options)
+    end
+
+    def key(identifier, _options)
+      [self.class.name + ':' + root, identifier.to_s]
+    end
+
+    def public_url(identifier, _sourcemap_directory)
+      path = filter.items[identifier].path
+      return path unless path.nil?
+
+      raw_filename = filter.items[identifier].raw_filename
+      return if raw_filename.nil?
+
+      ::Sass::Util.file_uri_from_path(raw_filename)
+    end
+
+    def to_s
+      'Nanoc Sass Importer'
+    end
+
+    def self.raw_filename_to_item_map_for_config(config, items)
+      @raw_filename_to_item_map ||= {}
+      @raw_filename_to_item_map[config.object_id] ||=
+        {}.tap do |map|
+          items.each do |item|
+            if item.raw_filename
+              path = Pathname.new(item.raw_filename).realpath.to_s
+              map[path] = item
+            end
+          end
+        end
+    end
+
+    def raw_filename_to_item(filename)
+      realpath = Pathname.new(filename).realpath.to_s
+
+      map = self.class.raw_filename_to_item_map_for_config(filter.config, filter.items)
+      map[realpath]
+    end
+  end
+end

--- a/nanoc/nanoc.manifest
+++ b/nanoc/nanoc.manifest
@@ -227,6 +227,8 @@ lib/nanoc/filters/redcloth.rb
 lib/nanoc/filters/relativize_paths.rb
 lib/nanoc/filters/rubypants.rb
 lib/nanoc/filters/sass.rb
+lib/nanoc/filters/sass/functions.rb
+lib/nanoc/filters/sass/importer.rb
 lib/nanoc/filters/slim.rb
 lib/nanoc/filters/typogruby.rb
 lib/nanoc/filters/uglify_js.rb

--- a/nanoc/spec/nanoc/cli/error_handler_spec.rb
+++ b/nanoc/spec/nanoc/cli/error_handler_spec.rb
@@ -181,7 +181,7 @@ describe Nanoc::CLI::ErrorHandler, stdio: true do
       requires = Nanoc::Filter.all.flat_map(&:requires)
       described =
         Nanoc::CLI::ErrorHandler::GEM_NAMES.keys +
-        ['erb', 'rdoc', 'nanoc/filters/sass/sass_filesystem_importer']
+        ['erb', 'rdoc', 'nanoc/filters/sass/importer', 'nanoc/filters/sass/functions']
 
       missing = requires - described
 

--- a/nanoc/spec/nanoc/filters/sass_spec.rb
+++ b/nanoc/spec/nanoc/filters/sass_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Nanoc::Filters::Sass do
+describe Nanoc::Filters::SassCommon do
   context 'with item, items, config context' do
     subject(:sass) { ::Nanoc::Filter.named(:sass).new(sass_params) }
     subject(:sass_sourcemap) { ::Nanoc::Filter.named(:sass_sourcemap).new(sass_sourcemap_params) }


### PR DESCRIPTION
This will Nanoc not _always_ load Sass, but only when the `:sass` filter is used.

Without this, users of Nanoc 4.10.0 would get

```
1: from /usr/local/lib/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in require' /usr/local/lib/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:inrequire': cannot load such file -- sass (LoadError)
```

### To do

* [ ] Tests — but this is particularly hard to test…

### Related issues

(none)
