### PR TITLE
Fix: Support non-writable binary content cache files

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -175,10 +175,11 @@ Naming/VariableNumber:
     - 'nanoc-core/spec/nanoc/core/aggregate_data_source_spec.rb'
     - 'nanoc/spec/nanoc/rule_dsl/action_sequence_calculator_spec.rb'
 
-# Offense count: 4
+# Offense count: 5
 RSpec/AnyInstance:
   Exclude:
     - 'nanoc-cli/spec/nanoc/cli/commands/shell_spec.rb'
+    - 'nanoc/spec/nanoc/regressions/gh_1572_spec.rb'
 
 # Offense count: 55
 RSpec/Be:

--- a/nanoc-core/lib/nanoc/core/binary_compiled_content_cache.rb
+++ b/nanoc-core/lib/nanoc/core/binary_compiled_content_cache.rb
@@ -92,6 +92,10 @@ module Nanoc
         end
       end
 
+      def use_clonefile?
+        defined?(Clonefile)
+      end
+
       private
 
       def dirname
@@ -132,7 +136,7 @@ module Nanoc
         # changed outside of Nanoc.
 
         # Try clonefile
-        if defined?(Clonefile)
+        if use_clonefile?
           FileUtils.rm_f(to)
           begin
             res = Clonefile.always(from, to)
@@ -142,6 +146,9 @@ module Nanoc
         end
 
         # Fall back to old-school copy
+        if File.file?(to)
+          FileUtils.rm_f(to)
+        end
         FileUtils.cp(from, to)
       end
     end

--- a/nanoc/spec/nanoc/regressions/gh_1572_spec.rb
+++ b/nanoc/spec/nanoc/regressions/gh_1572_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+describe 'GH-1572', site: true, stdio: true do
+  # rubocop:disable RSpec/ExampleLength
+  example do
+    FileUtils.mkdir_p('content')
+
+    allow_any_instance_of(Nanoc::Core::BinaryCompiledContentCache)
+      .to receive(:use_clonefile?)
+      .and_return(false)
+
+    File.write('content/repro.jpg', '<data>')
+    File.chmod(0o400, 'content/repro.jpg')
+    expect(File.stat('content/repro.jpg').mode).to eq(0o100400)
+
+    Nanoc::CLI.run([])
+    expect(File.file?('output/repro.jpg')).to be(true)
+    expect(File.read('output/repro.jpg')).to eq('<data>')
+    expect(File.stat('output/repro.jpg').mode).to eq(0o100400)
+
+    FileUtils.rm_f('output/repro.jpg')
+    Nanoc::CLI.run([])
+    expect(File.file?('output/repro.jpg')).to be(true)
+    expect(File.read('output/repro.jpg')).to eq('<data>')
+    expect(File.stat('output/repro.jpg').mode).to eq(0o100400)
+  end
+  # rubocop:enable RSpec/ExampleLength
+end


### PR DESCRIPTION
### Detailed description

A non-writable binary file in `content/` will lead to file with the same permissions (non-writable) in the binary compiled content cache, and the cached file will not be overwriteable, which makes Nanoc crash.

This fix removes the file from the binary compiled content cache before attempting to write it. This retains the permissions (which is intentional).

### To do

* [x] Regression test
* [ ] In-detail test
* [ ] Refactor so we don’t need `#allow_any_instance_of`

### Related issues

Fixes #1572: nanoc 4.12 binary cache copies read-only source permissions then attempts to open for writing.