### PR TITLE
Wait longer for files to appear

### DIFF
--- a/nanoc-core/lib/nanoc/core/compilation_item_rep_view.rb
+++ b/nanoc-core/lib/nanoc/core/compilation_item_rep_view.rb
@@ -3,6 +3,12 @@
 module Nanoc
   module Core
     class CompilationItemRepView < ::Nanoc::Core::BasicItemRepView
+      # How long to wait before the requested file appears.
+      #
+      # This is a bit of a hack -- ideally, Nanoc would know that the file is
+      # being generated, and wait the appropriate amount of time.
+      FILE_APPEAR_TIMEOUT = 10.0
+
       # @abstract
       def item_view_class
         Nanoc::Core::CompilationItemView
@@ -27,7 +33,7 @@ module Nanoc
         # Wait for file to exist
         if res
           start = Time.now
-          sleep 0.05 until File.file?(res) || Time.now - start > 1.0
+          sleep 0.05 until File.file?(res) || Time.now - start > FILE_APPEAR_TIMEOUT
           raise Nanoc::Core::Errors::InternalInconsistency, "File did not apear in time: #{res}" unless File.file?(res)
         end
 


### PR DESCRIPTION
### Detailed description

At the moment, when an output file is needed, Nanoc will wait at most 1s for that file to appear (it could be in process of being filtered still).

1s is not enough, so this bumps up the timeout to 10s.

Ideally, this would not be necessary, and Nanoc would know that this file is being processed and that it is okay to wait for an extended amount of time, without timeout.

### To do

* [ ] Tests

### Related issues

n/a