### PR TITLE
Let dep tracker properly recognise re-added items

### DIFF
--- a/nanoc-core/lib/nanoc/core/dependency_store.rb
+++ b/nanoc-core/lib/nanoc/core/dependency_store.rb
@@ -184,8 +184,8 @@ module Nanoc
         @graph = Nanoc::Core::DirectedGraph.new([nil] + refs)
 
         # Load vertices
-        previous_refs = new_data[:vertices]
-        previous_objects = Set.new(refs2objs(previous_refs))
+        previous_objects = refs2objs(new_data[:vertices])
+        previous_refs = objs2refs(previous_objects)
 
         # Load edges
         new_data[:edges].each do |edge|

--- a/nanoc/spec/nanoc/regressions/gh_1463_spec.rb
+++ b/nanoc/spec/nanoc/regressions/gh_1463_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+describe 'GH-1463', site: true, stdio: true do
+  before do
+    FileUtils.mkdir_p('content')
+    FileUtils.mkdir_p('content/org1')
+
+    File.write('content/org1.erb', <<~CONTENT)
+      <ul>
+      <% children_of(@item).each do |c| %>
+        <li><%= c[:title] %></li>
+      <% end %>
+      </ul>
+    CONTENT
+
+    File.write('content/org1/oink.md', <<~CONTENT)
+      ---
+      title: Oink
+      ---
+
+      here is oink content
+    CONTENT
+
+    FileUtils.mkdir_p('lib')
+    File.write('lib/default.rb', <<~LIB)
+      include Nanoc::Helpers::ChildParent
+    LIB
+
+    File.write('Rules', <<~RULES)
+      compile '/**/*' do
+        filter :erb
+        write ext: 'html'
+      end
+    RULES
+  end
+
+  example do
+    Nanoc::CLI.run([])
+    expect(File.file?('output/org1.html')).to be(true)
+    expect(File.read('output/org1.html')).to match(%r{<li>Oink</li>})
+
+    # Remove oink
+    FileUtils.rm('content/org1/oink.md')
+    Nanoc::CLI.run([])
+    expect(File.file?('output/org1.html')).to be(true)
+    expect(File.read('output/org1.html')).not_to match(%r{<li>Oink</li>})
+
+    # Re-add oink
+    File.write('content/org1/oink.md', <<~CONTENT)
+      ---
+      title: Oink
+      ---
+
+      here is oink content
+    CONTENT
+    Nanoc::CLI.run([])
+    expect(File.file?('output/org1.html')).to be(true)
+    expect(File.read('output/org1.html')).to match(%r{<li>Oink</li>})
+  end
+end


### PR DESCRIPTION
### Detailed description

Fixes #1463 

### To do

* [ ] Refactor dependency tracker so that this does not happen as easily again
* [ ] Fine-grained tests

### Related issues

#1463 
