### PR TITLE
Don’t use --initial-branch option of `git init`

### DIFF
--- a/nanoc-deploying/spec/nanoc/deploying/deployers/git_spec.rb
+++ b/nanoc-deploying/spec/nanoc/deploying/deployers/git_spec.rb
@@ -18,15 +18,21 @@ describe Nanoc::Deploying::Deployers::Git, stdio: true do
   end
 
   def add_changes_to_remote
-    system('git', 'init', '--quiet', '--initial-branch=master', 'rere_tmp')
+    system('git', 'init', '--quiet', 'rere_tmp')
     Dir.chdir('rere_tmp') do
       system('git', 'config', 'user.name', 'Zebra Platypus')
       system('git', 'config', 'user.email', 'zebra@platypus.example.com')
       system('git', 'remote', 'add', 'origin', '../rere')
 
+      # Ensure we’re on the master branch (--initial-branch is not supported by all Git versions)
+      unless `git symbolic-ref --short HEAD` == 'master'
+        system('git', 'checkout', '--quiet', '-b', 'master')
+      end
+
       File.write('evil.txt', 'muaha')
       system('git', 'add', 'evil.txt')
       system('git', 'commit', '--quiet', '-m', 'muaha')
+
       system('git', 'checkout', '--quiet', '-b', 'giraffe')
       system('git', 'push', '--quiet', 'origin', 'master')
       system('git', 'push', '--quiet', 'origin', 'giraffe')
@@ -140,7 +146,7 @@ describe Nanoc::Deploying::Deployers::Git, stdio: true do
 
   shared_examples 'remote configured properly' do
     before do
-      system('git', 'init', '--bare', '--quiet', '--initial-branch=master', 'rere')
+      system('git', 'init', '--bare', '--quiet', 'rere')
     end
 
     context 'default branch' do
@@ -157,6 +163,11 @@ describe Nanoc::Deploying::Deployers::Git, stdio: true do
         before do
           Dir.chdir(output_dir) do
             system('git', 'commit', '--quiet', '-m', 'init', '--allow-empty')
+
+            # Ensure we’re on the master branch (--initial-branch is not supported by all Git versions)
+            unless `git symbolic-ref --short HEAD` == 'master'
+              system('git', 'checkout', '--quiet', '-b', 'master')
+            end
           end
         end
 
@@ -218,7 +229,13 @@ describe Nanoc::Deploying::Deployers::Git, stdio: true do
     context 'output dir is a Git repo' do
       before do
         Dir.chdir(output_dir) do
-          system('git', 'init', '--initial-branch=master', '--quiet')
+          system('git', 'init', '--quiet')
+
+          # Ensure we’re on the master branch (--initial-branch is not supported by all Git versions)
+          unless `git symbolic-ref --short HEAD` == 'master'
+            system('git', 'checkout', '--quiet', '-b', 'master')
+          end
+
           system('git', 'config', 'user.name', 'Donkey Giraffe')
           system('git', 'config', 'user.email', 'donkey@giraffe.example.com')
         end


### PR DESCRIPTION
### Detailed description

It’s only supported in Git versions newer than what CircleCI provides.

### To do

* [ ] Remove error message `fatal: A branch named 'master' already exists.`.

### Related issues

n/a