### PR TITLE
Enable Instrumentor only when needed

### DIFF
--- a/nanoc-cli/lib/nanoc/cli/compile_listeners/timing_recorder.rb
+++ b/nanoc-cli/lib/nanoc/cli/compile_listeners/timing_recorder.rb
@@ -25,6 +25,8 @@ module Nanoc::CLI::CompileListeners
 
     # @see Listener#start
     def start
+      Nanoc::Core::Instrumentor.enable
+
       on(:stage_ran) do |duration, klass|
         @stages_summary.observe(duration, name: klass.to_s.sub(/.*::/, ''))
       end
@@ -65,6 +67,8 @@ module Nanoc::CLI::CompileListeners
 
     # @see Listener#stop
     def stop
+      Nanoc::Core::Instrumentor.disable
+
       print_profiling_feedback
     end
 

--- a/nanoc-core/lib/nanoc/core/instrumentor.rb
+++ b/nanoc-core/lib/nanoc/core/instrumentor.rb
@@ -4,13 +4,36 @@ module Nanoc
   module Core
     # @api private
     class Instrumentor
+      @enabled = false
+
+      def self.enable
+        if block_given?
+          begin
+            enable
+            yield
+          ensure
+            disable
+          end
+        else
+          @enabled = true
+        end
+      end
+
+      def self.disable
+        @enabled = false
+      end
+
       def self.call(key, *args)
-        stopwatch = DDMetrics::Stopwatch.new
-        stopwatch.start
-        yield
-      ensure
-        stopwatch.stop
-        Nanoc::Core::NotificationCenter.post(key, stopwatch.duration, *args)
+        return yield unless @enabled
+
+        begin
+          stopwatch = DDMetrics::Stopwatch.new
+          stopwatch.start
+          yield
+        ensure
+          stopwatch.stop
+          Nanoc::Core::NotificationCenter.post(key, stopwatch.duration, *args)
+        end
       end
     end
   end

--- a/nanoc-core/spec/nanoc/core/compilation_stage_spec.rb
+++ b/nanoc-core/spec/nanoc/core/compilation_stage_spec.rb
@@ -9,6 +9,10 @@ describe Nanoc::Core::CompilationStage do
 
   after { Timecop.return }
 
+  around do |ex|
+    Nanoc::Core::Instrumentor.enable { ex.run }
+  end
+
   describe '#call' do
     subject { stage.call }
 

--- a/nanoc-core/spec/nanoc/core/instrumentor_spec.rb
+++ b/nanoc-core/spec/nanoc/core/instrumentor_spec.rb
@@ -7,12 +7,29 @@ describe(Nanoc::Core::Instrumentor) do
 
   after { Timecop.return }
 
-  it 'sends notification' do
-    expect do
-      subject.call(:sample_notification, 'garbage', 123) do
-        # Go to a few seconds in the future
-        Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 5))
-      end
-    end.to send_notification(:sample_notification, 5.0, 'garbage', 123)
+  context 'when not enabled (i.e. by default)' do
+    it 'does not send notification' do
+      expect do
+        subject.call(:sample_notification, 'garbage', 123) do
+          # Go to a few seconds in the future
+          Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 5))
+        end
+      end.not_to send_notification(:sample_notification, 5.0, 'garbage', 123)
+    end
+  end
+
+  context 'when enabled' do
+    around do |ex|
+      described_class.enable { ex.run }
+    end
+
+    it 'sends notification' do
+      expect do
+        subject.call(:sample_notification, 'garbage', 123) do
+          # Go to a few seconds in the future
+          Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 5))
+        end
+      end.to send_notification(:sample_notification, 5.0, 'garbage', 123)
+    end
   end
 end


### PR DESCRIPTION
### Detailed description

This prevents the `Instrumentor` class from doing anything unless instrumentation is explicitly requested.

This leads to a measureable speedup.

### To do

* [x] Tests

### Related issues

n/a
