### PR TITLE
Make compatible with Haml 6.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ group :plugins do
   gem 'execjs', '~> 2.7'
   gem 'fog-aws'
   gem 'fog-local', '~> 0.6'
-  gem 'haml', '~> 5.0'
+  gem 'haml', '~> 6.0'
   gem 'kramdown'
   gem 'less', '~> 2.6', platforms: :ruby
   gem 'listen', '~> 3.1'

--- a/nanoc/lib/nanoc/filters/haml.rb
+++ b/nanoc/lib/nanoc/filters/haml.rb
@@ -22,7 +22,20 @@ module Nanoc::Filters
 
       # Get result
       proc = assigns[:content] ? -> { assigns[:content] } : nil
-      ::Haml::Engine.new(content, options).render(context, assigns, &proc)
+
+      # Render
+      haml_major_version = ::Haml::VERSION[0]
+      case haml_major_version
+      when '5'
+        ::Haml::Engine.new(content, options).render(context, assigns, &proc)
+      when '6'
+        template = Tilt::HamlTemplate.new(options) { content }
+        template.render(context, assigns, &proc)
+      else
+        raise Nanoc::Core::TrivialError.new(
+          "Cannot run Haml filter: unsupported Haml major version: #{haml_major_version}",
+        )
+      end
     end
   end
 end

--- a/nanoc/spec/nanoc/helpers/filtering_spec.rb
+++ b/nanoc/spec/nanoc/helpers/filtering_spec.rb
@@ -53,24 +53,5 @@ describe Nanoc::Helpers::Filtering, helper: true do
 
       it { is_expected.to eql('AbaahB') }
     end
-
-    context 'with Haml' do
-      subject { ::Haml::Engine.new(content).render(helper.get_binding) }
-
-      let(:content) do
-        <<~CONTENT
-          %p Foo.
-          - filter(:erb) do
-            <%= 'abc' + 'xyz' %>
-          %p Bar.
-        CONTENT
-      end
-
-      before do
-        require 'haml'
-      end
-
-      it { is_expected.to match(%r{^<p>Foo.</p>\s*abcxyz\s*<p>Bar.</p>$}) }
-    end
   end
 end

--- a/nanoc/test/filters/test_haml.rb
+++ b/nanoc/test/filters/test_haml.rb
@@ -43,7 +43,7 @@ class Nanoc::Filters::HamlTest < Nanoc::TestCase
       filter.setup_and_run('%p= this isn\'t really ruby so it\'ll break, muahaha')
     rescue SyntaxError, Haml::SyntaxError => e
       e.message =~ /(.+?):\d+: /
-      assert_match '?', Regexp.last_match[1]
+      assert_equal '(__TEMPLATE__)', Regexp.last_match[1]
       raised = true
     end
     assert raised
@@ -75,6 +75,6 @@ class Nanoc::Filters::HamlTest < Nanoc::TestCase
     # Run filter
     filter = ::Nanoc::Filters::Haml.new
     result = filter.setup_and_run("%body\n  ~ File.read('stuff')")
-    assert_match(/Max Payne&#x000A;Mona Sax/, result)
+    assert_match(/Max Payne\nMona Sax/, result)
   end
 end


### PR DESCRIPTION
### Detailed description

Nanoc currently supports Haml 5.x, but not the newly-released Haml 6. This adds compatibility with Haml 6.

Some drawbacks:

* This drops support for running the `filter` helper in Haml. It will still work in Haml 5.x, but not in Haml 6.x. As far as I can tell, it’s simply not supported, but it’s probably fine as Haml has built-in helpers that might just do the trick.

* Haml 5.x is supported, but there aren’t any test run against it. I could use [Appraisals](https://github.com/thoughtbot/appraisal) to test both Haml 5.x and 6.x, but I’m not sure it’s worth the effort.

### To do

* [x] Tests
* [ ] Documentation
* [ ] Feature flags

### Related issues

n/a
