### PR TITLE
Ignore redirects to self (misued for cookies)

### DIFF
--- a/nanoc-checking/lib/nanoc/checking/checks/external_links.rb
+++ b/nanoc-checking/lib/nanoc/checking/checks/external_links.rb
@@ -79,6 +79,9 @@ module Nanoc
               location = extract_location(res, url)
               return Result.new(href, 'redirection without a target location') if location.nil?
 
+              # ignore redirects back onto self (misused to set HTTP cookies)
+              return nil if href == location
+              
               if /^30[18]$/.match?(res.code)
                 return Result.new(href, "link has moved permanently to '#{location}'")
               end


### PR DESCRIPTION
### Detailed description

Websites increasingly common redirect URLs back onto itself to set HTTP cookies. This change just ignores redirects from /A to /A for permanent redirects. A proper fix would require to implement the `Referer` header and support session cookies. That’s too much work to support broken sites. This change could possibly ignore misconfigured websites that accidentally create permanent redirect loops without trying to force cookies upon clients.

### To do

(Include the to-do list for this PR to be finished here.)

* [ ] Tests
* [ ] Documentation
* [ ] Feature flags
* [ ] …

### Related issues

(Add issue IDs for related issues here.)
