### PR TITLE
add Date to the list of permitted classes for YAML

### DIFF
--- a/nanoc/lib/nanoc/data_sources/filesystem/parser.rb
+++ b/nanoc/lib/nanoc/data_sources/filesystem/parser.rb
@@ -4,6 +4,7 @@
 class Nanoc::DataSources::Filesystem
   class Parser
     SEPARATOR = /(-{5}|-{3})/.source
+    PERMITTED_YAML_CLASSES = [Symbol, Date]
 
     class ParseResult
       attr_reader :content
@@ -60,7 +61,7 @@ class Nanoc::DataSources::Filesystem
     # @return [Hash]
     def parse_metadata(data, filename)
       begin
-        meta = YAML.load(data) || {}
+        meta = YAML.load(data, permitted_classes: PERMITTED_YAML_CLASSES) || {}
       rescue => e
         raise Errors::UnparseableMetadata.new(filename, e)
       end

--- a/nanoc/spec/nanoc/data_sources/filesystem/parser_spec.rb
+++ b/nanoc/spec/nanoc/data_sources/filesystem/parser_spec.rb
@@ -237,6 +237,14 @@ describe Nanoc::DataSources::Filesystem::Parser do
           end
         end
 
+        context 'date attribute' do
+          let(:content) { "---\ncreated_at: 2022-01-01\n---" }
+
+          it 'has attributes' do
+            expect(subject.attributes).to eq('created_at' => Date.new(2022, 01, 01))
+          end
+        end
+
         context 'no content' do
           let(:content) { "---\ntitle: Welcome\n---\n" }
 


### PR DESCRIPTION
### Detailed description

In the latest versions of Psych (such as the one running with Ruby 3.1), only the Symbol class is allowed to be parsed.
See https://github.com/ruby/psych/blob/master/lib/psych.rb#L369

This change adds the `Date` class to the allowed objects. It's pretty common for date objects to be within metadata (for a `created_at` attribute in a blog for example).

### To do

* [x] Tests
