### PR TITLE
Fix nanoc-deploying build failure related to Fog

### DIFF
--- a/nanoc-deploying/spec/nanoc/deploying/deployers/fog_spec.rb
+++ b/nanoc-deploying/spec/nanoc/deploying/deployers/fog_spec.rb
@@ -24,6 +24,8 @@ describe Nanoc::Deploying::Deployers::Fog, stdio: true do
   let(:provider) { 'local' }
 
   before do
+    skip_unless_gem_available('fog/core')
+
     # create output
     FileUtils.mkdir_p('output')
     FileUtils.mkdir_p('output/etc')
@@ -71,7 +73,7 @@ describe Nanoc::Deploying::Deployers::Fog, stdio: true do
       let(:distribution) { Object.new }
 
       it 'does not actually invalidate' do
-        expect(::Fog::CDN).to receive(:new).with(provider: 'local', local_root: 'remote').and_return(cdn)
+        expect(::Fog::CDN).to receive(:new).with({ provider: 'local', local_root: 'remote' }).and_return(cdn)
         expect(cdn).to receive(:get_distribution).with('donkey-cdn').and_return(distribution)
 
         subject
@@ -154,7 +156,7 @@ describe Nanoc::Deploying::Deployers::Fog, stdio: true do
       let(:distribution) { Object.new }
 
       it 'invalidates' do
-        expect(::Fog::CDN).to receive(:new).with(provider: 'local', local_root: 'remote').and_return(cdn)
+        expect(::Fog::CDN).to receive(:new).with({ provider: 'local', local_root: 'remote' }).and_return(cdn)
         expect(cdn).to receive(:get_distribution).with('donkey-cdn').and_return(distribution)
         expect(cdn).to receive(:post_invalidation).with(distribution, contain_exactly('etc/meow', 'woof'))
 


### PR DESCRIPTION
### Detailed description

This issue happens on Ruby 3.x due to the way keyword arguments are handled differently from Ruby 2.x. This only affects tests, and is not a problem with nanoc-deploying itself.

```
1) Nanoc::Deploying::Deployers::Fog dry run with CDN ID does not actually invalidate
[11](https://github.com/nanoc/nanoc/runs/5166826011?check_suite_focus=true#step:11:11)
     Failure/Error: cdn = ::Fog::CDN.new(config_for_fog)
[12](https://github.com/nanoc/nanoc/runs/5166826011?check_suite_focus=true#step:11:12)

[13](https://github.com/nanoc/nanoc/runs/5166826011?check_suite_focus=true#step:11:13)
       Fog::CDN received :new with unexpected arguments
[14](https://github.com/nanoc/nanoc/runs/5166826011?check_suite_focus=true#step:11:14)
         expected: ({:local_root=>"remote", :provider=>"local"})
[15](https://github.com/nanoc/nanoc/runs/5166826011?check_suite_focus=true#step:11:15)
              got: ({:local_root=>"remote", :provider=>"local"})
[16](https://github.com/nanoc/nanoc/runs/5166826011?check_suite_focus=true#step:11:16)
     # ./lib/nanoc/deploying/deployers/fog.rb:111:in `run'
[17](https://github.com/nanoc/nanoc/runs/5166826011?check_suite_focus=true#step:11:17)
     # ./spec/nanoc/deploying/deployers/fog_spec.rb:4:in `block (2 levels) in <top (required)>'
[18](https://github.com/nanoc/nanoc/runs/5166826011?check_suite_focus=true#step:11:18)
     # ./spec/nanoc/deploying/deployers/fog_spec.rb:77:in `block (4 levels) in <top (required)>'
```

### To do

n/a

### Related issues

Unblocks #1567.