### PR TITLE
Drop Nokogumbo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,8 +65,7 @@ group :plugins do
   gem 'maruku'
   gem 'mime-types'
   gem 'mustache', '~> 1.0'
-  gem 'nokogiri', '~> 1.8'
-  gem 'nokogumbo', '~> 2.0', platforms: :ruby
+  gem 'nokogiri', '~> 1.12'
   gem 'pandoc-ruby'
   gem 'pygments.rb', '~> 2.0', platforms: :ruby
   gem 'rack'

--- a/nanoc-cli/lib/nanoc/cli/error_handler.rb
+++ b/nanoc-cli/lib/nanoc/cli/error_handler.rb
@@ -191,7 +191,6 @@ module Nanoc::CLI
       'mustache' => 'mustache',
       'nanoc/live' => 'nanoc-live',
       'nokogiri' => 'nokogiri',
-      'nokogumbo' => 'nokogumbo',
       'pandoc-ruby' => 'pandoc-ruby',
       'pry' => 'pry',
       'rack' => 'rack',

--- a/nanoc/lib/nanoc/filters/colorize_syntax.rb
+++ b/nanoc/lib/nanoc/filters/colorize_syntax.rb
@@ -80,7 +80,7 @@ module Nanoc::Filters
         require 'nokogiri'
         Nokogiri::HTML
       when :html5
-        require 'nokogumbo'
+        require 'nokogiri'
         Nokogiri::HTML5
       when :xml, :xhtml
         require 'nokogiri'

--- a/nanoc/lib/nanoc/filters/relativize_paths.rb
+++ b/nanoc/lib/nanoc/filters/relativize_paths.rb
@@ -114,7 +114,7 @@ module Nanoc::Filters
         require 'nokogiri'
         ::Nokogiri::HTML
       when :html5
-        require 'nokogumbo'
+        require 'nokogiri'
         ::Nokogiri::HTML5
       when :xml
         require 'nokogiri'

--- a/nanoc/test/filters/colorize_syntax/test_common.rb
+++ b/nanoc/test/filters/colorize_syntax/test_common.rb
@@ -54,7 +54,7 @@ class Nanoc::Filters::ColorizeSyntax::CommonTest < Nanoc::TestCase
   end
 
   def test_full_page_html5
-    skip_unless_have 'nokogumbo'
+    skip_unless_have 'nokogiri'
 
     # Create filter
     filter = ::Nanoc::Filters::ColorizeSyntax.new

--- a/nanoc/test/filters/test_relativize_paths.rb
+++ b/nanoc/test/filters/test_relativize_paths.rb
@@ -120,7 +120,7 @@ class Nanoc::Filters::RelativizePathsTest < Nanoc::TestCase
   end
 
   def test_filter_html5_with_boilerplate
-    skip_unless_have 'nokogumbo'
+    skip_unless_have 'nokogiri'
 
     # Create filter with mock item
     filter = Nanoc::Filters::RelativizePaths.new


### PR DESCRIPTION
### Detailed description

Nokogumbo has merged into Nokogiri. Prints warning every time Nanoc runs. Require Nokogiri ~> 1.12 and drop Nokogumbo.

### Related issues

Resolves #1546.