### PR TITLE
Allow specifying excluded files across all checks

### DIFF
--- a/nanoc-core/lib/nanoc/core/configuration-schema.json
+++ b/nanoc-core/lib/nanoc/core/configuration-schema.json
@@ -78,6 +78,18 @@
     "checks": {
       "type": "object",
       "properties": {
+        "all": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "exclude_files": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "internal_links": {
           "type": "object",
           "additionalProperties": false,

--- a/nanoc-core/spec/nanoc/core/configuration_spec.rb
+++ b/nanoc-core/spec/nanoc/core/configuration_spec.rb
@@ -647,6 +647,26 @@ describe Nanoc::Core::Configuration do
       end
     end
 
+    context 'invalid checks (all has invalid type)' do
+      let(:hash) do
+        { checks: { all: 123 } }
+      end
+
+      it 'passes' do
+        expect { subject }.to raise_error(JsonSchema::Error)
+      end
+    end
+
+    context 'invalid checks (all.exclude_files has invalid type)' do
+      let(:hash) do
+        { checks: { all: { exclude_files: 'everything' } } }
+      end
+
+      it 'passes' do
+        expect { subject }.to raise_error(JsonSchema::Error)
+      end
+    end
+
     context 'invalid checks (internal_links has invalid type)' do
       let(:hash) do
         { checks: { internal_links: 123 } }

--- a/nanoc/lib/nanoc/checking/check.rb
+++ b/nanoc/lib/nanoc/checking/check.rb
@@ -12,6 +12,8 @@ module Nanoc::Checking
   class Check < Nanoc::Core::Context
     extend DDPlugin::Plugin
 
+    DDMemoize.activate(self)
+
     attr_reader :issues
 
     def self.define(ident, &block)
@@ -64,6 +66,20 @@ module Nanoc::Checking
       end
 
       @issues << Issue.new(desc, subject, self.class)
+    end
+
+    # @private
+    def output_filenames
+      super.reject { |f| excluded_patterns.any? { |pat| pat.match?(f) } }
+    end
+
+    # @private
+    memoized def excluded_patterns
+      @config
+        .fetch(:checks, {})
+        .fetch(:all, {})
+        .fetch(:exclude_files, [])
+        .map { |pattern| Regexp.new(pattern) }
     end
 
     # @private

--- a/nanoc/spec/nanoc/checking/check_spec.rb
+++ b/nanoc/spec/nanoc/checking/check_spec.rb
@@ -54,11 +54,33 @@ describe Nanoc::Checking::Check do
     end
   end
 
-  describe '#output_html_filenames' do
-    subject { check.output_html_filenames }
+  describe '#output_filenames' do
+    subject { check.output_filenames }
 
     let(:check) do
-      described_class.new(output_filenames: output_filenames)
+      described_class.new(
+        output_filenames: output_filenames,
+        config: Nanoc::ConfigView.new(config, view_context),
+      )
+    end
+
+    let(:config) do
+      Nanoc::Core::Configuration.new(
+        dir: Dir.getwd,
+        hash: config_hash,
+      )
+    end
+
+    let(:config_hash) { {} }
+
+    let(:view_context) do
+      double(:view_context, dependency_tracker: dependency_tracker)
+    end
+
+    let(:dependency_tracker) do
+      double(:dependency_tracker).tap do |dt|
+        allow(dt).to receive(:bounce)
+      end
     end
 
     let(:output_filenames) do
@@ -72,12 +94,92 @@ describe Nanoc::Checking::Check do
       ]
     end
 
-    it { is_expected.to include('output/foo.html') }
-    it { is_expected.to include('output/foo.htm') }
-    it { is_expected.to include('output/foo.xhtml') }
+    context 'when exclude_files is unset' do
+      it { is_expected.to include('output/foo.htm') }
+      it { is_expected.to include('output/foo.html') }
+      it { is_expected.to include('output/foo.htmlx') }
+      it { is_expected.to include('output/foo.txt') }
+      it { is_expected.to include('output/foo.xhtml') }
+      it { is_expected.to include('output/foo.yhtml') }
+    end
 
-    it { is_expected.not_to include('output/foo.txt') }
-    it { is_expected.not_to include('output/foo.htmlx') }
-    it { is_expected.not_to include('output/foo.yhtml') }
+    context 'when exclude_files is set' do
+      let(:config_hash) do
+        { checks: { all: { exclude_files: ['foo.xhtml'] } } }
+      end
+
+      it { is_expected.to include('output/foo.htm') }
+      it { is_expected.to include('output/foo.html') }
+      it { is_expected.to include('output/foo.htmlx') }
+      it { is_expected.to include('output/foo.txt') }
+      it { is_expected.to include('output/foo.yhtml') }
+
+      it { is_expected.not_to include('output/foo.xhtml') }
+    end
+  end
+
+  describe '#output_html_filenames' do
+    subject { check.output_html_filenames }
+
+    let(:check) do
+      described_class.new(
+        output_filenames: output_filenames,
+        config: Nanoc::ConfigView.new(config, view_context),
+      )
+    end
+
+    let(:config) do
+      Nanoc::Core::Configuration.new(
+        dir: Dir.getwd,
+        hash: config_hash,
+      )
+    end
+
+    let(:config_hash) { {} }
+
+    let(:view_context) do
+      double(:view_context, dependency_tracker: dependency_tracker)
+    end
+
+    let(:dependency_tracker) do
+      double(:dependency_tracker).tap do |dt|
+        allow(dt).to receive(:bounce)
+      end
+    end
+
+    let(:output_filenames) do
+      [
+        'output/foo.html',
+        'output/foo.htm',
+        'output/foo.xhtml',
+        'output/foo.txt',
+        'output/foo.htmlx',
+        'output/foo.yhtml',
+      ]
+    end
+
+    context 'when exclude_files is unset' do
+      it { is_expected.to include('output/foo.html') }
+      it { is_expected.to include('output/foo.htm') }
+      it { is_expected.to include('output/foo.xhtml') }
+
+      it { is_expected.not_to include('output/foo.txt') }
+      it { is_expected.not_to include('output/foo.htmlx') }
+      it { is_expected.not_to include('output/foo.yhtml') }
+    end
+
+    context 'when exclude_files is set' do
+      let(:config_hash) do
+        { checks: { all: { exclude_files: ['foo.xhtml'] } } }
+      end
+
+      it { is_expected.to include('output/foo.html') }
+      it { is_expected.to include('output/foo.htm') }
+
+      it { is_expected.not_to include('output/foo.xhtml') }
+      it { is_expected.not_to include('output/foo.txt') }
+      it { is_expected.not_to include('output/foo.htmlx') }
+      it { is_expected.not_to include('output/foo.yhtml') }
+    end
   end
 end


### PR DESCRIPTION
### Detailed description

This allows specifying files to exclude across all checks. Previously, each check had its own way to specify files to exclude.

To exclude certain files, list then under the `exclude_files` property, under the `all` property of `checks`, e.g.

```
checks:
  all:
    exclude_files:
      - bad.html
      - worse.html
```

### To do

* [x] Tests
* [ ] Documentation
* [x] Update JSON schema

### Related issues

Closes nanoc/features#51.