### PR TITLE
Force-reset NotificationCenter after fork

### DIFF
--- a/guard-nanoc/lib/guard/nanoc.rb
+++ b/guard-nanoc/lib/guard/nanoc.rb
@@ -56,6 +56,9 @@ module Guard
     end
 
     def recompile
+      # Necessary, because forking and threading don’t work together.
+      ::Nanoc::Core::NotificationCenter.force_reset
+
       Dir.chdir(@dir) do
         site = ::Nanoc::Int::SiteLoader.new.new_from_cwd
         ::Nanoc::Int::Compiler.compile(site)

--- a/nanoc-core/lib/nanoc/core/notification_center.rb
+++ b/nanoc-core/lib/nanoc/core/notification_center.rb
@@ -48,6 +48,10 @@ module Nanoc
         @thread.join
       end
 
+      def force_stop
+        @queue << DONE
+      end
+
       def on(name, id = nil, &block)
         @notifications[name] << { id: id, block: block }
       end
@@ -85,6 +89,11 @@ module Nanoc
 
         def reset
           instance.stop
+          @_instance = nil
+        end
+
+        def force_reset
+          instance.force_stop
           @_instance = nil
         end
 


### PR DESCRIPTION
### Detailed description

The new `NotificationCenter` implementation uses a dedicated thread, but that unfortunately means that after a `fork`, the notification center stops working.

This fix forces a reset of the notification center right after forking.

### To do

Figure out how to test this.

### Related issues

Fixes #1409.