### PR TITLE
nanoc-cli: Only try to clean UTF-8 chars from UTF-8 strings

### DIFF
--- a/nanoc-cli/lib/nanoc/cli/stream_cleaners/utf8.rb
+++ b/nanoc-cli/lib/nanoc/cli/stream_cleaners/utf8.rb
@@ -8,7 +8,7 @@ module Nanoc
       class UTF8 < Abstract
         # @see Nanoc::CLI::StreamCleaners::Abstract#clean
         def clean(str)
-          return unless str.encoding.name == 'UTF-8'
+          return str unless str.encoding.name == 'UTF-8'
 
           # FIXME: this decomposition is not generally usable
           str

--- a/nanoc-cli/lib/nanoc/cli/stream_cleaners/utf8.rb
+++ b/nanoc-cli/lib/nanoc/cli/stream_cleaners/utf8.rb
@@ -8,6 +8,8 @@ module Nanoc
       class UTF8 < Abstract
         # @see Nanoc::CLI::StreamCleaners::Abstract#clean
         def clean(str)
+          return unless str.encoding.name == 'UTF-8'
+
           # FIXME: this decomposition is not generally usable
           str
             .unicode_normalize(:nfkd)

--- a/nanoc-cli/spec/nanoc/cli/stream_cleaners/utf8_spec.rb
+++ b/nanoc-cli/spec/nanoc/cli/stream_cleaners/utf8_spec.rb
@@ -9,7 +9,7 @@ describe Nanoc::CLI::StreamCleaners::UTF8 do
     it 'does not attempt to clean the string' do
       expect(str).not_to receive(:unicode_normalize)
 
-      subject.clean(str)
+      expect(subject.clean(str)).to eq(str)
     end
   end
 

--- a/nanoc-cli/spec/nanoc/cli/stream_cleaners/utf8_spec.rb
+++ b/nanoc-cli/spec/nanoc/cli/stream_cleaners/utf8_spec.rb
@@ -3,6 +3,16 @@
 describe Nanoc::CLI::StreamCleaners::UTF8 do
   subject { described_class.new }
 
+  context 'when passed a string that is not UTF-8 encoded' do
+    let(:str) { String.new('Not UTF-8', encoding: 'ASCII-8BIT') }
+
+    it 'does not attempt to clean the string' do
+      expect(str).not_to receive(:unicode_normalize)
+
+      subject.clean(str)
+    end
+  end
+
   it 'handles all cases' do
     expect(subject.clean('┼─ “© Denis” ‘and others…’ ─┼')).to eq('+- "(c) Denis" \'and others...\' -+')
   end


### PR DESCRIPTION
### Detailed description

Previously, when attempting to load a custom filter in a Windows Nanoc
installation, Nanoc was crashing with indications that the UTF-8 stream cleaner
was unable to process the supplied string.
Now, we only attempt to clean UTF-8 characters out of the string if it is UTF-8
encoded.

### To do

(Include the to-do list for this PR to be finished here.)

* [x] Tests

### Related issues

Should fix #1502. (Including the contracts gem issue).
