### PR TITLE
Include target rep and snapshot in compilation_suspended notification

### DIFF
--- a/nanoc/lib/nanoc/base/errors.rb
+++ b/nanoc/lib/nanoc/base/errors.rb
@@ -122,7 +122,7 @@ module Nanoc::Int
       #   compiled
       attr_reader :rep
 
-      # TODO: document
+      # @return [Symbol] The name of the snapshot that cannot yet be compiled
       attr_reader :snapshot_name
 
       # @param [Nanoc::Int::ItemRep] rep The item representation that cannot yet be

--- a/nanoc/lib/nanoc/base/services/compiler/phases/resume.rb
+++ b/nanoc/lib/nanoc/base/services/compiler/phases/resume.rb
@@ -19,7 +19,7 @@ module Nanoc::Int::Compiler::Phases
 
         case res
         when Nanoc::Int::Errors::UnmetDependency
-          Nanoc::Int::NotificationCenter.post(:compilation_suspended, rep, res)
+          Nanoc::Int::NotificationCenter.post(:compilation_suspended, rep, res.rep, res.snapshot_name)
           raise(res)
         when Proc
           fiber.resume(res.call)

--- a/nanoc/lib/nanoc/cli/commands/compile_listeners/debug_printer.rb
+++ b/nanoc/lib/nanoc/cli/commands/compile_listeners/debug_printer.rb
@@ -16,8 +16,8 @@ module Nanoc::CLI::Commands::CompileListeners
         puts "*** Ended compilation of #{rep.inspect}"
         puts
       end
-      Nanoc::Int::NotificationCenter.on(:compilation_suspended) do |rep, e|
-        puts "*** Suspended compilation of #{rep.inspect}: #{e.message}"
+      Nanoc::Int::NotificationCenter.on(:compilation_suspended) do |rep, target_rep, snapshot_name|
+        puts "*** Suspended compilation of #{rep.inspect}: depends on #{target_rep}, snapshot #{snapshot_name}"
       end
       Nanoc::Int::NotificationCenter.on(:cached_content_used) do |rep|
         puts "*** Used cached compiled content for #{rep.inspect} instead of recompiling"

--- a/nanoc/lib/nanoc/cli/commands/compile_listeners/timing_recorder.rb
+++ b/nanoc/lib/nanoc/cli/commands/compile_listeners/timing_recorder.rb
@@ -52,7 +52,7 @@ module Nanoc::CLI::Commands::CompileListeners
         @load_stores_summary.observe(duration, name: klass.to_s)
       end
 
-      on(:compilation_suspended) do |rep, _exception|
+      on(:compilation_suspended) do |rep, _target_rep, _snapshot_name|
         filter_stopwatches.fetch(rep).each(&:stop)
       end
 

--- a/nanoc/spec/nanoc/base/compiler_spec.rb
+++ b/nanoc/spec/nanoc/base/compiler_spec.rb
@@ -124,7 +124,7 @@ describe Nanoc::Int::Compiler do
         expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:compilation_started, rep).ordered
         expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:filtering_started, rep, :erb).ordered
         expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:dependency_created, item, other_item).ordered
-        expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:compilation_suspended, rep, anything).ordered
+        expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:compilation_suspended, rep, anything, anything).ordered
 
         # rep 2
         expect(Nanoc::Int::NotificationCenter).to receive(:post).with(:compilation_started, other_rep).ordered


### PR DESCRIPTION
It’s much cleaner to include the target rep and target snapshot name in the `compilation_suspended` notification, rather than the `Nanoc::Int::Errors::UnmetDependency` instance that caused it.