### PR TITLE
Sass improvements

### DIFF
--- a/nanoc/lib/nanoc.rb
+++ b/nanoc/lib/nanoc.rb
@@ -38,6 +38,7 @@ module Nanoc
 end
 
 # Load general requirements
+require 'base64'
 require 'cgi'
 require 'digest'
 require 'English'

--- a/nanoc/lib/nanoc/filters/sass.rb
+++ b/nanoc/lib/nanoc/filters/sass.rb
@@ -25,11 +25,14 @@ module Nanoc::Filters
         filename: rep.item.identifier.to_s,
         cache: false,
       )
+      css_path = options.delete(:css_path) || filter.object_id.to_s
       sourcemap_path = options.delete(:sourcemap_path)
 
       engine = ::Sass::Engine.new(content, options)
       css, sourcemap = sourcemap_path ? engine.render_with_sourcemap(sourcemap_path) : engine.render
-      [css, sourcemap&.to_json(css_uri: rep.path, type: rep.path.nil? ? :inline : :auto)]
+      sourcemap = sourcemap&.to_json(css_path: css_path, sourcemap_path: sourcemap_path, type: params[:sources_content] ? :inline : :auto)
+      sourcemap = sourcemap&.split("\n")&.reject { |l| l =~ /^\s*"file":\s*"#{filter.object_id.to_s}"\s*$/ }&.join("\n")
+      [css, sourcemap]
     end
   end
 

--- a/nanoc/spec/nanoc/filters/sass_spec.rb
+++ b/nanoc/spec/nanoc/filters/sass_spec.rb
@@ -273,6 +273,11 @@ describe Nanoc::Filters::SassCommon do
         expect(sass_sourcemap.setup_and_run(".foo #bar\n  color: #f00", sourcemap_path: 'main.css.map'))
           .not_to match(/{.*?"sources": \["#{item_main_default_rep.raw_path}"\].*?"file": ".*?".*?}/m)
       end
+
+      it 'generates inlined sourcemaps' do
+        expect(sass.setup_and_run(".foo #bar\n  color: #f00", css_path: 'main.css', sourcemap_path: :inline))
+          .to match(/.foo\s+#bar\s*\{\s*color:\s+(red|#f00);?\s*\}\s*\/\*# sourceMappingURL=data:application\/json;base64.*? \*\//)
+      end
     end
 
     context 'nanoc() sass function' do

--- a/nanoc/spec/nanoc/filters/sass_spec.rb
+++ b/nanoc/spec/nanoc/filters/sass_spec.rb
@@ -264,11 +264,14 @@ describe Nanoc::Filters::SassCommon do
 
     context 'sourcemaps' do
       it 'generates proper sourcemaps' do
-        expect(sass.setup_and_run(".foo #bar\n  color: #f00", sourcemap_path: 'main.sass.map'))
-          .to match(/.foo\s+#bar\s*\{\s*color:\s+(red|#f00);?\s*\}\s*\/\*# sourceMappingURL=main.sass.map \*\//)
+        expect(sass.setup_and_run(".foo #bar\n  color: #f00", sourcemap_path: 'main.css.map'))
+          .to match(/.foo\s+#bar\s*\{\s*color:\s+(red|#f00);?\s*\}\s*\/\*# sourceMappingURL=main.css.map \*\//)
 
-        expect(sass_sourcemap.setup_and_run(".foo #bar\n  color: #f00", sourcemap_path: 'main.sass.map'))
-          .to match(/{.*?"sources": \["#{item_main_default_rep.raw_path}"\].*?"file": "#{item_main_sourcemap_rep.raw_path}".*?}/m)
+        expect(sass_sourcemap.setup_and_run(".foo #bar\n  color: #f00", css_path: 'main.css', sourcemap_path: 'main.css.map'))
+          .to match(/{.*?"sources": \["#{item_main_default_rep.raw_path}"\].*?"file": "main\.css".*?}/m)
+
+        expect(sass_sourcemap.setup_and_run(".foo #bar\n  color: #f00", sourcemap_path: 'main.css.map'))
+          .not_to match(/{.*?"sources": \["#{item_main_default_rep.raw_path}"\].*?"file": ".*?".*?}/m)
       end
     end
 


### PR DESCRIPTION
This PR adds further improvements to the `:sass` and `:sass_sourcemap` filters.

### Detailed description

- `:sass` and `:sass_sourcemap` filters now require the `:css_path` option, which produces source maps where the optional `"file"` field has a correct value
- the `:sass` filter now supports the generation of inline, base 64 encoded, source maps

* [x] Tests
* [x] Documentation

### Related issues

https://github.com/nanoc/nanoc.ws/pull/227
