### PR TITLE
Warn when both guard-nanoc and nanoc-live are present

### DIFF
--- a/guard-nanoc/lib/nanoc/orig_cli/commands/live.rb
+++ b/guard-nanoc/lib/nanoc/orig_cli/commands/live.rb
@@ -19,6 +19,18 @@ module Nanoc::CLI::Commands
       require 'guard'
       require 'guard/commander'
 
+      if defined?(Nanoc::Live)
+        $stderr.puts '-' * 40
+        $stderr.puts 'NOTE:'
+        $stderr.puts 'You are using the `nanoc live` command provided by `guard-nanoc`, but the `nanoc-live` gem is also installed, which also provides a `nanoc live` command.'
+        if defined?(Bundler)
+          $stderr.puts 'Recommendation: Remove `guard-nanoc` from your Gemfile.'
+        else
+          $stderr.puts 'Recommendation: Uninstall `guard-nanoc`.'
+        end
+        $stderr.puts '-' * 40
+      end
+
       Thread.new do
         # Crash the entire process if the viewer dies for some reason (e.g.
         # the port is already bound).

--- a/nanoc-live/lib/nanoc/live/commands/live.rb
+++ b/nanoc-live/lib/nanoc/live/commands/live.rb
@@ -16,6 +16,18 @@ no_params
 module Nanoc::Live::Commands
   class Live < ::Nanoc::CLI::CommandRunner
     def run
+      if defined?(Guard::Nanoc)
+        $stderr.puts '-' * 40
+        $stderr.puts 'NOTE:'
+        $stderr.puts 'You are using the `nanoc live` command provided by `nanoc-live`, but the `guard-nanoc` gem is also installed, which also provides a `nanoc live` command.'
+        if defined?(Bundler)
+          $stderr.puts 'Recommendation: Remove `guard-nanoc` from your Gemfile.'
+        else
+          $stderr.puts 'Recommendation: Uninstall `guard-nanoc`.'
+        end
+        $stderr.puts '-' * 40
+      end
+
       self.class.enter_site_dir
 
       Thread.new do


### PR DESCRIPTION
### Detailed description

The “nanoc live” command can be provided by two gems. This is confusing, so let’s add a warning.

### To do

nothing

### Related issues

* fixes #1450
