### PR TITLE
Switch ERB to use keyword arguments

### DIFF
--- a/nanoc/lib/nanoc/filters/erb.rb
+++ b/nanoc/lib/nanoc/filters/erb.rb
@@ -27,7 +27,7 @@ module Nanoc::Filters
 
       # Get result
       trim_mode = params[:trim_mode]
-      erb = ::ERB.new(content, nil, trim_mode)
+      erb = ::ERB.new(content, trim_mode: trim_mode)
       erb.filename = filename
       erb.result(assigns_binding)
     end


### PR DESCRIPTION
### Detailed description

Positional arguments were deprecated in Ruby 3. Change is backwards-compatible to Ruby 2.3.

### Related issues

Resolves #1547.