### PR TITLE
Add atom:link[type] attributes

### DIFF
--- a/nanoc/lib/nanoc/helpers/blogging.rb
+++ b/nanoc/lib/nanoc/helpers/blogging.rb
@@ -120,8 +120,8 @@ module Nanoc::Helpers
           xml.updated(updated.__nanoc_to_iso8601_time)
 
           # Add links
-          xml.link(rel: 'alternate', href: (alt_link || root_url))
-          xml.link(rel: 'self',      href: feed_url)
+          xml.link(rel: 'alternate', href: (alt_link || root_url), type: 'text/html')
+          xml.link(rel: 'self',      href: feed_url,               type: 'application/atom+xml')
 
           # Add author information
           xml.author do
@@ -163,7 +163,7 @@ module Nanoc::Helpers
           end
 
           # Add link
-          xml.link(rel: 'alternate', href: url)
+          xml.link(rel: 'alternate', href: url, type: 'text/html')
 
           # Add content
           summary = excerpt_proc.call(article)


### PR DESCRIPTION
### Detailed description

Adds media type hints to all links in Atom feeds. Adds the `atom:link[type="text/html"]` attribute to all web links and `atom:link[type="application/atom+xml"]` to the Atom self link.

RFC 4287 section 4.2.7.3.

### To do

* [ ] Approve and merge.
