### PR TITLE
Cache binary content (Denis’ remix)

### DIFF
--- a/nanoc-core/lib/nanoc/core/content.rb
+++ b/nanoc-core/lib/nanoc/core/content.rb
@@ -41,6 +41,11 @@ module Nanoc
       def binary?
         raise NotImplementedError
       end
+
+      contract C::None => C::Bool
+      def textual?
+        !binary?
+      end
     end
   end
 end

--- a/nanoc/lib/nanoc/base/feature.rb
+++ b/nanoc/lib/nanoc/base/feature.rb
@@ -98,3 +98,7 @@ Nanoc::Feature.define('live_cmd', version: '4.11')
 # Tracking issue:
 # https://github.com/nanoc/features/issues/40
 Nanoc::Feature.define('toml', version: '4.11')
+
+# Tracking issue:
+# https://github.com/nanoc/features/issues/20
+Nanoc::Feature.define('binary_compiled_content_cache', version: '4.11')

--- a/nanoc/lib/nanoc/base/repos.rb
+++ b/nanoc/lib/nanoc/base/repos.rb
@@ -6,7 +6,9 @@ Nanoc::DataSource = Nanoc::Core::DataSource
 require_relative 'repos/store'
 
 require_relative 'repos/checksum_store'
+require_relative 'repos/binary_compiled_content_cache'
 require_relative 'repos/textual_compiled_content_cache'
+require_relative 'repos/compiled_content_cache'
 require_relative 'repos/config_loader'
 require_relative 'repos/dependency_store'
 require_relative 'repos/item_rep_repo'

--- a/nanoc/lib/nanoc/base/repos/binary_compiled_content_cache.rb
+++ b/nanoc/lib/nanoc/base/repos/binary_compiled_content_cache.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+module Nanoc
+  module Int
+    # Represents a cache than can be used to store already compiled content,
+    # to prevent it from being needlessly recompiled.
+    #
+    # @api private
+    class BinaryCompiledContentCache < ::Nanoc::Int::Store
+      include Nanoc::Core::ContractsSupport
+
+      contract C::KeywordArgs[config: Nanoc::Core::Configuration] => C::Any
+      def initialize(config:)
+        super(Nanoc::Int::Store.tmp_path_for(config: config, store_name: 'binary_content'), 1)
+
+        @cache = {}
+      end
+
+      contract Nanoc::Core::ItemRep => C::Maybe[C::HashOf[Symbol => Nanoc::Core::Content]]
+      # Returns the cached compiled content for the given item representation.
+      #
+      # This cached compiled content is a hash where the keys are the snapshot
+      # names, and the values the compiled content at the given snapshot.
+      def [](rep)
+        item_cache = @cache[rep.item.identifier] || {}
+
+        rep_cache = item_cache[rep.name]
+        return nil if rep_cache.nil?
+
+        rep_cache.transform_values do |filename|
+          Nanoc::Core::Content.create(filename, binary: true)
+        end
+      end
+
+      contract Nanoc::Core::ItemRep, C::HashOf[Symbol => Nanoc::Core::BinaryContent] => C::HashOf[Symbol => Nanoc::Core::Content]
+      # Sets the compiled content for the given representation.
+      #
+      # This cached compiled content is a hash where the keys are the snapshot
+      # names, and the values the compiled content at the given snapshot.
+      def []=(rep, content)
+        @cache[rep.item.identifier] ||= {}
+        @cache[rep.item.identifier][rep.name] ||= {}
+        rep_cache = @cache[rep.item.identifier][rep.name]
+
+        content.each do |snapshot, binary_content|
+          filename = build_filename(rep, snapshot)
+          rep_cache[snapshot] = filename
+
+          # Avoid reassigning the same content if this binary cached content was
+          # already used, because it was available and the item wasn’t oudated.
+          next if binary_content.filename == filename
+
+          # Copy
+          #
+          # NOTE: hardlinking is not an option in this case, because hardlinking
+          # would make it possible for the content to be (inadvertently)
+          # changed outside of Nanoc.
+          FileUtils.mkdir_p(File.dirname(filename))
+          FileUtils.cp(binary_content.filename, filename)
+        end
+      end
+
+      def prune(items:)
+        item_identifiers = Set.new(items.map(&:identifier))
+
+        @cache.each_key do |key|
+          # TODO: remove unused item reps
+          next if item_identifiers.include?(key)
+
+          @cache.delete(key)
+          path = dirname_for_item_identifier(key)
+          FileUtils.rm_rf(path)
+        end
+      end
+
+      def data
+        @cache
+      end
+
+      def data=(new_data)
+        @cache = {}
+
+        new_data.each_pair do |item_identifier, content_per_rep|
+          @cache[item_identifier] ||= content_per_rep
+        end
+      end
+
+      private
+
+      def dirname
+        filename + '_data'
+      end
+
+      def string_to_path_component(string)
+        string.gsub(/[^a-zA-Z0-9]+/, '_') +
+          '-' +
+          Digest::SHA1.hexdigest(string)[0..9]
+      end
+
+      def dirname_for_item_identifier(item_identifier)
+        File.join(
+          dirname,
+          string_to_path_component(item_identifier.to_s),
+        )
+      end
+
+      def dirname_for_item_rep(rep)
+        File.join(
+          dirname_for_item_identifier(rep.item.identifier),
+          string_to_path_component(rep.name.to_s),
+        )
+      end
+
+      def build_filename(rep, snapshot_name)
+        File.join(
+          dirname_for_item_rep(rep),
+          string_to_path_component(snapshot_name.to_s),
+        )
+      end
+    end
+  end
+end

--- a/nanoc/lib/nanoc/base/repos/binary_compiled_content_cache.rb
+++ b/nanoc/lib/nanoc/base/repos/binary_compiled_content_cache.rb
@@ -32,6 +32,12 @@ module Nanoc
         end
       end
 
+      contract Nanoc::Core::ItemRep => C::Bool
+      def include?(rep)
+        item_cache = @cache[rep.item.identifier] || {}
+        item_cache.key?(rep.name)
+      end
+
       contract Nanoc::Core::ItemRep, C::HashOf[Symbol => Nanoc::Core::BinaryContent] => C::HashOf[Symbol => Nanoc::Core::Content]
       # Sets the compiled content for the given representation.
       #

--- a/nanoc/lib/nanoc/base/repos/compiled_content_cache.rb
+++ b/nanoc/lib/nanoc/base/repos/compiled_content_cache.rb
@@ -53,7 +53,7 @@ module Nanoc
       # True if there is cached compiled content available for this item, and
       # all entries are present (either textual or binary).
       def full_cache_available?(rep)
-        key?(rep)
+        @textual_cache.include?(rep) && @binary_cache.include?(rep)
       end
 
       def load(*args)

--- a/nanoc/lib/nanoc/base/repos/compiled_content_cache.rb
+++ b/nanoc/lib/nanoc/base/repos/compiled_content_cache.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Nanoc
+  module Int
+    # Represents a cache than can be used to store already compiled content,
+    # to prevent it from being needlessly recompiled.
+    #
+    # @api private
+    class CompiledContentCache < ::Nanoc::Int::Store
+      include Nanoc::Core::ContractsSupport
+
+      contract C::KeywordArgs[config: Nanoc::Core::Configuration] => C::Any
+      def initialize(config:)
+        @textual_cache = Nanoc::Int::TextualCompiledContentCache.new(config: config)
+        @binary_cache = Nanoc::Int::BinaryCompiledContentCache.new(config: config)
+
+        @wrapped_caches = [@textual_cache, @binary_cache]
+      end
+
+      contract Nanoc::Core::ItemRep => C::Maybe[C::HashOf[Symbol => Nanoc::Core::Content]]
+      # Returns the cached compiled content for the given item representation.
+      #
+      # This cached compiled content is a hash where the keys are the snapshot
+      # names. and the values the compiled content at the given snapshot.
+      def [](rep)
+        textual_content_map = @textual_cache[rep]
+        binary_content_map = @binary_cache[rep]
+
+        # If either the textual or the binary content cache is nil, assume the
+        # cache is entirely absent.
+        #
+        # This is necessary to support the case where only textual content is
+        # cached (which was the case in older versions of Nanoc).
+        return nil if [textual_content_map, binary_content_map].any?(&:nil?)
+
+        textual_content_map.merge(binary_content_map)
+      end
+
+      contract Nanoc::Core::ItemRep, C::HashOf[Symbol => Nanoc::Core::Content] => C::Any
+      # Sets the compiled content for the given representation.
+      #
+      # This cached compiled content is a hash where the keys are the snapshot
+      # names and the values the compiled content at the given snapshot.
+      def []=(rep, content)
+        @textual_cache[rep] = content.select { |_key, c| c.textual? }
+        @binary_cache[rep] = content.select { |_key, c| c.binary? }
+      end
+
+      def prune(*args)
+        @wrapped_caches.each { |w| w.prune(*args) }
+      end
+
+      # True if there is cached compiled content available for this item, and
+      # all entries are present (either textual or binary).
+      def full_cache_available?(rep)
+        key?(rep)
+      end
+
+      def load(*args)
+        @wrapped_caches.each { |w| w.load(*args) }
+      end
+
+      def store(*args)
+        @wrapped_caches.each { |w| w.store(*args) }
+      end
+    end
+  end
+end

--- a/nanoc/lib/nanoc/base/repos/textual_compiled_content_cache.rb
+++ b/nanoc/lib/nanoc/base/repos/textual_compiled_content_cache.rb
@@ -26,12 +26,22 @@ module Nanoc
         item_cache[rep.name]
       end
 
-      contract Nanoc::Core::ItemRep, C::HashOf[Symbol => Nanoc::Core::TextualContent] => C::Any
+      contract Nanoc::Core::ItemRep => C::Bool
+      def include?(rep)
+        item_cache = @cache[rep.item.identifier] || {}
+        item_cache.key?(rep.name)
+      end
+
+      contract Nanoc::Core::ItemRep, C::HashOf[Symbol => Nanoc::Core::Content] => C::Any
       # Sets the compiled content for the given representation.
       #
       # This cached compiled content is a hash where the keys are the snapshot
       # names, and the values the compiled content at the given snapshot.
       def []=(rep, content)
+        # FIXME: once the binary content cache is properly enabled (no longer
+        # behind a feature flag), change contract to be TextualContent, rather
+        # than Content.
+
         @cache[rep.item.identifier] ||= {}
         @cache[rep.item.identifier][rep.name] = content
       end

--- a/nanoc/lib/nanoc/base/repos/textual_compiled_content_cache.rb
+++ b/nanoc/lib/nanoc/base/repos/textual_compiled_content_cache.rb
@@ -26,7 +26,7 @@ module Nanoc
         item_cache[rep.name]
       end
 
-      contract Nanoc::Core::ItemRep, C::HashOf[Symbol => Nanoc::Core::Content] => C::Any
+      contract Nanoc::Core::ItemRep, C::HashOf[Symbol => Nanoc::Core::TextualContent] => C::Any
       # Sets the compiled content for the given representation.
       #
       # This cached compiled content is a hash where the keys are the snapshot
@@ -48,7 +48,7 @@ module Nanoc
       end
 
       # True if there is cached compiled content available for this item, and
-      # all entries are textual. (Binary content cannot be cached.)
+      # all entries are textual.
       def full_cache_available?(rep)
         cache = self[rep]
         cache ? cache.none? { |_snapshot_name, content| content.binary? } : false

--- a/nanoc/lib/nanoc/base/services/compiler_loader.rb
+++ b/nanoc/lib/nanoc/base/services/compiler_loader.rb
@@ -21,7 +21,7 @@ module Nanoc
           Nanoc::Int::OutdatednessStore.new(config: site.config)
 
         compiled_content_cache =
-          Nanoc::Int::CompiledContentCache.new(config: site.config)
+          compiled_content_cache_class.new(config: site.config)
 
         params = {
           compiled_content_cache: compiled_content_cache,
@@ -33,6 +33,15 @@ module Nanoc
         }
 
         Nanoc::Int::Compiler.new(site, params)
+      end
+
+      def compiled_content_cache_class
+        feature_name = Nanoc::Feature::BINARY_COMPILED_CONTENT_CACHE
+        if Nanoc::Feature.enabled?(feature_name)
+          Nanoc::Int::CompiledContentCache
+        else
+          Nanoc::Int::TextualCompiledContentCache
+        end
       end
     end
   end

--- a/nanoc/lib/nanoc/base/services/compiler_loader.rb
+++ b/nanoc/lib/nanoc/base/services/compiler_loader.rb
@@ -21,7 +21,7 @@ module Nanoc
           Nanoc::Int::OutdatednessStore.new(config: site.config)
 
         compiled_content_cache =
-          Nanoc::Int::TextualCompiledContentCache.new(config: site.config)
+          Nanoc::Int::CompiledContentCache.new(config: site.config)
 
         params = {
           compiled_content_cache: compiled_content_cache,

--- a/nanoc/lib/nanoc/base/views/post_compile_item_rep_view.rb
+++ b/nanoc/lib/nanoc/base/views/post_compile_item_rep_view.rb
@@ -8,7 +8,7 @@ module Nanoc
 
     def compiled_content(snapshot: nil)
       compilation_context = @context.compilation_context
-      snapshot_contents = compilation_context.compiled_content_cache[_unwrap]
+      snapshot_contents = compilation_context.compiled_content_cache[_unwrap] || {}
 
       snapshot_name = snapshot || (snapshot_contents[:pre] ? :pre : :last)
 

--- a/nanoc/nanoc.manifest
+++ b/nanoc/nanoc.manifest
@@ -22,7 +22,9 @@ lib/nanoc/base/feature.rb
 lib/nanoc/base/repos.rb
 lib/nanoc/base/repos/action_sequence_store.rb
 lib/nanoc/base/repos/aggregate_data_source.rb
+lib/nanoc/base/repos/binary_compiled_content_cache.rb
 lib/nanoc/base/repos/checksum_store.rb
+lib/nanoc/base/repos/compiled_content_cache.rb
 lib/nanoc/base/repos/config_loader.rb
 lib/nanoc/base/repos/dependency_store.rb
 lib/nanoc/base/repos/in_mem_data_source.rb

--- a/nanoc/spec/nanoc/base/compiler_spec.rb
+++ b/nanoc/spec/nanoc/base/compiler_spec.rb
@@ -22,7 +22,7 @@ describe Nanoc::Int::Compiler do
   let(:action_provider) { double(:action_provider) }
 
   let(:compiled_content_cache) do
-    Nanoc::Int::TextualCompiledContentCache.new(config: config)
+    Nanoc::Int::CompiledContentCache.new(config: config)
   end
 
   let(:rep) { Nanoc::Core::ItemRep.new(item, :default) }

--- a/nanoc/spec/nanoc/base/repos/binary_compiled_content_cache_spec.rb
+++ b/nanoc/spec/nanoc/base/repos/binary_compiled_content_cache_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+describe Nanoc::Int::BinaryCompiledContentCache do
+  let(:cache) { described_class.new(config: config) }
+
+  let(:items) { [item] }
+
+  let(:item) { Nanoc::Core::Item.new('asdf', {}, '/foo.md') }
+  let(:item_rep) { Nanoc::Core::ItemRep.new(item, :default) }
+
+  let(:other_item) { Nanoc::Core::Item.new('asdf', {}, '/sneaky.md') }
+  let(:other_item_rep) { Nanoc::Core::ItemRep.new(other_item, :default) }
+
+  let(:content) do
+    Nanoc::Core::Content.create(File.join(Dir.getwd, 'bin.dat'), binary: true).tap do |c|
+      File.write(c.filename, 'b1n4ry')
+    end
+  end
+
+  let(:config) { Nanoc::Core::Configuration.new(dir: Dir.getwd).with_defaults }
+
+  it 'has no content by default' do
+    expect(cache[item_rep]).to be_nil
+  end
+
+  describe 'setting new content' do
+    subject do
+      cache[item_rep] = { last: content }
+    end
+
+    it 'sets content' do
+      expect { subject }
+        .to change { cache[item_rep] }
+        .from(nil)
+        .to(be_a(Hash))
+    end
+
+    it 'has correct content in cache' do
+      subject
+      expect(File.read(cache[item_rep][:last].filename)).to eql('b1n4ry')
+    end
+
+    it 'has correct filename in cache' do
+      subject
+      expect(cache[item_rep][:last].filename)
+        .to match(%r{tmp/nanoc/[a-z0-9]+/binary_content_data/_foo_md-299726ada7/default-7505d64a54/last-213ed3ea45\z})
+    end
+  end
+
+  describe 'setting empty content' do
+    subject do
+      cache[item_rep] = {}
+    end
+
+    it 'sets content' do
+      expect { subject }
+        .to change { cache[item_rep] }
+        .from(nil)
+        .to({})
+    end
+  end
+
+  describe 'replacing existing content with itself' do
+    before do
+      cache[item_rep] = { last: content }
+    end
+
+    subject do
+      cache[item_rep] = cache[item_rep]
+    end
+
+    it 'does not crash' do
+      expect { subject }
+        .not_to change { cache[item_rep][:last].filename }
+    end
+  end
+
+  describe '#prune' do
+    subject { cache.prune(items: items) }
+
+    before do
+      cache[item_rep] = { last: content }
+      cache[other_item_rep] = { last: content }
+    end
+
+    it 'empties content for unknown item' do
+      expect { subject }
+        .to change { cache[other_item_rep].nil? }
+        .from(false)
+        .to(true)
+    end
+
+    it 'retains content for known item' do
+      expect { subject }
+        .not_to change { cache[item_rep].nil? }
+        .from(false)
+    end
+
+    it 'deletes content for unknown item' do
+      pattern = 'tmp/nanoc/*/binary_content_data/*'
+      is_sneaky_md = ->(fn) { fn.end_with?('/binary_content_data/_sneaky_md-e0111278e4') }
+
+      expect { subject }
+        .to change { Dir[pattern].any? { |e| is_sneaky_md.call(e) } }
+        .from(true)
+        .to(false)
+    end
+
+    it 'retains content for known item' do
+      pattern = 'tmp/nanoc/*/binary_content_data/*'
+      is_foo_md = ->(fn) { fn.end_with?('/binary_content_data/_foo_md-299726ada7') }
+
+      expect { subject }
+        .not_to change { Dir[pattern].any? { |e| is_foo_md.call(e) } }
+        .from(true)
+    end
+  end
+
+  context 'nested items' do
+    let(:keep) { Nanoc::Core::Item.new('keep', {}, '/articles/keep/foo.md') }
+    let(:keep_item_rep) { Nanoc::Core::ItemRep.new(keep, :default) }
+
+    let(:remove) { Nanoc::Core::Item.new('remove', {}, '/articles/remove/foo.md') }
+    let(:remove_item_rep) { Nanoc::Core::ItemRep.new(remove, :default) }
+
+    let(:remove_dotted) { Nanoc::Core::Item.new('remove dotted', {}, '/articles/remove-dotted/foo.md') }
+    let(:remove_dotted_item_rep) { Nanoc::Core::ItemRep.new(remove_dotted, :default) }
+
+    before do
+      cache[keep_item_rep] = { last: content }
+      cache[remove_item_rep] = { last: content }
+      cache[remove_dotted_item_rep] = { '.last'.to_sym => content }
+
+      cache.prune(items: [keep])
+    end
+
+    it 'has content for kept items' do
+      expect(cache[keep_item_rep]).to be
+    end
+
+    it 'has no content for removed items' do
+      expect(cache[remove_item_rep]).to be_nil
+    end
+
+    it 'has no content for removed items with snapshots starting with a dot' do
+      expect(cache[remove_dotted_item_rep]).to be_nil
+    end
+  end
+end

--- a/nanoc/spec/nanoc/base/repos/compiled_content_cache_spec.rb
+++ b/nanoc/spec/nanoc/base/repos/compiled_content_cache_spec.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+describe Nanoc::Int::CompiledContentCache do
+  let(:cache) { described_class.new(config: config) }
+
+  let(:items) { [item] }
+
+  let(:item) { Nanoc::Core::Item.new('asdf', {}, '/foo.md') }
+  let(:item_rep) { Nanoc::Core::ItemRep.new(item, :default) }
+
+  let(:other_item) { Nanoc::Core::Item.new('asdf', {}, '/sneaky.md') }
+  let(:other_item_rep) { Nanoc::Core::ItemRep.new(other_item, :default) }
+
+  let(:textual_content) do
+    Nanoc::Core::Content.create('text')
+  end
+
+  let(:binary_content) do
+    Nanoc::Core::Content.create(File.join(Dir.getwd, 'bin.dat'), binary: true).tap do |c|
+      File.write(c.filename, 'b1n4ry')
+    end
+  end
+
+  let(:config) { Nanoc::Core::Configuration.new(dir: Dir.getwd).with_defaults }
+
+  it 'has no content by default' do
+    expect(cache[item_rep]).to be_nil
+  end
+
+  shared_examples 'properly-functioning compiled content cache' do
+    context 'setting only textual content' do
+      before do
+        cache[target_item_rep] = {
+          aaa: textual_content,
+        }
+      end
+
+      it 'has content' do
+        expect(cache[target_item_rep][:aaa].string).to eql(textual_content.string)
+      end
+
+      context 'after storing and loading' do
+        before do
+          cache.store
+          cache.load
+        end
+
+        it 'has content' do
+          expect(cache[target_item_rep][:aaa].string).to eql(textual_content.string)
+        end
+      end
+
+      context 'after pruning all items' do
+        before do
+          cache.prune(items: [])
+        end
+
+        it 'has no content' do
+          expect(cache[target_item_rep]).to be_nil
+        end
+      end
+
+      context 'after pruning no items' do
+        before do
+          cache.prune(items: [target_item_rep.item])
+        end
+
+        it 'has no content' do
+          expect(cache[target_item_rep]).not_to be_nil
+        end
+      end
+    end
+
+    context 'setting textual and binary content' do
+      before do
+        cache[target_item_rep] = {
+          aaa: textual_content,
+          bbb: binary_content,
+        }
+      end
+
+      it 'has content' do
+        expect(cache[target_item_rep][:aaa].string).to eql(textual_content.string)
+
+        expect(File.read(cache[target_item_rep][:bbb].filename))
+          .to eql('b1n4ry')
+      end
+
+      context 'after storing and loading' do
+        before do
+          cache.store
+          cache.load
+        end
+
+        it 'has content' do
+          expect(cache[target_item_rep][:aaa].string).to eql(textual_content.string)
+
+          expect(File.read(cache[target_item_rep][:bbb].filename))
+            .to eql('b1n4ry')
+        end
+      end
+
+      context 'after pruning all items' do
+        before do
+          cache.prune(items: [])
+        end
+
+        it 'has no content' do
+          expect(cache[target_item_rep]).to be_nil
+        end
+      end
+
+      context 'after pruning no items' do
+        before do
+          cache.prune(items: [target_item_rep.item])
+        end
+
+        it 'has no content' do
+          expect(cache[target_item_rep]).not_to be_nil
+        end
+      end
+    end
+
+    context 'setting only binary content' do
+      before do
+        cache[target_item_rep] = {
+          bbb: binary_content,
+        }
+      end
+
+      it 'has content' do
+        expect(File.read(cache[target_item_rep][:bbb].filename))
+          .to eql('b1n4ry')
+      end
+
+      context 'after storing and loading' do
+        before do
+          cache.store
+          cache.load
+        end
+
+        it 'has content' do
+          expect(File.read(cache[target_item_rep][:bbb].filename))
+            .to eql('b1n4ry')
+        end
+      end
+
+      context 'after pruning all items' do
+        before do
+          cache.prune(items: [])
+        end
+
+        it 'has no content' do
+          expect(cache[target_item_rep]).to be_nil
+        end
+      end
+
+      context 'after pruning no items' do
+        before do
+          cache.prune(items: [target_item_rep.item])
+        end
+
+        it 'has no content' do
+          expect(cache[target_item_rep]).not_to be_nil
+        end
+      end
+    end
+  end
+
+  context 'setting content on known item' do
+    let(:target_item_rep) { item_rep }
+
+    include_examples 'properly-functioning compiled content cache'
+  end
+
+  context 'setting content on unknown item' do
+    let(:target_item_rep) { other_item_rep }
+
+    include_examples 'properly-functioning compiled content cache'
+  end
+end

--- a/nanoc/spec/nanoc/base/services/compiler/phases/cache_spec.rb
+++ b/nanoc/spec/nanoc/base/services/compiler/phases/cache_spec.rb
@@ -10,7 +10,7 @@ describe Nanoc::Int::Compiler::Phases::Cache do
   end
 
   let(:compiled_content_cache) do
-    Nanoc::Int::TextualCompiledContentCache.new(config: config)
+    Nanoc::Int::CompiledContentCache.new(config: config)
   end
 
   let(:compiled_content_store) { Nanoc::Int::CompiledContentStore.new }
@@ -40,6 +40,8 @@ describe Nanoc::Int::Compiler::Phases::Cache do
     let(:is_outdated) { raise 'override me' }
 
     before do
+      rep.snapshot_defs = [Nanoc::Core::SnapshotDef.new(:last, binary: false)]
+
       allow(Nanoc::Core::NotificationCenter).to receive(:post).with(:phase_started, anything, anything)
       allow(Nanoc::Core::NotificationCenter).to receive(:post).with(:phase_yielded, anything, anything)
       allow(Nanoc::Core::NotificationCenter).to receive(:post).with(:phase_resumed, anything, anything)
@@ -81,6 +83,8 @@ describe Nanoc::Int::Compiler::Phases::Cache do
 
       context 'textual cached compiled content available' do
         before do
+          rep.snapshot_defs = [Nanoc::Core::SnapshotDef.new(:last, binary: false)]
+
           compiled_content_cache[rep] = { last: Nanoc::Core::TextualContent.new('cached') }
         end
 
@@ -112,33 +116,32 @@ describe Nanoc::Int::Compiler::Phases::Cache do
         let(:binary_filename) { Tempfile.open('test') { |fn| fn << binary_content }.path }
 
         before do
+          rep.snapshot_defs = [Nanoc::Core::SnapshotDef.new(:last, binary: true)]
+
           compiled_content_cache[rep] = { last: Nanoc::Core::BinaryContent.new(binary_filename) }
         end
 
         it 'reads content from cache' do
+          expect(Nanoc::Core::NotificationCenter).to receive(:post).with(:cached_content_used, rep)
           expect { subject }
             .to change { compiled_content_store.get(rep, :last) }
             .from(nil)
-            .to(some_textual_content('wrapped content'))
+            .to(some_binary_content(binary_content))
         end
 
         it 'marks rep as compiled' do
+          expect(Nanoc::Core::NotificationCenter).to receive(:post).with(:cached_content_used, rep)
           expect { subject }
             .to change { rep.compiled? }
             .from(false)
             .to(true)
         end
 
-        it 'changes compiled content cache' do
-          expect { subject }
-            .to change { compiled_content_cache[rep] }
-            .from(last: some_binary_content(binary_content))
-            .to(last: some_textual_content('wrapped content'))
-        end
+        it 'does not change compiled content cache' do
+          expect(Nanoc::Core::NotificationCenter).to receive(:post).with(:cached_content_used, rep)
 
-        it 'does not send notification' do
-          expect(Nanoc::Core::NotificationCenter).not_to receive(:post).with(:cached_content_used, rep)
-          subject
+          expect { subject }
+            .not_to change { compiled_content_cache[rep][:last].filename }
         end
       end
 

--- a/nanoc/spec/nanoc/base/services/compiler/stages/compile_reps_spec.rb
+++ b/nanoc/spec/nanoc/base/services/compiler/stages/compile_reps_spec.rb
@@ -25,7 +25,7 @@ describe Nanoc::Int::Compiler::Stages::CompileReps do
   let(:action_provider) { double(:action_provider) }
   let(:action_sequences) { double(:action_sequences) }
   let(:reps) { Nanoc::Int::ItemRepRepo.new }
-  let(:compiled_content_cache) { Nanoc::Int::TextualCompiledContentCache.new(config: config) }
+  let(:compiled_content_cache) { Nanoc::Int::CompiledContentCache.new(config: config) }
   let(:compiled_content_store) { Nanoc::Int::CompiledContentStore.new }
 
   let(:outdatedness_store) { Nanoc::Int::OutdatednessStore.new(config: config) }

--- a/nanoc/spec/nanoc/base/views/post_compile_item_rep_view_spec.rb
+++ b/nanoc/spec/nanoc/base/views/post_compile_item_rep_view_spec.rb
@@ -7,7 +7,14 @@ describe Nanoc::PostCompileItemRepView do
 
   it_behaves_like 'an item rep view'
 
-  let(:item_rep) { Nanoc::Core::ItemRep.new(item, :jacques) }
+  let(:item_rep) do
+    Nanoc::Core::ItemRep.new(item, :jacques).tap do |rep|
+      rep.snapshot_defs = snapshot_contents.map do |name, content|
+        Nanoc::Core::SnapshotDef.new(name, binary: content.binary?)
+      end
+    end
+  end
+
   let(:item) { Nanoc::Core::Item.new('asdf', {}, '/foo') }
   let(:view) { described_class.new(item_rep, view_context) }
 
@@ -37,7 +44,17 @@ describe Nanoc::PostCompileItemRepView do
   end
 
   let(:compiled_content_cache) do
-    Nanoc::Int::TextualCompiledContentCache.new(config: config).tap do |ccc|
+    # Pretend binary snapshots exist on disk so the binary cache can cache them.
+    snapshot_contents
+      .select { |_, content| content.binary? }
+      .each do |_, binary_content|
+        allow(FileUtils).to receive(:cp).with(binary_content.filename, anything)
+                                        .and_wrap_original do |_meth, _src, dst|
+          File.new(dst, 'w').close
+        end
+      end
+
+    Nanoc::Int::CompiledContentCache.new(config: config).tap do |ccc|
       ccc[item_rep] = snapshot_contents
     end
   end


### PR DESCRIPTION
### Detailed description

This is the same as #1398 with some modifications from my side. In particular:

* The textual and binary content caches now _only_ accept textual resp. binary content. I think the separation makes the design nicer.

* The binary content cache now keeps a data file which lists the items, their reps and their snapshots, rather than querying the filesystem. This is more in line with how `Store` is designed to work, but more importantly, this makes it possible to distinguish between the cases of an item having been compiled and resulting in no binary cached content, vs. the item _not_ having been compiled yet and the binary cached content not yet been available. This eliminates the need for `equals_snapshot_def`.

* Related, I was initially a bit worried about how backwards compatibility would be handled — if a site has leftovers in `tmp/nanoc` from an older version, will it work properly with a version of Nanoc that has binary content caching? It should, and part of the motivation of my refactoring is to make that a bit more clear. In particular, the implicit semantics of the compiled content caches was that if it returned `nil`, no usable compiled content is available and the affected item must be recompiled. This is still not quite clear yet, and I will work towards making that more explicit.

* There was some contract weirdness that was an error on my part, and didn’t reveal itself properly until the changes appeared. In particular, `a[b] = c` will _always_ return `c`, so giving it a contract for the return value makes no sense.

* The filenames used for caching are now a bit more artificial (all non-alphanumerical characters are replaced and a hash is appended, e.g. `/foo.md` becomes `_foo_md_6fb15048cf`). I’m more comfortable with this, because it makes the caching scheme rely less on the filesystem peculiarities, and I have the gut feeling that this is less likely to cause issues down the road.

* The current pruning system only prunes the content for entire items when they disappear. It does not remove content of a certain item _rep_ or a _snapshot_ when the item remains. I think I got away with it for textual items, but for binary items, it is likely to cause more issues down the line.

### To do

Let me get back to you about that.

* [x] The `???` comment needs, erm, to be replaced with something more meaningful.

* [x] Hardlinking is _not_ an option, and the relevant piece of code needs to have a comment explaining that, and probably also a test case that prevents it from happening in the future.

* [x] Remove `--backtrace` (does not belong in this PR)

* [ ] Prune not just items, but also their reps and snapshots.

### Related issues

* #1398 Cache binary content