### PR TITLE
Shuffle external links list (:elinks checker)

### DIFF
--- a/nanoc/lib/nanoc/checking/checks/external_links.rb
+++ b/nanoc/lib/nanoc/checking/checks/external_links.rb
@@ -12,7 +12,7 @@ module ::Nanoc::Checking::Checks
       # TODO: de-duplicate this (duplicated in internal links check)
       filenames = output_html_filenames.reject { |f| excluded_file?(f) }
       hrefs_with_filenames = ::Nanoc::Extra::LinkCollector.new(filenames, :external).filenames_per_href
-      results = select_invalid(hrefs_with_filenames.keys)
+      results = select_invalid(hrefs_with_filenames.keys.shuffle)
 
       # Report them
       results.each do |res|


### PR DESCRIPTION
### Detailed description

Shuffle the list of links to test. The set will normally be sorted per item they were collected in and in many situation trend towards having the same origin repeated multiple times in a row.

Same-origin distance distribution (number of other links between links to the same origin) in my set of 2000+ links from 500 items **before** to change:

    Min.   1st Qu.  Median    Mean   3rd Qu.    Max. 
     1.0       2.0    10.0   135.8     103.8  2089.0 

Same-origin distance distribution **after** to change:

    Min.   1st Qu.  Median    Mean   3rd Qu.    Max. 
     1.0      15.0    52.5   207.0     202.0  1842.0

It’s not perfect but it’s an improvement.

### Related issues

 - #1418