### PR TITLE
Make Checksummer behaviors externally configurable

### DIFF
--- a/nanoc/lib/nanoc/base/services.rb
+++ b/nanoc/lib/nanoc/base/services.rb
@@ -24,3 +24,10 @@ require_relative 'services/compiler/phases'
 require_relative 'services/compiler/stages'
 
 require_relative 'services/outdatedness_checker'
+
+# TODO: Move this into the entity, once the load order is improved (i.e. the
+# checksummer is loaded after CodeSnippet).
+Nanoc::Int::Checksummer.define_behavior(
+  Nanoc::Int::CodeSnippet,
+  Nanoc::Int::Checksummer::DataUpdateBehavior,
+)

--- a/nanoc/lib/nanoc/base/views.rb
+++ b/nanoc/lib/nanoc/base/views.rb
@@ -35,3 +35,10 @@ require_relative 'views/post_compile_item_view'
 require_relative 'views/post_compile_item_collection_view'
 require_relative 'views/post_compile_item_rep_view'
 require_relative 'views/post_compile_item_rep_collection_view'
+
+# TODO: Move this, once the load order is improved (i.e. the checksummer is
+# loded after the views are).
+Nanoc::Int::Checksummer.define_behavior(
+  Nanoc::View,
+  Nanoc::Int::Checksummer::UnwrapUpdateBehavior,
+)

--- a/nanoc/lib/nanoc/rule_dsl.rb
+++ b/nanoc/lib/nanoc/rule_dsl.rb
@@ -20,3 +20,13 @@ require_relative 'rule_dsl/routing_rule_context'
 require_relative 'rule_dsl/rule'
 require_relative 'rule_dsl/compilation_rule'
 require_relative 'rule_dsl/routing_rule'
+
+Nanoc::Int::Checksummer.define_behavior(
+  Nanoc::RuleDSL::CompilationRuleContext,
+  Nanoc::Int::Checksummer::RuleContextUpdateBehavior,
+)
+
+Nanoc::Int::Checksummer.define_behavior(
+  Nanoc::RuleDSL::RulesCollection,
+  Nanoc::Int::Checksummer::DataUpdateBehavior,
+)


### PR DESCRIPTION
The `Checksummer` always had the problem that it was aware of classes that live outside of the package it is defined in (e.g. it knew about the rule DSL, even though that is supposed to be not part of base).

This refactoring removes the knowledge of the rule DSL (and some other things) from the Checksummer, and instead lets the rule DSL inject update behavior into the checksummer.

This will make it possible for the Checksummer to live in Core.