### PR TITLE
Fix: Handle non-array keys when loading checksums

### DIFF
--- a/nanoc-core/lib/nanoc/core/checksum_store.rb
+++ b/nanoc-core/lib/nanoc/core/checksum_store.rb
@@ -64,7 +64,7 @@ module Nanoc
 
         @checksums = {}
         new_data.each_pair do |key, checksum|
-          if references.include?(key) || references.include?(key.first)
+          if references.include?(key) || (key.respond_to?(:first) && references.include?(key.first))
             @checksums[key] = checksum
           end
         end

--- a/nanoc-core/spec/nanoc/core/checksum_store_spec.rb
+++ b/nanoc-core/spec/nanoc/core/checksum_store_spec.rb
@@ -57,6 +57,28 @@ describe Nanoc::Core::ChecksumStore do
     end
   end
 
+  context 'after storing and loading missing data' do
+    let(:code_snippet_a) { Nanoc::Core::CodeSnippet.new('aaa', 'lib/aaa.rb') }
+    let(:code_snippet_b) { Nanoc::Core::CodeSnippet.new('bbb', 'lib/bbb.rb') }
+    let(:code_snippet_c) { Nanoc::Core::CodeSnippet.new('ccc', 'lib/ccc.rb') }
+
+    before do
+      store.add(code_snippet_a)
+      store.add(code_snippet_b)
+      store.add(code_snippet_c)
+      store.store
+
+      # remove B
+      store.objects = [code_snippet_a, code_snippet_c]
+      store.load
+    end
+
+    it 'has checksums for A and C' do
+      expect(store[code_snippet_a]).not_to be_nil
+      expect(store[code_snippet_c]).not_to be_nil
+    end
+  end
+
   context 'setting content on unknown non-document' do
     before { store.add(other_code_snippet) }
 


### PR DESCRIPTION
An exception was triggered on `key.first`, because not all keys are arrays (tuples). This exception would cause Store#load to delete the (presumed broken) checksums file, causing some checksusm to be nil, and therefore causing some items to be outdated.

(Describe the change in detail.)

### To do

* [x] Tests

### Related issues

Fixes #1471.
