### PR TITLE
Fix: Don’t redefine use_helper function (fixes #1548)

### DIFF
--- a/nanoc-core/lib/nanoc/core/code_snippet.rb
+++ b/nanoc-core/lib/nanoc/core/code_snippet.rb
@@ -36,7 +36,13 @@ module Nanoc
       # @return [void]
       def load
         # rubocop:disable Security/Eval
-        eval('def self.use_helper(mod); Nanoc::Core::Context.instance_eval { include mod }; end', TOPLEVEL_BINDING)
+        eval(<<~CODE, TOPLEVEL_BINDING)
+          unless respond_to?(:use_helper)
+            def self.use_helper(mod)
+              Nanoc::Core::Context.instance_eval { include mod }
+            end
+          end
+        CODE
         eval(@data, TOPLEVEL_BINDING, @filename)
         # rubocop:enable Security/Eval
         nil

--- a/nanoc-core/spec/nanoc/core/code_snippet_spec.rb
+++ b/nanoc-core/spec/nanoc/core/code_snippet_spec.rb
@@ -56,5 +56,18 @@ describe Nanoc::Core::CodeSnippet do
 
       expect(@foo).to eq('meow')
     end
+
+    describe 'calling twice' do
+      subject do
+        2.times { code_snippet.load }
+      end
+
+      let(:data) { 'def v5yqq2zmfcjr; "ok"; end' }
+
+      it 'does not warn' do
+        expect { subject }.not_to output(/warning: method redefined; discarding old use_helper/).to_stdout
+        expect { subject }.not_to output(/warning: method redefined; discarding old use_helper/).to_stderr
+      end
+    end
   end
 end


### PR DESCRIPTION
### Detailed description

Don’t redefine `use_helper` if it is already defined.

Unfortunately, this is tough to test automatically, as capturing stderr/stdio doesn’t seem possible with these types of warnings (presumably because Ruby prints to `STDOUT`/`STDERR` rather than `$stdout`/`$stderr`). I tested this manually though.

### To do

* [x] Tests
* [x] Documentation
* [x] Feature flags

### Related issues

Fixes #1548.