### PR TITLE
Replace ddmemoize with memo_wise

### DIFF
--- a/nanoc-checking/lib/nanoc/checking/check.rb
+++ b/nanoc-checking/lib/nanoc/checking/check.rb
@@ -13,7 +13,7 @@ module Nanoc
     class Check < Nanoc::Core::Context
       extend DDPlugin::Plugin
 
-      DDMemoize.activate(self)
+      prepend MemoWise
 
       attr_reader :issues
 
@@ -78,13 +78,14 @@ module Nanoc
       end
 
       # @private
-      memoized def excluded_patterns
+      def excluded_patterns
         @config
           .fetch(:checks, {})
           .fetch(:all, {})
           .fetch(:exclude_files, [])
           .map { |pattern| Regexp.new(pattern) }
       end
+      memo_wise :excluded_patterns
 
       # @private
       def output_html_filenames

--- a/nanoc-cli/lib/nanoc/cli/compile_listeners/timing_recorder.rb
+++ b/nanoc-cli/lib/nanoc/cli/compile_listeners/timing_recorder.rb
@@ -141,7 +141,6 @@ module Nanoc::CLI::CompileListeners
       print_table_for_summary_duration(:stages, @stages_summary) if Nanoc::CLI.verbosity >= 2
       print_table_for_summary(:outdatedness_rules, @outdatedness_rules_summary) if Nanoc::CLI.verbosity >= 2
       print_table_for_summary_duration(:load_stores, @load_stores_summary) if Nanoc::CLI.verbosity >= 2
-      print_ddmemoize_metrics if Nanoc::CLI.verbosity >= 2
     end
 
     def print_table_for_summary(name, summary)
@@ -156,11 +155,6 @@ module Nanoc::CLI::CompileListeners
 
       puts
       print_table(table_for_summary_durations(name, summary))
-    end
-
-    def print_ddmemoize_metrics
-      puts
-      DDMemoize.print_metrics
     end
 
     def print_table(rows)

--- a/nanoc-core/lib/nanoc/core.rb
+++ b/nanoc-core/lib/nanoc/core.rb
@@ -11,10 +11,10 @@ require 'yaml'
 # External gems
 require 'concurrent-ruby'
 require 'json_schema'
-require 'ddmemoize'
 require 'ddmetrics'
 require 'ddplugin'
 require 'hamster'
+require 'memo_wise'
 require 'slow_enumerator_tools'
 require 'tty-platform'
 require 'zeitwerk'
@@ -50,8 +50,6 @@ module Nanoc
     end
   end
 end
-
-DDMemoize.enable_metrics
 
 inflector_class = Class.new(Zeitwerk::Inflector) do
   def camelize(basename, abspath)

--- a/nanoc-core/lib/nanoc/core/action_sequence.rb
+++ b/nanoc-core/lib/nanoc/core/action_sequence.rb
@@ -3,9 +3,9 @@
 module Nanoc
   module Core
     class ActionSequence
-      include Nanoc::Core::ContractsSupport
+      # include Nanoc::Core::ContractsSupport
       include Enumerable
-      DDMemoize.activate(self)
+      prepend MemoWise
 
       attr_reader :item_rep
       attr_reader :actions
@@ -15,42 +15,43 @@ module Nanoc
         @actions = actions
       end
 
-      contract C::None => Numeric
+      # contract C::None => Numeric
       def size
         @actions.size
       end
 
-      contract Numeric => C::Maybe[Nanoc::Core::ProcessingAction]
+      # contract Numeric => C::Maybe[Nanoc::Core::ProcessingAction]
       def [](idx)
         @actions[idx]
       end
 
-      contract C::None => C::ArrayOf[Nanoc::Core::ProcessingAction]
+      # contract C::None => C::ArrayOf[Nanoc::Core::ProcessingAction]
       def snapshot_actions
         @actions.select { |a| a.is_a?(Nanoc::Core::ProcessingActions::Snapshot) }
       end
 
-      contract C::None => Array
+      # contract C::None => Array
       def paths
         snapshot_actions.map { |a| [a.snapshot_names, a.paths] }
       end
 
-      memoized def serialize
+      def serialize
         serialize_uncached
       end
+      memo_wise :serialize
 
-      contract C::None => Array
+      # contract C::None => Array
       def serialize_uncached
         to_a.map(&:serialize)
       end
 
-      contract C::Func[Nanoc::Core::ProcessingAction => C::Any] => self
+      # contract C::Func[Nanoc::Core::ProcessingAction => C::Any] => self
       def each
         @actions.each { |a| yield(a) }
         self
       end
 
-      contract C::Func[Nanoc::Core::ProcessingAction => C::Any] => self
+      # contract C::Func[Nanoc::Core::ProcessingAction => C::Any] => self
       def map
         self.class.new(
           @item_rep,

--- a/nanoc-core/lib/nanoc/core/identifiable_collection.rb
+++ b/nanoc-core/lib/nanoc/core/identifiable_collection.rb
@@ -3,9 +3,9 @@
 module Nanoc
   module Core
     class IdentifiableCollection
-      DDMemoize.activate(self)
+      prepend MemoWise
 
-      include Nanoc::Core::ContractsSupport
+      # include Nanoc::Core::ContractsSupport
       include Enumerable
 
       extend Forwardable
@@ -17,19 +17,19 @@ module Nanoc
         raise 'IdentifiableCollection is abstract and cannot be instantiated'
       end
 
-      contract C::Or[Hash, C::Named['Nanoc::Core::Configuration']], C::IterOf[C::RespondTo[:identifier]], C::Maybe[String] => C::Any
+      # contract C::Or[Hash, C::Named['Nanoc::Core::Configuration']], C::IterOf[C::RespondTo[:identifier]], C::Maybe[String] => C::Any
       def initialize_basic(config, objects = [], name = nil)
         @config = config
         @objects = Hamster::Vector.new(objects)
         @name = name
       end
 
-      contract C::None => String
+      # contract C::None => String
       def inspect
         "<#{self.class}>"
       end
 
-      contract C::None => self
+      # contract C::None => self
       def freeze
         @objects.freeze
         each(&:freeze)
@@ -37,7 +37,7 @@ module Nanoc
         super
       end
 
-      contract C::Any => C::Maybe[C::RespondTo[:identifier]]
+      # contract C::Any => C::Maybe[C::RespondTo[:identifier]]
       def [](arg)
         if frozen?
           get_memoized(arg)
@@ -46,7 +46,7 @@ module Nanoc
         end
       end
 
-      contract C::Any => C::IterOf[C::RespondTo[:identifier]]
+      # contract C::Any => C::IterOf[C::RespondTo[:identifier]]
       def find_all(arg)
         if frozen?
           find_all_memoized(arg)
@@ -55,27 +55,27 @@ module Nanoc
         end
       end
 
-      contract C::None => C::ArrayOf[C::RespondTo[:identifier]]
+      # contract C::None => C::ArrayOf[C::RespondTo[:identifier]]
       def to_a
         @objects.to_a
       end
 
-      contract C::None => C::Bool
+      # contract C::None => C::Bool
       def empty?
         @objects.empty?
       end
 
-      contract C::RespondTo[:identifier] => self
+      # contract C::RespondTo[:identifier] => self
       def add(obj)
         self.class.new(@config, @objects.add(obj))
       end
 
-      contract C::Func[C::RespondTo[:identifier] => C::Any] => self
+      # contract C::Func[C::RespondTo[:identifier] => C::Any] => self
       def reject(&block)
         self.class.new(@config, @objects.reject(&block))
       end
 
-      contract C::Any => C::Maybe[C::RespondTo[:identifier]]
+      # contract C::Any => C::Maybe[C::RespondTo[:identifier]]
       def object_with_identifier(identifier)
         if frozen?
           @mapping[identifier.to_s]
@@ -86,7 +86,7 @@ module Nanoc
 
       protected
 
-      contract C::Any => C::Maybe[C::RespondTo[:identifier]]
+      # contract C::Any => C::Maybe[C::RespondTo[:identifier]]
       def get_unmemoized(arg)
         case arg
         when Nanoc::Core::Identifier
@@ -100,21 +100,23 @@ module Nanoc
         end
       end
 
-      contract C::Any => C::Maybe[C::RespondTo[:identifier]]
-      memoized def get_memoized(arg)
-        get_unmemoized(arg)
+      # contract C::Any => C::Maybe[C::RespondTo[:identifier]]
+      def get_memoized(_arg)
+        # TODO: Figure out how to get memo_wise to work with subclasses
+        raise 'implement in subclasses'
       end
 
-      contract C::Any => C::IterOf[C::RespondTo[:identifier]]
+      # contract C::Any => C::IterOf[C::RespondTo[:identifier]]
       def find_all_unmemoized(arg)
         pat = Pattern.from(arg)
         select { |i| pat.match?(i.identifier) }
       end
 
-      contract C::Any => C::IterOf[C::RespondTo[:identifier]]
-      memoized def find_all_memoized(arg)
+      # contract C::Any => C::IterOf[C::RespondTo[:identifier]]
+      def find_all_memoized(arg)
         find_all_unmemoized(arg)
       end
+      memo_wise :find_all_memoized
 
       def object_matching_glob(glob)
         if use_globs?
@@ -130,7 +132,7 @@ module Nanoc
         end
       end
 
-      contract C::None => C::Bool
+      # contract C::None => C::Bool
       def use_globs?
         @config[:string_pattern_type] == 'glob'
       end

--- a/nanoc-core/lib/nanoc/core/item_collection.rb
+++ b/nanoc-core/lib/nanoc/core/item_collection.rb
@@ -3,9 +3,17 @@
 module Nanoc
   module Core
     class ItemCollection < IdentifiableCollection
+      prepend MemoWise
+
       def initialize(config, objects = [])
         initialize_basic(config, objects, 'items')
       end
+
+      # contract C::Any => C::Maybe[C::RespondTo[:identifier]]
+      def get_memoized(arg)
+        get_unmemoized(arg)
+      end
+      memo_wise :get_memoized
 
       def reference
         'items'

--- a/nanoc-core/lib/nanoc/core/layout_collection.rb
+++ b/nanoc-core/lib/nanoc/core/layout_collection.rb
@@ -3,9 +3,17 @@
 module Nanoc
   module Core
     class LayoutCollection < IdentifiableCollection
+      prepend MemoWise
+
       def initialize(config, objects = [])
         initialize_basic(config, objects, 'layouts')
       end
+
+      # contract C::Any => C::Maybe[C::RespondTo[:identifier]]
+      def get_memoized(arg)
+        get_unmemoized(arg)
+      end
+      memo_wise :get_memoized
 
       def reference
         'layouts'

--- a/nanoc-core/lib/nanoc/core/outdatedness_checker.rb
+++ b/nanoc-core/lib/nanoc/core/outdatedness_checker.rb
@@ -7,9 +7,9 @@ module Nanoc
     # @api private
     class OutdatednessChecker
       class Basic
-        DDMemoize.activate(self)
+        prepend MemoWise
 
-        include Nanoc::Core::ContractsSupport
+        # include Nanoc::Core::ContractsSupport
 
         Rules = Nanoc::Core::OutdatednessRules
 
@@ -46,16 +46,16 @@ module Nanoc
             Rules::LayoutCollectionExtended,
           ].freeze
 
-        C_OBJ_MAYBE_REP = C::Or[Nanoc::Core::Item, Nanoc::Core::ItemRep, Nanoc::Core::Configuration, Nanoc::Core::Layout, Nanoc::Core::ItemCollection, Nanoc::Core::LayoutCollection]
+        # C_OBJ_MAYBE_REP = C::Or[Nanoc::Core::Item, Nanoc::Core::ItemRep, Nanoc::Core::Configuration, Nanoc::Core::Layout, Nanoc::Core::ItemCollection, Nanoc::Core::LayoutCollection]
 
-        contract C::KeywordArgs[outdatedness_checker: OutdatednessChecker, reps: Nanoc::Core::ItemRepRepo] => C::Any
+        # contract C::KeywordArgs[outdatedness_checker: OutdatednessChecker, reps: Nanoc::Core::ItemRepRepo] => C::Any
         def initialize(outdatedness_checker:, reps:)
           @outdatedness_checker = outdatedness_checker
           @reps = reps
         end
 
-        contract C_OBJ_MAYBE_REP => C::Maybe[Nanoc::Core::OutdatednessStatus]
-        memoized def outdatedness_status_for(obj)
+        # contract C_OBJ_MAYBE_REP => C::Maybe[Nanoc::Core::OutdatednessStatus]
+        def outdatedness_status_for(obj)
           case obj
           when Nanoc::Core::ItemRep
             apply_rules(RULES_FOR_ITEM_REP, obj)
@@ -73,10 +73,11 @@ module Nanoc
             raise Nanoc::Core::Errors::InternalInconsistency, "do not know how to check outdatedness of #{obj.inspect}"
           end
         end
+        memo_wise :outdatedness_status_for
 
         private
 
-        contract C::ArrayOf[Class], C_OBJ_MAYBE_REP, Nanoc::Core::OutdatednessStatus => C::Maybe[Nanoc::Core::OutdatednessStatus]
+        # contract C::ArrayOf[Class], C_OBJ_MAYBE_REP, Nanoc::Core::OutdatednessStatus => C::Maybe[Nanoc::Core::OutdatednessStatus]
         def apply_rules(rules, obj, status = Nanoc::Core::OutdatednessStatus.new)
           rules.inject(status) do |acc, rule|
             if !acc.useful_to_apply?(rule)
@@ -92,15 +93,15 @@ module Nanoc
           end
         end
 
-        contract C::ArrayOf[Class], C::ArrayOf[C_OBJ_MAYBE_REP] => C::Maybe[Nanoc::Core::OutdatednessStatus]
+        # contract C::ArrayOf[Class], C::ArrayOf[C_OBJ_MAYBE_REP] => C::Maybe[Nanoc::Core::OutdatednessStatus]
         def apply_rules_multi(rules, objs)
           objs.inject(Nanoc::Core::OutdatednessStatus.new) { |acc, elem| apply_rules(rules, elem, acc) }
         end
       end
 
-      DDMemoize.activate(self)
+      prepend MemoWise
 
-      include Nanoc::Core::ContractsSupport
+      # include Nanoc::Core::ContractsSupport
 
       attr_reader :checksum_store
       attr_reader :checksums
@@ -111,11 +112,11 @@ module Nanoc
 
       Reasons = Nanoc::Core::OutdatednessReasons
 
-      C_OBJ = C::Or[Nanoc::Core::Item, Nanoc::Core::ItemRep, Nanoc::Core::Configuration, Nanoc::Core::Layout, Nanoc::Core::ItemCollection]
-      C_ITEM_OR_REP = C::Or[Nanoc::Core::Item, Nanoc::Core::ItemRep]
-      C_ACTION_SEQUENCES = C::HashOf[C_OBJ => Nanoc::Core::ActionSequence]
+      # C_OBJ = C::Or[Nanoc::Core::Item, Nanoc::Core::ItemRep, Nanoc::Core::Configuration, Nanoc::Core::Layout, Nanoc::Core::ItemCollection]
+      # C_ITEM_OR_REP = C::Or[Nanoc::Core::Item, Nanoc::Core::ItemRep]
+      # C_ACTION_SEQUENCES = C::HashOf[C_OBJ => Nanoc::Core::ActionSequence]
 
-      contract C::KeywordArgs[site: Nanoc::Core::Site, checksum_store: Nanoc::Core::ChecksumStore, checksums: Nanoc::Core::ChecksumCollection, dependency_store: Nanoc::Core::DependencyStore, action_sequence_store: Nanoc::Core::ActionSequenceStore, action_sequences: C_ACTION_SEQUENCES, reps: Nanoc::Core::ItemRepRepo] => C::Any
+      # contract C::KeywordArgs[site: Nanoc::Core::Site, checksum_store: Nanoc::Core::ChecksumStore, checksums: Nanoc::Core::ChecksumCollection, dependency_store: Nanoc::Core::DependencyStore, action_sequence_store: Nanoc::Core::ActionSequenceStore, action_sequences: C_ACTION_SEQUENCES, reps: Nanoc::Core::ItemRepRepo] => C::Any
       def initialize(site:, checksum_store:, checksums:, dependency_store:, action_sequence_store:, action_sequences:, reps:)
         @site = site
         @checksum_store = checksum_store
@@ -132,12 +133,12 @@ module Nanoc
         @action_sequences.fetch(rep)
       end
 
-      contract C_OBJ => C::Bool
+      # contract C_OBJ => C::Bool
       def outdated?(obj)
         outdatedness_reasons_for(obj).any?
       end
 
-      contract C_OBJ => C::IterOf[Reasons::Generic]
+      # contract C_OBJ => C::IterOf[Reasons::Generic]
       def outdatedness_reasons_for(obj)
         reasons = basic.outdatedness_status_for(obj).reasons
         if reasons.any?
@@ -151,12 +152,12 @@ module Nanoc
 
       private
 
-      contract C::None => Basic
+      # contract C::None => Basic
       def basic
         @_basic ||= Basic.new(outdatedness_checker: self, reps: @reps)
       end
 
-      contract C_OBJ, Hamster::Set => C::Bool
+      # contract C_OBJ, Hamster::Set => C::Bool
       def outdated_due_to_dependencies?(obj, processed = Hamster::Set.new)
         # Convert from rep to item if necessary
         obj = obj.item if obj.is_a?(Nanoc::Core::ItemRep)
@@ -188,7 +189,7 @@ module Nanoc
         is_outdated
       end
 
-      contract Nanoc::Core::Dependency => C::Bool
+      # contract Nanoc::Core::Dependency => C::Bool
       def dependency_causes_outdatedness?(dependency)
         return true if dependency.from.nil?
 

--- a/nanoc-core/lib/nanoc/core/outdatedness_rules/code_snippets_modified.rb
+++ b/nanoc-core/lib/nanoc/core/outdatedness_rules/code_snippets_modified.rb
@@ -4,9 +4,9 @@ module Nanoc
   module Core
     module OutdatednessRules
       class CodeSnippetsModified < Nanoc::Core::OutdatednessRule
-        DDMemoize.activate(self)
+        prepend MemoWise
 
-        include Nanoc::Core::ContractsSupport
+        # include Nanoc::Core::ContractsSupport
 
         affects_props :raw_content, :attributes, :compiled_content, :path
 
@@ -18,13 +18,14 @@ module Nanoc
 
         private
 
-        memoized def any_snippets_modified?(outdatedness_checker)
+        def any_snippets_modified?(outdatedness_checker)
           outdatedness_checker.site.code_snippets.any? do |cs|
             ch_old = outdatedness_checker.checksum_store[cs]
             ch_new = outdatedness_checker.checksums.checksum_for(cs)
             ch_old != ch_new
           end
         end
+        memo_wise :any_snippets_modified?
       end
     end
   end

--- a/nanoc-core/nanoc-core.gemspec
+++ b/nanoc-core/nanoc-core.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.6'
 
   s.add_runtime_dependency('concurrent-ruby', '~> 1.1')
-  s.add_runtime_dependency('ddmemoize', '~> 1.0')
   s.add_runtime_dependency('ddmetrics', '~> 1.0')
   s.add_runtime_dependency('ddplugin', '~> 1.0')
   s.add_runtime_dependency('hamster', '~> 3.0')
   s.add_runtime_dependency('json_schema', '~> 0.19')
+  s.add_runtime_dependency('memo_wise', '~> 1.5')
   s.add_runtime_dependency('slow_enumerator_tools', '~> 1.0')
   s.add_runtime_dependency('tty-platform', '~> 0.2')
   s.add_runtime_dependency('zeitwerk', '~> 2.1')

--- a/nanoc/lib/nanoc/filters/relativize_paths.rb
+++ b/nanoc/lib/nanoc/filters/relativize_paths.rb
@@ -8,7 +8,7 @@ module Nanoc::Filters
     require 'nanoc/helpers/link_to'
     include Nanoc::Helpers::LinkTo
 
-    DDMemoize.activate(self)
+    prepend MemoWise
 
     SELECTORS =
       [
@@ -79,7 +79,7 @@ module Nanoc::Filters
       end
     end
 
-    memoized def excludes(params)
+    def excludes(params)
       raw = [params.fetch(:exclude, [])].flatten
       raw.map do |exclusion|
         case exclusion
@@ -90,6 +90,7 @@ module Nanoc::Filters
         end
       end
     end
+    memo_wise :excludes
 
     def exclude?(path, params)
       # TODO: Use #match? on newer Ruby versions

--- a/nanoc/lib/nanoc/rule_dsl/action_sequence_calculator.rb
+++ b/nanoc/lib/nanoc/rule_dsl/action_sequence_calculator.rb
@@ -2,8 +2,6 @@
 
 module Nanoc::RuleDSL
   class ActionSequenceCalculator
-    DDMemoize.activate(self)
-
     class UnsupportedObjectTypeException < ::Nanoc::Error
       def initialize(obj)
         super("Do not know how to calculate the action sequence for #{obj.inspect}")


### PR DESCRIPTION
### Detailed description

Replaces nanoc’s usage of [ddmemoize](https://github.com/ddfreyne/ddmemoize) with [memo_wise](https://github.com/panorama-ed/memo_wise).

This fixes #1559, likely because it no longer relies on soft references. This might mean increased memory usage, but this should be fine as Nanoc doesn’t memoize *that* much data.

It also means we lose memoization metrics, as memo_wise doesn’t provide those. This is probably fine.

Future work:

* `memo_wise` doesn’t seem to properly support memoization in superclasses. This is a problem for `IdentifiableCollection`, but for now I’ve done the memoization on the subclass instead. Possibly related: https://github.com/panorama-ed/memo_wise/issues/262 and https://github.com/panorama-ed/memo_wise/pull/265 (though that PR did not resolve the issue for me).

Fun `ddmemoize` fact: This was extracted from Nanoc many years ago, only has one release (1.0.0), has only one page of Git commits (https://github.com/ddfreyne/ddmemoize/commits/master) and has not been updated in 4 years, but still works well — up until now, apparently, because #1559 is throwing sand in the gears.

### To do

n/a

### Related issues

Fixes https://github.com/nanoc/nanoc/issues/1559.
