### PR TITLE
Set a User-Agent for HTTP requests from :elinks

### DIFF
--- a/nanoc/lib/nanoc/checking/checks/external_links.rb
+++ b/nanoc/lib/nanoc/checking/checks/external_links.rb
@@ -125,6 +125,7 @@ module ::Nanoc::Checking::Checks
 
     def request_url_once(url)
       req = Net::HTTP::Get.new(path_for_url(url))
+      req['User-Agent'] = "Mozilla/5.0 Nanoc/#{Nanoc::VERSION} (link rot checker)"
       http = Net::HTTP.new(url.host, url.port)
       if url.instance_of? URI::HTTPS
         http.use_ssl = true


### PR DESCRIPTION
### Detailed description

* The default “Ruby” User-Agent is blocked everywhere so replace it.
* Include “Mozilla/5.0” to pass through a lot of blocking filters and because it’s required due to the legacy of the web.
* Include Nanoc software name and version to identify the software making the request.
* Describe the purpose of the request to help webmasters make informed blocking decisions.

Proposed User-Agent string:

    Mozilla/5.0 Nanoc/4.11.2 (link rot checker)

### To do

* [ ] Agree on User-Agent string.
* [ ] Add to change log.

## More details

In my own set of 1800 links, this change reduces the number of HTTP 403 Forbidden responses from 482 to 17. (Most of these are  probably hosted by a single large provider like Cloudflare.) This could probably be reduced even further by faking a mainstream web browser’s User-Agent string. However, I’d rather live with a handful of blocked tests than start faking User-Agents.