### PR TITLE
Make TempFilenameFactory threadsafe

### DIFF
--- a/nanoc-core/lib/nanoc/core/temp_filename_factory.rb
+++ b/nanoc-core/lib/nanoc/core/temp_filename_factory.rb
@@ -14,6 +14,7 @@ module Nanoc
       def initialize
         @counts = {}
         @root_dir = Dir.mktmpdir('nanoc')
+        @mutex = Mutex.new
       end
 
       # @param [String] prefix A string prefix to include in the temporary
@@ -21,8 +22,11 @@ module Nanoc
       #
       # @return [String] A new unused filename
       def create(prefix)
-        count = @counts.fetch(prefix, 0)
-        @counts[prefix] = count + 1
+        count = nil
+        @mutex.synchronize do
+          count = @counts.fetch(prefix, 0)
+          @counts[prefix] = count + 1
+        end
 
         dirname  = File.join(@root_dir, prefix)
         filename = File.join(@root_dir, prefix, count.to_s)

--- a/nanoc-core/spec/nanoc/core/temp_filename_factory_spec.rb
+++ b/nanoc-core/spec/nanoc/core/temp_filename_factory_spec.rb
@@ -40,6 +40,20 @@ describe Nanoc::Core::TempFilenameFactory do
       path = subject.create(prefix)
       expect(File.file?(path)).not_to be(true)
     end
+
+    it 'is threadsafe' do
+      pool = Concurrent::FixedThreadPool.new(100)
+
+      # Post
+      10_000.times { pool.post { subject.create(prefix) } }
+
+      # Wait for completion
+      pool.shutdown
+      pool.wait_for_termination
+
+      # Check
+      expect(subject.create(prefix)).to end_with('/10000')
+    end
   end
 
   describe '#cleanup' do


### PR DESCRIPTION
It is used in multiple places (CompilationPhases::Write specifically) and therefore needs to be threadsafe.

### To do

* [x] Tests

### Related issues

Fixes #1501.
