### PR TITLE
Report permanent redirects as errors in :external_links

### DIFF
--- a/nanoc/lib/nanoc/checking/checks/external_links.rb
+++ b/nanoc/lib/nanoc/checking/checks/external_links.rb
@@ -77,6 +77,10 @@ module ::Nanoc::Checking::Checks
           location = extract_location(res, url)
           return Result.new(href, 'redirection without a target location') if location.nil?
 
+          if /^30[18]$/.match?(res.code)
+            return Result.new(href, "link have moved permanently to '#{location}'") 
+          end
+
           url = URI.parse(location)
         elsif res.code == '200'
           return nil


### PR DESCRIPTION
### Detailed description

Report permanently redirected links as errors. Anyone concerned with link rot (e.g. anyone running this checker) will want to update their links as redirects tend to go away over time. This is the expected behavior for the 301 and 308 response codes in accordance with RFC 7538 and RFC 7231. I’ve written [a wall of text on the subject](https://www.ctrl.blog/entry/permanent-redirects.html) for anyone who might be interested in the details.

Prior art: The popular (700k installs) Broken Link Checker plugin for WordPress reports on permanent redirects.

### To do

* [ ] New behavior is on by default but should this have an off switch? I’d say no.

If required then this should be some generic something to filter out errors by status codes rather than an off switch per check-criteria.