### PR TITLE
Fix: Properly recalculate refs2objs when items/layouts change

### DIFF
--- a/nanoc-cli/lib/nanoc/cli/commands/show-data.rb
+++ b/nanoc-cli/lib/nanoc/cli/commands/show-data.rb
@@ -99,15 +99,17 @@ module Nanoc::CLI::Commands
               'items'
             when Nanoc::Core::LayoutCollection
               'layouts'
+            when nil
+              '(unknown)'
             else
-              raise Nanoc::Core::Errors::InternalInconsistency, "unexpected pred type #{pred}"
+              raise Nanoc::Core::Errors::InternalInconsistency, "unexpected pred type #{pred.inspect}"
             end
 
           pred_identifier =
             case pred
             when Nanoc::Core::Document
               pred.identifier.to_s
-            when Nanoc::Core::Configuration
+            when Nanoc::Core::Configuration, nil
               nil
             when Nanoc::Core::IdentifiableCollection
               case dep.props.raw_content
@@ -117,13 +119,13 @@ module Nanoc::CLI::Commands
                 "matching any of #{dep.props.raw_content.sort.join(', ')}"
               end
             else
-              raise Nanoc::Core::Errors::InternalInconsistency, "unexpected pred type #{pred}"
+              raise Nanoc::Core::Errors::InternalInconsistency, "unexpected pred type #{pred.inspect}"
             end
 
           if pred
             puts "  [ #{format '%6s', type} ] (#{dep.props}) #{pred_identifier}"
           else
-            puts '  ( removed item )'
+            puts '  ( removed )'
           end
         end
         puts '  (nothing)' if dependencies.empty?

--- a/nanoc-core/spec/nanoc/core/dependency_store_spec.rb
+++ b/nanoc-core/spec/nanoc/core/dependency_store_spec.rb
@@ -148,6 +148,20 @@ describe Nanoc::Core::DependencyStore do
         end
       end
 
+      context 'dependency on item that will be removed' do
+        before do
+          store.record_dependency(item_a, item_b)
+          store.items = Nanoc::Core::ItemCollection.new(config, [item_a])
+        end
+
+        it 'retains dependency, but from nil' do
+          deps = store.dependencies_causing_outdatedness_of(item_a)
+          expect(deps.size).to be(1)
+          expect(deps[0].from).to eql(nil)
+          expect(deps[0].to).to eql(item_a)
+        end
+      end
+
       context 'one prop' do
         before do
           store.record_dependency(item_a, item_b, compiled_content: true)

--- a/nanoc/spec/nanoc/regressions/gh_1554_spec.rb
+++ b/nanoc/spec/nanoc/regressions/gh_1554_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+describe 'GH-1554', site: true, stdio: true do
+  # rubocop:disable RSpec/ExampleLength
+  example do
+    FileUtils.mkdir_p('content')
+    FileUtils.mkdir_p('content/parts')
+
+    File.write('content/main.erb', 'Stuff')
+    File.write('content/parts/a.txt', "---\ndraft: false\n---\nPart A")
+    File.write('content/parts/b.txt', "---\ndraft: false\n---\nPart B")
+
+    File.write('Rules', <<~CONTENT)
+      preprocess do
+        @items.delete_if { |i| i[:draft] }
+      end
+
+      compile '/*.erb' do
+        filter :erb
+        write ext: 'txt'
+      end
+
+      compile '/**/*.txt' do
+        write ext: 'txt'
+      end
+    CONTENT
+
+    File.write('content/main.erb', '<%= @items.find_all("/parts/*").map(&:compiled_content).sort.join("\n") %>')
+
+    Nanoc::CLI.run([])
+    expect(File.file?('output/main.txt')).to be(true)
+    expect(File.read('output/main.txt')).to eq("Part A\nPart B")
+
+    File.write('content/parts/b.txt', "---\ndraft: true\n---\nPart B")
+    Nanoc::CLI.run([])
+    expect(File.file?('output/main.txt')).to be(true)
+    expect(File.read('output/main.txt')).to eq('Part A')
+  end
+  # rubocop:enable RSpec/ExampleLength
+end


### PR DESCRIPTION
### Detailed description

`DependencyStore` did not properly handle items or layouts being removed in the preprocessor.

### To do

* [x] Tests
* [x] ~~Documentation~~
* [x] ~~Feature flags~~

### Related issues

Fixes #1554.