### PR TITLE
Emit warning when contracts is loaded

### DIFF
--- a/common/spec/spec_helper_head_core.rb
+++ b/common/spec/spec_helper_head_core.rb
@@ -8,6 +8,8 @@ if ENV['CI'] == 'true'
   SimpleCov.formatter = SimpleCov::Formatter::Codecov
 end
 
+ENV['NANOC_DEV_MODE'] = 'true'
+
 require 'fuubar'
 require 'rspec/its'
 require 'timecop'

--- a/nanoc-core/lib/nanoc/core/contracts_support.rb
+++ b/nanoc-core/lib/nanoc/core/contracts_support.rb
@@ -103,6 +103,8 @@ module Nanoc
           ::Contracts.const_set('Named', EnabledContracts::Named)
           ::Contracts.const_set('IterOf', EnabledContracts::IterOf)
           ::Contracts.const_set('AbsolutePathString', EnabledContracts::AbsolutePathString)
+
+          warn_about_performance
         end
 
         @_contracts_support__should_enable
@@ -125,6 +127,24 @@ module Nanoc
           base.extend(DisabledContracts)
           base.const_set('C', DisabledContracts)
         end
+      end
+
+      def self.warn_about_performance
+        return if ENV.key?('CI')
+        return if ENV.key?('NANOC_DEV_MODE')
+
+        puts '-' * 78
+        puts 'A NOTE ABOUT PERFORMANCE:'
+        puts 'The `contracts` gem is loaded, which enables extra run-time checks, but can drastically reduce Nanoc’s performance. The `contracts` gem is intended for development purposes, and is not recommended for day-to-day Nanoc usage.'
+        puts
+
+        if defined?(Bundler)
+          puts 'To speed up compilation, remove `contracts` from the Gemfile and run `bundle install`.'
+        else
+          puts 'To speed up compilation, either uninstall the `contracts` gem, or use Bundler (https://bundler.io/) with a Gemfile that doesn’t include `contracts`.'
+        end
+
+        puts '-' * 78
       end
     end
   end

--- a/nanoc-core/spec/meta_spec.rb
+++ b/nanoc-core/spec/meta_spec.rb
@@ -76,7 +76,12 @@ describe 'meta', chdir: false do
 
   it 'doesn’t log anything' do
     # TODO: don’t have any exceptions
-    regular_files = Dir['lib/nanoc/core/**/*.rb'] - ['lib/nanoc/core/data_source.rb']
+    regular_files =
+      Dir['lib/nanoc/core/**/*.rb'] -
+      [
+        'lib/nanoc/core/data_source.rb',
+        'lib/nanoc/core/contracts_support.rb',
+      ]
 
     expect(regular_files).to all(satisfy do |fn|
       content = File.read(fn)


### PR DESCRIPTION
### Detailed description

Nanoc will emit a warning when it notices that `contracts` is loaded.

When using Bundler:

```
------------------------------------------------------------------------------
A NOTE ABOUT PERFORMANCE:
The `contracts` gem is loaded, which enables extra run-time checks, but can
drastically reduce Nanoc’s performance. The `contracts` gem is intended for
development purposes, and is not recommended for day-to-day Nanoc usage.

To speed up compilation, remove `contracts` from the Gemfile and run
`bundle install`.
------------------------------------------------------------------------------
```

When not using Bundler:

```
------------------------------------------------------------------------------
A NOTE ABOUT PERFORMANCE:
The `contracts` gem is loaded, which enables extra run-time checks, but can
drastically reduce Nanoc’s performance. The `contracts` gem is intended for
development purposes, and is not recommended for day-to-day Nanoc usage.

To speed up compilation, either uninstall the `contracts` gem, or use Bundler
(https://bundler.io/) with a Gemfile that doesn’t include `contracts`.
------------------------------------------------------------------------------
```

If `NANOC_DEV_MODE` or `CI` is set, this warning will not be printed.

### Related issues

Fixes #1483
