### PR TITLE
Fix crash in show-data when printing layout outdatedness

### DIFF
--- a/nanoc/lib/nanoc/base/services/outdatedness_checker.rb
+++ b/nanoc/lib/nanoc/base/services/outdatedness_checker.rb
@@ -156,10 +156,13 @@ module Nanoc
         @_basic ||= Basic.new(outdatedness_checker: self, reps: @reps)
       end
 
-      contract C_ITEM_OR_REP, Hamster::Set => C::Bool
+      contract C_OBJ, Hamster::Set => C::Bool
       def outdated_due_to_dependencies?(obj, processed = Hamster::Set.new)
         # Convert from rep to item if necessary
         obj = obj.item if obj.is_a?(Nanoc::Core::ItemRep)
+
+        # Only items can have dependencies
+        return false unless obj.is_a?(Nanoc::Core::Item)
 
         # Get from cache
         if @objects_outdated_due_to_dependencies.key?(obj)

--- a/nanoc/spec/nanoc/regressions/gh_1428_spec.rb
+++ b/nanoc/spec/nanoc/regressions/gh_1428_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+describe 'GH-1428', site: true, stdio: true do
+  before do
+    FileUtils.mkdir_p('layouts')
+    File.write('layouts/default.erb', 'layout stuff')
+
+    File.write('Rules', <<~EOS)
+      ignore '/*'
+      layout '/*', :erb
+    EOS
+  end
+
+  example do
+    Nanoc::CLI.run([])
+    Nanoc::CLI.run(['show-data'])
+  end
+end


### PR DESCRIPTION
### Detailed description

`show-data` prints the outdatedness status of layouts. Unfortunately, the tests mock out the outdatedness checker, and the _real_ outdatedness checker does not permit calling `outdated_due_to_dependencies?` on layouts, only items and item reps.

This appears to be mostly a problem with the contracts that have been set up; the code appears to work fine without contracts in place.

Changing the `show-data` specs to not mock the outdatedness checker is rather difficult at this point, however.

### To do

* [x] Tests

### Related issues

Fixes #1428.
