### PR TITLE
Let default Rules handle index.* files (fixes #1485)

### DIFF
--- a/nanoc-cli/lib/nanoc/cli/commands/create-site.rb
+++ b/nanoc-cli/lib/nanoc/cli/commands/create-site.rb
@@ -35,14 +35,14 @@ module Nanoc::CLI::Commands
     DEFAULT_RULES = <<~EOS unless defined? DEFAULT_RULES
       #!/usr/bin/env ruby
 
-      compile '/index.html' do
-        layout '/default.*'
-        write '/index.html'
-      end
-
       compile '/**/*.html' do
         layout '/default.*'
-        write item.identifier.without_ext + '/index.html'
+
+        if item.identifier =~ '**/index.*'
+          write item.identifier.to_s
+        else
+          write item.identifier.without_ext + '/index.html'
+        end
       end
 
       # This is an example rule that matches Markdown (.md) files, and filters them
@@ -52,7 +52,12 @@ module Nanoc::CLI::Commands
       #compile '/**/*.md' do
       #  filter :kramdown
       #  layout '/default.*'
-      #  write item.identifier.without_ext + '/index.html'
+      #
+      #  if item.identifier =~ '**/index.*'
+      #    write item.identifier.to_s
+      #  else
+      #    write item.identifier.without_ext + '/index.html'
+      #  end
       #end
 
       compile '/**/*' do

--- a/nanoc/test/orig_cli/commands/test_create_site.rb
+++ b/nanoc/test/orig_cli/commands/test_create_site.rb
@@ -123,4 +123,28 @@ class Nanoc::CLI::Commands::CreateSiteTest < Nanoc::TestCase
       refute File.file?('output/blah.txt')
     end
   end
+
+  def test_default_site_routes_items_properly
+    Nanoc::CLI.run %w[create_site foo]
+
+    FileUtils.cd('foo') do
+      FileUtils.mkdir_p('content/bar')
+      File.write('content/index.html', 'Index')
+      File.write('content/foo.html', 'Foo')
+      File.write('content/bar/index.html', 'Bar Index')
+      File.write('content/bar/qux.html', 'Bar Qux')
+
+      site = Nanoc::Core::SiteLoader.new.new_from_cwd
+      Nanoc::Core::Compiler.compile(site)
+
+      assert File.file?('output/index.html')
+      assert File.file?('output/foo/index.html')
+      assert File.file?('output/bar/index.html')
+      assert File.file?('output/bar/qux/index.html')
+      assert_match(/Index/, File.read('output/index.html'))
+      assert_match(/Foo/, File.read('output/foo/index.html'))
+      assert_match(/Bar Index/, File.read('output/bar/index.html'))
+      assert_match(/Bar Qux/, File.read('output/bar/qux/index.html'))
+    end
+  end
 end


### PR DESCRIPTION
### Detailed description

This changes the default rules so it handles `index` filenames a bit better:

* `/index.md` --> `/index.html`
* `/index.html` --> `/index.html`
* `/foo/index.md` --> `/foo/index.html`
* `/foo/index.html` --> `/foo/index.html`

### To do

* [ ] Does the default Rules file need clarifying comments?
* [ ] (AFTER MERGE) Update the nanoc.ws documentation to reflect the new default Rules file

### Related issues

Fixes #1485.