### PR TITLE
Prefer copy-on-write cloning to hardlinking

### DIFF
--- a/nanoc-core/lib/nanoc/core.rb
+++ b/nanoc-core/lib/nanoc/core.rb
@@ -9,6 +9,7 @@ require 'tmpdir'
 require 'yaml'
 
 # External gems
+require 'clonefile'
 require 'concurrent-ruby'
 require 'json_schema'
 require 'ddmemoize'

--- a/nanoc-core/lib/nanoc/core/item_rep_writer.rb
+++ b/nanoc-core/lib/nanoc/core/item_rep_writer.rb
@@ -78,6 +78,14 @@ module Nanoc
       end
 
       def smart_cp(from, to)
+        # Try clonefile
+        FileUtils.rm_f(to)
+        begin
+          res = Clonefile.always(from, to)
+          return if res
+        rescue Clonefile::UnsupportedPlatform, Errno::ENOTSUP, Errno::EXDEV, Errno::EINVAL
+        end
+
         # Try with hardlink
         begin
           FileUtils.ln(from, to, force: true)

--- a/nanoc-core/nanoc-core.gemspec
+++ b/nanoc-core/nanoc-core.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '~> 2.4'
 
+  s.add_runtime_dependency('clonefile', '~> 0.5.2')
   s.add_runtime_dependency('concurrent-ruby', '~> 1.1')
   s.add_runtime_dependency('ddmemoize', '~> 1.0')
   s.add_runtime_dependency('ddmetrics', '~> 1.0')

--- a/nanoc-core/spec/nanoc/core/item_rep_writer_spec.rb
+++ b/nanoc-core/spec/nanoc/core/item_rep_writer_spec.rb
@@ -65,15 +65,6 @@ describe Nanoc::Core::ItemRepWriter do
         expect(File.read('output/blah.dat')).to eql('binary donkey stuff')
       end
 
-      it 'uses hard links' do
-        subject
-
-        input = File.stat(snapshot_contents[:donkey].filename)
-        output = File.stat('output/blah.dat')
-
-        expect(input.ino).to eq(output.ino)
-      end
-
       context 'output file already exists' do
         let(:old_mtime) { Time.at((Time.now - 600).to_i) }
 

--- a/nanoc-live/spec/nanoc/live/live_recompiler_spec.rb
+++ b/nanoc-live/spec/nanoc/live/live_recompiler_spec.rb
@@ -124,7 +124,7 @@ describe Nanoc::Live::LiveRecompiler, site: true, stdio: true, fork: true do
 
     sleep 1.0 # HFS+ mtime resolution is 1s
     File.write('lib/lol.rb', 'def greeting; "yo"; end')
-    sleep 0.1 until File.read('output/lol.html') == 'yo'
+    sleep 0.1 until File.file?('output/lol.html') && File.read('output/lol.html') == 'yo'
 
     # Stop
     Process.kill('INT', pid)


### PR DESCRIPTION
### Detailed description

This is based on #1509 by @da2x.

I’ve tested this out locally and it seems to work wonderfully — it does not have the disadvantage of a hardlink (a file being shared between content/ and output/), but still has all its advantages.

The difference with #1509 is that it uses clonefile the same way as hardlinks: it doesn’t use `content.filename` but just `tmp_path` (which is a location inside `tmp/`, or `content/` if no filters were applied) and `raw_path` (which is a location in `output/`). It also doesn’t use `FileUtils.identical?`, which is not needed and would make compilation slower.

A 20 GB file in content/ is instantly copied* to output/.

### To do

* ~~Tests~~ — This is particularly hard to test, as a clone is almost identical to a copy.
* ~~Feature flags~~ — This behavior is not enabled unless you explicitly add `clonefile` to the Gemfile
* [ ] Attribution

### Related issues

#1509