### PR TITLE
Use Psych 4

### DIFF
--- a/nanoc-core/lib/nanoc/core/config_loader.rb
+++ b/nanoc-core/lib/nanoc/core/config_loader.rb
@@ -54,7 +54,7 @@ module Nanoc
       end
 
       def load_file(filename)
-        YAML.load_file(filename)
+        YAML.safe_load_file(filename)
       end
 
       # @api private

--- a/nanoc-core/lib/nanoc/core/config_loader.rb
+++ b/nanoc-core/lib/nanoc/core/config_loader.rb
@@ -4,6 +4,8 @@ module Nanoc
   module Core
     # @api private
     class ConfigLoader
+      PERMITTED_YAML_CLASSES = [Symbol, Date, Time].freeze
+
       class NoConfigFileFoundError < ::Nanoc::Core::Error
         def initialize
           super('No configuration file found')
@@ -54,7 +56,7 @@ module Nanoc
       end
 
       def load_file(filename)
-        YAML.safe_load_file(filename)
+        YAML.safe_load_file(filename, permitted_classes: PERMITTED_YAML_CLASSES)
       end
 
       # @api private

--- a/nanoc-core/nanoc-core.gemspec
+++ b/nanoc-core/nanoc-core.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('hamster', '~> 3.0')
   s.add_runtime_dependency('json_schema', '~> 0.19')
   s.add_runtime_dependency('memo_wise', '~> 1.5')
+  s.add_runtime_dependency('psych', '~> 4.0')
   s.add_runtime_dependency('slow_enumerator_tools', '~> 1.0')
   s.add_runtime_dependency('tty-platform', '~> 0.2')
   s.add_runtime_dependency('zeitwerk', '~> 2.1')

--- a/nanoc/lib/nanoc/data_sources/filesystem.rb
+++ b/nanoc/lib/nanoc/data_sources/filesystem.rb
@@ -48,6 +48,8 @@ module Nanoc::DataSources
   #
   # @api private
   class Filesystem < Nanoc::DataSource
+    PERMITTED_YAML_CLASSES = Nanoc::Core::ConfigLoader::PERMITTED_YAML_CLASSES
+
     class AmbiguousMetadataAssociationError < ::Nanoc::Core::Error
       def initialize(content_filenames, meta_filename)
         super("There are multiple content files (#{content_filenames.sort.join(', ')}) that could match the file containing metadata (#{meta_filename}).")
@@ -150,7 +152,7 @@ module Nanoc::DataSources
       is_binary = content_filename && !@site_config[:text_extensions].include?(File.extname(content_filename)[1..-1])
 
       if is_binary && klass == Nanoc::Core::Item
-        meta = (meta_filename && YAML.safe_load_file(meta_filename, permitted_classes: Parser::PERMITTED_YAML_CLASSES)) || {}
+        meta = (meta_filename && YAML.safe_load_file(meta_filename, permitted_classes: PERMITTED_YAML_CLASSES)) || {}
 
         ProtoDocument.new(is_binary: true, filename: content_filename, attributes: meta)
       elsif is_binary && klass == Nanoc::Core::Layout

--- a/nanoc/lib/nanoc/data_sources/filesystem.rb
+++ b/nanoc/lib/nanoc/data_sources/filesystem.rb
@@ -150,7 +150,7 @@ module Nanoc::DataSources
       is_binary = content_filename && !@site_config[:text_extensions].include?(File.extname(content_filename)[1..-1])
 
       if is_binary && klass == Nanoc::Core::Item
-        meta = (meta_filename && YAML.load_file(meta_filename, permitted_classes: Parser::PERMITTED_YAML_CLASSES)) || {}
+        meta = (meta_filename && YAML.safe_load_file(meta_filename, permitted_classes: Parser::PERMITTED_YAML_CLASSES)) || {}
 
         ProtoDocument.new(is_binary: true, filename: content_filename, attributes: meta)
       elsif is_binary && klass == Nanoc::Core::Layout

--- a/nanoc/lib/nanoc/data_sources/filesystem/parser.rb
+++ b/nanoc/lib/nanoc/data_sources/filesystem/parser.rb
@@ -4,7 +4,7 @@
 class Nanoc::DataSources::Filesystem
   class Parser
     SEPARATOR = /(-{5}|-{3})/.source
-    PERMITTED_YAML_CLASSES = [Symbol, Date, Time].freeze
+    PERMITTED_YAML_CLASSES = Nanoc::Core::ConfigLoader::PERMITTED_YAML_CLASSES
 
     class ParseResult
       attr_reader :content


### PR DESCRIPTION
### Detailed description

This adds a dependency on Psych 4.x, which fixes #1577. The `YAML.safe_load` and `YAML.safe_load_file` functions are now used consistently throughout. Having a single, consistent Psych version eliminates issues like #1577 which arise from different behavior in incompatible major versions. 

### To do

n/a

### Related issues

Fixes #1577.
