### PR TITLE
On EACCES, copy instead of hardlink

### DIFF
--- a/nanoc/lib/nanoc/base/services/item_rep_writer.rb
+++ b/nanoc/lib/nanoc/base/services/item_rep_writer.rb
@@ -61,7 +61,7 @@ module Nanoc
         if is_modified
           begin
             FileUtils.ln(temp_path, raw_path, force: true)
-          rescue Errno::EXDEV
+          rescue Errno::EXDEV, Errno::EACCES
             FileUtils.cp(temp_path, raw_path)
           end
         end


### PR DESCRIPTION
Fixes #1405. (Or rather, works around the issue…)

It is possible for hardlinking to fail when copying works fine. In that case, fall back to copying instead of hardlinking.

To do: Figure out a way to test this.

### Why?

According to [facebook/create-react-app#1832 (comment)](https://github.com/facebook/create-react-app/issues/1832#issuecomment-445500936):

> Due to Android's SELinux policies, you cannot hard link as non-root