### PR TITLE
Use stopwatch for FileActionPrinter

### DIFF
--- a/nanoc/spec/nanoc/cli/commands/compile/file_action_printer_spec.rb
+++ b/nanoc/spec/nanoc/cli/commands/compile/file_action_printer_spec.rb
@@ -49,7 +49,7 @@ describe Nanoc::CLI::Commands::CompileListeners::FileActionPrinter, stdio: true 
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
     Nanoc::Int::NotificationCenter.post(:compilation_suspended, rep, :__irrelevant__)
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 3))
-    Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
+    Nanoc::Int::NotificationCenter.post(:compilation_resumed, rep)
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 6))
 
     expect { Nanoc::Int::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', true, true) }


### PR DESCRIPTION
Rather than managing time ourselves, we can use `DDMetrics::Stopwatch` to record durations.

This also introduces `compilation_resumed`, which is needed to handle suspended compilation properly.