### PR TITLE
“git push” even if repo does not need a commit

### DIFF
--- a/nanoc-deploying/lib/nanoc/deploying/deployers/git.rb
+++ b/nanoc-deploying/lib/nanoc/deploying/deployers/git.rb
@@ -102,7 +102,7 @@ module Nanoc
         end
 
         def run_cmd(cmd, dry_run: false)
-          TTY::Command.new(printer: :null).run(*cmd, dry_run: dry_run)
+          TTY::Command.new(**tty_command_options).run(*cmd, dry_run: dry_run)
         end
 
         def run_cmd_unless_dry(cmd)
@@ -110,7 +110,15 @@ module Nanoc
         end
 
         def clean_repo?
-          TTY::Command.new(printer: :null).run('git status --porcelain').out.empty?
+          TTY::Command.new(**tty_command_options).run('git status --porcelain').out.empty?
+        end
+
+        def tty_command_options
+          if Nanoc::CLI.verbosity >= 1
+            { uuid: false }
+          else
+            { printer: :null }
+          end
         end
       end
     end

--- a/nanoc-deploying/lib/nanoc/deploying/deployers/git.rb
+++ b/nanoc-deploying/lib/nanoc/deploying/deployers/git.rb
@@ -78,13 +78,15 @@ module Nanoc
               raise Errors::BranchDoesNotExist.new(branch)
             end
 
-            return if clean_repo?
+            # Commit (if needed)
+            unless clean_repo?
+              msg = "Automated commit at #{Time.now.utc} by Nanoc #{Nanoc::VERSION}"
+              author = 'Nanoc <>'
+              run_cmd_unless_dry(%w[git add -A])
+              run_cmd_unless_dry(%W[git commit -a --author #{author} -m #{msg}])
+            end
 
-            msg = "Automated commit at #{Time.now.utc} by Nanoc #{Nanoc::VERSION}"
-            author = 'Nanoc <>'
-            run_cmd_unless_dry(%w[git add -A])
-            run_cmd_unless_dry(%W[git commit -a --author #{author} -m #{msg}])
-
+            # Push
             if forced
               run_cmd_unless_dry(%W[git push -f #{remote} #{branch}])
             else

--- a/nanoc-deploying/spec/nanoc/deploying/deployers/git_spec.rb
+++ b/nanoc-deploying/spec/nanoc/deploying/deployers/git_spec.rb
@@ -45,8 +45,10 @@ describe Nanoc::Deploying::Deployers::Git, stdio: true do
 
   shared_examples 'branch configured properly' do
     context 'clean working copy' do
-      it 'does not commit or push' do
-        subject
+      it 'does not commit, but still pushes' do
+        expect { subject }
+          .to output(/Deploying via Git to branch “#{branch}” on remote “#{remote}”…/)
+          .to_stdout
       end
     end
 


### PR DESCRIPTION
### Detailed description

If the `output/` directory is clean (nothing to commit), then the Git deployer (as part of `nanoc deploy`) should still attempt to `git push`.

Additionally, this change makes `--verbose` print out the executed `git` commands.

### To do

* [x] Tests

### Related issues

n/a