### PR TITLE
Do copy-on-write cloning of unchanged output files.

### DIFF
--- a/nanoc-core/lib/nanoc/core.rb
+++ b/nanoc-core/lib/nanoc/core.rb
@@ -20,6 +20,12 @@ require 'tomlrb'
 require 'tty-platform'
 require 'zeitwerk'
 
+# Optional gems
+begin
+  require 'clonefile'
+rescue LoadError
+end
+
 module Nanoc
   module Core
     # Similar to `nil` except that it can only be compared against using


### PR DESCRIPTION
### Detailed description

Do a copy-on-write (CoW) filesystem-aware reflink-copy/extent cloning when item_rep is identical to the source content (item_rep.item). This is like a hardlink, except the two files are detached when either of them are changed. So you get the deduplication benefit, without the risk of accidentally changing a source file when modifying an output file. This assumes that item_rep.item.filename is a file on the disk and that it’s a source file. Fallback to a hardlink or full copy, as per the old implementation.

Requires the [clonefile gem](https://rubygems.org/gems/clonefile). Feature is not enabled by default, but kicks in when this gem is installed.

The gem supports Btrfs, OCFS2, and XFS on Linux 4.5+; and APFS on macOS 10.12.1+. (No ZFS support yet, sorry.)

### To do

* [ ] Document optional gem in installation instructions.
* [ ] Existing tests cover the basic functionality. Adding tests to inspect the files system to determine whether a file extent is a hardlink, cloned/reflink, or regular file would be nice. However, this is a huge task and requires more specific test OS environments.