### PR TITLE
Escape URLs so terminals can detect them properly

### DIFF
--- a/nanoc-checking/lib/nanoc/checking/checks/external_links.rb
+++ b/nanoc-checking/lib/nanoc/checking/checks/external_links.rb
@@ -21,7 +21,7 @@ module Nanoc
             filenames = hrefs_with_filenames[res.href]
             filenames.each do |filename|
               add_issue(
-                "broken reference to #{res.href}: #{res.explanation}",
+                "broken reference to <#{res.href}>: #{res.explanation}",
                 subject: filename,
               )
             end

--- a/nanoc-checking/lib/nanoc/checking/checks/internal_links.rb
+++ b/nanoc-checking/lib/nanoc/checking/checks/internal_links.rb
@@ -25,7 +25,7 @@ module Nanoc
               next if valid?(href, filename)
 
               add_issue(
-                "broken reference to #{href}",
+                "broken reference to <#{href}>",
                 subject: filename,
               )
             end

--- a/nanoc-checking/spec/nanoc/checking/checks/external_links_spec.rb
+++ b/nanoc-checking/spec/nanoc/checking/checks/external_links_spec.rb
@@ -116,7 +116,7 @@ describe ::Nanoc::Checking::Checks::ExternalLinks do
       check.run
       expect(check.issues.size).to eq(1)
       expect(check.issues.first.description)
-        .to eq('broken reference to http://example.com/x: redirection without a target location')
+        .to eq('broken reference to <http://example.com/x>: redirection without a target location')
     end
   end
 
@@ -137,7 +137,7 @@ describe ::Nanoc::Checking::Checks::ExternalLinks do
       check.run
       expect(check.issues.size).to eq(1)
       expect(check.issues.first.description)
-        .to eq('broken reference to mailto:lol: invalid URI')
+        .to eq('broken reference to <mailto:lol>: invalid URI')
     end
   end
 
@@ -166,7 +166,7 @@ describe ::Nanoc::Checking::Checks::ExternalLinks do
 
       expect(check.issues.size).to eq(1)
       expect(check.issues.first.description)
-        .to match(%r{broken reference to http://localhost:1234/ink_luded: Failed to open TCP connection})
+        .to match(%r{broken reference to <http://localhost:1234/ink_luded>: Failed to open TCP connection})
     end
   end
 
@@ -200,7 +200,7 @@ describe ::Nanoc::Checking::Checks::ExternalLinks do
 
       expect(check.issues.size).to eq(1)
       expect(check.issues.first.description)
-        .to match(%r{broken reference to http://example.com/ink_luded: 404})
+        .to match(%r{broken reference to <http://example.com/ink_luded>: 404})
     end
   end
 end


### PR DESCRIPTION
### Detailed description

Escape links as `<url>`, so terminals don’t interpret unwanted characters as being part of the link. E.g. the link from the message `broken reference to https://nanoc.app/: error` would be interpreted as `https://nanoc.app/:` instead of `https://nanoc.app/` as expected. This small change fixes that issue.

### To do

All done and I’ve updated the affected tests.