### PR TITLE
Rename Layout/IndentFirstArrayElement

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,7 +24,7 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   EnforcedStyle: consistent
 
 Naming/UncommunicativeMethodParamName:


### PR DESCRIPTION
### Detailed description

    Error: The `Layout/IndentArray` cop has been renamed to `Layout/IndentFirstArrayElement`.
    (obsolete configuration found in .rubocop.yml, please update it)