### PR TITLE
Fix some more “Using the last argument …” warnings

### DIFF
--- a/nanoc-core/lib/nanoc/core/compiled_content_cache.rb
+++ b/nanoc-core/lib/nanoc/core/compiled_content_cache.rb
@@ -46,8 +46,8 @@ module Nanoc
         @binary_cache[rep] = content.select { |_key, c| c.binary? }
       end
 
-      def prune(*args)
-        @wrapped_caches.each { |w| w.prune(*args) }
+      def prune(items:)
+        @wrapped_caches.each { |w| w.prune(items: items) }
       end
 
       # True if there is cached compiled content available for this item, and

--- a/nanoc-core/lib/nanoc/core/compiler_loader.rb
+++ b/nanoc-core/lib/nanoc/core/compiler_loader.rb
@@ -32,7 +32,7 @@ module Nanoc
           outdatedness_store: outdatedness_store,
         }
 
-        Nanoc::Core::Compiler.new(site, params)
+        Nanoc::Core::Compiler.new(site, **params)
       end
 
       def compiled_content_cache_class

--- a/nanoc-core/lib/nanoc/core/dependency_store.rb
+++ b/nanoc-core/lib/nanoc/core/dependency_store.rb
@@ -113,7 +113,7 @@ module Nanoc
         src_ref = obj2ref(src)
         dst_ref = obj2ref(dst)
 
-        existing_props = Nanoc::Core::DependencyProps.new(@graph.props_for(dst_ref, src_ref) || {})
+        existing_props = Nanoc::Core::DependencyProps.new(**(@graph.props_for(dst_ref, src_ref) || {}))
         new_props = Nanoc::Core::DependencyProps.new(raw_content: raw_content, attributes: attributes, compiled_content: compiled_content, path: path)
         props = existing_props.merge(new_props)
 

--- a/nanoc-core/spec/nanoc/core/compilation_item_view_spec.rb
+++ b/nanoc-core/spec/nanoc/core/compilation_item_view_spec.rb
@@ -243,7 +243,7 @@ describe Nanoc::Core::CompilationItemView do
   end
 
   describe '#compiled_content' do
-    subject { view.compiled_content(params) }
+    subject { view.compiled_content(**params) }
 
     let(:view) { described_class.new(item, view_context) }
 
@@ -322,7 +322,7 @@ describe Nanoc::Core::CompilationItemView do
   end
 
   describe '#path' do
-    subject { view.path(params) }
+    subject { view.path(**params) }
 
     let(:view) { described_class.new(item, view_context) }
 


### PR DESCRIPTION
This fixes (hopefully) all remaining “warning: Using the last argument as keyword parameters is deprecated” warnings.

### Related issues

Fixes remaining issues related to #1479.
