### PR TITLE
Remove obsolete #on_main_fiber

### DIFF
--- a/nanoc/lib/nanoc/base/services/compiler/phases/resume.rb
+++ b/nanoc/lib/nanoc/base/services/compiler/phases/resume.rb
@@ -22,8 +22,6 @@ module Nanoc::Int::Compiler::Phases
         when Nanoc::Int::Errors::UnmetDependency
           Nanoc::Int::NotificationCenter.post(:compilation_suspended, rep, res)
           raise(res)
-        when Proc
-          fiber.resume(res.call)
         when DONE # rubocop:disable Lint/EmptyWhen
           # ignore
         else

--- a/nanoc/lib/nanoc/base/services/filter.rb
+++ b/nanoc/lib/nanoc/base/services/filter.rb
@@ -217,11 +217,6 @@ module Nanoc
       end
     end
 
-    # @api private
-    def on_main_fiber(&block)
-      Fiber.yield(block)
-    end
-
     # Creates a dependency from the item that is currently being filtered onto
     # the given collection of items. In other words, require the given items
     # to be compiled first before this items is processed.

--- a/nanoc/lib/nanoc/filters/less.rb
+++ b/nanoc/lib/nanoc/filters/less.rb
@@ -21,10 +21,8 @@ module Nanoc::Filters
 
       # Add filename to load path
       paths = [File.dirname(@item[:content_filename])]
-      on_main_fiber do
-        parser = ::Less::Parser.new(paths: paths)
-        parser.parse(content).to_css(params)
-      end
+      parser = ::Less::Parser.new(paths: paths)
+      parser.parse(content).to_css(params)
     end
 
     def imported_filenames_from(content)


### PR DESCRIPTION
`#on_main_fiber` was needed because of a former V8/therubyracer bug that prevented code from executing on a non-main fiber. This now works, so the `#on_main_fiber` hack can be removed.