### PR TITLE
Install bundle into a cacheable location

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,9 +20,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: bundler-a-${{ runner.os }}-${{ matrix.ruby-version }}-${{ hashFiles('Gemfile') }}
+          key: bundler-b-${{ runner.os }}-${{ matrix.ruby-version }}-${{ hashFiles('Gemfile') }}
 
-      - run: bundle install
+      - run: bundle install --path=vendor/bundle
 
       - name: Test nanoc-core
         run: bundle exec rake nanoc-core


### PR DESCRIPTION
This makes `bundle install` use `--path`, so that it installs in a place where the `cache` GitHub action can be used.