### PR TITLE
Fix handling of protocol-relative URLs

### DIFF
--- a/nanoc/lib/nanoc/extra/link_collector.rb
+++ b/nanoc/lib/nanoc/extra/link_collector.rb
@@ -113,10 +113,15 @@ module ::Nanoc::Extra
 
       # Resolve paths relative to the filename, return invalid URIs as-is
       uris.map! do |uri|
-        begin
-          URI.join(base_uri, uri).to_s
-        rescue
+        if uri.start_with?('//')
+          # Don’t modify protocol-relative URLs. They’re absolute!
           uri
+        else
+          begin
+            URI.join(base_uri, uri).to_s
+          rescue
+            uri
+          end
         end
       end
 

--- a/nanoc/test/checking/checks/test_internal_links.rb
+++ b/nanoc/test/checking/checks/test_internal_links.rb
@@ -143,4 +143,18 @@ class Nanoc::Checking::Checks::InternalLinksTest < Nanoc::TestCase
       assert check.issues.empty?
     end
   end
+
+  def test_protocol_relative_url
+    # Protocol-relative URLs are not internal links.
+
+    with_site do |site|
+      FileUtils.mkdir_p('output')
+      File.write('output/a.html', '<a href="//example.com/broken">broken</a>')
+
+      check = Nanoc::Checking::Checks::InternalLinks.create(site)
+      check.run
+
+      assert check.issues.empty?
+    end
+  end
 end

--- a/nanoc/test/extra/test_link_collector.rb
+++ b/nanoc/test/extra/test_link_collector.rb
@@ -145,4 +145,26 @@ class Nanoc::Extra::LinkCollectorTest < Nanoc::TestCase
     assert_includes hrefs, 'https://nanoc.ws/'
     assert_includes hrefs, 'https://nanoc.ws/all-your-base-are-belong-to-us'
   end
+
+  def test_protocol_relative_urls
+    File.write('a.html', '<a href="//example.com/broken">broken</a>')
+
+    external_collector =
+      Nanoc::Extra::LinkCollector.new(['a.html'], :external)
+
+    internal_collector =
+      Nanoc::Extra::LinkCollector.new(['a.html'], :internal)
+
+    hrefs = external_collector.filenames_per_href.keys
+    assert_includes hrefs, '//example.com/broken'
+    refute_includes hrefs, 'http://example.com/broken'
+    refute_includes hrefs, 'file:///example.com/broken'
+    refute_includes hrefs, 'file://example.com/broken'
+
+    hrefs = internal_collector.filenames_per_href.keys
+    refute_includes hrefs, '//example.com/broken'
+    refute_includes hrefs, 'http://example.com/broken'
+    refute_includes hrefs, 'file:///example.com/broken'
+    refute_includes hrefs, 'file://example.com/broken'
+  end
 end


### PR DESCRIPTION
Protocol-relative URLs (e.g. `//example.com/foo`) were previously treated as internal links (e.g. `file:///example.com/foo`).

### To do

* [x] Tests

### Related issues

Fixes #1442.
