### PR TITLE
Fix GitHub Actions bundle install path

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,7 +23,9 @@ jobs:
           path: vendor/bundle
           key: bundler-b-${{ runner.os }}-${{ matrix.ruby-version }}-${{ hashFiles('Gemfile') }}
 
-      - run: bundle install --path=vendor/bundle
+      - run: |
+          bundle config set --local path 'vendor/bundle'
+          bundle install
 
       - name: Test nanoc-core
         run: bundle exec rake nanoc_core:test

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,7 +25,7 @@ jobs:
 
       - run: |
           bundle config set --local path 'vendor/bundle'
-          bundle install
+          bundle install --jobs "$(nproc)"
 
       - name: Test nanoc-core
         run: bundle exec rake nanoc_core:test


### PR DESCRIPTION
### Detailed description

Using `bundle install --path` is deprecated, use recommended/up to date way to configure install path.

```
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local path 'vendor/bundle'`, and stop using this flag
```

I also took the opportunity to install gems in parallel.

### Related issues

Follow up of nanoc/nanoc/pull/1534
