### PR TITLE
Use concurrent-ruby’s thread pool implementation

### DIFF
--- a/nanoc-core/lib/nanoc/core.rb
+++ b/nanoc-core/lib/nanoc/core.rb
@@ -9,6 +9,7 @@ require 'tmpdir'
 require 'yaml'
 
 # External gems
+require 'concurrent-ruby'
 require 'json_schema'
 require 'ddmemoize'
 require 'ddmetrics'

--- a/nanoc-core/lib/nanoc/core/compilation_phases/write.rb
+++ b/nanoc-core/lib/nanoc/core/compilation_phases/write.rb
@@ -6,45 +6,6 @@ module Nanoc
       class Write < Abstract
         include Nanoc::Core::ContractsSupport
 
-        class Worker
-          def initialize(queue:, compiled_content_store:)
-            @queue = queue
-            @compiled_content_store = compiled_content_store
-          end
-
-          def start
-            @thread = Thread.new do
-              Thread.current.abort_on_exception = true
-              Thread.current.priority = -1 # schedule I/O work ASAP
-
-              writer = Nanoc::Core::ItemRepWriter.new
-
-              while rep = @queue.pop # rubocop:disable Lint/AssignmentInCondition
-                writer.write_all(rep, @compiled_content_store)
-              end
-            end
-          end
-
-          def join
-            @thread.join
-          end
-        end
-
-        class WorkerPool
-          def initialize(queue:, size:, compiled_content_store:)
-            @workers = Array.new(size) { Worker.new(queue: queue, compiled_content_store: compiled_content_store) }
-          end
-
-          def start
-            @workers.each(&:start)
-          end
-
-          def join
-            @workers.each(&:join)
-          end
-        end
-
-        QUEUE_SIZE = 40
         WORKER_POOL_SIZE = 5
 
         def initialize(compiled_content_store:, wrapped:)
@@ -52,19 +13,16 @@ module Nanoc
 
           @compiled_content_store = compiled_content_store
 
-          @queue = SizedQueue.new(QUEUE_SIZE)
-          @worker_pool = WorkerPool.new(queue: @queue, size: WORKER_POOL_SIZE, compiled_content_store: @compiled_content_store)
-        end
+          @pool = Concurrent::FixedThreadPool.new(WORKER_POOL_SIZE)
 
-        def start
-          super
-          @worker_pool.start
+          @writer = Nanoc::Core::ItemRepWriter.new
         end
 
         def stop
+          @pool.shutdown
+          @pool.wait_for_termination
+
           super
-          @queue.close
-          @worker_pool.join
         end
 
         contract Nanoc::Core::ItemRep, C::KeywordArgs[is_outdated: C::Bool], C::Func[C::None => C::Any] => C::Any
@@ -76,7 +34,9 @@ module Nanoc
           # notification happens before the :rep_write_enqueued one.
           Nanoc::Core::NotificationCenter.post(:rep_write_enqueued, rep)
 
-          @queue << rep
+          @pool.post do
+            @writer.write_all(rep, @compiled_content_store)
+          end
         end
       end
     end

--- a/nanoc-core/nanoc-core.gemspec
+++ b/nanoc-core/nanoc-core.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '~> 2.4'
 
+  s.add_runtime_dependency('concurrent-ruby', '~> 1.1')
   s.add_runtime_dependency('ddmemoize', '~> 1.0')
   s.add_runtime_dependency('ddmetrics', '~> 1.0')
   s.add_runtime_dependency('ddplugin', '~> 1.0')


### PR DESCRIPTION
### Detailed description

As #1501 revealed, the thread pool implementation in the `Write` phase has issues. Rather than fixing the implementation, this replaces the implementation with what `concurrent-ruby` provides, which is likely superior in all ways.

### To do

* [x] Tests
* ~~Documentation~~
* ~~Feature flags~~

### Related issues

This should fix #1501.