### PR TITLE
Performance: Speed up NotWritten outdatedness rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,7 @@ Naming/MethodParameterName:
   AllowedNames:
     - "to" # destination
     - "e" # element
+    - "fn" # filename
     - "id" # identifier
     - "io" # IO instance
     - "y" # enumerator yielder

--- a/nanoc-core/lib/nanoc/core/outdatedness_rules/not_written.rb
+++ b/nanoc-core/lib/nanoc/core/outdatedness_rules/not_written.rb
@@ -6,10 +6,30 @@ module Nanoc
       class NotWritten < Nanoc::Core::OutdatednessRule
         affects_props :raw_content, :attributes, :compiled_content, :path
 
-        def apply(obj, _outdatedness_checker)
-          if obj.raw_paths.values.flatten.compact.any? { |fn| !File.file?(fn) }
+        def apply(obj, outdatedness_checker)
+          if obj.raw_paths.values.flatten.compact.any? { |fn| !exist?(fn, outdatedness_checker) }
             Nanoc::Core::OutdatednessReasons::NotWritten
           end
+        end
+
+        private
+
+        def exist?(fn, outdatedness_checker)
+          all(outdatedness_checker).include?(fn)
+        end
+
+        def all(outdatedness_checker)
+          # NOTE: Cached per outdatedness checker, so that unrelated invocations
+          # later on don’t reuse an old cache.
+
+          @all ||= {}
+          @all[outdatedness_checker] ||= Set.new(
+            Dir.glob("#{site_root(outdatedness_checker)}/**/*", File::FNM_DOTMATCH),
+          )
+        end
+
+        def site_root(outdatedness_checker)
+          outdatedness_checker.site.config.output_dir
         end
       end
     end

--- a/nanoc-core/spec/nanoc/core/outdatedness_rules_spec.rb
+++ b/nanoc-core/spec/nanoc/core/outdatedness_rules_spec.rb
@@ -123,7 +123,7 @@ describe Nanoc::Core::OutdatednessRules do
       end
 
       context 'path for last snapshot' do
-        let(:path) { Dir.getwd + '/foo.txt' }
+        let(:path) { Dir.getwd + '/output/foo.txt' }
 
         before { item_rep.raw_paths = { last: [path] } }
 
@@ -132,14 +132,39 @@ describe Nanoc::Core::OutdatednessRules do
         end
 
         context 'written' do
-          before { File.write(path, 'hello') }
+          before do
+            FileUtils.mkdir_p(File.dirname(path))
+            File.write(path, 'hello')
+          end
 
           it { is_expected.to be_nil }
         end
       end
 
       context 'path for other snapshot' do
-        let(:path) { Dir.getwd + '/foo.txt' }
+        let(:path) { Dir.getwd + '/output/foo.txt' }
+
+        before { item_rep.raw_paths = { donkey: [path] } }
+
+        context 'not written' do
+          it { is_expected.not_to be_nil }
+        end
+
+        context 'written' do
+          before do
+            FileUtils.mkdir_p(File.dirname(path))
+            File.write(path, 'hello')
+          end
+
+          it { is_expected.to be_nil }
+        end
+      end
+
+      context 'path inside output dir not inside current directory' do
+        let(:path) { output_dir + '/foo.txt' }
+
+        let(:config) { super().merge(output_dir: output_dir) }
+        let(:output_dir) { Dir.mktmpdir('nanoc-outdatendess-rules-spec') }
 
         before { item_rep.raw_paths = { donkey: [path] } }
 


### PR DESCRIPTION
### Detailed description

This changes the `NotWritten` to pre-load the list of files in the output directory, so that the filesystem only has to be accessed once, rather than for every file.

This leads to a nice speedup. For one particular site:

```
                                          x │ count     min     .50     .90     .95     max     tot
────────────────────────────────────────────┼──────────────────────────────────────────────────────
 Nanoc::Core::OutdatednessRules::NotWritten │  3704   0.00s   0.00s   0.01s   0.01s   0.05s   4.77s
```

```
                                          x │ count     min     .50     .90     .95     max     tot
────────────────────────────────────────────┼──────────────────────────────────────────────────────
 Nanoc::Core::OutdatednessRules::NotWritten │  3704   0.00s   0.00s   0.00s   0.00s   0.05s   0.07s
```

Before: 4.77s. After: 0.07s. That’s a 60x–70x speedup of the `NotWritten` rule.

### To do

(Include the to-do list for this PR to be finished here.)

* [x] Tests
* [x] Check in output directory, not in `Dir.pwd`

Future work could entail excluding directories such as `.git/`, but that’d likely require switching from `Dir.glob` to `Find`, which might not yield much of a speedup. In any case, the `NotWritten` rule is no longer a bottleneck now.

### Related issues

n/a