### PR TITLE
Don’t fall back to :last content if :pre content is not yet available

### DIFF
--- a/nanoc/lib/nanoc/base/repos/compiled_content_store.rb
+++ b/nanoc/lib/nanoc/base/repos/compiled_content_store.rb
@@ -44,7 +44,8 @@ module Nanoc
       contract C::KeywordArgs[rep: Nanoc::Core::ItemRep, snapshot: C::Optional[C::Maybe[Symbol]]] => Nanoc::Core::Content
       def raw_compiled_content(rep:, snapshot: nil)
         # Get name of last pre-layout snapshot
-        snapshot_name = snapshot || (get(rep, :pre) ? :pre : :last)
+        has_pre = rep.snapshot_defs.any? { |sd| sd.name == :pre }
+        snapshot_name = snapshot || (has_pre ? :pre : :last)
 
         # Check existance of snapshot
         snapshot_def = rep.snapshot_defs.reverse.find { |sd| sd.name == snapshot_name }

--- a/nanoc/spec/nanoc/base/repos/compiled_content_store_spec.rb
+++ b/nanoc/spec/nanoc/base/repos/compiled_content_store_spec.rb
@@ -144,6 +144,26 @@ describe Nanoc::Int::CompiledContentStore do
       let(:expected_snapshot_name) { :last }
 
       include_examples 'a snapshot'
+
+      context 'when :pre and :last snapshot definitions exist' do
+        before do
+          rep.snapshot_defs = [
+            Nanoc::Core::SnapshotDef.new(:pre, binary: false),
+            Nanoc::Core::SnapshotDef.new(:last, binary: false),
+          ]
+        end
+
+        context 'when :last, but no :pre content is available' do
+          before do
+            content = Nanoc::Core::TextualContent.new('hellos')
+            repo.set_all(rep, last: content)
+          end
+
+          it 'does not use :last' do
+            expect { subject }.to yield_from_fiber(an_instance_of(Nanoc::Int::Errors::UnmetDependency))
+          end
+        end
+      end
     end
 
     context 'snapshot not specified' do
@@ -152,6 +172,26 @@ describe Nanoc::Int::CompiledContentStore do
       let(:expected_snapshot_name) { :last }
 
       include_examples 'a snapshot'
+
+      context 'when :pre and :last snapshot definitions exist' do
+        before do
+          rep.snapshot_defs = [
+            Nanoc::Core::SnapshotDef.new(:pre, binary: false),
+            Nanoc::Core::SnapshotDef.new(:last, binary: false),
+          ]
+        end
+
+        context 'when :last, but no :pre content is available' do
+          before do
+            content = Nanoc::Core::TextualContent.new('hellos')
+            repo.set_all(rep, last: content)
+          end
+
+          it 'does not use :last' do
+            expect { subject }.to yield_from_fiber(an_instance_of(Nanoc::Int::Errors::UnmetDependency))
+          end
+        end
+      end
     end
 
     context 'snapshot :pre specified' do

--- a/nanoc/spec/nanoc/regressions/gh_1412_spec.rb
+++ b/nanoc/spec/nanoc/regressions/gh_1412_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+describe 'GH-1412', site: true, stdio: true do
+  before do
+    FileUtils.mkdir_p('content')
+    File.write('content/a.erb', 'A <%= @items["/b.*"].compiled_content %>')
+    File.write('content/b.erb', 'B <%= @items["/a.*"].compiled_content %>')
+
+    FileUtils.mkdir_p('layouts')
+    File.write('layouts/default.erb', '[<%= yield %>]')
+
+    File.write('Rules', <<~EOS)
+      compile '/*' do
+        layout '/default.*'
+        filter :erb
+        write ext: 'html'
+      end
+
+      layout '/*', :erb
+    EOS
+  end
+
+  example do
+    Nanoc::CLI.run([])
+
+    expect(File.file?('output/a.html')).to be(true)
+    expect(File.read('output/a.html')).to eq('[A B <%= @items["/a.*"].compiled_content %>]')
+    expect(File.file?('output/b.html')).to be(true)
+    expect(File.read('output/b.html')).to eq('[B A <%= @items["/b.*"].compiled_content %>]')
+  end
+end


### PR DESCRIPTION
If the compiled content of an item is requested, there is the possibility that Nanoc will fall back to `:last`, even though `:pre` is available. This can happen when the `:pre` compiled content is not yet available.

Fixes #1412.