### PR TITLE
Improve performance (part III)

### DIFF
--- a/nanoc-cli/spec/nanoc/cli/commands/show_data_spec.rb
+++ b/nanoc-cli/spec/nanoc/cli/commands/show_data_spec.rb
@@ -55,42 +55,6 @@ describe Nanoc::CLI::Commands::ShowData, stdio: true do
       end
     end
 
-    context 'dependency (without props) from config to dog' do
-      before do
-        dependency_store.record_dependency(item_dog, config)
-      end
-
-      it 'outputs no dependencies for /about.md' do
-        expect { subject }.to output(%r{^item /about.md depends on:\n  \(nothing\)$}m).to_stdout
-      end
-
-      it 'outputs dependencies for /dog.md' do
-        expect { subject }.to output(%r{^item /dog.md depends on:\n  \[  config \] \(racp\)$}m).to_stdout
-      end
-
-      it 'outputs no dependencies for /other.dat' do
-        expect { subject }.to output(%r{^item /other.dat depends on:\n  \(nothing\)$}m).to_stdout
-      end
-    end
-
-    context 'dependency (without props) from about to dog' do
-      before do
-        dependency_store.record_dependency(item_dog, item_about)
-      end
-
-      it 'outputs no dependencies for /about.md' do
-        expect { subject }.to output(%r{^item /about.md depends on:\n  \(nothing\)$}m).to_stdout
-      end
-
-      it 'outputs dependencies for /dog.md' do
-        expect { subject }.to output(%r{^item /dog.md depends on:\n  \[    item \] \(racp\) /about.md$}m).to_stdout
-      end
-
-      it 'outputs no dependencies for /other.dat' do
-        expect { subject }.to output(%r{^item /other.dat depends on:\n  \(nothing\)$}m).to_stdout
-      end
-    end
-
     context 'dependency (with raw_content prop) from about to dog' do
       before do
         dependency_store.record_dependency(item_dog, item_about, raw_content: true)

--- a/nanoc-core/lib/nanoc/core/dependency_props.rb
+++ b/nanoc-core/lib/nanoc/core/dependency_props.rb
@@ -111,7 +111,7 @@ module Nanoc
       def raw_content?
         case @raw_content
         when Set
-          @raw_content.any?
+          !@raw_content.empty?
         else
           @raw_content
         end
@@ -121,7 +121,7 @@ module Nanoc
       def attributes?
         case @attributes
         when Set
-          @attributes.any?
+          !@attributes.empty?
         else
           @attributes
         end

--- a/nanoc-core/lib/nanoc/core/dependency_props.rb
+++ b/nanoc-core/lib/nanoc/core/dependency_props.rb
@@ -173,10 +173,6 @@ module Nanoc
         end
       end
 
-      def any_active?
-        compiled_content? || path? || raw_content? || attributes?
-      end
-
       contract C::None => Set
       def active
         Set.new.tap do |pr|

--- a/nanoc-core/lib/nanoc/core/dependency_store.rb
+++ b/nanoc-core/lib/nanoc/core/dependency_store.rb
@@ -71,12 +71,7 @@ module Nanoc
           Nanoc::Core::Dependency.new(
             other_object,
             object,
-            Nanoc::Core::DependencyProps.new(
-              raw_content: props.fetch(:raw_content, false),
-              attributes: props.fetch(:attributes, false),
-              compiled_content: props.fetch(:compiled_content, false),
-              path: props.fetch(:path, false),
-            ),
+            props,
           )
         end
       end
@@ -192,15 +187,22 @@ module Nanoc
         refs.map { |r| ref2obj(r) }
       end
 
-      # TODO: Return not a Hash, but a DependencyProps instead
       def props_for(from, to)
         props = @graph.props_for(obj2ref(from), obj2ref(to))
+        return props if props
 
-        if props&.any_active?
-          props.to_h
-        else
-          { raw_content: true, attributes: true, compiled_content: true, path: true }
-        end
+        # This is for backwards compatibility, in case there are no dependency
+        # props available yet. Pretend everything is set to `true`; it’ll be
+        # recompiled and correct props will be available in the next run.
+        #
+        # NOTE: This isn’t covered by tests, yet. (Not trivial to test because
+        # it’s not a condition that can arise in the current Nanoc version.)
+        Nanoc::Core::DependencyProps.new(
+          raw_content: true,
+          attributes: true,
+          compiled_content: true,
+          path: true,
+        )
       end
 
       def data

--- a/nanoc-core/lib/nanoc/core/mutable_document_view_mixin.rb
+++ b/nanoc-core/lib/nanoc/core/mutable_document_view_mixin.rb
@@ -26,13 +26,7 @@ module Nanoc
       #
       # @see Hash#[]=
       def []=(key, value)
-        disallowed_value_classes = Set.new([
-          Nanoc::Core::Item,
-          Nanoc::Core::Layout,
-          Nanoc::Core::CompilationItemView,
-          Nanoc::Core::LayoutView,
-        ])
-        if disallowed_value_classes.include?(value.class)
+        if disallowed_value_class?(value.class)
           raise DisallowedAttributeValueError.new(value)
         end
 
@@ -54,6 +48,21 @@ module Nanoc
       def update_attributes(hash)
         hash.each { |k, v| _unwrap.set_attribute(k, v) }
         self
+      end
+
+      private
+
+      def disallowed_value_class?(klass)
+        # NOTE: We’re explicitly disabling Style/MultipleComparison, because
+        # the suggested alternative (Array#include?) carries a measurable
+        # performance penatly.
+        #
+        # rubocop:disable Style/MultipleComparison
+        klass == Nanoc::Core::Item ||
+          klass == Nanoc::Core::Layout ||
+          klass == Nanoc::Core::CompilationItemView ||
+          klass == Nanoc::Core::LayoutView
+        # rubocop:enable Style/MultipleComparison
       end
     end
   end

--- a/nanoc-core/lib/nanoc/core/outdatedness_checker.rb
+++ b/nanoc-core/lib/nanoc/core/outdatedness_checker.rb
@@ -196,7 +196,7 @@ module Nanoc
           active = status.props.active & dependency.props.active
           active.delete(:attributes) if attributes_unaffected?(status, dependency)
 
-          active.any?
+          !active.empty?
         end
       end
 

--- a/nanoc-core/lib/nanoc/core/outdatedness_rule.rb
+++ b/nanoc-core/lib/nanoc/core/outdatedness_rule.rb
@@ -23,11 +23,39 @@ module Nanoc
       end
 
       def self.affects_props(*names)
-        @affected_props = Set.new(names)
+        @affects_raw_content = false
+        @affects_attributes = false
+        @affects_compiled_content = false
+        @affects_path = false
+
+        names.each do |name|
+          case name
+          when :raw_content
+            @affects_raw_content = true
+          when :attributes
+            @affects_attributes = true
+          when :compiled_content
+            @affects_compiled_content = true
+          when :path
+            @affects_path = true
+          end
+        end
       end
 
-      def self.affected_props
-        @affected_props
+      def self.affects_raw_content?
+        @affects_raw_content
+      end
+
+      def self.affects_attributes?
+        @affects_attributes
+      end
+
+      def self.affects_compiled_content?
+        @affects_compiled_content
+      end
+
+      def self.affects_path?
+        @affects_path
       end
     end
   end

--- a/nanoc-core/lib/nanoc/core/outdatedness_status.rb
+++ b/nanoc-core/lib/nanoc/core/outdatedness_status.rb
@@ -13,7 +13,12 @@ module Nanoc
       end
 
       def useful_to_apply?(rule)
-        (rule.affected_props - @props.active).any?
+        return true if rule.affects_raw_content? && !@props.raw_content?
+        return true if rule.affects_attributes? && !@props.attributes?
+        return true if rule.affects_compiled_content? && !@props.compiled_content?
+        return true if rule.affects_path? && !@props.path?
+
+        false
       end
 
       def update(reason)

--- a/nanoc-core/spec/nanoc/core/dependency_store_spec.rb
+++ b/nanoc-core/spec/nanoc/core/dependency_store_spec.rb
@@ -48,14 +48,6 @@ describe Nanoc::Core::DependencyStore do
           expect(deps[0].to).to eql(item_a)
         end
 
-        it 'returns true for all props by default' do
-          deps = store.dependencies_causing_outdatedness_of(item_a)
-          expect(deps[0].props.raw_content?).to be(true)
-          expect(deps[0].props.attributes?).to be(true)
-          expect(deps[0].props.compiled_content?).to be(true)
-          expect(deps[0].props.path?).to be(true)
-        end
-
         it 'returns nothing for the others' do
           expect(store.dependencies_causing_outdatedness_of(item_b)).to be_empty
           expect(store.dependencies_causing_outdatedness_of(item_c)).to be_empty
@@ -108,14 +100,6 @@ describe Nanoc::Core::DependencyStore do
           deps = store.dependencies_causing_outdatedness_of(item_a)
           expect(deps.size).to be(1)
         end
-
-        it 'returns true for all props' do
-          deps = store.dependencies_causing_outdatedness_of(item_a)
-          expect(deps[0].props.raw_content?).to be(true)
-          expect(deps[0].props.compiled_content?).to be(true)
-          expect(deps[0].props.path?).to be(true)
-          expect(deps[0].props.attributes?).to be(true)
-        end
       end
 
       context 'no props' do
@@ -132,14 +116,6 @@ describe Nanoc::Core::DependencyStore do
           deps = store.dependencies_causing_outdatedness_of(item_a)
           expect(deps[0].from).to eql(item_b)
           expect(deps[0].to).to eql(item_a)
-        end
-
-        it 'returns true for all props by default' do
-          deps = store.dependencies_causing_outdatedness_of(item_a)
-          expect(deps[0].props.raw_content?).to be(true)
-          expect(deps[0].props.attributes?).to be(true)
-          expect(deps[0].props.compiled_content?).to be(true)
-          expect(deps[0].props.path?).to be(true)
         end
 
         it 'returns nothing for the others' do


### PR DESCRIPTION
### Detailed description

This continues the progress made in improving performance.

The main learning: `Set#any?` is *slow* -- much better to use `Set#empty?` and negate.

I also realised that `Set`s can be avoided if the possible elements are limited and known ahead of time. `Set` is rather slow, and more verbose code can be a lot faster.

### To do

* [ ] Tests
  * It’d be nice to have a test case for `#props_for` returning nil, but by now it’s less and less likely that there’s such old versions of Nanoc around that require this very tiny bit of backwards compatibility.

### Related issues

Two other performance-focused PRs:
* #1602 
* #1603
