### PR TITLE
Spelling and more descriptive error

### DIFF
--- a/nanoc-core/lib/nanoc/core/compilation_item_rep_view.rb
+++ b/nanoc-core/lib/nanoc/core/compilation_item_rep_view.rb
@@ -34,7 +34,7 @@ module Nanoc
         if res
           start = Time.now
           sleep 0.05 until File.file?(res) || Time.now - start > FILE_APPEAR_TIMEOUT
-          raise Nanoc::Core::Errors::InternalInconsistency, "File did not appear in time: #{res}" unless File.file?(res)
+          raise Nanoc::Core::Errors::InternalInconsistency, "File raw_path did not appear in time (#{FILE_APPEAR_TIMEOUT}s): #{res}" unless File.file?(res)
         end
 
         res

--- a/nanoc-core/lib/nanoc/core/compilation_item_rep_view.rb
+++ b/nanoc-core/lib/nanoc/core/compilation_item_rep_view.rb
@@ -34,7 +34,7 @@ module Nanoc
         if res
           start = Time.now
           sleep 0.05 until File.file?(res) || Time.now - start > FILE_APPEAR_TIMEOUT
-          raise Nanoc::Core::Errors::InternalInconsistency, "File did not apear in time: #{res}" unless File.file?(res)
+          raise Nanoc::Core::Errors::InternalInconsistency, "File did not appear in time: #{res}" unless File.file?(res)
         end
 
         res


### PR DESCRIPTION
I've seen this randomly for as long as I've used Nanoc, but I've never bothered to read the code to learn that it was caused by my use of `raw_path`. I thought it was just some random item that sometimes randomly failed. (E.g. sitemaps cause this through `File.mtime(item.raw_path)`.)

I can calculate the item[:mtime] in the preprocessor and save myself random errors, but first I needed to learn that this was caused by `raw_path`. Hoping the new error can help others better understand what happens and save them time.