### PR TITLE
Log the filename when it is not absolute

### DIFF
--- a/nanoc-core/lib/nanoc/core/content.rb
+++ b/nanoc-core/lib/nanoc/core/content.rb
@@ -11,7 +11,7 @@ module Nanoc
       contract C::Maybe[String] => C::Any
       def initialize(filename)
         if filename && Pathname.new(filename).relative?
-          raise ArgumentError, 'Content filename is not absolute'
+          raise ArgumentError, "Content filename #{filename} is not absolute"
         end
 
         @filename = filename


### PR DESCRIPTION
### Detailed description

Log the filename when it is not absolute to give better feedback to the user