### PR TITLE
Deep merge hrefs and resource_uris

### DIFF
--- a/nanoc/test/checking/checks/test_internal_links.rb
+++ b/nanoc/test/checking/checks/test_internal_links.rb
@@ -35,6 +35,22 @@ class Nanoc::Checking::Checks::InternalLinksTest < Nanoc::TestCase
     end
   end
 
+  def test_merge_uris
+    with_site do |site|
+      # Create files
+      FileUtils.mkdir_p('output')
+      File.open('output/page.html', 'w') { |io| io.write('<a href="README.html">README</a>') }
+      File.open('output/index.html', 'w') { |io| io.write('<link rel="canonical" href="README.html">') }
+
+      # Create check
+      check = Nanoc::Checking::Checks::InternalLinks.create(site)
+      check.run
+
+      # Test
+      assert check.issues.size == 2
+    end
+  end
+
   def test_valid?
     with_site do |site|
       # Create files


### PR DESCRIPTION
### Detailed description

By using `.merge` and not 'deep merging' we don't get the full list of filenames because `.merge` will allow the incoming Hash (`resource_uris_with_filenames`) to override the source Hash (`hrefs_with_filenames`).

This ultimately leads to invalid href's not being detected / reported.
 