### PR TITLE
Allow Sass to import files even if they don’t have an item

### DIFF
--- a/nanoc/lib/nanoc/filters/sass/importer.rb
+++ b/nanoc/lib/nanoc/filters/sass/importer.rb
@@ -20,15 +20,16 @@ module Nanoc::Filters::SassCommon
       return unless raw_filename
 
       item = raw_filename_to_item(raw_filename)
-      # it doesn't make sense to import a file, from Nanoc's content if the corresponding item has been deleted
-      raise "unable to map #{raw_filename} to any item" if item.nil?
 
-      filter.depend_on([item])
+      content = item ? item.raw_content : File.read(raw_filename)
+      filename = item ? item.identifier.to_s : raw_filename
+
+      filter.depend_on([item]) if item
 
       options[:syntax] = syntax
-      options[:filename] = item.identifier.to_s
+      options[:filename] = filename
       options[:importer] = self
-      ::Sass::Engine.new(item.raw_content, options)
+      ::Sass::Engine.new(content, options)
     end
 
     def find(identifier, options)

--- a/nanoc/spec/nanoc/filters/sass_spec.rb
+++ b/nanoc/spec/nanoc/filters/sass_spec.rb
@@ -88,11 +88,13 @@ describe Nanoc::Filters::SassCommon do
         rep.raw_paths = rep.paths = { last: [Dir.getwd + '/output/style/main.sass'] }
       end
     end
+
     let(:item_main_sourcemap_rep) do
       Nanoc::Int::ItemRep.new(item_main, :sourcemap).tap do |rep|
         rep.raw_paths = rep.paths = { last: [Dir.getwd + '/output/style/main.sass.map'] }
       end
     end
+
     let(:item_main_view) { Nanoc::CompilationItemView.new(item_main, view_context) }
     let(:item_main_default_rep_view) { Nanoc::CompilationItemRepView.new(item_main_default_rep, view_context) }
     let(:item_main_sourcemap_rep_view) { Nanoc::CompilationItemRepView.new(item_main_sourcemap_rep, view_context) }
@@ -122,9 +124,11 @@ describe Nanoc::Filters::SassCommon do
         reps << item_main_sourcemap_rep
       end
     end
+
     let(:dependency_tracker) { Nanoc::Int::DependencyTracker.new(dependency_store) }
     let(:dependency_store) { Nanoc::Int::DependencyStore.new(empty_items, empty_layouts, config) }
     let(:compilation_context) { double(:compilation_context) }
+
     let(:snapshot_repo) do
       Nanoc::Int::SnapshotRepo.new.tap do |repo|
         repo.set(reps[item_blue].first, :last, Nanoc::Int::TextualContent.new('.blue { color: blue }'))
@@ -229,7 +233,7 @@ describe Nanoc::Filters::SassCommon do
       before { File.write('_external.scss', 'body { font: 100%; }') }
 
       context 'load_path set' do
-        it 'can import by relative path' do
+        it 'can import (using load paths) by relative path' do
           expect(sass.setup_and_run('@import external', load_paths: ['.']))
             .to match(/\Abody\s+\{\s*font:\s+100%;?\s*\}\s*\z/)
         end
@@ -241,9 +245,14 @@ describe Nanoc::Filters::SassCommon do
       end
 
       context 'load_path not set' do
-        it 'cannot import by relative path' do
+        it 'cannot import (using load paths) by relative path' do
           expect { sass.setup_and_run('@import external') }
             .to raise_error(::Sass::SyntaxError, /File to import not found/)
+        end
+
+        it 'can import (using importer) by relative path' do
+          expect(sass.setup_and_run('@import "../../_external"'))
+            .to match(/\Abody\s+\{\s*font:\s+100%;?\s*\}\s*\z/)
         end
       end
     end

--- a/nanoc/spec/nanoc/regressions/gh_1378_spec.rb
+++ b/nanoc/spec/nanoc/regressions/gh_1378_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe 'GH-1378', site: true, stdio: true do
+  before do
+    FileUtils.mkdir_p('content')
+    File.write('outside.scss', 'p { color: red; }')
+    File.write('content/style.scss', '@import "../outside.scss";')
+
+    File.write('Rules', <<~EOS)
+      compile '/*' do
+        filter :sass, syntax: :scss
+        write ext: 'css'
+      end
+    EOS
+  end
+
+  example do
+    expect { Nanoc::CLI.run([]) }
+      .to change { File.file?('output/style.css') }
+      .from(false)
+      .to(true)
+
+    expect(File.read('output/style.css')).to match(/p\s*{\s*color:\s*red;\s*}/)
+  end
+end


### PR DESCRIPTION
Fix backwards-incompatible change in 4.10’s Sass filter.

### Detailed description

When no load paths are given to the Sass filter, it should still be able to resolve relative paths (e.g. `../external`) and successfully import. This isn’t currently possible, because the Sass filter assumes that the files have a corresponding Nanoc item.

This change allows the Sass filter to (again) import such files.

### To do

(Include the to-do list for this PR to be finished here.)

* [x] Tests

### Related issues

Fixes #1378.