### PR TITLE
HTML-escape single quotes

### DIFF
--- a/nanoc/lib/nanoc/helpers/html_escape.rb
+++ b/nanoc/lib/nanoc/helpers/html_escape.rb
@@ -29,6 +29,7 @@ module Nanoc::Helpers
           .gsub('<', '&lt;')
           .gsub('>', '&gt;')
           .gsub('"', '&quot;')
+          .gsub("'", '&#39;')
       else
         raise 'The #html_escape or #h function needs either a ' \
           'string or a block to HTML-escape, but neither a string nor a block was given'

--- a/nanoc/spec/nanoc/helpers/html_escape_spec.rb
+++ b/nanoc/spec/nanoc/helpers/html_escape_spec.rb
@@ -4,10 +4,28 @@ describe Nanoc::Helpers::HTMLEscape, helper: true do
   describe '#html_escape' do
     subject { helper.html_escape(string) }
 
-    context 'given strings to escape' do
-      let(:string) { '< > & "' }
+    context 'when given angular brackets' do
+      let(:string) { '<br/>' }
 
-      it { is_expected.to eql('&lt; &gt; &amp; &quot;') }
+      it { is_expected.to eql('&lt;br/&gt;') }
+    end
+
+    context 'when given ampersand' do
+      let(:string) { 'red & blue' }
+
+      it { is_expected.to eql('red &amp; blue') }
+    end
+
+    context 'when given double quotes' do
+      let(:string) { 'projection="isometric"' }
+
+      it { is_expected.to eql('projection=&quot;isometric&quot;') }
+    end
+
+    context 'when given single quotes' do
+      let(:string) { "projection='perspective'" }
+
+      it { is_expected.to eql('projection=&#39;perspective&#39;') }
     end
 
     context 'given a block' do


### PR DESCRIPTION
### Detailed description

This changes the HTML-escape code to also escape single-quotes (`'`).

This is necessary for security reasons, and it is what Rails does as well (see [`ERB::Util`](https://api.rubyonrails.org/classes/ERB/Util.html)).

### To do

* [x] Tests

### Related issues

Fixes #1590.
