### PR TITLE
Relativize `value` attribute of <param>, not `content`

### DIFF
--- a/nanoc/lib/nanoc/filters/relativize_paths.rb
+++ b/nanoc/lib/nanoc/filters/relativize_paths.rb
@@ -15,7 +15,7 @@ module Nanoc::Filters
         '*/@href',
         '*/@src',
         'object/@data',
-        'param[@name="movie"]/@content',
+        'param[@name="movie"]/@value',
         'form/@action',
         'comment()',
       ].freeze

--- a/nanoc/spec/nanoc/filters/relativize_paths_spec.rb
+++ b/nanoc/spec/nanoc/filters/relativize_paths_spec.rb
@@ -129,10 +129,10 @@ describe Nanoc::Filters::RelativizePaths do
         it { is_expected.to eq('<object data="../foo/bar"></object>') }
       end
 
-      context 'param content' do
-        let(:content) { '<param name="movie" content="/foo/bar.swf">' }
+      context 'param value' do
+        let(:content) { '<param name="movie" value="/foo/bar.swf">' }
 
-        it { is_expected.to eq('<param name="movie" content="../foo/bar.swf">') }
+        it { is_expected.to eq('<param name="movie" value="../foo/bar.swf">') }
       end
     end
 

--- a/nanoc/test/filters/test_relativize_paths.rb
+++ b/nanoc/test/filters/test_relativize_paths.rb
@@ -384,11 +384,11 @@ class Nanoc::Filters::RelativizePathsTest < Nanoc::TestCase
       @item_rep.paths[:last] = ['/woof/meow/']
     end
 
-    raw_content    = %(<object data="/example"><param name="movie" content="/example"></object>)
+    raw_content    = %(<object data="/example"><param name="movie" value="/example"></object>)
     actual_content = filter.setup_and_run(raw_content, type: :html)
 
     assert_match(/<object data="..\/..\/example">/, actual_content)
-    assert_match(/<param (name="movie" )?content="..\/..\/example"/, actual_content)
+    assert_match(/<param (name="movie" )?value="..\/..\/example"/, actual_content)
   end
 
   def test_filter_form


### PR DESCRIPTION
The `param` element has an attribute `value`, not `content`. Therefore, the `relativize_paths` filter needs to be updated to use `value` instead.