### PR TITLE
Support attribute-level dependencies on item collections

### DIFF
--- a/nanoc-cli/lib/nanoc/cli/commands/show-data.rb
+++ b/nanoc-cli/lib/nanoc/cli/commands/show-data.rb
@@ -151,7 +151,17 @@ module Nanoc::CLI::Commands
           outcome << 'matching any attribute'
         when Set
           dep.props.attributes.each do |elem|
-            outcome << "matching attribute #{elem.inspect}"
+            case elem
+            when Symbol
+              outcome << "matching attribute #{elem.inspect} (any value)"
+            when Array
+              outcome << "matching attribute pair #{elem[0].inspect} => #{elem[1].inspect}"
+            else
+              raise(
+                Nanoc::Core::Errors::InternalInconsistency,
+                "unexpected prop attribute element #{elem.inspect}",
+              )
+            end
           end
         else
           raise(

--- a/nanoc-core/lib/nanoc/core/dependency_props.rb
+++ b/nanoc-core/lib/nanoc/core/dependency_props.rb
@@ -19,8 +19,18 @@ module Nanoc
 
       C_ATTR =
         C::Or[
-          C::SetOf[Symbol],
-          C::ArrayOf[Symbol],
+          C::SetOf[
+            C::Or[
+              Symbol,          # any value
+              [Symbol, C::Any] # pair (specific value)
+            ],
+          ],
+          C::ArrayOf[
+            C::Or[
+              Symbol,          # any value
+              [Symbol, C::Any] # pair (specific value)
+            ],
+          ],
           C::Bool
         ]
 
@@ -66,6 +76,23 @@ module Nanoc
           s << (attributes? ? 'a' : '_')
           s << (compiled_content? ? 'c' : '_')
           s << (path? ? 'p' : '_')
+
+          if @raw_content.is_a?(Set)
+            @raw_content.each do |elem|
+              s << '; raw_content('
+              s << elem.inspect
+              s << ')'
+            end
+          end
+
+          if @attributes.is_a?(Set)
+            @attributes.each do |elem|
+              s << '; attr('
+              s << elem.inspect
+              s << ')'
+            end
+          end
+
           s << ')'
         end
       end
@@ -153,6 +180,15 @@ module Nanoc
           pr << :attributes if attributes?
           pr << :compiled_content if compiled_content?
           pr << :path if path?
+        end
+      end
+
+      def attribute_keys
+        case @attributes
+        when Enumerable
+          @attributes.map { |a| a.is_a?(Array) ? a.first : a }
+        else
+          []
         end
       end
 

--- a/nanoc-core/lib/nanoc/core/dependency_store.rb
+++ b/nanoc-core/lib/nanoc/core/dependency_store.rb
@@ -15,6 +15,7 @@ module Nanoc
       C_ATTR =
         C::Or[
           C::ArrayOf[Symbol],
+          C::HashOf[Symbol => C::Any],
           C::Bool
         ]
 
@@ -139,6 +140,11 @@ module Nanoc
 
         src_ref = obj2ref(src)
         dst_ref = obj2ref(dst)
+
+        # Convert attributes into key-value pairs, if necessary
+        if attributes.is_a?(Hash)
+          attributes = attributes.to_a
+        end
 
         existing_props = @graph.props_for(dst_ref, src_ref)
         new_props = Nanoc::Core::DependencyProps.new(raw_content: raw_content, attributes: attributes, compiled_content: compiled_content, path: path)

--- a/nanoc-core/lib/nanoc/core/dependency_tracker.rb
+++ b/nanoc-core/lib/nanoc/core/dependency_tracker.rb
@@ -23,6 +23,7 @@ module Nanoc
       C_ATTR =
         C::Or[
           C::ArrayOf[Symbol],
+          C::HashOf[Symbol => C::Any],
           C::Bool
         ]
 

--- a/nanoc-core/lib/nanoc/core/feature.rb
+++ b/nanoc-core/lib/nanoc/core/feature.rb
@@ -90,3 +90,5 @@ module Nanoc
     end
   end
 end
+
+Nanoc::Core::Feature.define('where', version: '4.12')

--- a/nanoc-core/lib/nanoc/core/outdatedness_status.rb
+++ b/nanoc-core/lib/nanoc/core/outdatedness_status.rb
@@ -22,6 +22,10 @@ module Nanoc
           props: @props.merge(reason.props),
         )
       end
+
+      def inspect
+        "<#{self.class} reasons=#{@reasons.inspect} props=#{@props.inspect}>"
+      end
     end
   end
 end


### PR DESCRIPTION
### Detailed description

This adds support for queries like `@items.where(kind: 'article')`, which would return a collection of all items where the `kind` attribute is `"article"`.

In behavior, this is nearly identical to `@items.select { _1[:kind] == 'article' }`, but is more friendly to the dependency tracker and outdatedness checker. For example:

* This creates only a single dependency, onto the item collection, rather than individual dependencies for each item. This cuts down on the number of dependencies. A lower number of dependencies means the dependency is smaller, and can be loaded/stored more quickly. For large sites, with many thousands of items, this can make a significant difference.

* This prevents items from being marked outdated if their `kind` attribute changes from something that isn’t `"article"` to something else that isn’t `"article"` either (e.g. from `"note"` to `"thought"`). This can reduce the number of redundant recompiles.

For now, this feature is available only behind a feature flag. Set the `NANOC_FEATURES` environment variable to `where` to enable usage of `.where(…)`. (Alternatively, set it to `all` to enable all feature flags.)

### To do

* [x] Tests
* [x] Refactoring
* [ ] Documentation (**pending -- will be added later**)
* [x] Feature flags

### Related issues

n/a
