### PR TITLE
Implement accurate checksumming for Set

### DIFF
--- a/nanoc-core/lib/nanoc/core/checksummer.rb
+++ b/nanoc-core/lib/nanoc/core/checksummer.rb
@@ -81,7 +81,8 @@ module Nanoc
           # NOTE: Other behaviors are registered elsewhere
           # (search for `define_behavior`).
 
-          define_behavior(Array, ArrayUpdateBehavior)
+          define_behavior(Array, CollectionUpdateBehavior)
+          define_behavior(Set, SetUpdateBehavior)
           define_behavior(FalseClass, NoUpdateBehavior)
           define_behavior(Hash, HashUpdateBehavior)
           define_behavior(NilClass, NoUpdateBehavior)
@@ -96,7 +97,7 @@ module Nanoc
           define_behavior(Nanoc::Core::Configuration, HashUpdateBehavior)
           define_behavior(Nanoc::Core::Context, ContextUpdateBehavior)
           define_behavior(Nanoc::Core::CodeSnippet, DataUpdateBehavior)
-          define_behavior(Nanoc::Core::IdentifiableCollection, ArrayUpdateBehavior)
+          define_behavior(Nanoc::Core::IdentifiableCollection, CollectionUpdateBehavior)
           define_behavior(Nanoc::Core::Identifier, ToSUpdateBehavior)
           define_behavior(Nanoc::Core::Item, DocumentUpdateBehavior)
           define_behavior(Nanoc::Core::ItemRep, ItemRepUpdateBehavior)
@@ -194,12 +195,19 @@ module Nanoc
         end
       end
 
-      class ArrayUpdateBehavior < UpdateBehavior
+      class CollectionUpdateBehavior < UpdateBehavior
         def self.update(obj, digest)
           obj.each do |el|
             yield(el)
             digest.update(',')
           end
+        end
+      end
+
+      class SetUpdateBehavior < CollectionUpdateBehavior
+        def self.update(obj, digest)
+          # Similar to CollectionUpdateBehavior, but sorted for consistency.
+          super(obj.sort { |a, b| (a <=> b) || 0 }, digest)
         end
       end
 

--- a/nanoc-core/spec/nanoc/core/checksummer_spec.rb
+++ b/nanoc-core/spec/nanoc/core/checksummer_spec.rb
@@ -97,6 +97,30 @@ describe Nanoc::Core::Checksummer do
     end
   end
 
+  context 'Set' do
+    let(:obj) { Set.new(%w[hello goodbye]) }
+
+    it { is_expected.to eql('Set<String<goodbye>,String<hello>,>') }
+
+    context 'different order' do
+      let(:obj) { Set.new(%w[goodbye hello]) }
+
+      it { is_expected.to eql('Set<String<goodbye>,String<hello>,>') }
+    end
+
+    context 'recursive' do
+      let(:obj) { Set.new.tap { |set| set << Set.new.add('hello').add(set) } }
+
+      it { is_expected.to eql('Set<Set<String<hello>,Set<recur>,>,>') }
+    end
+
+    context 'non-serializable' do
+      let(:obj) { Set.new.add(-> {}) }
+
+      it { is_expected.to match(/\ASet<Proc<#<Proc:0x.*>>,>\z/) }
+    end
+  end
+
   context 'Hash' do
     let(:obj) { { 'a' => 'foo', 'b' => 'bar' } }
 


### PR DESCRIPTION
### Detailed description

The `Checksummer` now knows how to handle a `Set`, without using `Marshal.dump` (which causes the checksums to fluctuate, and items be marked as outdated).

Additionally, this renames `ArrayUpdateBehavior` to `CollectionUpdateBehavior`. This way, it reflects that it can be used for other collections as well.

### To do

* [x] Tests
* ~~[ ] Documentation~~
* ~~[ ] Feature flags~~

### Related issues

n/a