### PR TITLE
Test Slim 4.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ group :plugins do
   gem 'rouge', '~> 3.1'
   gem 'rubypants'
   gem 'sass'
-  gem 'slim', '~> 3.0'
+  gem 'slim', '~> 4.0'
   gem 'therubyracer', '~> 0.12', platforms: :ruby
   gem 'typogruby'
   gem 'uglifier'


### PR DESCRIPTION
Slim is now at 4.x. This PR updates the dependency’s version, so we test on the latest version of Slim.