### PR TITLE
Relativize srcset

### DIFF
--- a/nanoc/lib/nanoc/extra.rb
+++ b/nanoc/lib/nanoc/extra.rb
@@ -17,4 +17,5 @@ end
 
 require_relative 'extra/link_collector'
 require_relative 'extra/jruby_nokogiri_warner'
+require_relative 'extra/srcset_parser'
 require_relative 'extra/core_ext'

--- a/nanoc/lib/nanoc/extra/srcset_parser.rb
+++ b/nanoc/lib/nanoc/extra/srcset_parser.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Nanoc
+  module Extra
+    # @api private
+    class SrcsetParser
+      class InvalidFormat < ::Nanoc::Core::Error
+        def initialize
+          super('Invalid srcset format')
+        end
+      end
+
+      REGEX_REST =
+        /
+          (               # Zero or one of the following:
+            (             #   A width descriptor, consisting of:
+              \s+         #     ASCII whitespace
+              \d+         #     a valid non-negative integer
+              w           #     a U+0077 LATIN SMALL LETTER W character
+            )
+            |
+            (             #   A pixel density descriptor, consisting of
+              \s+         #     ASCII whitespace
+              (\d*\.)?\d+ #     a valid floating-point number
+              x           #     and a U+0078 LATIN SMALL LETTER X character.
+            )
+          )*
+        /x.freeze
+
+      def initialize(value)
+        @value = value
+      end
+
+      def call
+        matches = []
+
+        loop do
+          match = {}
+
+          scan(/\s*/)
+          match[:url] = scan(/[^, ]+/)
+          match[:rest] = scan(REGEX_REST)
+          scan(/\s*/)
+
+          if try_scan(/,/)
+            matches << match
+            next
+          end
+
+          if eos?
+            matches << match
+            break
+          end
+        end
+
+        matches
+      rescue InvalidFormat
+        @value
+      end
+
+      private
+
+      def scan(pattern)
+        match = try_scan(pattern)
+
+        match || raise(InvalidFormat)
+      end
+
+      def try_scan(pattern)
+        scanner.scan(pattern)
+      end
+
+      def eos?
+        scanner.eos?
+      end
+
+      def scanner
+        @_scanner ||= StringScanner.new(@value)
+      end
+    end
+  end
+end

--- a/nanoc/nanoc.manifest
+++ b/nanoc/nanoc.manifest
@@ -17,6 +17,7 @@ lib/nanoc/extra/core_ext.rb
 lib/nanoc/extra/core_ext/time.rb
 lib/nanoc/extra/jruby_nokogiri_warner.rb
 lib/nanoc/extra/link_collector.rb
+lib/nanoc/extra/srcset_parser.rb
 lib/nanoc/filters.rb
 lib/nanoc/filters/asciidoc.rb
 lib/nanoc/filters/asciidoctor.rb

--- a/nanoc/spec/nanoc/extra/srcset_parser_spec.rb
+++ b/nanoc/spec/nanoc/extra/srcset_parser_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+describe Nanoc::Extra::SrcsetParser do
+  subject(:parsed) { described_class.new(value).call }
+
+  let(:value) { 'http://example.com/a.jpg' }
+
+  test_cases = {
+    'http://example.com/a.jpg 2w 3x' =>
+      [{ url: 'http://example.com/a.jpg', rest: ' 2w 3x' }],
+
+    'http://example.com/a.jpg 2w' =>
+      [{ url: 'http://example.com/a.jpg', rest: ' 2w' }],
+
+    'http://example.com/a.jpg 2w 2w 2w 2w 2w' =>
+      [{ url: 'http://example.com/a.jpg', rest: ' 2w 2w 2w 2w 2w' }],
+
+    'http://example.com/a.jpg 123456x' =>
+      [{ url: 'http://example.com/a.jpg', rest: ' 123456x' }],
+
+    '   http://example.com/a.jpg 2w 3x   ' =>
+      [{ url: 'http://example.com/a.jpg', rest: ' 2w 3x' }],
+
+    '   http://example.com/a.jpg 2w 3x  , http://example.com/b.jpg  4x 4x 5w  ' =>
+      [{ url: 'http://example.com/a.jpg', rest: ' 2w 3x' }, { url: 'http://example.com/b.jpg', rest: '  4x 4x 5w' }],
+  }
+
+  test_cases.each do |input, expected_output|
+    context "with #{input}" do
+      let(:value) { input }
+
+      it 'parses properly' do
+        expect(parsed).to eq(expected_output)
+      end
+    end
+  end
+end

--- a/nanoc/spec/nanoc/filters/relativize_paths_spec.rb
+++ b/nanoc/spec/nanoc/filters/relativize_paths_spec.rb
@@ -134,6 +134,12 @@ describe Nanoc::Filters::RelativizePaths do
 
         it { is_expected.to eq('<param name="movie" value="../foo/bar.swf">') }
       end
+
+      context 'img srcset' do
+        let(:content) { '<img srcset="  /foo/bar.png 1w 2x , /foo/bloop.png 2w, /foo/asdf.jpg 12w 128x ">' }
+
+        it { is_expected.to eq('<img srcset="../foo/bar.png 1w 2x,../foo/bloop.png 2w,../foo/asdf.jpg 12w 128x">') }
+      end
     end
 
     context 'XHTML' do


### PR DESCRIPTION
This lets the `relativize_paths` filter deal with `srcset` attributes.

### To do

* [x] Tests

### Related issues

Fixes #1475.
