### PR TITLE
Add support video/@poster to relativize_paths

### DIFF
--- a/nanoc/lib/nanoc/filters/relativize_paths.rb
+++ b/nanoc/lib/nanoc/filters/relativize_paths.rb
@@ -15,6 +15,7 @@ module Nanoc::Filters
         '*/@href',
         '*/@src',
         'object/@data',
+        'video/@poster',
         'param[@name="movie"]/@value',
         'form/@action',
         'comment()',


### PR DESCRIPTION
## Detailed description

Add the selector `video/@poster` to `SELECTORS` of `:relativize_paths` filter in order to relativize the path in `poster` attribute of `video` tag.

## Example of generated HTML

Before:

```html
<video poster="/assets/example.png">
  <source src="../assets/example.mp4" type="video/mp4">
</video>
```

After:

```html
<video poster="../assets/example.png">
  <source src="../assets/example.mp4" type="video/mp4">
</video>
```

## References

1. [\<video\>: The Video Embed element - HTML: HyperText Markup Language | MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#attributes)

