### PR TITLE
Allow same Yaml classes for binary and frontmatter

### DIFF
--- a/nanoc/lib/nanoc/data_sources/filesystem.rb
+++ b/nanoc/lib/nanoc/data_sources/filesystem.rb
@@ -48,6 +48,8 @@ module Nanoc::DataSources
   #
   # @api private
   class Filesystem < Nanoc::DataSource
+    PERMITTED_YAML_CLASSES = [Symbol, Date, Time].freeze
+
     class AmbiguousMetadataAssociationError < ::Nanoc::Core::Error
       def initialize(content_filenames, meta_filename)
         super("There are multiple content files (#{content_filenames.sort.join(', ')}) that could match the file containing metadata (#{meta_filename}).")
@@ -150,7 +152,7 @@ module Nanoc::DataSources
       is_binary = content_filename && !@site_config[:text_extensions].include?(File.extname(content_filename)[1..-1])
 
       if is_binary && klass == Nanoc::Core::Item
-        meta = (meta_filename && YAML.load_file(meta_filename)) || {}
+        meta = (meta_filename && YAML.load_file(meta_filename, permitted_classes: PERMITTED_YAML_CLASSES)) || {}
 
         ProtoDocument.new(is_binary: true, filename: content_filename, attributes: meta)
       elsif is_binary && klass == Nanoc::Core::Layout


### PR DESCRIPTION
Psych-4.0 changes to safe_load by default. Compilation breaks with below error for anyone with binary files accompanied by a Yaml file with a date. 

```
Psych::DisallowedClass: Tried to load unspecified class: Date
```

The DateClass isn’t allowed in safe_load mode. Nanoc expects it to be for e.g. created_at. Duplicating code from parser.b to allow same classes in all Yaml source files and front matter.
