### PR TITLE
Fix rubocop test

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -345,9 +345,6 @@ Lint/RedundantDirGlobSort: # (new in 1.8)
 Style/EndlessMethod: # (new in 1.8)
   Enabled: true
 
-Gemspec/DateAssignment: # (new in 1.10)
-  Enabled: true
-
 Lint/NumberedParameterAssignment: # (new in 1.9)
   Enabled: true
 

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group :devel do
   gem 'rspec'
   gem 'rspec-its', '~> 1.2'
   gem 'rspec-mocks'
-  gem 'rubocop'
+  gem 'rubocop', '< 1.31'
   gem 'rubocop-minitest'
   gem 'rubocop-rake'
   gem 'rubocop-rspec'

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group :devel do
   gem 'rspec'
   gem 'rspec-its', '~> 1.2'
   gem 'rspec-mocks'
-  gem 'rubocop', '< 1.31'
+  gem 'rubocop', '~> 1.31'
   gem 'rubocop-minitest'
   gem 'rubocop-rake'
   gem 'rubocop-rspec'

--- a/nanoc-cli/lib/nanoc/cli/cleaning_stream.rb
+++ b/nanoc-cli/lib/nanoc/cli/cleaning_stream.rb
@@ -139,11 +139,9 @@ module Nanoc
       end
 
       # @see ARGF.set_encoding
-      # rubocop:disable Naming/AccessorMethodName, Lint/RedundantCopDisableDirective
       def set_encoding(*args)
         @stream.set_encoding(*args)
       end
-      # rubocop:enable Naming/AccessorMethodName, Lint/RedundantCopDisableDirective
 
       protected
 

--- a/nanoc-cli/lib/nanoc/cli/cleaning_stream.rb
+++ b/nanoc-cli/lib/nanoc/cli/cleaning_stream.rb
@@ -139,11 +139,11 @@ module Nanoc
       end
 
       # @see ARGF.set_encoding
-      # rubocop:disable Naming/AccessorMethodName
+      # rubocop:disable Naming/AccessorMethodName, Lint/RedundantCopDisableDirective
       def set_encoding(*args)
         @stream.set_encoding(*args)
       end
-      # rubocop:enable Naming/AccessorMethodName
+      # rubocop:enable Naming/AccessorMethodName, Lint/RedundantCopDisableDirective
 
       protected
 


### PR DESCRIPTION
### Detailed description

This is a minor edit that should get the green check back for rubocop.

The first commit fixes the currently-emitted error that [showed up](https://github.com/nanoc/nanoc/runs/7055937582?check_suite_focus=true) running rubocop 1.30.1 on the last test run in June. That error was due to a minor change added in that exact version, here: https://github.com/rubocop/rubocop/commit/a83732be3767cd50f821aba4b3d01542ff6f6f86

The second and third commits fix what would have been a newly-emitted error, unrelated to the first, showing up just a couple days later when rubocop released its version 1.31. One of the cops nanoc is using got removed in a breaking change: https://github.com/rubocop/rubocop/commit/c6a4e91f1badf3c41921949d7afd982c8c959b05

The second commit is the minimum possible fix that just restricts rubocop to versions before the breaking change.

The third, which I would recommend for future compatibility, fixes it by requiring rubocop 1.31+, past that breaking change, and also fixing the config, which have to happen together. This also allows simplifying the fix in the first commit, for the same reason.

Honestly you may just want to squash all these commits together, but I figured I'd separate them out to let you pick and choose if you want.

Thanks for this project!

### To do

Ready to go!

### Related issues

None that I'm aware of.