### PR TITLE
Make pruner print things on dry run

### DIFF
--- a/nanoc-cli/lib/nanoc/cli/commands/prune.rb
+++ b/nanoc-cli/lib/nanoc/cli/commands/prune.rb
@@ -22,6 +22,10 @@ module Nanoc::CLI::Commands
       res = Nanoc::Core::Compiler.new_for(@site).run_until_reps_built
       reps = res.fetch(:reps)
 
+      listener_class = Nanoc::CLI::CompileListeners::FileActionPrinter
+      listener = listener_class.new(reps: reps)
+      listener.start_safely
+
       if options.key?(:yes)
         Nanoc::Core::Pruner.new(@site.config, reps, exclude: prune_config_exclude).run
       elsif options.key?(:'dry-run')
@@ -32,6 +36,8 @@ module Nanoc::CLI::Commands
         $stderr.puts 'Please ensure that the output directory does not contain any files (such as images or stylesheets) that are necessary but are not managed by Nanoc. If you want to get a list of all files that would be removed, pass --dry-run.'
         exit 1
       end
+    ensure
+      listener&.stop_safely
     end
 
     protected

--- a/nanoc-cli/lib/nanoc/cli/compile_listeners/file_action_printer.rb
+++ b/nanoc-cli/lib/nanoc/cli/compile_listeners/file_action_printer.rb
@@ -59,6 +59,10 @@ module Nanoc::CLI::CompileListeners
       on(:file_pruned) do |path|
         Nanoc::CLI::Logger.instance.file(:high, :delete, path)
       end
+
+      on(:file_listed_for_pruning) do |path|
+        Nanoc::CLI::Logger.instance.file(:high, :delete, '(dry run) ' + path)
+      end
     end
 
     # @see Listener#stop

--- a/nanoc-core/lib/nanoc/core/pruner.rb
+++ b/nanoc-core/lib/nanoc/core/pruner.rb
@@ -111,8 +111,12 @@ module Nanoc
       end
 
       def log_delete_and_run(thing)
-        Nanoc::Core::NotificationCenter.post(:file_pruned, thing)
-        yield unless @dry_run
+        if @dry_run
+          Nanoc::Core::NotificationCenter.post(:file_listed_for_pruning, thing)
+        else
+          Nanoc::Core::NotificationCenter.post(:file_pruned, thing)
+          yield
+        end
       end
     end
   end

--- a/nanoc/test/orig_cli/commands/test_prune.rb
+++ b/nanoc/test/orig_cli/commands/test_prune.rb
@@ -65,7 +65,11 @@ class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
       File.open('output2/foo.html', 'w')   { |io| io.write 'this is a foo.' }
       File.open('output2/index.html', 'w') { |io| io.write 'this is a index.' }
 
-      Nanoc::CLI.run %w[prune --dry-run]
+      io = capturing_stdio do
+        Nanoc::CLI.run %w[prune --dry-run]
+      end
+      assert_match %r{^\s+delete\s+\(dry run\) .*\/output2\/index\.html$}, io[:stdout]
+      assert_match %r{^\s+delete\s+\(dry run\) .*\/output2\/foo\.html$}, io[:stdout]
 
       assert File.file?('output2/index.html')
       assert File.file?('output2/foo.html')


### PR DESCRIPTION
The notification center approach works only during compilation; invoking `nanoc prune` won’t set up the right notification listeners.

CC @Fjan 

### Detailed description

The output has also changed slightly, to reflect the actual “delete” log entry more closely.

### To do

* [x] Tests

### Related issues

Fixes #1474 
