### PR TITLE
Fix documentation in view and live commands

### DIFF
--- a/guard-nanoc/lib/guard/nanoc/live_command.rb
+++ b/guard-nanoc/lib/guard/nanoc/live_command.rb
@@ -8,7 +8,7 @@ description <<~EOS
   two commands for details. The options are forwarded to `nanoc view` only.
 EOS
 
-required :H, :handler,       'specify the handler to use (webrick/mongrel/...)'
+required :H, :handler,       'specify the handler to use (webrick/puma/...)'
 required :o, :host,          'specify the host to listen on (default: 0.0.0.0)', default: '127.0.0.1'
 required :p, :port,          'specify the port to listen on (default: 3000)', transform: ::Nanoc::CLI::Transform::Port, default: 3000
 flag     :L, :'live-reload', 'reload on changes'

--- a/nanoc-cli/lib/nanoc/cli/commands/view.rb
+++ b/nanoc-cli/lib/nanoc/cli/commands/view.rb
@@ -8,7 +8,7 @@ description <<~EOS
   `adsf` (not `asdf`!).
 EOS
 
-required :H, :handler, 'specify the handler to use (webrick/mongrel/...)'
+required :H, :handler, 'specify the handler to use (webrick/puma/...)'
 required :o, :host,    'specify the host to listen on (default: 127.0.0.1)', default: '127.0.0.1'
 required :p, :port,    'specify the port to listen on (default: 3000)', transform: Nanoc::CLI::Transform::Port, default: 3000
 flag :L, :'live-reload', 'reload on changes'

--- a/nanoc-cli/lib/nanoc/cli/commands/view.rb
+++ b/nanoc-cli/lib/nanoc/cli/commands/view.rb
@@ -4,7 +4,7 @@ usage 'view [options]'
 summary 'start the web server that serves static files'
 description <<~EOS
   Start the static web server. Unless specified, the web server will run on port
-  3000 and listen on all IP addresses. Running this static web server requires
+  3000 and listen 127.0.0.1. Running this static web server requires
   `adsf` (not `asdf`!).
 EOS
 

--- a/nanoc-live/lib/nanoc/live/commands/live.rb
+++ b/nanoc-live/lib/nanoc/live/commands/live.rb
@@ -4,8 +4,8 @@ usage 'live'
 summary 'auto-recompile and serve'
 description <<~EOS
   Starts the live recompiler along with the static web server. Unless specified,
-  the web server will run on port 3000 and listen on all IP addresses. Running
-  this static web server requires `adsf` (not `asdf`!).
+  the web server will run on port 3000 and listen on 127.0.0.1. Running this
+  static web server requires `adsf` (not `asdf`!).
 EOS
 
 required :H, :handler, 'specify the handler to use (webrick/puma/...)'

--- a/nanoc-live/lib/nanoc/live/commands/live.rb
+++ b/nanoc-live/lib/nanoc/live/commands/live.rb
@@ -8,7 +8,7 @@ description <<~EOS
   this static web server requires `adsf` (not `asdf`!).
 EOS
 
-required :H, :handler, 'specify the handler to use (webrick/mongrel/...)'
+required :H, :handler, 'specify the handler to use (webrick/puma/...)'
 required :o, :host,    'specify the host to listen on (default: 127.0.0.1)', default: '127.0.0.1'
 required :p, :port,    'specify the port to listen on (default: 3000)', transform: Nanoc::CLI::Transform::Port, default: 3000
 no_params


### PR DESCRIPTION
### Detailed description

- Replaces `mongrel` with `puma` in documentation.
- Fixes incorrect mention that `view` and `live` listen on all IP addresses by default.

### To do

n/a

### Related issues

Fixes #1584.
