### PR TITLE
Simplify notification center usage in compilation listeners

### DIFF
--- a/guard-nanoc/lib/guard/nanoc.rb
+++ b/guard-nanoc/lib/guard/nanoc.rb
@@ -43,7 +43,7 @@ module Guard
 
       ::Nanoc::CLI::Commands::CompileListeners::FileActionPrinter
         .new(reps: [])
-        .start
+        .start_safely
     end
 
     def recompile_in_subprocess

--- a/nanoc/lib/nanoc/cli/commands/compile_listeners/abstract.rb
+++ b/nanoc/lib/nanoc/cli/commands/compile_listeners/abstract.rb
@@ -16,25 +16,38 @@ module Nanoc::CLI::Commands::CompileListeners
     # @abstract
     def stop; end
 
-    def run_while
+    def wrapped_start
+      @_notification_names = []
       start
+    end
+
+    def wrapped_stop
+      stop
+
+      @_notification_names.each do |name|
+        Nanoc::Int::NotificationCenter.remove(name, self)
+      end
+    end
+
+    def run_while
+      wrapped_start
       yield
     ensure
-      stop
+      wrapped_stop
     end
 
     def start_safely
-      start
+      wrapped_start
       @_started = true
     end
 
     def stop_safely
-      stop if @_started
+      wrapped_stop if @_started
       @_started = false
     end
 
     def on(sym)
-      # TODO: clean up on stop
+      @_notification_names << sym
       Nanoc::Int::NotificationCenter.on(sym, self) { |*args| yield(*args) }
     end
   end

--- a/nanoc/lib/nanoc/cli/commands/compile_listeners/debug_printer.rb
+++ b/nanoc/lib/nanoc/cli/commands/compile_listeners/debug_printer.rb
@@ -9,26 +9,32 @@ module Nanoc::CLI::Commands::CompileListeners
 
     # @see Listener#start
     def start
-      Nanoc::Int::NotificationCenter.on(:compilation_started) do |rep|
+      on(:compilation_started) do |rep|
         puts "*** Started compilation of #{rep.inspect}"
       end
-      Nanoc::Int::NotificationCenter.on(:compilation_ended) do |rep|
+
+      on(:compilation_ended) do |rep|
         puts "*** Ended compilation of #{rep.inspect}"
         puts
       end
-      Nanoc::Int::NotificationCenter.on(:compilation_suspended) do |rep, target_rep, snapshot_name|
+
+      on(:compilation_suspended) do |rep, target_rep, snapshot_name|
         puts "*** Suspended compilation of #{rep.inspect}: depends on #{target_rep}, snapshot #{snapshot_name}"
       end
-      Nanoc::Int::NotificationCenter.on(:cached_content_used) do |rep|
+
+      on(:cached_content_used) do |rep|
         puts "*** Used cached compiled content for #{rep.inspect} instead of recompiling"
       end
-      Nanoc::Int::NotificationCenter.on(:filtering_started) do |rep, filter_name|
+
+      on(:filtering_started) do |rep, filter_name|
         puts "*** Started filtering #{rep.inspect} with #{filter_name}"
       end
-      Nanoc::Int::NotificationCenter.on(:filtering_ended) do |rep, filter_name|
+
+      on(:filtering_ended) do |rep, filter_name|
         puts "*** Ended filtering #{rep.inspect} with #{filter_name}"
       end
-      Nanoc::Int::NotificationCenter.on(:dependency_created) do |src, dst|
+
+      on(:dependency_created) do |src, dst|
         puts "*** Dependency created from #{src.inspect} onto #{dst.inspect}"
       end
     end

--- a/nanoc/lib/nanoc/cli/commands/compile_listeners/diff_generator.rb
+++ b/nanoc/lib/nanoc/cli/commands/compile_listeners/diff_generator.rb
@@ -11,10 +11,12 @@ module Nanoc::CLI::Commands::CompileListeners
     def start
       setup_diffs
       old_contents = {}
-      Nanoc::Int::NotificationCenter.on(:rep_write_started, self) do |rep, path|
+
+      on(:rep_write_started) do |rep, path|
         old_contents[rep] = File.file?(path) ? File.read(path) : nil
       end
-      Nanoc::Int::NotificationCenter.on(:rep_write_ended, self) do |rep, binary, path, _is_created, _is_modified|
+
+      on(:rep_write_ended) do |rep, binary, path, _is_created, _is_modified|
         unless binary
           new_contents = File.file?(path) ? File.read(path) : nil
           if old_contents[rep] && new_contents
@@ -27,11 +29,6 @@ module Nanoc::CLI::Commands::CompileListeners
 
     # @see Listener#stop
     def stop
-      super
-
-      Nanoc::Int::NotificationCenter.remove(:rep_write_started, self)
-      Nanoc::Int::NotificationCenter.remove(:rep_write_ended, self)
-
       teardown_diffs
     end
 

--- a/nanoc/lib/nanoc/cli/commands/compile_listeners/timing_recorder.rb
+++ b/nanoc/lib/nanoc/cli/commands/compile_listeners/timing_recorder.rb
@@ -95,7 +95,6 @@ module Nanoc::CLI::Commands::CompileListeners
     # @see Listener#stop
     def stop
       print_profiling_feedback
-      super
     end
 
     protected

--- a/nanoc/spec/nanoc/cli/commands/compile/file_action_printer_spec.rb
+++ b/nanoc/spec/nanoc/cli/commands/compile/file_action_printer_spec.rb
@@ -21,7 +21,7 @@ describe Nanoc::CLI::Commands::CompileListeners::FileActionPrinter, stdio: true 
   end
 
   it 'records from compilation_started to rep_write_ended' do
-    listener.start
+    listener.start_safely
 
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 0))
     Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
@@ -32,8 +32,8 @@ describe Nanoc::CLI::Commands::CompileListeners::FileActionPrinter, stdio: true 
   end
 
   it 'stops listening after #stop' do
-    listener.start
-    listener.stop
+    listener.start_safely
+    listener.stop_safely
 
     Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
 
@@ -42,7 +42,7 @@ describe Nanoc::CLI::Commands::CompileListeners::FileActionPrinter, stdio: true 
   end
 
   it 'records from compilation_started over compilation_suspended to rep_write_ended' do
-    listener.start
+    listener.start_safely
 
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 0))
     Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
@@ -57,7 +57,7 @@ describe Nanoc::CLI::Commands::CompileListeners::FileActionPrinter, stdio: true 
   end
 
   it 'records from compilation_started over rep_write_{enqueued,started} to rep_write_ended' do
-    listener.start
+    listener.start_safely
 
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 0))
     Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
@@ -72,11 +72,11 @@ describe Nanoc::CLI::Commands::CompileListeners::FileActionPrinter, stdio: true 
   end
 
   context 'log level = high' do
-    before { listener.start }
+    before { listener.start_safely }
     before { Nanoc::CLI::Logger.instance.level = :high }
 
     it 'does not print skipped (uncompiled) reps' do
-      expect { listener.stop }
+      expect { listener.stop_safely }
         .not_to output(/skip/).to_stdout
     end
 
@@ -99,11 +99,11 @@ describe Nanoc::CLI::Commands::CompileListeners::FileActionPrinter, stdio: true 
   end
 
   context 'log level = low' do
-    before { listener.start }
+    before { listener.start_safely }
     before { Nanoc::CLI::Logger.instance.level = :low }
 
     it 'prints skipped (uncompiled) reps' do
-      expect { listener.stop }
+      expect { listener.stop_safely }
         .to output(/skip.*\/hi\.html/).to_stdout
     end
 

--- a/nanoc/spec/nanoc/cli/commands/compile/timing_recorder_spec.rb
+++ b/nanoc/spec/nanoc/cli/commands/compile/timing_recorder_spec.rb
@@ -8,7 +8,7 @@ describe Nanoc::CLI::Commands::CompileListeners::TimingRecorder, stdio: true do
 
   before { Nanoc::CLI.verbosity = 2 }
 
-  before { listener.start }
+  before { listener.start_safely }
   after { listener.stop_safely }
 
   let(:reps) do
@@ -41,7 +41,7 @@ describe Nanoc::CLI::Commands::CompileListeners::TimingRecorder, stdio: true do
     Timecop.freeze(Time.local(2008, 9, 1, 10, 14, 3))
     Nanoc::Int::NotificationCenter.post(:filtering_ended, rep, :erb)
 
-    expect { listener.stop }
+    expect { listener.stop_safely }
       .to output(/^\s*erb │     2   1\.00s   1\.50s   1\.90s   1\.95s   2\.00s   3\.00s$/).to_stdout
   end
 
@@ -213,14 +213,14 @@ describe Nanoc::CLI::Commands::CompileListeners::TimingRecorder, stdio: true do
   it 'prints stage durations' do
     Nanoc::Int::NotificationCenter.post(:stage_ran, 1.23, 'donkey_stage')
 
-    expect { listener.stop }
+    expect { listener.stop_safely }
       .to output(/^\s*donkey_stage │ 1\.23s$/).to_stdout
   end
 
   it 'prints out outdatedness rule durations' do
     Nanoc::Int::NotificationCenter.post(:outdatedness_rule_ran, 1.0, Nanoc::Int::OutdatednessRules::CodeSnippetsModified)
 
-    expect { listener.stop }
+    expect { listener.stop_safely }
       .to output(/^\s*CodeSnippetsModified │     1   1\.00s   1\.00s   1\.00s   1\.00s   1\.00s   1\.00s$/).to_stdout
   end
 
@@ -248,12 +248,12 @@ describe Nanoc::CLI::Commands::CompileListeners::TimingRecorder, stdio: true do
   it 'prints load store durations' do
     Nanoc::Int::NotificationCenter.post(:store_loaded, 1.23, Nanoc::Int::ChecksumStore)
 
-    expect { listener.stop }
+    expect { listener.stop_safely }
       .to output(/^\s*Nanoc::Int::ChecksumStore │ 1\.23s$/).to_stdout
   end
 
   it 'skips printing empty metrics' do
-    expect { listener.stop }
+    expect { listener.stop_safely }
       .not_to output(/filters|phases|stages/).to_stdout
   end
 end

--- a/nanoc/test/cli/commands/test_compile.rb
+++ b/nanoc/test/cli/commands/test_compile.rb
@@ -138,10 +138,10 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
 
     # Listen
     listener = new_file_action_printer([rep])
-    listener.start
+    listener.start_safely
     Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
     Nanoc::Int::NotificationCenter.post(:rep_write_ended, rep, false, rep.raw_path, false, true)
-    listener.stop
+    listener.stop_safely
 
     # Check
     assert_equal 1, listener.events.size
@@ -159,9 +159,9 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
 
     # Listen
     listener = new_file_action_printer([rep])
-    listener.start
+    listener.start_safely
     Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
-    listener.stop
+    listener.stop_safely
 
     # Check
     assert_equal 1, listener.events.size


### PR DESCRIPTION
This lets all compilation listeners use the built-in `#on`, and also lets it unsubscribe automatically, reducing the chance of errors.