### PR TITLE
Use `compact` on `Socket.getifaddrs.map`

### DIFF
--- a/nanoc-cli/spec/nanoc/cli/commands/view_spec.rb
+++ b/nanoc-cli/spec/nanoc/cli/commands/view_spec.rb
@@ -69,7 +69,7 @@ describe Nanoc::CLI::Commands::View, site: true, stdio: true, fork: true do
     end
 
     it 'does not listen on non-local interfaces' do
-      addresses = Socket.getifaddrs.map(&:addr).select(&:ipv4?).map(&:ip_address)
+      addresses = Socket.getifaddrs.map(&:addr).compact.select(&:ipv4?).map(&:ip_address)
       non_local_addresses = addresses - ['127.0.0.1']
 
       if non_local_addresses.empty?


### PR DESCRIPTION
In certain situations, when a TUN device is present (e.g., when a VPN
is connected), `Socket.getifaddrs.map(&:addr)` can contain one or more
`nil` elements.  This can lead to errors like the following:

``` ruby
(irb):6:in `select': undefined method `ipv4?' for nil:NilClass (NoMethodError)
        from (irb):6:in `<main>'
        from /usr/lib/ruby/gems/3.0.0/gems/irb-1.3.5/exe/irb:11:in `<top (required)>'
        from /usr/bin/irb3.0:23:in `load'
        from /usr/bin/irb3.0:23:in `<main>'

```

This commit prevents such errors by using `compact` to remove any
`nil` elements from the map before passing it to `select`.