### PR TITLE
Remove safe_level support in ERB

### DIFF
--- a/nanoc/lib/nanoc/filters/erb.rb
+++ b/nanoc/lib/nanoc/filters/erb.rb
@@ -11,9 +11,6 @@ module Nanoc::Filters
     #
     # @param [String] content The content to filter
     #
-    # @option params [Integer] :safe_level (nil) The safe level (`$SAFE`) to
-    #   use while running this filter
-    #
     # @option params [String] :trim_mode (nil) The trim mode to use
     #
     # @return [String] The filtered content
@@ -29,9 +26,8 @@ module Nanoc::Filters
       assigns_binding = context.get_binding(&proc)
 
       # Get result
-      safe_level = params[:safe_level]
       trim_mode = params[:trim_mode]
-      erb = ::ERB.new(content, safe_level, trim_mode)
+      erb = ::ERB.new(content, nil, trim_mode)
       erb.filename = filename
       erb.result(assigns_binding)
     end

--- a/nanoc/spec/nanoc/filters/erb_spec.rb
+++ b/nanoc/spec/nanoc/filters/erb_spec.rb
@@ -134,34 +134,4 @@ describe Nanoc::Filters::ERB do
       end
     end
   end
-
-  context 'safe level' do
-    subject do
-      filter.setup_and_run('<%= eval File.read("moo") %>', params)
-    end
-
-    let(:filter) { described_class.new }
-
-    let(:res) { { success: false } }
-
-    before do
-      File.write('moo', '1+2')
-    end
-
-    context 'safe level unchanged' do
-      let(:params) { {} }
-
-      it 'honors safe level' do
-        expect(subject).to eq('3')
-      end
-    end
-
-    context 'safe level set' do
-      let(:params) { { safe_level: 1 } }
-
-      it 'honors safe level' do
-        expect { subject }.to raise_error(SecurityError)
-      end
-    end
-  end
 end


### PR DESCRIPTION
### Detailed description

$SAFE_LEVEL and ERB’s safe_level parameter are deprecated and will be removed in Ruby 3. For Nanoc, keeping it around doesn’t make sense, as it’s not working properly anymore anyway, and it’s not useful for Nanoc.

This brings us a step closer to making Nanoc work on Ruby 2.7.

### To do

n/a

### Related issues

n/a
