### PR TITLE
Use read-only tx in Store#load

### DIFF
--- a/nanoc-core/lib/nanoc/core/store.rb
+++ b/nanoc-core/lib/nanoc/core/store.rb
@@ -81,7 +81,7 @@ module Nanoc
         return unless File.file?(filename)
 
         begin
-          pstore.transaction do
+          pstore.transaction(true) do
             return if pstore[:version] != version
 
             self.data = pstore[:data]


### PR DESCRIPTION
### Detailed description

This changes `Store#load` to use a read-only transaction, which should speed up loading site data.

### To do

n/a

### Related issues

n/a