### PR TITLE
Fixed 'nanoc()' Sass function definition

### DIFF
--- a/nanoc/lib/nanoc/filters/sass/functions.rb
+++ b/nanoc/lib/nanoc/filters/sass/functions.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ::Sass::Script::Functions
-  def nanoc(string, params)
+  def nanoc(string, params = {})
     assert_type string, :String
     assert_type params, :Hash
     result = options[:importer].filter.instance_eval(string.value)


### PR DESCRIPTION
### Detailed description

The `nanoc()` Sass function takes optional keyword arguments. The counterpart Ruby function must be defined with a default hash.