### PR TITLE
Add Time to the list of permitted classes for YAML

### DIFF
--- a/nanoc/lib/nanoc/data_sources/filesystem/parser.rb
+++ b/nanoc/lib/nanoc/data_sources/filesystem/parser.rb
@@ -4,7 +4,7 @@
 class Nanoc::DataSources::Filesystem
   class Parser
     SEPARATOR = /(-{5}|-{3})/.source
-    PERMITTED_YAML_CLASSES = [Symbol, Date].freeze
+    PERMITTED_YAML_CLASSES = [Symbol, Date, Time].freeze
 
     class ParseResult
       attr_reader :content


### PR DESCRIPTION
### Detailed description

Nanoc 4.12.4 on Ruby 3.1.0 fails to parse metadata for pages if it contains a timestamp.
```
Nanoc::DataSources::Filesystem::Errors::UnparseableMetadata: Could not parse metadata for /path/to/article.yaml: Tried to load unspecified class: Time
```

This change adds the `Time` class to the allowed objects.

### To do

* [x] Tests

### Related issues

#1560
