### PR TITLE
Remove Nanoc::Identifier re-export

### DIFF
--- a/nanoc/NEWS.md
+++ b/nanoc/NEWS.md
@@ -979,8 +979,8 @@ Changes:
 Enhancements:
 
 * Removed unused options from CLI
-* Added `Nanoc::Identifier#without_ext`
-* Made `Nanoc::Identifier#=~` work with a glob
+* Added `Nanoc::Core::Identifier#without_ext`
+* Made `Nanoc::Core::Identifier#=~` work with a glob
 * Added `Nanoc::LayoutCollectionView#[]`
 * Allowed creation of site in current directory (#549) [David Alexander]
 

--- a/nanoc/lib/nanoc/base/entities.rb
+++ b/nanoc/lib/nanoc/base/entities.rb
@@ -2,8 +2,6 @@
 
 require_relative 'entities/directed_graph'
 
-Nanoc::Identifier = Nanoc::Core::Identifier
-
 require_relative 'entities/processing_action'
 require_relative 'entities/processing_actions'
 

--- a/nanoc/lib/nanoc/base/entities/document.rb
+++ b/nanoc/lib/nanoc/base/entities/document.rb
@@ -14,7 +14,7 @@ module Nanoc
         @attributes.value
       end
 
-      # @return [Nanoc::Identifier]
+      # @return [Nanoc::Core::Identifier]
       attr_reader :identifier
 
       # @return [String, nil]
@@ -28,7 +28,7 @@ module Nanoc
 
       c_content = C::Or[String, Nanoc::Core::Content]
       c_attributes = C::Or[Hash, Proc]
-      c_identifier = C::Or[String, Nanoc::Identifier]
+      c_identifier = C::Or[String, Nanoc::Core::Identifier]
       c_checksum_data = C::KeywordArgs[
         checksum_data: C::Optional[C::Maybe[String]],
         content_checksum_data: C::Optional[C::Maybe[String]],
@@ -40,7 +40,7 @@ module Nanoc
       #
       # @param [Hash, Proc] attributes
       #
-      # @param [String, Nanoc::Identifier] identifier
+      # @param [String, Nanoc::Core::Identifier] identifier
       #
       # @param [String, nil] checksum_data
       #
@@ -50,7 +50,7 @@ module Nanoc
       def initialize(content, attributes, identifier, checksum_data: nil, content_checksum_data: nil, attributes_checksum_data: nil)
         @content = Nanoc::Core::Content.create(content)
         @attributes = Nanoc::Core::LazyValue.new(attributes).map(&:__nanoc_symbolize_keys_recursively)
-        @identifier = Nanoc::Identifier.from(identifier)
+        @identifier = Nanoc::Core::Identifier.from(identifier)
 
         @checksum_data = checksum_data
         @content_checksum_data = content_checksum_data
@@ -81,9 +81,9 @@ module Nanoc
         raise NotImplementedError
       end
 
-      contract C::Or[Nanoc::Identifier, String] => Nanoc::Identifier
+      contract C::Or[Nanoc::Core::Identifier, String] => Nanoc::Core::Identifier
       def identifier=(new_identifier)
-        @identifier = Nanoc::Identifier.from(new_identifier)
+        @identifier = Nanoc::Core::Identifier.from(new_identifier)
       end
 
       contract Nanoc::Core::Content => C::Any

--- a/nanoc/lib/nanoc/base/entities/identifiable_collection.rb
+++ b/nanoc/lib/nanoc/base/entities/identifiable_collection.rb
@@ -89,7 +89,7 @@ module Nanoc::Int
     contract C::Any => C::Maybe[C::RespondTo[:identifier]]
     def get_unmemoized(arg)
       case arg
-      when Nanoc::Identifier
+      when Nanoc::Core::Identifier
         object_with_identifier(arg)
       when String
         object_with_identifier(arg) || object_matching_glob(arg)

--- a/nanoc/lib/nanoc/base/services/checksummer.rb
+++ b/nanoc/lib/nanoc/base/services/checksummer.rb
@@ -90,7 +90,7 @@ module Nanoc::Int
           NoUpdateBehavior
         when Time
           ToIToSUpdateBehavior
-        when Nanoc::Identifier
+        when Nanoc::Core::Identifier
           ToSUpdateBehavior
         when Nanoc::RuleDSL::RulesCollection, Nanoc::Int::CodeSnippet
           DataUpdateBehavior

--- a/nanoc/lib/nanoc/base/views/identifiable_collection_view.rb
+++ b/nanoc/lib/nanoc/base/views/identifiable_collection_view.rb
@@ -56,7 +56,7 @@ module Nanoc
 
       prop_attribute =
         case arg
-        when String, Nanoc::Identifier
+        when String, Nanoc::Core::Identifier
           [arg.to_s]
         when Regexp
           [arg]
@@ -93,7 +93,7 @@ module Nanoc
     def [](arg)
       prop_attribute =
         case arg
-        when String, Nanoc::Identifier
+        when String, Nanoc::Core::Identifier
           [arg.to_s]
         when Regexp
           [arg]

--- a/nanoc/lib/nanoc/base/views/mixins/document_view_mixin.rb
+++ b/nanoc/lib/nanoc/base/views/mixins/document_view_mixin.rb
@@ -31,7 +31,7 @@ module Nanoc
       self.class.hash ^ identifier.hash
     end
 
-    # @return [Nanoc::Identifier]
+    # @return [Nanoc::Core::Identifier]
     def identifier
       _unwrap.identifier
     end

--- a/nanoc/lib/nanoc/base/views/mixins/mutable_document_view_mixin.rb
+++ b/nanoc/lib/nanoc/base/views/mixins/mutable_document_view_mixin.rb
@@ -40,9 +40,9 @@ module Nanoc
 
     # Sets the identifier to the given argument.
     #
-    # @param [String, Nanoc::Identifier] arg
+    # @param [String, Nanoc::Core::Identifier] arg
     def identifier=(arg)
-      _unwrap.identifier = Nanoc::Identifier.from(arg)
+      _unwrap.identifier = Nanoc::Core::Identifier.from(arg)
     end
 
     # Updates the attributes based on the given hash.

--- a/nanoc/lib/nanoc/base/views/mutable_item_collection_view.rb
+++ b/nanoc/lib/nanoc/base/views/mutable_item_collection_view.rb
@@ -15,7 +15,7 @@ module Nanoc
     #
     # @param [Hash] attributes A hash containing this item's attributes.
     #
-    # @param [Nanoc::Identifier, String] identifier This item's identifier.
+    # @param [Nanoc::Core::Identifier, String] identifier This item's identifier.
     #
     # @param [Boolean] binary Whether or not this item is binary
     #

--- a/nanoc/lib/nanoc/base/views/mutable_layout_collection_view.rb
+++ b/nanoc/lib/nanoc/base/views/mutable_layout_collection_view.rb
@@ -13,7 +13,7 @@ module Nanoc
     #
     # @param [Hash] attributes A hash containing this layout's attributes.
     #
-    # @param [Nanoc::Identifier, String] identifier This layout's identifier.
+    # @param [Nanoc::Core::Identifier, String] identifier This layout's identifier.
     #
     # @return [self]
     def create(content, attributes, identifier)

--- a/nanoc/lib/nanoc/data_sources/filesystem.rb
+++ b/nanoc/lib/nanoc/data_sources/filesystem.rb
@@ -351,7 +351,7 @@ module Nanoc::DataSources
     # can be the content filename or the meta filename.
     def identifier_for_filename(filename)
       if config[:identifier_type] == 'full'
-        return Nanoc::Identifier.new(filename)
+        return Nanoc::Core::Identifier.new(filename)
       end
 
       regex =
@@ -360,7 +360,7 @@ module Nanoc::DataSources
         else
           allow_periods_in_identifiers? ? /\.[^\/\.]+$/ : /\.[^\/]+$/
         end
-      Nanoc::Identifier.new(filename.sub(regex, ''), type: :legacy)
+      Nanoc::Core::Identifier.new(filename.sub(regex, ''), type: :legacy)
     end
 
     # Returns the base name of filename, i.e. filename with the first or all

--- a/nanoc/lib/nanoc/helpers/breadcrumbs.rb
+++ b/nanoc/lib/nanoc/helpers/breadcrumbs.rb
@@ -49,7 +49,7 @@ module Nanoc::Helpers
       def self.patterns_for_prefix(prefix)
         prefixes =
           unfold(prefix) do |old_prefix|
-            new_prefix = Nanoc::Identifier.new(old_prefix).without_ext
+            new_prefix = Nanoc::Core::Identifier.new(old_prefix).without_ext
             new_prefix == old_prefix ? nil : new_prefix
           end
 
@@ -110,7 +110,7 @@ module Nanoc::Helpers
       tiebreaker = Int::ERROR_TIEBREAKER if tiebreaker == :error
 
       if @item.identifier.legacy?
-        prefixes.map { |pr| @items[Nanoc::Identifier.new('/' + pr, type: :legacy)] }
+        prefixes.map { |pr| @items[Nanoc::Core::Identifier.new('/' + pr, type: :legacy)] }
       else
         ancestral_prefixes = prefixes.reject { |pr| pr =~ /^\/index\./ }[0..-2]
         ancestral_items =

--- a/nanoc/lib/nanoc/rule_dsl/action_recorder.rb
+++ b/nanoc/lib/nanoc/rule_dsl/action_recorder.rb
@@ -37,7 +37,7 @@ module Nanoc
         @any_layouts = true
       end
 
-      MaybePathlike = C::Or[nil, Nanoc::UNDEFINED, String, Nanoc::Identifier]
+      MaybePathlike = C::Or[nil, Nanoc::UNDEFINED, String, Nanoc::Core::Identifier]
       contract Symbol, C::KeywordArgs[path: C::Optional[MaybePathlike]] => nil
       def snapshot(snapshot_name, path: Nanoc::UNDEFINED)
         unless Nanoc::UNDEFINED.equal?(path)

--- a/nanoc/lib/nanoc/rule_dsl/compilation_rule_context.rb
+++ b/nanoc/lib/nanoc/rule_dsl/compilation_rule_context.rb
@@ -73,7 +73,7 @@ module Nanoc::RuleDSL
       @_write_snapshot_counter += 1
 
       case arg
-      when String, Nanoc::Identifier, nil
+      when String, Nanoc::Core::Identifier, nil
         snapshot(snapshot_name, path: arg)
       when Hash
         if arg.key?(:ext)

--- a/nanoc/lib/nanoc/rule_dsl/rule.rb
+++ b/nanoc/lib/nanoc/rule_dsl/rule.rb
@@ -23,7 +23,7 @@ module Nanoc::RuleDSL
     end
 
     # @api private
-    contract Nanoc::Identifier => C::Or[nil, C::ArrayOf[String]]
+    contract Nanoc::Core::Identifier => C::Or[nil, C::ArrayOf[String]]
     def matches(identifier)
       @pattern.captures(identifier)
     end

--- a/nanoc/lib/nanoc/spec.rb
+++ b/nanoc/lib/nanoc/spec.rb
@@ -73,7 +73,7 @@ module Nanoc
       #
       # @param [Hash] attributes A hash containing this item's attributes
       #
-      # @param [Nanoc::Identifier, String] identifier This item's identifier
+      # @param [Nanoc::Core::Identifier, String] identifier This item's identifier
       #
       # @return [Nanoc::CompilationItemView] A view for the newly created item
       def create_item(content, attributes, identifier)
@@ -88,7 +88,7 @@ module Nanoc
       #
       # @param [Hash] attributes A hash containing this layout's attributes
       #
-      # @param [Nanoc::Identifier, String] identifier This layout's identifier
+      # @param [Nanoc::Core::Identifier, String] identifier This layout's identifier
       #
       # @return [Nanoc::CompilationItemView] A view for the newly created layout
       def create_layout(content, attributes, identifier)

--- a/nanoc/spec/nanoc/base/checksummer_spec.rb
+++ b/nanoc/spec/nanoc/base/checksummer_spec.rb
@@ -157,8 +157,8 @@ describe Nanoc::Int::Checksummer do
     it { is_expected.to match(/\A(Integer|Fixnum)<3>\z/) }
   end
 
-  context 'Nanoc::Identifier' do
-    let(:obj) { Nanoc::Identifier.new('/foo.md') }
+  context 'Nanoc::Core::Identifier' do
+    let(:obj) { Nanoc::Core::Identifier.new('/foo.md') }
     it { is_expected.to eql('Nanoc::Core::Identifier<String</foo.md>>') }
   end
 

--- a/nanoc/spec/nanoc/base/entities/document_spec.rb
+++ b/nanoc/spec/nanoc/base/entities/document_spec.rb
@@ -76,13 +76,13 @@ shared_examples 'a document' do
     describe 'identifier arg' do
       context 'string' do
         it 'converts identifier' do
-          expect(subject.identifier).to be_a(Nanoc::Identifier)
+          expect(subject.identifier).to be_a(Nanoc::Core::Identifier)
           expect(subject.identifier.to_s).to eql('/home.md')
         end
       end
 
       context 'identifier' do
-        let(:identifier_arg) { Nanoc::Identifier.new('/foo.md') }
+        let(:identifier_arg) { Nanoc::Core::Identifier.new('/foo.md') }
 
         it 'retains identifier' do
           expect(subject.identifier).to equal(identifier_arg)
@@ -238,18 +238,18 @@ shared_examples 'a document' do
 
     it 'refuses changing to a string that does not contain a full identifier' do
       expect { document.identifier = '/thing/' }
-        .to raise_error(Nanoc::Identifier::InvalidFullIdentifierError)
+        .to raise_error(Nanoc::Core::Identifier::InvalidFullIdentifierError)
     end
 
     it 'allos changing to a full identifier' do
-      document.identifier = Nanoc::Identifier.new('/thing')
+      document.identifier = Nanoc::Core::Identifier.new('/thing')
 
       expect(document.identifier.to_s).to eq('/thing')
       expect(document.identifier).to be_full
     end
 
     it 'allos changing to a legacy identifier' do
-      document.identifier = Nanoc::Identifier.new('/thing/', type: :legacy)
+      document.identifier = Nanoc::Core::Identifier.new('/thing/', type: :legacy)
 
       expect(document.identifier).to eq('/thing/')
       expect(document.identifier).to be_legacy

--- a/nanoc/spec/nanoc/base/entities/identifiable_collection_spec.rb
+++ b/nanoc/spec/nanoc/base/entities/identifiable_collection_spec.rb
@@ -22,8 +22,8 @@ describe Nanoc::Int::IdentifiableCollection do
     describe '#[]' do
       let(:objects) do
         [
-          Nanoc::Int::Item.new('asdf', {}, Nanoc::Identifier.new('/one')),
-          Nanoc::Int::Item.new('asdf', {}, Nanoc::Identifier.new('/two')),
+          Nanoc::Int::Item.new('asdf', {}, Nanoc::Core::Identifier.new('/one')),
+          Nanoc::Int::Item.new('asdf', {}, Nanoc::Core::Identifier.new('/two')),
         ]
       end
 
@@ -78,9 +78,9 @@ describe Nanoc::Int::IdentifiableCollection do
     describe '#find_all' do
       let(:objects) do
         [
-          double(:identifiable, identifier: Nanoc::Identifier.new('/about.css')),
-          double(:identifiable, identifier: Nanoc::Identifier.new('/about.md')),
-          double(:identifiable, identifier: Nanoc::Identifier.new('/style.css')),
+          double(:identifiable, identifier: Nanoc::Core::Identifier.new('/about.css')),
+          double(:identifiable, identifier: Nanoc::Core::Identifier.new('/about.md')),
+          double(:identifiable, identifier: Nanoc::Core::Identifier.new('/style.css')),
         ]
       end
 
@@ -112,9 +112,9 @@ describe Nanoc::Int::IdentifiableCollection do
     describe '#object_with_identifier' do
       let(:objects) do
         [
-          Nanoc::Int::Item.new('stuff', {}, Nanoc::Identifier.new('/about.css')),
-          Nanoc::Int::Item.new('stuff', {}, Nanoc::Identifier.new('/about.md')),
-          Nanoc::Int::Item.new('stuff', {}, Nanoc::Identifier.new('/style.css')),
+          Nanoc::Int::Item.new('stuff', {}, Nanoc::Core::Identifier.new('/about.css')),
+          Nanoc::Int::Item.new('stuff', {}, Nanoc::Core::Identifier.new('/about.md')),
+          Nanoc::Int::Item.new('stuff', {}, Nanoc::Core::Identifier.new('/style.css')),
         ]
       end
 
@@ -128,7 +128,7 @@ describe Nanoc::Int::IdentifiableCollection do
       end
 
       context 'with identifier' do
-        let(:arg) { Nanoc::Identifier.new('/about.css') }
+        let(:arg) { Nanoc::Core::Identifier.new('/about.css') }
         it { is_expected.to eq(objects[0]) }
       end
 

--- a/nanoc/spec/nanoc/base/repos/data_source_spec.rb
+++ b/nanoc/spec/nanoc/base/repos/data_source_spec.rb
@@ -27,7 +27,7 @@ describe Nanoc::DataSource, stdio: true do
 
       expect(item.content.string).to eql('stuff')
       expect(item.attributes[:title]).to eql('Stuff!')
-      expect(item.identifier).to eql(Nanoc::Identifier.new('/asdf'))
+      expect(item.identifier).to eql(Nanoc::Core::Identifier.new('/asdf'))
       expect(item.checksum_data).to eql('abcdef')
     end
 
@@ -36,7 +36,7 @@ describe Nanoc::DataSource, stdio: true do
 
       expect(item.content.string).to eql('stuff')
       expect(item.attributes[:title]).to eql('Stuff!')
-      expect(item.identifier).to eql(Nanoc::Identifier.new('/asdf'))
+      expect(item.identifier).to eql(Nanoc::Core::Identifier.new('/asdf'))
       expect(item.content_checksum_data).to eql('con-cs')
       expect(item.attributes_checksum_data).to eql('attr-cs')
     end
@@ -48,7 +48,7 @@ describe Nanoc::DataSource, stdio: true do
 
       expect(layout.content.string).to eql('stuff')
       expect(layout.attributes[:title]).to eql('Stuff!')
-      expect(layout.identifier).to eql(Nanoc::Identifier.new('/asdf'))
+      expect(layout.identifier).to eql(Nanoc::Core::Identifier.new('/asdf'))
       expect(layout.checksum_data).to eql('abcdef')
     end
 
@@ -57,7 +57,7 @@ describe Nanoc::DataSource, stdio: true do
 
       expect(layout.content.string).to eql('stuff')
       expect(layout.attributes[:title]).to eql('Stuff!')
-      expect(layout.identifier).to eql(Nanoc::Identifier.new('/asdf'))
+      expect(layout.identifier).to eql(Nanoc::Core::Identifier.new('/asdf'))
       expect(layout.content_checksum_data).to eql('con-cs')
       expect(layout.attributes_checksum_data).to eql('attr-cs')
     end

--- a/nanoc/spec/nanoc/base/services/executor_spec.rb
+++ b/nanoc/spec/nanoc/base/services/executor_spec.rb
@@ -580,7 +580,7 @@ describe Nanoc::Int::Executor do
       let(:arg) { '/default' }
 
       let(:layouts) do
-        [Nanoc::Int::Layout.new('head <%= @foo %> foot', {}, Nanoc::Identifier.new('/default/', type: :legacy))]
+        [Nanoc::Int::Layout.new('head <%= @foo %> foot', {}, Nanoc::Core::Identifier.new('/default/', type: :legacy))]
       end
 
       it { is_expected.to eq(layouts[0]) }

--- a/nanoc/spec/nanoc/base/views/item_view_spec.rb
+++ b/nanoc/spec/nanoc/base/views/item_view_spec.rb
@@ -57,7 +57,7 @@ describe Nanoc::CompilationItemView do
     context 'with parent' do
       context 'full identifier' do
         let(:identifier) do
-          Nanoc::Identifier.new('/parent/me.md')
+          Nanoc::Core::Identifier.new('/parent/me.md')
         end
 
         let(:parent_item) do
@@ -71,11 +71,11 @@ describe Nanoc::CompilationItemView do
 
       context 'legacy identifier' do
         let(:identifier) do
-          Nanoc::Identifier.new('/parent/me/', type: :legacy)
+          Nanoc::Core::Identifier.new('/parent/me/', type: :legacy)
         end
 
         let(:parent_item) do
-          Nanoc::Int::Item.new('parent', {}, Nanoc::Identifier.new('/parent/', type: :legacy))
+          Nanoc::Int::Item.new('parent', {}, Nanoc::Core::Identifier.new('/parent/', type: :legacy))
         end
 
         it 'returns a view for the parent' do
@@ -98,8 +98,8 @@ describe Nanoc::CompilationItemView do
 
         context 'with root parent' do
           let(:parent_item) { Nanoc::Int::Item.new('parent', {}, parent_identifier) }
-          let(:identifier) { Nanoc::Identifier.new('/me/', type: :legacy) }
-          let(:parent_identifier) { Nanoc::Identifier.new('/', type: :legacy) }
+          let(:identifier) { Nanoc::Core::Identifier.new('/me/', type: :legacy) }
+          let(:parent_identifier) { Nanoc::Core::Identifier.new('/', type: :legacy) }
 
           it 'returns a view for the parent' do
             expect(subject.class).to eql(Nanoc::CompilationItemView)
@@ -116,7 +116,7 @@ describe Nanoc::CompilationItemView do
 
       context 'full identifier' do
         let(:identifier) do
-          Nanoc::Identifier.new('/me.md')
+          Nanoc::Core::Identifier.new('/me.md')
         end
 
         it 'raises' do
@@ -126,7 +126,7 @@ describe Nanoc::CompilationItemView do
 
       context 'legacy identifier' do
         let(:identifier) do
-          Nanoc::Identifier.new('/me/', type: :legacy)
+          Nanoc::Core::Identifier.new('/me/', type: :legacy)
         end
 
         it { is_expected.to be_nil }
@@ -156,7 +156,7 @@ describe Nanoc::CompilationItemView do
 
     context 'full identifier' do
       let(:identifier) do
-        Nanoc::Identifier.new('/me.md')
+        Nanoc::Core::Identifier.new('/me.md')
       end
 
       let(:children) do
@@ -170,11 +170,11 @@ describe Nanoc::CompilationItemView do
 
     context 'legacy identifier' do
       let(:identifier) do
-        Nanoc::Identifier.new('/me/', type: :legacy)
+        Nanoc::Core::Identifier.new('/me/', type: :legacy)
       end
 
       let(:children) do
-        [Nanoc::Int::Item.new('child', {}, Nanoc::Identifier.new('/me/child/', type: :legacy))]
+        [Nanoc::Int::Item.new('child', {}, Nanoc::Core::Identifier.new('/me/child/', type: :legacy))]
       end
 
       it 'returns views for the children' do

--- a/nanoc/spec/nanoc/base/views/support/identifiable_collection_view_examples.rb
+++ b/nanoc/spec/nanoc/base/views/support/identifiable_collection_view_examples.rb
@@ -27,8 +27,8 @@ shared_examples 'an identifiable collection view' do
       collection_class.new(
         config,
         [
-          double(:identifiable, identifier: Nanoc::Identifier.new('/foo')),
-          double(:identifiable, identifier: Nanoc::Identifier.new('/bar')),
+          double(:identifiable, identifier: Nanoc::Core::Identifier.new('/foo')),
+          double(:identifiable, identifier: Nanoc::Core::Identifier.new('/bar')),
         ],
       )
     end
@@ -54,9 +54,9 @@ shared_examples 'an identifiable collection view' do
       collection_class.new(
         config,
         [
-          double(:identifiable, identifier: Nanoc::Identifier.new('/foo')),
-          double(:identifiable, identifier: Nanoc::Identifier.new('/bar')),
-          double(:identifiable, identifier: Nanoc::Identifier.new('/baz')),
+          double(:identifiable, identifier: Nanoc::Core::Identifier.new('/foo')),
+          double(:identifiable, identifier: Nanoc::Core::Identifier.new('/bar')),
+          double(:identifiable, identifier: Nanoc::Core::Identifier.new('/baz')),
         ],
       )
     end
@@ -76,9 +76,9 @@ shared_examples 'an identifiable collection view' do
       collection_class.new(
         config,
         [
-          double(:identifiable, identifier: Nanoc::Identifier.new('/foo')),
-          double(:identifiable, identifier: Nanoc::Identifier.new('/bar')),
-          double(:identifiable, identifier: Nanoc::Identifier.new('/baz')),
+          double(:identifiable, identifier: Nanoc::Core::Identifier.new('/foo')),
+          double(:identifiable, identifier: Nanoc::Core::Identifier.new('/bar')),
+          double(:identifiable, identifier: Nanoc::Core::Identifier.new('/baz')),
         ],
       )
     end
@@ -102,9 +102,9 @@ shared_examples 'an identifiable collection view' do
       collection_class.new(
         config,
         [
-          double(:identifiable, identifier: Nanoc::Identifier.new('/foo')),
-          double(:identifiable, identifier: Nanoc::Identifier.new('/bar')),
-          double(:identifiable, identifier: Nanoc::Identifier.new('/baz')),
+          double(:identifiable, identifier: Nanoc::Core::Identifier.new('/foo')),
+          double(:identifiable, identifier: Nanoc::Core::Identifier.new('/bar')),
+          double(:identifiable, identifier: Nanoc::Core::Identifier.new('/baz')),
         ],
       )
     end
@@ -121,11 +121,11 @@ shared_examples 'an identifiable collection view' do
 
   describe '#[]' do
     let(:page_object) do
-      double(:identifiable, identifier: Nanoc::Identifier.new('/page.erb'))
+      double(:identifiable, identifier: Nanoc::Core::Identifier.new('/page.erb'))
     end
 
     let(:home_object) do
-      double(:identifiable, identifier: Nanoc::Identifier.new('/home.erb'))
+      double(:identifiable, identifier: Nanoc::Core::Identifier.new('/home.erb'))
     end
 
     let(:wrapped) do
@@ -169,7 +169,7 @@ shared_examples 'an identifiable collection view' do
     end
 
     context 'identifier' do
-      let(:arg) { Nanoc::Identifier.new('/home.erb') }
+      let(:arg) { Nanoc::Core::Identifier.new('/home.erb') }
 
       it 'creates dependency' do
         expect(dependency_tracker).to receive(:bounce).with(wrapped, raw_content: ['/home.erb'])
@@ -231,9 +231,9 @@ shared_examples 'an identifiable collection view' do
       collection_class.new(
         config,
         [
-          double(:identifiable, identifier: Nanoc::Identifier.new('/about.css')),
-          double(:identifiable, identifier: Nanoc::Identifier.new('/about.md')),
-          double(:identifiable, identifier: Nanoc::Identifier.new('/style.css')),
+          double(:identifiable, identifier: Nanoc::Core::Identifier.new('/about.css')),
+          double(:identifiable, identifier: Nanoc::Core::Identifier.new('/about.md')),
+          double(:identifiable, identifier: Nanoc::Core::Identifier.new('/style.css')),
         ],
       )
     end

--- a/nanoc/spec/nanoc/base/views/support/item_rep_view_examples.rb
+++ b/nanoc/spec/nanoc/base/views/support/item_rep_view_examples.rb
@@ -141,7 +141,7 @@ shared_examples 'an item rep view' do
 
     subject { view.hash }
 
-    it { should == described_class.hash ^ Nanoc::Identifier.new('/foo').hash ^ :jacques.hash }
+    it { should == described_class.hash ^ Nanoc::Core::Identifier.new('/foo').hash ^ :jacques.hash }
   end
 
   describe '#snapshot?' do

--- a/nanoc/spec/nanoc/base/views/support/mutable_document_view_examples.rb
+++ b/nanoc/spec/nanoc/base/views/support/mutable_document_view_examples.rb
@@ -126,7 +126,7 @@ shared_examples 'a mutable document view' do
     end
 
     context 'given an identifier' do
-      let(:arg) { Nanoc::Identifier.new('/about.adoc') }
+      let(:arg) { Nanoc::Core::Identifier.new('/about.adoc') }
 
       it 'changes the identifier' do
         subject
@@ -138,7 +138,7 @@ shared_examples 'a mutable document view' do
       let(:arg) { :donkey }
 
       it 'raises' do
-        expect { subject }.to raise_error(Nanoc::Identifier::NonCoercibleObjectError)
+        expect { subject }.to raise_error(Nanoc::Core::Identifier::NonCoercibleObjectError)
       end
     end
   end

--- a/nanoc/spec/nanoc/base/views/support/mutable_identifiable_collection_view_examples.rb
+++ b/nanoc/spec/nanoc/base/views/support/mutable_identifiable_collection_view_examples.rb
@@ -13,7 +13,7 @@ shared_examples 'a mutable identifiable collection view' do
     let(:wrapped) do
       collection_class.new(
         config,
-        [double(:identifiable, identifier: Nanoc::Identifier.new('/asdf'))],
+        [double(:identifiable, identifier: Nanoc::Core::Identifier.new('/asdf'))],
       )
     end
 

--- a/nanoc/spec/nanoc/data_sources/filesystem_spec.rb
+++ b/nanoc/spec/nanoc/data_sources/filesystem_spec.rb
@@ -47,7 +47,7 @@ describe Nanoc::DataSources::Filesystem, site: true do
 
           expect(subject[0].content.string).to eq('test 1')
           expect(subject[0].attributes).to eq(expected_attributes)
-          expect(subject[0].identifier).to eq(Nanoc::Identifier.new('/bar/', type: :legacy))
+          expect(subject[0].identifier).to eq(Nanoc::Core::Identifier.new('/bar/', type: :legacy))
           expect(subject[0].checksum_data).to be_nil
           expect(subject[0].attributes_checksum_data).to be_a(String)
           expect(subject[0].attributes_checksum_data.size).to eq(20)
@@ -100,7 +100,7 @@ describe Nanoc::DataSources::Filesystem, site: true do
 
           expect(subject[0].content).to be_a(Nanoc::Core::BinaryContent)
           expect(subject[0].attributes).to eq(expected_attributes)
-          expect(subject[0].identifier).to eq(Nanoc::Identifier.new('/bar/', type: :legacy))
+          expect(subject[0].identifier).to eq(Nanoc::Core::Identifier.new('/bar/', type: :legacy))
           expect(subject[0].checksum_data).to be_nil
           expect(subject[0].attributes_checksum_data).to be_a(String)
           expect(subject[0].attributes_checksum_data.size).to eq(20)
@@ -146,11 +146,11 @@ describe Nanoc::DataSources::Filesystem, site: true do
           items = subject.sort_by { |i| i.identifier.to_s }
 
           expect(items[0].content).to be_a(Nanoc::Core::TextualContent)
-          expect(items[0].identifier).to eq(Nanoc::Identifier.new('/a.md', type: :full))
+          expect(items[0].identifier).to eq(Nanoc::Core::Identifier.new('/a.md', type: :full))
           expect(items[0].attributes[:title]).to eq('Aaah')
 
           expect(items[1].content).to be_a(Nanoc::Core::TextualContent)
-          expect(items[1].identifier).to eq(Nanoc::Identifier.new('/a.txt', type: :full))
+          expect(items[1].identifier).to eq(Nanoc::Core::Identifier.new('/a.txt', type: :full))
           expect(items[1].attributes[:title]).to eq('Hi')
         end
       end
@@ -189,11 +189,11 @@ describe Nanoc::DataSources::Filesystem, site: true do
           items = subject.sort_by { |i| i.identifier.to_s }
 
           expect(items[0].content).to be_a(Nanoc::Core::TextualContent)
-          expect(items[0].identifier).to eq(Nanoc::Identifier.new('/a.md', type: :full))
+          expect(items[0].identifier).to eq(Nanoc::Core::Identifier.new('/a.md', type: :full))
           expect(items[0].attributes[:title]).to eq('Ho')
 
           expect(items[1].content).to be_a(Nanoc::Core::TextualContent)
-          expect(items[1].identifier).to eq(Nanoc::Identifier.new('/a.txt', type: :full))
+          expect(items[1].identifier).to eq(Nanoc::Core::Identifier.new('/a.txt', type: :full))
           expect(items[1].attributes[:title]).to eq('Hi')
         end
       end
@@ -213,11 +213,11 @@ describe Nanoc::DataSources::Filesystem, site: true do
           items = subject.sort_by { |i| i.identifier.to_s }
 
           expect(items[0].content).to be_a(Nanoc::Core::TextualContent)
-          expect(items[0].identifier).to eq(Nanoc::Identifier.new('/a.md', type: :full))
+          expect(items[0].identifier).to eq(Nanoc::Core::Identifier.new('/a.md', type: :full))
           expect(items[0].attributes[:title]).to be_nil
 
           expect(items[1].content).to be_a(Nanoc::Core::TextualContent)
-          expect(items[1].identifier).to eq(Nanoc::Identifier.new('/a.txt', type: :full))
+          expect(items[1].identifier).to eq(Nanoc::Core::Identifier.new('/a.txt', type: :full))
           expect(items[1].attributes[:title]).to be_nil
         end
       end
@@ -236,7 +236,7 @@ describe Nanoc::DataSources::Filesystem, site: true do
 
           expect(subject[0].content).to be_a(Nanoc::Core::TextualContent)
           expect(subject[0].content.string).to eq("---\ntitle: Hi\n---\n\nhi")
-          expect(subject[0].identifier).to eq(Nanoc::Identifier.new('/a.txt', type: :full))
+          expect(subject[0].identifier).to eq(Nanoc::Core::Identifier.new('/a.txt', type: :full))
           expect(subject[0].attributes[:title]).to be_nil
           expect(subject[0].attributes[:author]).to eq('Denis')
         end

--- a/nanoc/spec/nanoc/helpers/breadcrumbs_spec.rb
+++ b/nanoc/spec/nanoc/helpers/breadcrumbs_spec.rb
@@ -12,7 +12,7 @@ describe Nanoc::Helpers::Breadcrumbs, helper: true, stdio: true do
     context 'legacy identifiers' do
       context 'root' do
         before do
-          ctx.create_item('root', {}, Nanoc::Identifier.new('/', type: :legacy))
+          ctx.create_item('root', {}, Nanoc::Core::Identifier.new('/', type: :legacy))
 
           ctx.item = ctx.items['/']
         end
@@ -24,8 +24,8 @@ describe Nanoc::Helpers::Breadcrumbs, helper: true, stdio: true do
 
       context 'root and direct child' do
         before do
-          ctx.create_item('child', {}, Nanoc::Identifier.new('/foo/', type: :legacy))
-          ctx.create_item('root', {}, Nanoc::Identifier.new('/', type: :legacy))
+          ctx.create_item('child', {}, Nanoc::Core::Identifier.new('/foo/', type: :legacy))
+          ctx.create_item('root', {}, Nanoc::Core::Identifier.new('/', type: :legacy))
 
           ctx.item = ctx.items['/foo/']
         end
@@ -37,9 +37,9 @@ describe Nanoc::Helpers::Breadcrumbs, helper: true, stdio: true do
 
       context 'root, child and grandchild' do
         before do
-          ctx.create_item('grandchild', {}, Nanoc::Identifier.new('/foo/bar/', type: :legacy))
-          ctx.create_item('child', {}, Nanoc::Identifier.new('/foo/', type: :legacy))
-          ctx.create_item('root', {}, Nanoc::Identifier.new('/', type: :legacy))
+          ctx.create_item('grandchild', {}, Nanoc::Core::Identifier.new('/foo/bar/', type: :legacy))
+          ctx.create_item('child', {}, Nanoc::Core::Identifier.new('/foo/', type: :legacy))
+          ctx.create_item('root', {}, Nanoc::Core::Identifier.new('/', type: :legacy))
 
           ctx.item = ctx.items['/foo/bar/']
         end
@@ -51,8 +51,8 @@ describe Nanoc::Helpers::Breadcrumbs, helper: true, stdio: true do
 
       context 'root, missing child and grandchild' do
         before do
-          ctx.create_item('grandchild', {}, Nanoc::Identifier.new('/foo/bar/', type: :legacy))
-          ctx.create_item('root', {}, Nanoc::Identifier.new('/', type: :legacy))
+          ctx.create_item('grandchild', {}, Nanoc::Core::Identifier.new('/foo/bar/', type: :legacy))
+          ctx.create_item('root', {}, Nanoc::Core::Identifier.new('/', type: :legacy))
 
           ctx.item = ctx.items['/foo/bar/']
         end
@@ -66,7 +66,7 @@ describe Nanoc::Helpers::Breadcrumbs, helper: true, stdio: true do
     context 'non-legacy identifiers' do
       context 'root' do
         before do
-          ctx.create_item('root', {}, Nanoc::Identifier.new('/index.md'))
+          ctx.create_item('root', {}, Nanoc::Core::Identifier.new('/index.md'))
 
           ctx.item = ctx.items['/index.md']
         end
@@ -78,8 +78,8 @@ describe Nanoc::Helpers::Breadcrumbs, helper: true, stdio: true do
 
       context 'root and direct child' do
         before do
-          ctx.create_item('child', {}, Nanoc::Identifier.new('/foo.md'))
-          ctx.create_item('root', {}, Nanoc::Identifier.new('/index.md'))
+          ctx.create_item('child', {}, Nanoc::Core::Identifier.new('/foo.md'))
+          ctx.create_item('root', {}, Nanoc::Core::Identifier.new('/index.md'))
 
           ctx.item = ctx.items['/foo.md']
         end
@@ -91,9 +91,9 @@ describe Nanoc::Helpers::Breadcrumbs, helper: true, stdio: true do
 
       context 'root, child and grandchild' do
         before do
-          ctx.create_item('grandchild', {}, Nanoc::Identifier.new('/foo/bar.md'))
-          ctx.create_item('child', {}, Nanoc::Identifier.new('/foo.md'))
-          ctx.create_item('root', {}, Nanoc::Identifier.new('/index.md'))
+          ctx.create_item('grandchild', {}, Nanoc::Core::Identifier.new('/foo/bar.md'))
+          ctx.create_item('child', {}, Nanoc::Core::Identifier.new('/foo.md'))
+          ctx.create_item('root', {}, Nanoc::Core::Identifier.new('/index.md'))
 
           ctx.item = ctx.items['/foo/bar.md']
         end
@@ -105,8 +105,8 @@ describe Nanoc::Helpers::Breadcrumbs, helper: true, stdio: true do
 
       context 'root, missing child and grandchild' do
         before do
-          ctx.create_item('grandchild', {}, Nanoc::Identifier.new('/foo/bar.md'))
-          ctx.create_item('root', {}, Nanoc::Identifier.new('/index.md'))
+          ctx.create_item('grandchild', {}, Nanoc::Core::Identifier.new('/foo/bar.md'))
+          ctx.create_item('root', {}, Nanoc::Core::Identifier.new('/index.md'))
 
           ctx.item = ctx.items['/foo/bar.md']
         end
@@ -120,8 +120,8 @@ describe Nanoc::Helpers::Breadcrumbs, helper: true, stdio: true do
         # No special handling of non-root index.* files.
 
         before do
-          ctx.create_item('grandchild', {}, Nanoc::Identifier.new('/foo/index.md'))
-          ctx.create_item('root', {}, Nanoc::Identifier.new('/index.md'))
+          ctx.create_item('grandchild', {}, Nanoc::Core::Identifier.new('/foo/index.md'))
+          ctx.create_item('root', {}, Nanoc::Core::Identifier.new('/index.md'))
 
           ctx.item = ctx.items['/foo/index.md']
         end
@@ -133,11 +133,11 @@ describe Nanoc::Helpers::Breadcrumbs, helper: true, stdio: true do
 
       context 'item with version number component in path' do
         before do
-          ctx.create_item('grandchild', {}, Nanoc::Identifier.new('/1.5/stuff.md'))
-          ctx.create_item('child0', {}, Nanoc::Identifier.new('/1.4.md'))
-          ctx.create_item('child1', {}, Nanoc::Identifier.new('/1.5.md'))
-          ctx.create_item('child2', {}, Nanoc::Identifier.new('/1.6.md'))
-          ctx.create_item('root', {}, Nanoc::Identifier.new('/index.md'))
+          ctx.create_item('grandchild', {}, Nanoc::Core::Identifier.new('/1.5/stuff.md'))
+          ctx.create_item('child0', {}, Nanoc::Core::Identifier.new('/1.4.md'))
+          ctx.create_item('child1', {}, Nanoc::Core::Identifier.new('/1.5.md'))
+          ctx.create_item('child2', {}, Nanoc::Core::Identifier.new('/1.6.md'))
+          ctx.create_item('root', {}, Nanoc::Core::Identifier.new('/index.md'))
 
           ctx.item = ctx.items['/1.5/stuff.md']
         end
@@ -156,11 +156,11 @@ describe Nanoc::Helpers::Breadcrumbs, helper: true, stdio: true do
 
       context 'item with multiple extensions in path' do
         before do
-          ctx.create_item('grandchild', {}, Nanoc::Identifier.new('/foo/stuff.md'))
-          ctx.create_item('child0', {}, Nanoc::Identifier.new('/foo.md.erb'))
-          ctx.create_item('child1', {}, Nanoc::Identifier.new('/foo.md'))
-          ctx.create_item('child2', {}, Nanoc::Identifier.new('/foo.erb'))
-          ctx.create_item('root', {}, Nanoc::Identifier.new('/index.md'))
+          ctx.create_item('grandchild', {}, Nanoc::Core::Identifier.new('/foo/stuff.md'))
+          ctx.create_item('child0', {}, Nanoc::Core::Identifier.new('/foo.md.erb'))
+          ctx.create_item('child1', {}, Nanoc::Core::Identifier.new('/foo.md'))
+          ctx.create_item('child2', {}, Nanoc::Core::Identifier.new('/foo.erb'))
+          ctx.create_item('root', {}, Nanoc::Core::Identifier.new('/index.md'))
 
           ctx.item = ctx.items['/foo/stuff.md']
         end
@@ -235,11 +235,11 @@ describe Nanoc::Helpers::Breadcrumbs, helper: true, stdio: true do
 
       context 'child with multiple extensions' do
         before do
-          ctx.create_item('grandchild1', {}, Nanoc::Identifier.new('/foo/stuff.zip'))
-          ctx.create_item('grandchild2', {}, Nanoc::Identifier.new('/foo/stuff.md'))
-          ctx.create_item('grandchild3', {}, Nanoc::Identifier.new('/foo/stuff.png'))
-          ctx.create_item('child', {}, Nanoc::Identifier.new('/foo.md'))
-          ctx.create_item('root', {}, Nanoc::Identifier.new('/index.md'))
+          ctx.create_item('grandchild1', {}, Nanoc::Core::Identifier.new('/foo/stuff.zip'))
+          ctx.create_item('grandchild2', {}, Nanoc::Core::Identifier.new('/foo/stuff.md'))
+          ctx.create_item('grandchild3', {}, Nanoc::Core::Identifier.new('/foo/stuff.png'))
+          ctx.create_item('child', {}, Nanoc::Core::Identifier.new('/foo.md'))
+          ctx.create_item('root', {}, Nanoc::Core::Identifier.new('/index.md'))
 
           ctx.item = ctx.items['/foo/stuff.md']
         end

--- a/nanoc/spec/nanoc/helpers/child_parent_spec.rb
+++ b/nanoc/spec/nanoc/helpers/child_parent_spec.rb
@@ -8,12 +8,12 @@ describe Nanoc::Helpers::ChildParent, helper: true do
     let(:item) { ctx.items[identifier] }
 
     context 'legacy identifier' do
-      let(:identifier) { Nanoc::Identifier.new('/foo/', type: :legacy) }
+      let(:identifier) { Nanoc::Core::Identifier.new('/foo/', type: :legacy) }
 
       before do
-        ctx.create_item('abc', {}, Nanoc::Identifier.new('/foo/a/', type: :legacy))
-        ctx.create_item('def', {}, Nanoc::Identifier.new('/foo/a/b/', type: :legacy))
-        ctx.create_item('xyz', {}, Nanoc::Identifier.new('/bar/', type: :legacy))
+        ctx.create_item('abc', {}, Nanoc::Core::Identifier.new('/foo/a/', type: :legacy))
+        ctx.create_item('def', {}, Nanoc::Core::Identifier.new('/foo/a/b/', type: :legacy))
+        ctx.create_item('xyz', {}, Nanoc::Core::Identifier.new('/bar/', type: :legacy))
       end
 
       it 'returns only direct children' do
@@ -22,13 +22,13 @@ describe Nanoc::Helpers::ChildParent, helper: true do
     end
 
     context 'full identifier' do
-      let(:identifier) { Nanoc::Identifier.new('/foo.md', type: :full) }
+      let(:identifier) { Nanoc::Core::Identifier.new('/foo.md', type: :full) }
 
       before do
-        ctx.create_item('abc', {}, Nanoc::Identifier.new('/foo/a.md', type: :full))
-        ctx.create_item('def', {}, Nanoc::Identifier.new('/foo/a/b.md', type: :full))
-        ctx.create_item('xyz', {}, Nanoc::Identifier.new('/bar.md', type: :full))
-        ctx.create_item('xyz', {}, Nanoc::Identifier.new('/foo/a/index.md', type: :full))
+        ctx.create_item('abc', {}, Nanoc::Core::Identifier.new('/foo/a.md', type: :full))
+        ctx.create_item('def', {}, Nanoc::Core::Identifier.new('/foo/a/b.md', type: :full))
+        ctx.create_item('xyz', {}, Nanoc::Core::Identifier.new('/bar.md', type: :full))
+        ctx.create_item('xyz', {}, Nanoc::Core::Identifier.new('/foo/a/index.md', type: :full))
       end
 
       it 'returns only direct children' do
@@ -44,13 +44,13 @@ describe Nanoc::Helpers::ChildParent, helper: true do
     let(:item) { ctx.items[identifier] }
 
     context 'legacy identifier' do
-      let(:identifier) { Nanoc::Identifier.new('/foo/bar/', type: :legacy) }
+      let(:identifier) { Nanoc::Core::Identifier.new('/foo/bar/', type: :legacy) }
 
       before do
-        ctx.create_item('abc', {}, Nanoc::Identifier.new('/foo/', type: :legacy))
-        ctx.create_item('def', {}, Nanoc::Identifier.new('/foo/qux/', type: :legacy))
-        ctx.create_item('xyz', {}, Nanoc::Identifier.new('/foo/bar/asdf/', type: :legacy))
-        ctx.create_item('opq', {}, Nanoc::Identifier.new('/', type: :legacy))
+        ctx.create_item('abc', {}, Nanoc::Core::Identifier.new('/foo/', type: :legacy))
+        ctx.create_item('def', {}, Nanoc::Core::Identifier.new('/foo/qux/', type: :legacy))
+        ctx.create_item('xyz', {}, Nanoc::Core::Identifier.new('/foo/bar/asdf/', type: :legacy))
+        ctx.create_item('opq', {}, Nanoc::Core::Identifier.new('/', type: :legacy))
       end
 
       it 'returns parent' do
@@ -59,13 +59,13 @@ describe Nanoc::Helpers::ChildParent, helper: true do
     end
 
     context 'full identifier' do
-      let(:identifier) { Nanoc::Identifier.new('/foo/bar.md', type: :full) }
+      let(:identifier) { Nanoc::Core::Identifier.new('/foo/bar.md', type: :full) }
 
       before do
-        ctx.create_item('abc', {}, Nanoc::Identifier.new('/foo.md', type: :full))
-        ctx.create_item('def', {}, Nanoc::Identifier.new('/foo/qux.md', type: :full))
-        ctx.create_item('xyz', {}, Nanoc::Identifier.new('/foo/bar/asdf.md', type: :full))
-        ctx.create_item('opq', {}, Nanoc::Identifier.new('/index.md', type: :full))
+        ctx.create_item('abc', {}, Nanoc::Core::Identifier.new('/foo.md', type: :full))
+        ctx.create_item('def', {}, Nanoc::Core::Identifier.new('/foo/qux.md', type: :full))
+        ctx.create_item('xyz', {}, Nanoc::Core::Identifier.new('/foo/bar/asdf.md', type: :full))
+        ctx.create_item('opq', {}, Nanoc::Core::Identifier.new('/index.md', type: :full))
       end
 
       it 'returns parent' do

--- a/nanoc/spec/nanoc/helpers/rendering_spec.rb
+++ b/nanoc/spec/nanoc/helpers/rendering_spec.rb
@@ -17,7 +17,7 @@ describe Nanoc::Helpers::Rendering, helper: true do
     end
 
     context 'legacy identifier' do
-      let(:layout_identifier) { Nanoc::Identifier.new('/partial/', type: :legacy) }
+      let(:layout_identifier) { Nanoc::Core::Identifier.new('/partial/', type: :legacy) }
 
       context 'cleaned identifier' do
         subject { helper.instance_eval { render('/partial/') } }
@@ -61,7 +61,7 @@ describe Nanoc::Helpers::Rendering, helper: true do
     end
 
     context 'full-style identifier' do
-      let(:layout_identifier) { Nanoc::Identifier.new('/partial.erb') }
+      let(:layout_identifier) { Nanoc::Core::Identifier.new('/partial.erb') }
 
       context 'layout without instructions' do
         let(:layout_content) { 'blah' }

--- a/nanoc/spec/nanoc/rule_dsl/action_recorder_spec.rb
+++ b/nanoc/spec/nanoc/rule_dsl/action_recorder_spec.rb
@@ -128,7 +128,7 @@ describe Nanoc::RuleDSL::ActionRecorder do
         end
 
         context 'explicit path given as identifier' do
-          let(:subject_params) { { path: Nanoc::Identifier.from('/routed-foo.html') } }
+          let(:subject_params) { { path: Nanoc::Core::Identifier.from('/routed-foo.html') } }
 
           it 'records' do
             subject

--- a/nanoc/spec/nanoc/rule_dsl/action_sequence_calculator_spec.rb
+++ b/nanoc/spec/nanoc/rule_dsl/action_sequence_calculator_spec.rb
@@ -38,7 +38,7 @@ describe(Nanoc::RuleDSL::ActionSequenceCalculator) do
     context 'with item rep' do
       let(:obj) { Nanoc::Int::ItemRep.new(item, :csv) }
 
-      let(:item) { Nanoc::Int::Item.new('content', {}, Nanoc::Identifier.from('/list.md')) }
+      let(:item) { Nanoc::Int::Item.new('content', {}, Nanoc::Core::Identifier.from('/list.md')) }
 
       context 'no rules exist' do
         it 'raises error' do

--- a/nanoc/spec/nanoc/rule_dsl/rule_context_spec.rb
+++ b/nanoc/spec/nanoc/rule_dsl/rule_context_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 shared_examples 'a rule context' do
-  let(:item_identifier) { Nanoc::Identifier.new('/foo.md') }
+  let(:item_identifier) { Nanoc::Core::Identifier.new('/foo.md') }
   let(:item) { Nanoc::Int::Item.new('content', {}, item_identifier) }
   let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd) }
   let(:items) { Nanoc::Int::ItemCollection.new(config) }
@@ -59,12 +59,12 @@ shared_examples 'a rule context' do
     end
 
     context 'with legacy identifier and children/parent' do
-      let(:item_identifier) { Nanoc::Identifier.new('/foo/', type: :legacy) }
+      let(:item_identifier) { Nanoc::Core::Identifier.new('/foo/', type: :legacy) }
 
-      let(:parent_identifier) { Nanoc::Identifier.new('/', type: :legacy) }
+      let(:parent_identifier) { Nanoc::Core::Identifier.new('/', type: :legacy) }
       let(:parent) { Nanoc::Int::Item.new('parent', {}, parent_identifier) }
 
-      let(:child_identifier) { Nanoc::Identifier.new('/foo/bar/', type: :legacy) }
+      let(:child_identifier) { Nanoc::Core::Identifier.new('/foo/bar/', type: :legacy) }
       let(:child) { Nanoc::Int::Item.new('child', {}, child_identifier) }
 
       let(:items) do
@@ -98,12 +98,12 @@ shared_examples 'a rule context' do
   describe '#items' do
     subject { rule_context.items }
 
-    let(:item_identifier) { Nanoc::Identifier.new('/foo/', type: :legacy) }
+    let(:item_identifier) { Nanoc::Core::Identifier.new('/foo/', type: :legacy) }
 
-    let(:parent_identifier) { Nanoc::Identifier.new('/', type: :legacy) }
+    let(:parent_identifier) { Nanoc::Core::Identifier.new('/', type: :legacy) }
     let(:parent) { Nanoc::Int::Item.new('parent', {}, parent_identifier) }
 
-    let(:child_identifier) { Nanoc::Identifier.new('/foo/bar/', type: :legacy) }
+    let(:child_identifier) { Nanoc::Core::Identifier.new('/foo/bar/', type: :legacy) }
     let(:child) { Nanoc::Int::Item.new('child', {}, child_identifier) }
 
     let(:items) do
@@ -144,7 +144,7 @@ describe(Nanoc::RuleDSL::RoutingRuleContext) do
     described_class.new(rep: rep, site: site, view_context: view_context)
   end
 
-  let(:item_identifier) { Nanoc::Identifier.new('/foo.md') }
+  let(:item_identifier) { Nanoc::Core::Identifier.new('/foo.md') }
   let(:item) { Nanoc::Int::Item.new('content', {}, item_identifier) }
   let(:rep) { Nanoc::Int::ItemRep.new(item, :default) }
   let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd) }
@@ -170,7 +170,7 @@ describe(Nanoc::RuleDSL::CompilationRuleContext) do
     described_class.new(rep: rep, site: site, recorder: recorder, view_context: view_context)
   end
 
-  let(:item_identifier) { Nanoc::Identifier.new('/foo.md') }
+  let(:item_identifier) { Nanoc::Core::Identifier.new('/foo.md') }
   let(:item) { Nanoc::Int::Item.new('content', {}, item_identifier) }
   let(:rep) { Nanoc::Int::ItemRep.new(item, :default) }
   let(:config) { Nanoc::Int::Configuration.new(dir: Dir.getwd) }
@@ -263,7 +263,7 @@ describe(Nanoc::RuleDSL::CompilationRuleContext) do
     context 'with identifier' do
       context 'calling once' do
         subject { rule_context.write(identifier) }
-        let(:identifier) { Nanoc::Identifier.new('/foo.html') }
+        let(:identifier) { Nanoc::Core::Identifier.new('/foo.html') }
 
         it 'makes a request to the recorder' do
           expect(recorder).to receive(:snapshot).with(:_0, path: '/foo.html')
@@ -277,8 +277,8 @@ describe(Nanoc::RuleDSL::CompilationRuleContext) do
           rule_context.write(identifier_b)
         end
 
-        let(:identifier_a) { Nanoc::Identifier.new('/foo.html') }
-        let(:identifier_b) { Nanoc::Identifier.new('/bar.html') }
+        let(:identifier_a) { Nanoc::Core::Identifier.new('/foo.html') }
+        let(:identifier_b) { Nanoc::Core::Identifier.new('/bar.html') }
 
         it 'makes two requests to the recorder with unique snapshot names' do
           expect(recorder).to receive(:snapshot).with(:_0, path: '/foo.html')

--- a/nanoc/spec/nanoc/rule_dsl/rule_spec.rb
+++ b/nanoc/spec/nanoc/rule_dsl/rule_spec.rb
@@ -12,12 +12,12 @@ shared_examples 'a generic rule' do
     subject { rule.matches(identifier) }
 
     context 'does not match' do
-      let(:identifier) { Nanoc::Identifier.new('/moo/', type: :legacy) }
+      let(:identifier) { Nanoc::Core::Identifier.new('/moo/', type: :legacy) }
       it { is_expected.to be_nil }
     end
 
     context 'matches' do
-      let(:identifier) { Nanoc::Identifier.new('/foo/bar/', type: :legacy) }
+      let(:identifier) { Nanoc::Core::Identifier.new('/foo/bar/', type: :legacy) }
       it { is_expected.to eql(%w[foo bar]) }
     end
   end

--- a/nanoc/test/base/test_site.rb
+++ b/nanoc/test/base/test_site.rb
@@ -107,11 +107,11 @@ class Nanoc::Int::SiteTest < Nanoc::TestCase
       site = Nanoc::Int::SiteLoader.new.new_from_cwd
 
       site.items.each do |item|
-        assert_equal Nanoc::Identifier, item.identifier.class
+        assert_equal Nanoc::Core::Identifier, item.identifier.class
       end
 
       site.layouts.each do |layout|
-        assert_equal Nanoc::Identifier, layout.identifier.class
+        assert_equal Nanoc::Core::Identifier, layout.identifier.class
       end
     end
   end

--- a/nanoc/test/data_sources/test_filesystem.rb
+++ b/nanoc/test/data_sources/test_filesystem.rb
@@ -145,10 +145,10 @@ class Nanoc::DataSources::FilesystemTest < Nanoc::TestCase
 
     # Get input and expected output
     expected = {
-      '/foo' => Nanoc::Identifier.new('/foo', type: :full),
-      '/foo.html' => Nanoc::Identifier.new('/foo.html',       type: :full),
-      '/foo/index.html' => Nanoc::Identifier.new('/foo/index.html', type: :full),
-      '/foo.html.erb' => Nanoc::Identifier.new('/foo.html.erb', type: :full),
+      '/foo' => Nanoc::Core::Identifier.new('/foo', type: :full),
+      '/foo.html' => Nanoc::Core::Identifier.new('/foo.html',       type: :full),
+      '/foo/index.html' => Nanoc::Core::Identifier.new('/foo/index.html', type: :full),
+      '/foo.html.erb' => Nanoc::Core::Identifier.new('/foo.html.erb', type: :full),
     }
 
     # Check


### PR DESCRIPTION
This removes `Nanoc::Identifier` as an alias for `Nanoc::Core::Identifier`. It isn’t necessary, and the other Core classes don’t have reexports either.

(This might change in the future, though.)