### PR TITLE
Don't hardcode the current class in Nanoc::Checking::Check

### DIFF
--- a/nanoc-checking/lib/nanoc/checking/check.rb
+++ b/nanoc-checking/lib/nanoc/checking/check.rb
@@ -18,7 +18,7 @@ module Nanoc
       attr_reader :issues
 
       def self.define(ident, &block)
-        klass = Class.new(::Nanoc::Checking::Check) { identifier(ident) }
+        klass = Class.new(self) { identifier(ident) }
         klass.send(:define_method, :run) do
           instance_exec(&block)
         end


### PR DESCRIPTION
### Detailed description

This very simple change avoid repeating a class name. It also has the very nice side effect of allowing one to subclass Nanoc::Checking::Check to use custom helpers.

Example with a `ensure_matches_regex` helper:

```ruby
class ContentCheck < Nanoc::Checking::Check
  def ensure_matches_regex(filename, regex)
    add_issue(name, subject: filename) if File.read(filename).match?(regex)
  end
end

ContentCheck.define(:foobar) do
  @output_filenames.each do |filename|
    ensure_matches_regex(filename, /html/)
  end
end
```

