### PR TITLE
Let RulesModified check dependent objects as well

### DIFF
--- a/nanoc/lib/nanoc/base/services/outdatedness_rules/rules_modified.rb
+++ b/nanoc/lib/nanoc/base/services/outdatedness_rules/rules_modified.rb
@@ -5,11 +5,37 @@ module Nanoc::Int::OutdatednessRules
     affects_props :compiled_content, :path
 
     def apply(obj, outdatedness_checker)
+      # Check rules of obj itself
+      if rules_modified?(obj, outdatedness_checker)
+        return Nanoc::Int::OutdatednessReasons::RulesModified
+      end
+
+      # Check rules of layouts used by obj
+      layouts = layouts_touched_by(obj, outdatedness_checker)
+      if layouts.any? { |layout| rules_modified?(layout, outdatedness_checker) }
+        return Nanoc::Int::OutdatednessReasons::RulesModified
+      end
+
+      nil
+    end
+
+    private
+
+    def rules_modified?(obj, outdatedness_checker)
       seq_old = outdatedness_checker.action_sequence_store[obj]
       seq_new = outdatedness_checker.action_sequence_for(obj).serialize
-      unless seq_old.eql?(seq_new)
-        Nanoc::Int::OutdatednessReasons::RulesModified
-      end
+
+      !seq_old.eql?(seq_new)
+    end
+
+    def layouts_touched_by(obj, outdatedness_checker)
+      actions = outdatedness_checker.action_sequence_store[obj]
+      layout_actions = actions.select { |a| a.first == :layout }
+
+      layout_actions.map do |layout_action|
+        layout_pattern = layout_action[1]
+        outdatedness_checker.site.layouts[layout_pattern]
+      end.compact
     end
   end
 end

--- a/nanoc/spec/nanoc/regressions/gh_1372_spec.rb
+++ b/nanoc/spec/nanoc/regressions/gh_1372_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+describe 'GH-1372', site: true, stdio: true do
+  before do
+    FileUtils.mkdir_p('content')
+    File.write('content/home.erb', 'hello')
+
+    FileUtils.mkdir_p('layouts')
+    File.write('layouts/default.haml', '#main= yield')
+
+    File.write('Rules', <<~EOS)
+      compile '/*' do
+        layout '/default.*'
+        write ext: 'html'
+      end
+
+      layout '/**/*', :haml, remove_whitespace: false
+    EOS
+  end
+
+  example do
+    Nanoc::CLI.run(['--verbose'])
+
+    File.write('Rules', <<~EOS)
+      compile '/*' do
+        layout '/default.*'
+        write ext: 'html'
+      end
+
+      layout '/**/*', :haml, remove_whitespace: true
+    EOS
+
+    expect { Nanoc::CLI.run(['--verbose']) }
+      .to output(%r{update.*output/home\.html$}).to_stdout
+  end
+end


### PR DESCRIPTION
When the params of a layout were changed, Nanoc wouldn’t recompile items that use this layout, because it only checked the rules of the item itself — not of the layout that it depends on.

### To do

* [x] Tests
  * [x] Regression test
  * [x] Test to verify filter used for layout

### Related issues

Fixes #1372.