### PR TITLE
Use dedicated thread for notification center

### DIFF
--- a/common/spec/spec_helper_foot.rb
+++ b/common/spec/spec_helper_foot.rb
@@ -245,7 +245,10 @@ RSpec::Matchers.define :send_notification do |name, *expected_args|
     Nanoc::Int::NotificationCenter.on(name, self) do |*actual_args|
       @actual_notifications << actual_args
     end
+
     actual.call
+    Nanoc::Int::NotificationCenter.sync
+
     @actual_notifications.any? { |c| c == expected_args }
   end
 
@@ -254,7 +257,7 @@ RSpec::Matchers.define :send_notification do |name, *expected_args|
   end
 
   failure_message do |_actual|
-    s = "expected that proc would send notification #{name.inspect} with args #{expected_args.inspect}"
+    s = +"expected that proc would send notification #{name.inspect} with args #{expected_args.inspect}"
     if @actual_notifications.any?
       s << " (received #{@actual_notifications.size} times with other arguments: #{@actual_notifications.map(&:inspect).join(', ')})"
     end

--- a/nanoc/lib/nanoc/base/services/item_rep_writer.rb
+++ b/nanoc/lib/nanoc/base/services/item_rep_writer.rb
@@ -42,6 +42,9 @@ module Nanoc::Int
         :rep_write_started, item_rep, raw_path
       )
 
+      # Sync (needed so that diff generator can read the old contents)
+      Nanoc::Int::NotificationCenter.sync
+
       content = snapshot_repo.get(item_rep, snapshot_name)
       if content.binary?
         temp_path = content.filename

--- a/nanoc/lib/nanoc/base/services/notification_center.rb
+++ b/nanoc/lib/nanoc/base/services/notification_center.rb
@@ -12,116 +12,86 @@ module Nanoc::Int
   # @api private
   class NotificationCenter
     DONE = Object.new
+    SYNC = Object.new
 
-    class << self
-      # Adds the given block to the list of blocks that should be called when
-      # the notification with the given name is received.
-      #
-      # @param [String, Symbol] name The name of the notification that will
-      #   cause the given block to be called.
-      #
-      # @param [String, Symbol, nil] id An identifier for the block. This is
-      #   only used to be able to remove the block (using the remove method)
-      #   later. Can be nil, but this is not recommended because it prevents
-      #   the given notification block from being unregistered.
-      #
-      # @yield [*args] Will be executed with the arguments passed to {.post}
-      #
-      # @return [void]
-      def on(name, id = nil, &block)
-        initialize_if_necessary(name)
+    def initialize
+      @thread = nil
 
-        # Add observer
-        @notifications[name] << { id: id, block: block }
-      end
+      # name => observers dictionary
+      @notifications = Hash.new { |hash, name| hash[name] = [] }
 
-      def start_unless_started
-        @thread ||= Thread.new do
-          Thread.current.abort_on_exception = true
+      @queue = Queue.new
 
-          loop do
-            elem = @queue.pop
-            break if DONE.equal?(elem)
+      @sync_queue = Queue.new
+      on(SYNC, self) { @sync_queue << true }
+    end
 
-            name = elem[0]
-            args = elem[1]
+    def start
+      @thread ||= Thread.new do
+        Thread.current.abort_on_exception = true
 
-            initialize_if_necessary(name)
+        loop do
+          elem = @queue.pop
+          break if DONE.equal?(elem)
 
-            @notifications[name].each do |observer|
-              observer[:block].call(*args)
-            end
+          name = elem[0]
+          args = elem[1]
+
+          @notifications[name].each do |observer|
+            observer[:block].call(*args)
           end
         end
       end
+    end
 
-      # Posts a notification with the given name and the given arguments.
-      #
-      # @param [String, Symbol] name The name of the notification that should
-      #   be posted.
-      #
-      # @param args Arguments that wil be passed to the blocks handling the
-      #   notification.
-      #
-      # @return [void]
+    def stop
+      @queue << DONE
+      @thread.join
+    end
+
+    def on(name, id = nil, &block)
+      @notifications[name] << { id: id, block: block }
+    end
+
+    def remove(name, id)
+      @notifications[name].reject! { |i| i[:id] == id }
+    end
+
+    def post(name, *args)
+      @queue << [name, args]
+      self
+    end
+
+    def sync
+      post(SYNC)
+      @sync_queue.pop
+    end
+
+    class << self
+      def instance
+        @_instance ||= new.tap(&:start)
+      end
+
+      def on(name, id = nil, &block)
+        instance.on(name, id, &block)
+      end
+
       def post(name, *args)
-        initialize_if_necessary(name)
-        @queue << [name, args]
+        instance.post(name, *args)
         self
       end
 
-      # Removes the block with the given identifier from the list of blocks
-      # that should be called when the notification with the given name is
-      # posted.
-      #
-      # @param [String, Symbol] name The name of the notification that should
-      #   no longer be registered.
-      #
-      # @param [String, Symbol] id The identifier of the block that should be
-      #   removed.
-      #
-      # @return [void]
       def remove(name, id)
-        initialize_if_necessary(name)
-
-        # Remove relevant observers
-        @notifications[name].reject! { |i| i[:id] == id }
+        instance.remove(name, id)
       end
 
-      # @api private
-      #
-      # @return [void]
       def reset
-        # FIXME: ugh this @__xyz business is awful
-
-        @notifications = nil
-        @__sync_queue_set_up = false
-        @__sync_queue = nil
-        @queue&.clear
+        instance.stop
+        @_instance = nil
       end
 
       def sync
-        maybe_setup_sync_queue
-        post(:__sync)
-        @__sync_queue.pop
-      end
-
-      private
-
-      def maybe_setup_sync_queue
-        @__sync_queue_set_up ||=
-          begin
-            @__sync_queue ||= Queue.new
-            on(:__sync, self) { @__sync_queue << true }
-            true
-          end
-      end
-
-      def initialize_if_necessary(name)
-        @queue ||= Queue.new
-        start_unless_started
-        @notifications ||= {}       # name => observers dictionary
-        @notifications[name] ||= [] # list of observers
+        instance.sync
       end
     end
   end

--- a/nanoc/lib/nanoc/base/services/notification_center.rb
+++ b/nanoc/lib/nanoc/base/services/notification_center.rb
@@ -78,7 +78,6 @@ module Nanoc::Int
 
       def post(name, *args)
         instance.post(name, *args)
-        self
       end
 
       def remove(name, id)

--- a/nanoc/spec/nanoc/base/services/notification_center_spec.rb
+++ b/nanoc/spec/nanoc/base/services/notification_center_spec.rb
@@ -2,24 +2,24 @@
 
 describe Nanoc::Int::NotificationCenter do
   it 'receives notification after subscribing' do
-    ping_received = false
+    res = false
     Nanoc::Int::NotificationCenter.on :ping_received, :test do
-      ping_received = true
+      res = true
     end
 
-    Nanoc::Int::NotificationCenter.post :ping_received
-    expect(ping_received).to be
+    Nanoc::Int::NotificationCenter.post(:ping_received).sync
+    expect(res).to be
   end
 
   it 'does not receive notification after unsubscribing' do
-    ping_received = false
+    res = false
     Nanoc::Int::NotificationCenter.on :ping_received, :test do
-      ping_received = true
+      res = true
     end
 
     Nanoc::Int::NotificationCenter.remove :ping_received, :test
 
-    Nanoc::Int::NotificationCenter.post :ping_received
-    expect(ping_received).not_to be
+    Nanoc::Int::NotificationCenter.post(:ping_received).sync
+    expect(res).not_to be
   end
 end

--- a/nanoc/spec/nanoc/base/services/notification_center_spec.rb
+++ b/nanoc/spec/nanoc/base/services/notification_center_spec.rb
@@ -1,25 +1,37 @@
 # frozen_string_literal: true
 
-describe Nanoc::Int::NotificationCenter do
+shared_examples 'a notification center' do
   it 'receives notification after subscribing' do
     res = false
-    Nanoc::Int::NotificationCenter.on :ping_received, :test do
+    subject.on :ping_received, :test do
       res = true
     end
 
-    Nanoc::Int::NotificationCenter.post(:ping_received).sync
+    subject.post(:ping_received).sync
     expect(res).to be
   end
 
   it 'does not receive notification after unsubscribing' do
     res = false
-    Nanoc::Int::NotificationCenter.on :ping_received, :test do
+    subject.on :ping_received, :test do
       res = true
     end
 
-    Nanoc::Int::NotificationCenter.remove :ping_received, :test
+    subject.remove :ping_received, :test
 
-    Nanoc::Int::NotificationCenter.post(:ping_received).sync
+    subject.post(:ping_received).sync
     expect(res).not_to be
+  end
+end
+
+describe Nanoc::Int::NotificationCenter do
+  describe 'class' do
+    subject { described_class }
+    it_behaves_like 'a notification center'
+  end
+
+  describe 'instance' do
+    subject { described_class.instance }
+    it_behaves_like 'a notification center'
   end
 end

--- a/nanoc/spec/nanoc/cli/commands/compile/file_action_printer_spec.rb
+++ b/nanoc/spec/nanoc/cli/commands/compile/file_action_printer_spec.rb
@@ -25,10 +25,10 @@ describe Nanoc::CLI::Commands::CompileListeners::FileActionPrinter, stdio: true 
     listener.start_safely
 
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 0))
-    Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
+    Nanoc::Int::NotificationCenter.post(:compilation_started, rep).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
 
-    expect { Nanoc::Int::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', true, true) }
+    expect { Nanoc::Int::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', true, true).sync }
       .to output(/create.*\[1\.00s\]/).to_stdout
   end
 
@@ -36,9 +36,9 @@ describe Nanoc::CLI::Commands::CompileListeners::FileActionPrinter, stdio: true 
     listener.start_safely
     listener.stop_safely
 
-    Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
+    Nanoc::Int::NotificationCenter.post(:compilation_started, rep).sync
 
-    expect { Nanoc::Int::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', true, true) }
+    expect { Nanoc::Int::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', true, true).sync }
       .not_to output(/create/).to_stdout
   end
 
@@ -46,14 +46,14 @@ describe Nanoc::CLI::Commands::CompileListeners::FileActionPrinter, stdio: true 
     listener.start_safely
 
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 0))
-    Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
+    Nanoc::Int::NotificationCenter.post(:compilation_started, rep).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
-    Nanoc::Int::NotificationCenter.post(:compilation_suspended, rep, :__irrelevant__)
+    Nanoc::Int::NotificationCenter.post(:compilation_suspended, rep, :__irrelevant__).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 3))
-    Nanoc::Int::NotificationCenter.post(:compilation_resumed, rep)
+    Nanoc::Int::NotificationCenter.post(:compilation_resumed, rep).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 6))
 
-    expect { Nanoc::Int::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', true, true) }
+    expect { Nanoc::Int::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', true, true).sync }
       .to output(/create.*\[4\.00s\]/).to_stdout
   end
 
@@ -61,14 +61,14 @@ describe Nanoc::CLI::Commands::CompileListeners::FileActionPrinter, stdio: true 
     listener.start_safely
 
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 0))
-    Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
+    Nanoc::Int::NotificationCenter.post(:compilation_started, rep).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
-    Nanoc::Int::NotificationCenter.post(:rep_write_enqueued, rep)
+    Nanoc::Int::NotificationCenter.post(:rep_write_enqueued, rep).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 3))
-    Nanoc::Int::NotificationCenter.post(:rep_write_started, rep)
+    Nanoc::Int::NotificationCenter.post(:rep_write_started, rep).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 6))
 
-    expect { Nanoc::Int::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', true, true) }
+    expect { Nanoc::Int::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', true, true).sync }
       .to output(/create.*\[4\.00s\]/).to_stdout
   end
 
@@ -82,19 +82,19 @@ describe Nanoc::CLI::Commands::CompileListeners::FileActionPrinter, stdio: true 
     end
 
     it 'prints nothing' do
-      Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
+      Nanoc::Int::NotificationCenter.post(:compilation_started, rep).sync
       Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
 
-      expect { Nanoc::Int::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', false, false) }
+      expect { Nanoc::Int::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', false, false).sync }
         .not_to output(/identical/).to_stdout
     end
 
     it 'prints nothing' do
-      Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
-      Nanoc::Int::NotificationCenter.post(:cached_content_used, rep)
+      Nanoc::Int::NotificationCenter.post(:compilation_started, rep).sync
+      Nanoc::Int::NotificationCenter.post(:cached_content_used, rep).sync
       Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
 
-      expect { Nanoc::Int::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', false, false) }
+      expect { Nanoc::Int::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', false, false).sync }
         .not_to output(/cached/).to_stdout
     end
   end
@@ -109,19 +109,19 @@ describe Nanoc::CLI::Commands::CompileListeners::FileActionPrinter, stdio: true 
     end
 
     it 'prints “identical” if not cached' do
-      Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
+      Nanoc::Int::NotificationCenter.post(:compilation_started, rep).sync
       Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
 
-      expect { Nanoc::Int::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', false, false) }
+      expect { Nanoc::Int::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', false, false).sync }
         .to output(/identical/).to_stdout
     end
 
     it 'prints “cached” if cached' do
-      Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
-      Nanoc::Int::NotificationCenter.post(:cached_content_used, rep)
+      Nanoc::Int::NotificationCenter.post(:compilation_started, rep).sync
+      Nanoc::Int::NotificationCenter.post(:cached_content_used, rep).sync
       Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
 
-      expect { Nanoc::Int::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', false, false) }
+      expect { Nanoc::Int::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', false, false).sync }
         .to output(/cached/).to_stdout
     end
   end

--- a/nanoc/spec/nanoc/cli/commands/compile/timing_recorder_spec.rb
+++ b/nanoc/spec/nanoc/cli/commands/compile/timing_recorder_spec.rb
@@ -33,13 +33,13 @@ describe Nanoc::CLI::Commands::CompileListeners::TimingRecorder, stdio: true do
 
   it 'prints filters table' do
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 0))
-    Nanoc::Int::NotificationCenter.post(:filtering_started, rep, :erb)
+    Nanoc::Int::NotificationCenter.post(:filtering_started, rep, :erb).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
-    Nanoc::Int::NotificationCenter.post(:filtering_ended, rep, :erb)
+    Nanoc::Int::NotificationCenter.post(:filtering_ended, rep, :erb).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 14, 1))
-    Nanoc::Int::NotificationCenter.post(:filtering_started, rep, :erb)
+    Nanoc::Int::NotificationCenter.post(:filtering_started, rep, :erb).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 14, 3))
-    Nanoc::Int::NotificationCenter.post(:filtering_ended, rep, :erb)
+    Nanoc::Int::NotificationCenter.post(:filtering_ended, rep, :erb).sync
 
     expect { listener.stop_safely }
       .to output(/^\s*erb │     2   1\.00s   1\.50s   1\.90s   1\.95s   2\.00s   3\.00s$/).to_stdout
@@ -47,9 +47,9 @@ describe Nanoc::CLI::Commands::CompileListeners::TimingRecorder, stdio: true do
 
   it 'records single from filtering_started to filtering_ended' do
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 0))
-    Nanoc::Int::NotificationCenter.post(:filtering_started, rep, :erb)
+    Nanoc::Int::NotificationCenter.post(:filtering_started, rep, :erb).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
-    Nanoc::Int::NotificationCenter.post(:filtering_ended, rep, :erb)
+    Nanoc::Int::NotificationCenter.post(:filtering_ended, rep, :erb).sync
 
     expect(listener.filters_summary.get(name: 'erb').min).to eq(1.00)
     expect(listener.filters_summary.get(name: 'erb').avg).to eq(1.00)
@@ -60,13 +60,13 @@ describe Nanoc::CLI::Commands::CompileListeners::TimingRecorder, stdio: true do
 
   it 'records multiple from filtering_started to filtering_ended' do
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 0))
-    Nanoc::Int::NotificationCenter.post(:filtering_started, rep, :erb)
+    Nanoc::Int::NotificationCenter.post(:filtering_started, rep, :erb).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
-    Nanoc::Int::NotificationCenter.post(:filtering_ended, rep, :erb)
+    Nanoc::Int::NotificationCenter.post(:filtering_ended, rep, :erb).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 14, 1))
-    Nanoc::Int::NotificationCenter.post(:filtering_started, rep, :erb)
+    Nanoc::Int::NotificationCenter.post(:filtering_started, rep, :erb).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 14, 3))
-    Nanoc::Int::NotificationCenter.post(:filtering_ended, rep, :erb)
+    Nanoc::Int::NotificationCenter.post(:filtering_ended, rep, :erb).sync
 
     expect(listener.filters_summary.get(name: 'erb').min).to eq(1.00)
     expect(listener.filters_summary.get(name: 'erb').avg).to eq(1.50)
@@ -77,13 +77,13 @@ describe Nanoc::CLI::Commands::CompileListeners::TimingRecorder, stdio: true do
 
   it 'records filters in nested filtering_started/filtering_ended' do
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 0))
-    Nanoc::Int::NotificationCenter.post(:filtering_started, rep, :outer)
+    Nanoc::Int::NotificationCenter.post(:filtering_started, rep, :outer).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
-    Nanoc::Int::NotificationCenter.post(:filtering_started, rep, :inner)
+    Nanoc::Int::NotificationCenter.post(:filtering_started, rep, :inner).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 3))
-    Nanoc::Int::NotificationCenter.post(:filtering_ended, rep, :inner)
+    Nanoc::Int::NotificationCenter.post(:filtering_ended, rep, :inner).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 6))
-    Nanoc::Int::NotificationCenter.post(:filtering_ended, rep, :outer)
+    Nanoc::Int::NotificationCenter.post(:filtering_ended, rep, :outer).sync
 
     expect(listener.filters_summary.get(name: 'inner').min).to eq(2.00)
     expect(listener.filters_summary.get(name: 'inner').avg).to eq(2.00)
@@ -100,17 +100,17 @@ describe Nanoc::CLI::Commands::CompileListeners::TimingRecorder, stdio: true do
 
   it 'pauses outer stopwatch when suspended' do
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 0))
-    Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
-    Nanoc::Int::NotificationCenter.post(:filtering_started, rep, :outer)
+    Nanoc::Int::NotificationCenter.post(:compilation_started, rep).sync
+    Nanoc::Int::NotificationCenter.post(:filtering_started, rep, :outer).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
-    Nanoc::Int::NotificationCenter.post(:filtering_started, rep, :inner)
+    Nanoc::Int::NotificationCenter.post(:filtering_started, rep, :inner).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 3))
-    Nanoc::Int::NotificationCenter.post(:compilation_suspended, rep, :__anything__)
+    Nanoc::Int::NotificationCenter.post(:compilation_suspended, rep, :__anything__).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 6))
-    Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
+    Nanoc::Int::NotificationCenter.post(:compilation_started, rep).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 10))
-    Nanoc::Int::NotificationCenter.post(:filtering_ended, rep, :inner)
-    Nanoc::Int::NotificationCenter.post(:filtering_ended, rep, :outer)
+    Nanoc::Int::NotificationCenter.post(:filtering_ended, rep, :inner).sync
+    Nanoc::Int::NotificationCenter.post(:filtering_ended, rep, :outer).sync
 
     expect(listener.filters_summary.get(name: 'outer').min).to eq(7.00)
     expect(listener.filters_summary.get(name: 'outer').avg).to eq(7.00)
@@ -120,15 +120,15 @@ describe Nanoc::CLI::Commands::CompileListeners::TimingRecorder, stdio: true do
   end
 
   it 'records single from filtering_started over compilation_{suspended,started} to filtering_ended' do
-    Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
+    Nanoc::Int::NotificationCenter.post(:compilation_started, rep).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 0))
-    Nanoc::Int::NotificationCenter.post(:filtering_started, rep, :erb)
+    Nanoc::Int::NotificationCenter.post(:filtering_started, rep, :erb).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
-    Nanoc::Int::NotificationCenter.post(:compilation_suspended, rep, :__anything__)
+    Nanoc::Int::NotificationCenter.post(:compilation_suspended, rep, :__anything__).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 3))
-    Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
+    Nanoc::Int::NotificationCenter.post(:compilation_started, rep).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 7))
-    Nanoc::Int::NotificationCenter.post(:filtering_ended, rep, :erb)
+    Nanoc::Int::NotificationCenter.post(:filtering_ended, rep, :erb).sync
 
     expect(listener.filters_summary.get(name: 'erb').min).to eq(5.00)
     expect(listener.filters_summary.get(name: 'erb').avg).to eq(5.00)
@@ -139,9 +139,9 @@ describe Nanoc::CLI::Commands::CompileListeners::TimingRecorder, stdio: true do
 
   it 'records single phase start+stop' do
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 0))
-    Nanoc::Int::NotificationCenter.post(:phase_started, 'donkey', rep)
+    Nanoc::Int::NotificationCenter.post(:phase_started, 'donkey', rep).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
-    Nanoc::Int::NotificationCenter.post(:phase_ended, 'donkey', rep)
+    Nanoc::Int::NotificationCenter.post(:phase_ended, 'donkey', rep).sync
 
     expect(listener.phases_summary.get(name: 'donkey').min).to eq(1.00)
     expect(listener.phases_summary.get(name: 'donkey').avg).to eq(1.00)
@@ -152,13 +152,13 @@ describe Nanoc::CLI::Commands::CompileListeners::TimingRecorder, stdio: true do
 
   it 'records multiple phase start+stop' do
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 0))
-    Nanoc::Int::NotificationCenter.post(:phase_started, 'donkey', rep)
+    Nanoc::Int::NotificationCenter.post(:phase_started, 'donkey', rep).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
-    Nanoc::Int::NotificationCenter.post(:phase_ended, 'donkey', rep)
+    Nanoc::Int::NotificationCenter.post(:phase_ended, 'donkey', rep).sync
     Timecop.freeze(Time.local(2008, 9, 1, 11, 6, 0))
-    Nanoc::Int::NotificationCenter.post(:phase_started, 'donkey', rep)
+    Nanoc::Int::NotificationCenter.post(:phase_started, 'donkey', rep).sync
     Timecop.freeze(Time.local(2008, 9, 1, 11, 6, 2))
-    Nanoc::Int::NotificationCenter.post(:phase_ended, 'donkey', rep)
+    Nanoc::Int::NotificationCenter.post(:phase_ended, 'donkey', rep).sync
 
     expect(listener.phases_summary.get(name: 'donkey').min).to eq(1.00)
     expect(listener.phases_summary.get(name: 'donkey').avg).to eq(1.50)
@@ -169,13 +169,13 @@ describe Nanoc::CLI::Commands::CompileListeners::TimingRecorder, stdio: true do
 
   it 'records single phase start+yield+resume+stop' do
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 0))
-    Nanoc::Int::NotificationCenter.post(:phase_started, 'donkey', rep)
+    Nanoc::Int::NotificationCenter.post(:phase_started, 'donkey', rep).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
-    Nanoc::Int::NotificationCenter.post(:phase_yielded, 'donkey', rep)
+    Nanoc::Int::NotificationCenter.post(:phase_yielded, 'donkey', rep).sync
     Timecop.freeze(Time.local(2008, 9, 1, 11, 6, 0))
-    Nanoc::Int::NotificationCenter.post(:phase_resumed, 'donkey', rep)
+    Nanoc::Int::NotificationCenter.post(:phase_resumed, 'donkey', rep).sync
     Timecop.freeze(Time.local(2008, 9, 1, 11, 6, 2))
-    Nanoc::Int::NotificationCenter.post(:phase_ended, 'donkey', rep)
+    Nanoc::Int::NotificationCenter.post(:phase_ended, 'donkey', rep).sync
 
     expect(listener.phases_summary.get(name: 'donkey').min).to eq(3.00)
     expect(listener.phases_summary.get(name: 'donkey').avg).to eq(3.00)
@@ -186,15 +186,15 @@ describe Nanoc::CLI::Commands::CompileListeners::TimingRecorder, stdio: true do
 
   it 'records single phase start+yield+abort+start+stop' do
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 0))
-    Nanoc::Int::NotificationCenter.post(:phase_started, 'donkey', rep)
+    Nanoc::Int::NotificationCenter.post(:phase_started, 'donkey', rep).sync
     Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
-    Nanoc::Int::NotificationCenter.post(:phase_yielded, 'donkey', rep)
+    Nanoc::Int::NotificationCenter.post(:phase_yielded, 'donkey', rep).sync
     Timecop.freeze(Time.local(2008, 9, 1, 11, 6, 0))
-    Nanoc::Int::NotificationCenter.post(:phase_aborted, 'donkey', rep)
+    Nanoc::Int::NotificationCenter.post(:phase_aborted, 'donkey', rep).sync
     Timecop.freeze(Time.local(2008, 9, 1, 12, 7, 2))
-    Nanoc::Int::NotificationCenter.post(:phase_started, 'donkey', rep)
+    Nanoc::Int::NotificationCenter.post(:phase_started, 'donkey', rep).sync
     Timecop.freeze(Time.local(2008, 9, 1, 12, 7, 5))
-    Nanoc::Int::NotificationCenter.post(:phase_ended, 'donkey', rep)
+    Nanoc::Int::NotificationCenter.post(:phase_ended, 'donkey', rep).sync
 
     expect(listener.phases_summary.get(name: 'donkey').min).to eq(1.00)
     expect(listener.phases_summary.get(name: 'donkey').avg).to eq(2.00)
@@ -204,28 +204,28 @@ describe Nanoc::CLI::Commands::CompileListeners::TimingRecorder, stdio: true do
   end
 
   it 'records stage duration' do
-    Nanoc::Int::NotificationCenter.post(:stage_ran, 1.23, 'donkey_stage')
+    Nanoc::Int::NotificationCenter.post(:stage_ran, 1.23, 'donkey_stage').sync
 
     expect(listener.stages_summary.get(name: 'donkey_stage').sum).to eq(1.23)
     expect(listener.stages_summary.get(name: 'donkey_stage').count).to eq(1)
   end
 
   it 'prints stage durations' do
-    Nanoc::Int::NotificationCenter.post(:stage_ran, 1.23, 'donkey_stage')
+    Nanoc::Int::NotificationCenter.post(:stage_ran, 1.23, 'donkey_stage').sync
 
     expect { listener.stop_safely }
       .to output(/^\s*donkey_stage │ 1\.23s$/).to_stdout
   end
 
   it 'prints out outdatedness rule durations' do
-    Nanoc::Int::NotificationCenter.post(:outdatedness_rule_ran, 1.0, Nanoc::Int::OutdatednessRules::CodeSnippetsModified)
+    Nanoc::Int::NotificationCenter.post(:outdatedness_rule_ran, 1.0, Nanoc::Int::OutdatednessRules::CodeSnippetsModified).sync
 
     expect { listener.stop_safely }
       .to output(/^\s*CodeSnippetsModified │     1   1\.00s   1\.00s   1\.00s   1\.00s   1\.00s   1\.00s$/).to_stdout
   end
 
   it 'records single outdatedness rule duration' do
-    Nanoc::Int::NotificationCenter.post(:outdatedness_rule_ran, 1.0, Nanoc::Int::OutdatednessRules::CodeSnippetsModified)
+    Nanoc::Int::NotificationCenter.post(:outdatedness_rule_ran, 1.0, Nanoc::Int::OutdatednessRules::CodeSnippetsModified).sync
 
     expect(listener.outdatedness_rules_summary.get(name: 'CodeSnippetsModified').min).to eq(1.00)
     expect(listener.outdatedness_rules_summary.get(name: 'CodeSnippetsModified').avg).to eq(1.00)
@@ -235,8 +235,8 @@ describe Nanoc::CLI::Commands::CompileListeners::TimingRecorder, stdio: true do
   end
 
   it 'records multiple outdatedness rule duration' do
-    Nanoc::Int::NotificationCenter.post(:outdatedness_rule_ran, 1.0, Nanoc::Int::OutdatednessRules::CodeSnippetsModified)
-    Nanoc::Int::NotificationCenter.post(:outdatedness_rule_ran, 3.0, Nanoc::Int::OutdatednessRules::CodeSnippetsModified)
+    Nanoc::Int::NotificationCenter.post(:outdatedness_rule_ran, 1.0, Nanoc::Int::OutdatednessRules::CodeSnippetsModified).sync
+    Nanoc::Int::NotificationCenter.post(:outdatedness_rule_ran, 3.0, Nanoc::Int::OutdatednessRules::CodeSnippetsModified).sync
 
     expect(listener.outdatedness_rules_summary.get(name: 'CodeSnippetsModified').min).to eq(1.00)
     expect(listener.outdatedness_rules_summary.get(name: 'CodeSnippetsModified').avg).to eq(2.00)
@@ -246,7 +246,7 @@ describe Nanoc::CLI::Commands::CompileListeners::TimingRecorder, stdio: true do
   end
 
   it 'prints load store durations' do
-    Nanoc::Int::NotificationCenter.post(:store_loaded, 1.23, Nanoc::Int::ChecksumStore)
+    Nanoc::Int::NotificationCenter.post(:store_loaded, 1.23, Nanoc::Int::ChecksumStore).sync
 
     expect { listener.stop_safely }
       .to output(/^\s*Nanoc::Int::ChecksumStore │ 1\.23s$/).to_stdout

--- a/nanoc/spec/nanoc/helpers/filtering_spec.rb
+++ b/nanoc/spec/nanoc/helpers/filtering_spec.rb
@@ -19,15 +19,12 @@ describe Nanoc::Helpers::Filtering, helper: true do
     context 'basic case' do
       it { is_expected.to eql('AXB') }
 
-      it 'notifies' do
-        ns = Set.new
-        Nanoc::Int::NotificationCenter.on(:filtering_started) { ns << :filtering_started }
-        Nanoc::Int::NotificationCenter.on(:filtering_ended)   { ns << :filtering_ended   }
+      it 'notifies filtering_started' do
+        expect { subject }.to send_notification(:filtering_started, ctx.item_rep._unwrap, :erb)
+      end
 
-        subject
-
-        expect(ns).to include(:filtering_started)
-        expect(ns).to include(:filtering_ended)
+      it 'notifies filtering_ended' do
+        expect { subject }.to send_notification(:filtering_ended, ctx.item_rep._unwrap, :erb)
       end
     end
 

--- a/nanoc/test/cli/commands/test_compile.rb
+++ b/nanoc/test/cli/commands/test_compile.rb
@@ -139,8 +139,8 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
     # Listen
     listener = new_file_action_printer([rep])
     listener.start_safely
-    Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
-    Nanoc::Int::NotificationCenter.post(:rep_write_ended, rep, false, rep.raw_path, false, true)
+    Nanoc::Int::NotificationCenter.post(:compilation_started, rep).sync
+    Nanoc::Int::NotificationCenter.post(:rep_write_ended, rep, false, rep.raw_path, false, true).sync
     listener.stop_safely
 
     # Check
@@ -160,7 +160,7 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
     # Listen
     listener = new_file_action_printer([rep])
     listener.start_safely
-    Nanoc::Int::NotificationCenter.post(:compilation_started, rep)
+    Nanoc::Int::NotificationCenter.post(:compilation_started, rep).sync
     listener.stop_safely
 
     # Check


### PR DESCRIPTION
This will eliminate confusion about which thread executes a notification callback, and limit the amount of locking that will have to be done.