### PR TITLE
Let `write nil` always skip routing rule

### DIFF
--- a/nanoc/lib/nanoc/base/entities/processing_actions/snapshot.rb
+++ b/nanoc/lib/nanoc/base/entities/processing_actions/snapshot.rb
@@ -23,7 +23,7 @@ module Nanoc::Int::ProcessingActions
 
     contract C::KeywordArgs[snapshot_names: C::Optional[C::IterOf[Symbol]], paths: C::Optional[C::IterOf[String]]] => self
     def update(snapshot_names: [], paths: [])
-      self.class.new(@snapshot_names + snapshot_names, @paths + paths)
+      self.class.new(@snapshot_names + snapshot_names.to_a, @paths + paths.to_a)
     end
 
     contract C::None => String

--- a/nanoc/lib/nanoc/rule_dsl/action_recorder.rb
+++ b/nanoc/lib/nanoc/rule_dsl/action_recorder.rb
@@ -12,7 +12,7 @@ module Nanoc
         @any_layouts = false
         @last_snapshot = false
         @pre_snapshot = false
-        @skip_routing_rule = false
+        @snapshots_for_which_to_skip_routing_rule = Set.new
       end
 
       def inspect
@@ -40,7 +40,9 @@ module Nanoc
       MaybePathlike = C::Or[nil, Nanoc::UNDEFINED, String, Nanoc::Identifier]
       contract Symbol, C::KeywordArgs[path: C::Optional[MaybePathlike]] => nil
       def snapshot(snapshot_name, path: Nanoc::UNDEFINED)
-        @skip_routing_rule = path.nil?
+        unless Nanoc::UNDEFINED.equal?(path)
+          @snapshots_for_which_to_skip_routing_rule << snapshot_name
+        end
 
         path =
           if Nanoc::UNDEFINED.equal?(path) || path.nil?
@@ -69,9 +71,9 @@ module Nanoc
         @any_layouts
       end
 
-      contract C::None => C::Bool
-      def skip_routing_rule?
-        @skip_routing_rule
+      contract C::None => Set
+      def snapshots_for_which_to_skip_routing_rule
+        @snapshots_for_which_to_skip_routing_rule
       end
 
       contract C::None => C::Bool

--- a/nanoc/spec/nanoc/integration/write_nil_spec.rb
+++ b/nanoc/spec/nanoc/integration/write_nil_spec.rb
@@ -1,45 +1,78 @@
 # frozen_string_literal: true
 
 describe 'write nil (skip routing rule)', site: true, stdio: true do
-  before do
-    File.write('content/foo.md', 'foo')
+  context 'write non-nil + write nil' do
+    before do
+      File.write('content/foo.md', 'foo')
 
-    File.write('Rules', <<~EOS)
-      compile '/foo.*' do
-        write '/foo-via-compilation-rule.txt'
-        write nil
-      end
+      File.write('Rules', <<~EOS)
+        compile '/foo.*' do
+          write '/foo-via-compilation-rule.txt'
+          write nil
+        end
 
-      route '/foo.*' do
-        '/foo-via-routing-rule.txt'
-      end
-    EOS
+        route '/foo.*' do
+          '/foo-via-routing-rule.txt'
+        end
+      EOS
+    end
+
+    it 'starts off empty' do
+      expect(File.file?('output/foo-via-compilation-rule.txt')).not_to be
+      expect(File.file?('output/foo-via-routing-rule.txt')).not_to be
+    end
+
+    it 'outputs creation of correct file' do
+      expect { Nanoc::CLI.run(%w[compile --verbose]) rescue nil }
+        .to output(/create.*output\/foo-via-compilation-rule\.txt/).to_stdout
+    end
+
+    it 'does not output creation of incorrect file' do
+      expect { Nanoc::CLI.run(%w[compile --verbose]) rescue nil }
+        .not_to output(/create.*output\/foo-via-routing-rule\.txt/).to_stdout
+    end
+
+    it 'creates correct file' do
+      expect { Nanoc::CLI.run(%w[compile --verbose --debug]) rescue nil }
+        .to change { File.file?('output/foo-via-compilation-rule.txt') }
+        .from(false)
+        .to(true)
+    end
+
+    it 'does not create incorrect file' do
+      expect { Nanoc::CLI.run(%w[compile --verbose --debug]) rescue nil }
+        .not_to change { File.file?('output/foo-via-routing-rule.txt') }
+    end
   end
 
-  it 'starts off empty' do
-    expect(File.file?('output/foo-via-compilation-rule.txt')).not_to be
-    expect(File.file?('output/foo-via-routing-rule.txt')).not_to be
-  end
+  context 'write nil only' do
+    before do
+      File.write('content/foo.md', 'foo')
 
-  it 'outputs creation of correct file' do
-    expect { Nanoc::CLI.run(%w[compile --verbose]) rescue nil }
-      .to output(/create.*output\/foo-via-compilation-rule\.txt/).to_stdout
-  end
+      File.write('Rules', <<~EOS)
+        compile '/foo.*' do
+          write nil
+        end
 
-  it 'does not output creation of incorrect file' do
-    expect { Nanoc::CLI.run(%w[compile --verbose]) rescue nil }
-      .not_to output(/create.*output\/foo-via-routing-rule\.txt/).to_stdout
-  end
+        route '/foo.*' do
+          '/foo-via-routing-rule.txt'
+        end
+      EOS
+    end
 
-  it 'creates correct file' do
-    expect { Nanoc::CLI.run(%w[compile --verbose --debug]) rescue nil }
-      .to change { File.file?('output/foo-via-compilation-rule.txt') }
-      .from(false)
-      .to(true)
-  end
+    it 'starts off empty' do
+      expect(File.file?('output/foo-via-compilation-rule.txt')).not_to be
+      expect(File.file?('output/foo-via-routing-rule.txt')).not_to be
+    end
 
-  it 'does not create incorrect file' do
-    expect { Nanoc::CLI.run(%w[compile --verbose --debug]) rescue nil }
-      .not_to change { File.file?('output/foo-via-routing-rule.txt') }
+    it 'does not output creation of incorrect file' do
+      expect { Nanoc::CLI.run(%w[compile --verbose]) rescue nil }
+        .not_to output(/create.*output\/foo-via-routing-rule\.txt/).to_stdout
+    end
+
+    it 'does not create incorrect file' do
+      expect { Nanoc::CLI.run(%w[compile --verbose --debug]) rescue nil }
+        .not_to change { File.file?('output/foo-via-routing-rule.txt') }
+    end
   end
 end

--- a/nanoc/spec/nanoc/regressions/gh_1374_spec.rb
+++ b/nanoc/spec/nanoc/regressions/gh_1374_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+describe 'GH-1374', site: true, stdio: true do
+  before do
+    FileUtils.mkdir_p('content')
+    File.write('content/test.md', 'hello')
+
+    File.write('Rules', <<~EOS)
+      compile '/*' do
+        write nil
+      end
+
+      passthrough '/*'
+    EOS
+  end
+
+  example do
+    expect { Nanoc::CLI.run([]) }
+      .not_to change { File.file?('output/test.md') }
+      .from(false)
+  end
+end

--- a/nanoc/spec/nanoc/rule_dsl/action_recorder_spec.rb
+++ b/nanoc/spec/nanoc/rule_dsl/action_recorder_spec.rb
@@ -102,7 +102,9 @@ describe Nanoc::RuleDSL::ActionRecorder do
           end
 
           it 'keeps skip_routing_rule' do
-            expect { subject }.not_to change { recorder.skip_routing_rule? }
+            expect { subject }
+              .not_to change { recorder.snapshots_for_which_to_skip_routing_rule }
+              .from(Set.new)
           end
         end
 
@@ -117,8 +119,11 @@ describe Nanoc::RuleDSL::ActionRecorder do
             expect(action_sequence[0].paths).to eql(['/routed-foo.html'])
           end
 
-          it 'keeps skip_routing_rule' do
-            expect { subject }.not_to change { recorder.skip_routing_rule? }
+          it 'sets skip_routing_rule' do
+            expect { subject }
+              .to change { recorder.snapshots_for_which_to_skip_routing_rule }
+              .from(Set.new)
+              .to(Set.new([:foo]))
           end
         end
 
@@ -133,8 +138,11 @@ describe Nanoc::RuleDSL::ActionRecorder do
             expect(action_sequence[0].paths).to eql(['/routed-foo.html'])
           end
 
-          it 'keeps skip_routing_rule' do
-            expect { subject }.not_to change { recorder.skip_routing_rule? }
+          it 'sets skip_routing_rule' do
+            expect { subject }
+              .to change { recorder.snapshots_for_which_to_skip_routing_rule }
+              .from(Set.new)
+              .to(Set.new([:foo]))
           end
         end
 
@@ -151,9 +159,9 @@ describe Nanoc::RuleDSL::ActionRecorder do
 
           it 'sets skip_routing_rule' do
             expect { subject }
-              .to change { recorder.skip_routing_rule? }
-              .from(false)
-              .to(true)
+              .to change { recorder.snapshots_for_which_to_skip_routing_rule }
+              .from(Set.new)
+              .to(Set.new([:foo]))
           end
         end
       end


### PR DESCRIPTION
### Detailed description

The `skip_routing_rule` was properly set up, but somehow not used.

If, after snapshot compaction, there is *any* path assigned to a snapshot action, the routing rule will be skipped. For example:

1. snapshot `a`, no paths
1. snapshot `b`, some paths
1. any filter
1. snapshot `c`, no paths

In the example above, only for snapshot `c` would the routing rule be used (if any).

### To do

* [x] Tests

### Related issues

Fixes #1374.
