### PR TITLE
Let Zeitwerk ignore anything in core/core_ext

### DIFF
--- a/nanoc-core/lib/nanoc/core.rb
+++ b/nanoc-core/lib/nanoc/core.rb
@@ -27,9 +27,7 @@ end
 loader = Zeitwerk::Loader.new
 loader.inflector = inflector_class.new
 loader.push_dir(__dir__ + '/..')
-loader.ignore(File.expand_path('core/core_ext/array.rb', __dir__))
-loader.ignore(File.expand_path('core/core_ext/hash.rb', __dir__))
-loader.ignore(File.expand_path('core/core_ext/string.rb', __dir__))
+loader.ignore(File.expand_path('core/core_ext', __dir__))
 loader.setup
 loader.eager_load
 


### PR DESCRIPTION
I don't know if the original listing file by file was intentional (in which case please just disregard this PR), but it is possible to let Zeitwerk ignore directories too.