### PR TITLE
Add snapshot_name to UnmetDependency error

### DIFF
--- a/nanoc/lib/nanoc/base/errors.rb
+++ b/nanoc/lib/nanoc/base/errors.rb
@@ -122,11 +122,16 @@ module Nanoc::Int
       #   compiled
       attr_reader :rep
 
+      # TODO: document
+      attr_reader :snapshot_name
+
       # @param [Nanoc::Int::ItemRep] rep The item representation that cannot yet be
       #   compiled
-      def initialize(rep)
+      def initialize(rep, snapshot_name)
         @rep = rep
-        super("The current item cannot be compiled yet because of an unmet dependency on the “#{rep.item.identifier}” item (rep “#{rep.name}”).")
+        @snapshot_name = snapshot_name
+
+        super("The current item cannot be compiled yet because of an unmet dependency on the “#{rep.item.identifier}” item (rep “#{rep.name}”, snapshot “#{snapshot_name}”).")
       end
     end
 

--- a/nanoc/lib/nanoc/base/repos/snapshot_repo.rb
+++ b/nanoc/lib/nanoc/base/repos/snapshot_repo.rb
@@ -46,7 +46,7 @@ module Nanoc::Int
       stopped_moving = snapshot_name != :last || rep.compiled?
       is_usable_snapshot = get(rep, snapshot_name) && stopped_moving
       unless is_usable_snapshot
-        Fiber.yield(Nanoc::Int::Errors::UnmetDependency.new(rep))
+        Fiber.yield(Nanoc::Int::Errors::UnmetDependency.new(rep, snapshot_name))
         return raw_compiled_content(rep: rep, snapshot: snapshot)
       end
 

--- a/nanoc/lib/nanoc/base/views/compilation_item_rep_view.rb
+++ b/nanoc/lib/nanoc/base/views/compilation_item_rep_view.rb
@@ -20,7 +20,7 @@ module Nanoc
       res = @item_rep.raw_path(snapshot: snapshot)
 
       unless @item_rep.compiled?
-        Fiber.yield(Nanoc::Int::Errors::UnmetDependency.new(@item_rep))
+        Fiber.yield(Nanoc::Int::Errors::UnmetDependency.new(@item_rep, snapshot))
       end
 
       # Wait for file to exist

--- a/nanoc/lib/nanoc/helpers/capturing.rb
+++ b/nanoc/lib/nanoc/helpers/capturing.rb
@@ -67,7 +67,8 @@ module Nanoc::Helpers
           dependency_tracker.bounce(@requested_item._unwrap, compiled_content: true)
 
           unless rep.compiled?
-            Fiber.yield(Nanoc::Int::Errors::UnmetDependency.new(rep))
+            # FIXME: is :last appropriate?
+            Fiber.yield(Nanoc::Int::Errors::UnmetDependency.new(rep, :last))
             return run
           end
         end

--- a/nanoc/spec/nanoc/base/services/item_rep_selector_spec.rb
+++ b/nanoc/spec/nanoc/base/services/item_rep_selector_spec.rb
@@ -35,7 +35,7 @@ describe Nanoc::Int::ItemRepSelector do
 
       dependencies.fetch(rep.name, []).each do |name|
         unless successfully_yielded.include?(name)
-          raise Nanoc::Int::Errors::UnmetDependency.new(names_to_reps[name])
+          raise Nanoc::Int::Errors::UnmetDependency.new(names_to_reps[name], :foo)
         end
       end
 
@@ -63,7 +63,7 @@ describe Nanoc::Int::ItemRepSelector do
         selector.each do |_rep|
           idx += 1
 
-          raise Nanoc::Int::Errors::UnmetDependency.new(reps_array[2]) if idx == 1
+          raise Nanoc::Int::Errors::UnmetDependency.new(reps_array[2], :foo) if idx == 1
         end
       end
 
@@ -98,7 +98,7 @@ describe Nanoc::Int::ItemRepSelector do
           idx += 1
 
           begin
-            raise Nanoc::Int::Errors::UnmetDependency.new(reps_array[2]) if idx == 1
+            raise Nanoc::Int::Errors::UnmetDependency.new(reps_array[2], :foo) if idx == 1
           rescue => e
             raise Nanoc::Int::Errors::CompilationError.new(e, rep)
           end
@@ -114,7 +114,7 @@ describe Nanoc::Int::ItemRepSelector do
   describe 'cycle' do
     context 'dependency on self' do
       subject do
-        selector.each { |r| raise Nanoc::Int::Errors::UnmetDependency.new(r) }
+        selector.each { |r| raise Nanoc::Int::Errors::UnmetDependency.new(r, :foo) }
       end
 
       example do
@@ -131,11 +131,11 @@ describe Nanoc::Int::ItemRepSelector do
         selector.each do |r|
           case r
           when reps_array[0]
-            raise Nanoc::Int::Errors::UnmetDependency.new(reps_array[1])
+            raise Nanoc::Int::Errors::UnmetDependency.new(reps_array[1], :foo)
           when reps_array[1]
-            raise Nanoc::Int::Errors::UnmetDependency.new(reps_array[2])
+            raise Nanoc::Int::Errors::UnmetDependency.new(reps_array[2], :foo)
           when reps_array[2]
-            raise Nanoc::Int::Errors::UnmetDependency.new(reps_array[0])
+            raise Nanoc::Int::Errors::UnmetDependency.new(reps_array[0], :foo)
           end
         end
       end


### PR DESCRIPTION
By adding `snapshot_name to the `UnmetDependency` error, an instance of this error now has all information needed to track hard dependencies.

This isn’t directly used yet, but in the future, this can be used to figure out more fine-grained dependencies on snapshot level, and coordinate between multiple dependent reps being compiled.