### PR TITLE
Prefer YAML.safe_load over YAML.load

### DIFF
--- a/nanoc-core/nanoc-core.gemspec
+++ b/nanoc-core/nanoc-core.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('hamster', '~> 3.0')
   s.add_runtime_dependency('json_schema', '~> 0.19')
   s.add_runtime_dependency('memo_wise', '~> 1.5')
-  s.add_runtime_dependency('psych', '~> 4.0')
   s.add_runtime_dependency('slow_enumerator_tools', '~> 1.0')
   s.add_runtime_dependency('tty-platform', '~> 0.2')
   s.add_runtime_dependency('zeitwerk', '~> 2.1')

--- a/nanoc/lib/nanoc/data_sources/filesystem/parser.rb
+++ b/nanoc/lib/nanoc/data_sources/filesystem/parser.rb
@@ -61,7 +61,7 @@ class Nanoc::DataSources::Filesystem
     # @return [Hash]
     def parse_metadata(data, filename)
       begin
-        meta = YAML.load(data, permitted_classes: PERMITTED_YAML_CLASSES) || {}
+        meta = YAML.safe_load(data, permitted_classes: PERMITTED_YAML_CLASSES) || {}
       rescue => e
         raise Errors::UnparseableMetadata.new(filename, e)
       end


### PR DESCRIPTION
This replaces `YAML.load(…, permitted_classes: …)` with `YAML.safe_load(…, permitted_classes: …)`, which works on Ruby 2.6+ without requiring a newer version of Psych.

The runtime dependency on `psych` 4.0+ is removed, as it’s no longer needed.

Context:

* [this commit’s comments](https://github.com/nanoc/nanoc/commit/b3755eca87b4372c8755dfc170f38653fb15a710#commitcomment-64201618)
* [mailing list discussion](https://groups.google.com/g/nanoc/c/eLQavTSFhVU)