### PR TITLE
Improve performance of outdatedness checker

### DIFF
--- a/nanoc-core/lib/nanoc/core/checksum_collection.rb
+++ b/nanoc-core/lib/nanoc/core/checksum_collection.rb
@@ -9,6 +9,8 @@ module Nanoc
 
       def initialize(checksums)
         @checksums = checksums
+
+        @_attribute_checksums = {}
       end
 
       contract c_obj => C::Maybe[String]
@@ -23,7 +25,7 @@ module Nanoc
 
       contract c_obj => C::Maybe[C::HashOf[Symbol, String]]
       def attributes_checksum_for(obj)
-        @checksums[[obj.reference, :each_attribute]]
+        @_attribute_checksums[obj] ||= @checksums[[obj.reference, :each_attribute]]
       end
 
       def to_h

--- a/nanoc-core/lib/nanoc/core/checksum_store.rb
+++ b/nanoc-core/lib/nanoc/core/checksum_store.rb
@@ -21,6 +21,8 @@ module Nanoc
         @objects = objects
 
         @checksums = {}
+
+        invalidate_memoization
       end
 
       contract c_obj => C::Maybe[String]
@@ -50,7 +52,7 @@ module Nanoc
 
       contract c_obj => C::Maybe[C::HashOf[Symbol, String]]
       def attributes_checksum_for(obj)
-        @checksums[[obj.reference, :each_attribute]]
+        @_attribute_checksums[obj] ||= @checksums[[obj.reference, :each_attribute]]
       end
 
       protected
@@ -60,6 +62,8 @@ module Nanoc
       end
 
       def data=(new_data)
+        invalidate_memoization
+
         references = Set.new(@objects.map(&:reference))
 
         @checksums = {}
@@ -68,6 +72,12 @@ module Nanoc
             @checksums[key] = checksum
           end
         end
+      end
+
+      private
+
+      def invalidate_memoization
+        @_attribute_checksums = {}
       end
     end
   end

--- a/nanoc-core/lib/nanoc/core/document.rb
+++ b/nanoc-core/lib/nanoc/core/document.rb
@@ -49,6 +49,9 @@ module Nanoc
         @checksum_data = checksum_data
         @content_checksum_data = content_checksum_data
         @attributes_checksum_data = attributes_checksum_data
+
+        # Precalculate hash for performance
+        @hash = [self.class, identifier].hash
       end
 
       # @return [Hash]
@@ -107,7 +110,7 @@ module Nanoc
 
       contract C::None => C::Num
       def hash
-        [self.class, identifier].hash
+        @hash
       end
 
       contract C::Any => C::Bool

--- a/nanoc-core/lib/nanoc/core/outdatedness_checker.rb
+++ b/nanoc-core/lib/nanoc/core/outdatedness_checker.rb
@@ -269,10 +269,6 @@ module Nanoc
 
           new_object_checksums = checksums.attributes_checksum_for(object)
 
-          # Ignore any attribute not mentioned in the dependency
-          old_object_checksums = old_object_checksums.select { |k, _v| dep_checksums.key?(k) }
-          new_object_checksums = new_object_checksums.select { |k, _v| dep_checksums.key?(k) }
-
           dep_checksums.any? do |key, dep_value|
             # Get old and new checksum for this particular attribute
             old_value = old_object_checksums[key]


### PR DESCRIPTION
### Detailed description

After some detailed profiling of `DetermineOutdatedness#run`, I found some hotspots that I tweaked.

For one particular site, this decreased the duration of `DetermineOutdatedness#run` from just over 7s to just over 4s. The call to `OutdatednessChecker#attributes_prop_causes_outdatedness?`  went from taking 45% to taking 6.4% of `DetermineOutdatedness#run` execution time.

### To do

* [x] Tests

### Related issues

n/a