### PR TITLE
Add nanoc-tilt filter

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -66,6 +66,10 @@ jobs:
         run: bundle exec rake nanoc_live:test
         timeout-minutes: 3
 
+      - name: Test nanoc-tilt
+        run: bundle exec rake nanoc_tilt:test
+        timeout-minutes: 3
+
       - name: Test nanoc-spec
         run: bundle exec rake nanoc_spec:test
         timeout-minutes: 3

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gemspec path: 'nanoc-deploying'
 gemspec path: 'nanoc-external'
 gemspec path: 'nanoc-live'
 gemspec path: 'nanoc-spec'
+gemspec path: 'nanoc-tilt'
 gemspec path: 'guard-nanoc'
 
 group :devel do

--- a/Rakefile
+++ b/Rakefile
@@ -25,6 +25,7 @@ packages = %w[
   nanoc-external
   nanoc-live
   nanoc-spec
+  nanoc-tilt
   guard-nanoc
 ]
 

--- a/nanoc-tilt/.rspec
+++ b/nanoc-tilt/.rspec
@@ -1,0 +1,3 @@
+-r ./spec/spec_helper.rb
+--format Fuubar
+--color

--- a/nanoc-tilt/LICENSE
+++ b/nanoc-tilt/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2014–… Denis Defreyne and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/nanoc-tilt/NEWS.md
+++ b/nanoc-tilt/NEWS.md
@@ -1,0 +1,5 @@
+# nanoc-tilt news
+
+## 1.0.0 (2022-10-29)
+
+Initial release.

--- a/nanoc-tilt/README.md
+++ b/nanoc-tilt/README.md
@@ -1,0 +1,31 @@
+# nanoc-tilt
+
+This provides a filter that allows [Nanoc](https://nanoc.app) to process content via [Tilt](https://github.com/rtomayko/tilt).
+
+## Installation
+
+Add `nanoc-tilt` to the `nanoc` group of your Gemfile:
+
+```ruby
+group :nanoc do
+  gem 'nanoc-tilt'
+end
+```
+
+## Usage
+
+Call the `:tilt` filter. For example:
+
+```ruby
+filter :tilt
+```
+
+Options passed to this filter will be passed on to the tilt filter. For example:
+
+```ruby
+filter :tilt, args: { escape: true }
+```
+
+```ruby
+filter :tilt, args: { escape: false }
+```

--- a/nanoc-tilt/Rakefile
+++ b/nanoc-tilt/Rakefile
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new(:rubocop)
+
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.verbose = false
+end
+
+task test: :spec
+
+task :gem do
+  sh('gem build *.gemspec')
+end
+
+task default: %i[test rubocop]

--- a/nanoc-tilt/lib/nanoc-tilt.rb
+++ b/nanoc-tilt/lib/nanoc-tilt.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'nanoc/tilt'

--- a/nanoc-tilt/lib/nanoc/tilt.rb
+++ b/nanoc-tilt/lib/nanoc/tilt.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Nanoc
+  module Tilt
+  end
+end
+
+require 'tilt'
+
+require 'nanoc/tilt/version'
+require 'nanoc/tilt/filter'

--- a/nanoc-tilt/lib/nanoc/tilt/filter.rb
+++ b/nanoc-tilt/lib/nanoc/tilt/filter.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Nanoc
+  module Tilt
+    class Filter < Nanoc::Filter
+      identifier :tilt
+
+      # Runs the content through [Tilt](https://github.com/rtomayko/tilt).
+      # Parameters passed as `:args` will be passed on to Tilt.
+      #
+      # @param [String] content The content to filter
+      #
+      # @return [String] The filtered content
+      def run(content, params = {})
+        # Get options
+        options = params.fetch(:args, {})
+
+        # Create context
+        context = ::Nanoc::Core::Context.new(assigns)
+
+        # Get result
+        proc = assigns[:content] ? -> { assigns[:content] } : nil
+
+        # Find Tilt template class
+        ext = item.identifier.ext || item[:extension]
+        template_class = ::Tilt[ext]
+
+        # Render
+        template = template_class.new(options) { content }
+        template.render(context, assigns, &proc)
+      end
+    end
+  end
+end

--- a/nanoc-tilt/lib/nanoc/tilt/version.rb
+++ b/nanoc-tilt/lib/nanoc/tilt/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Nanoc
+  module Tilt
+    VERSION = '1.0.0'
+  end
+end

--- a/nanoc-tilt/nanoc-tilt.gemspec
+++ b/nanoc-tilt/nanoc-tilt.gemspec
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative 'lib/nanoc/tilt/version'
+
+Gem::Specification.new do |s|
+  s.name        = 'nanoc-tilt'
+  s.version     = Nanoc::Tilt::VERSION
+  s.homepage    = 'https://nanoc.ws/'
+  s.summary     = 'Tilt filter for Nanoc'
+  s.description = 'Provides a :tilt filter for Nanoc'
+  s.author      = 'Denis Defreyne'
+  s.email       = 'denis+rubygems@denis.ws'
+  s.license     = 'MIT'
+
+  s.files         = ['NEWS.md', 'README.md'] + Dir['lib/**/*.rb']
+  s.require_paths = ['lib']
+
+  s.required_ruby_version = '>= 2.7'
+
+  s.add_runtime_dependency('nanoc-core', '~> 4.11', '>= 4.11.14')
+  s.add_runtime_dependency('tilt', '~> 2.0')
+  s.metadata['rubygems_mfa_required'] = 'true'
+end

--- a/nanoc-tilt/nanoc-tilt.manifest
+++ b/nanoc-tilt/nanoc-tilt.manifest
@@ -1,0 +1,7 @@
+NEWS.md
+README.md
+
+lib/nanoc-tilt.rb
+lib/nanoc/tilt.rb
+lib/nanoc/tilt/filter.rb
+lib/nanoc/tilt/version.rb

--- a/nanoc-tilt/spec/gem_spec.rb
+++ b/nanoc-tilt/spec/gem_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+describe 'nanoc-tilt.gem', chdir: false, stdio: true do
+  subject(:build_gem) do
+    TTY::Command.new.run('gem build nanoc-tilt.gemspec')
+  end
+
+  around do |ex|
+    Dir['*.gem'].each { |f| FileUtils.rm(f) }
+    ex.run
+    Dir['*.gem'].each { |f| FileUtils.rm(f) }
+  end
+
+  it 'builds gem' do
+    expect { build_gem }
+      .to change { Dir['*.gem'] }
+      .from([])
+      .to(include(match(/^nanoc-tilt-.*\.gem$/)))
+  end
+end

--- a/nanoc-tilt/spec/manifest_spec.rb
+++ b/nanoc-tilt/spec/manifest_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+describe 'manifest', chdir: false do
+  example do
+    expect('nanoc-tilt').to have_a_valid_manifest
+  end
+end

--- a/nanoc-tilt/spec/nanoc/tilt/filter_spec.rb
+++ b/nanoc-tilt/spec/nanoc/tilt/filter_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+describe Nanoc::Tilt::Filter do
+  it 'supports .erb' do
+    item = Nanoc::Core::Item.new('stuff', {}, '/foo.erb')
+    item_rep = Nanoc::Core::ItemRep.new(item, :default)
+
+    filter = ::Nanoc::Tilt::Filter.new({ item: item, item_rep: item_rep })
+
+    res = filter.run('<%= "a" * 3 %>')
+    expect(res.strip).to eq('aaa')
+  end
+
+  it 'supports .erb with options' do
+    item = Nanoc::Core::Item.new('stuff', {}, '/foo.erb')
+    item_rep = Nanoc::Core::ItemRep.new(item, :default)
+
+    filter = ::Nanoc::Tilt::Filter.new({ item: item, item_rep: item_rep })
+
+    res = filter.run('<%= "&" * 3 %>', args: { escape: false })
+    expect(res.strip).to eq('&&&')
+
+    res = filter.run('<%= "&" * 3 %>', args: { escape: true })
+    expect(res.strip).to eq('&amp;&amp;&amp;')
+  end
+end

--- a/nanoc-tilt/spec/spec_helper.rb
+++ b/nanoc-tilt/spec/spec_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require_relative '../../common/spec/spec_helper_head'
+
+require 'nanoc/tilt'
+
+require_relative '../../common/spec/spec_helper_foot'

--- a/scripts/release
+++ b/scripts/release
@@ -30,6 +30,7 @@ version_constant =
     'nanoc-external' => 'Nanoc::External::VERSION',
     'nanoc-live' => 'Nanoc::Live::VERSION',
     'nanoc-spec' => 'Nanoc::Spec::VERSION',
+    'nanoc-tilt' => 'Nanoc::Tilt::VERSION',
     'guard-nanoc' => 'Guard::GUARD_NANOC_VERSION',
   }.fetch(gem_name) do
     $stderr.puts "Error: Unknown gem name: #{gem_name}"
@@ -46,6 +47,7 @@ gem_dir =
     'nanoc-external' => 'nanoc-external',
     'nanoc-live' => 'nanoc-live',
     'nanoc-spec' => 'nanoc-spec',
+    'nanoc-tilt' => 'nanoc-tilt',
     'guard-nanoc' => 'guard-nanoc',
   }.fetch(gem_name) do
     $stderr.puts "Error: Unknown gem name: #{gem_name}"
@@ -62,6 +64,7 @@ gem_path =
     'nanoc-external' => 'nanoc/external',
     'nanoc-live' => 'nanoc/live',
     'nanoc-spec' => 'nanoc/spec',
+    'nanoc-tilt' => 'nanoc/tilt',
     'guard-nanoc' => 'guard/nanoc',
   }.fetch(gem_name) do
     $stderr.puts "Error: Unknown gem name: #{gem_name}"


### PR DESCRIPTION
### Detailed description

Adds a `:tilt` filter. Similar to the existing [nanoc-tilt gem](https://rubygems.org/gems/nanoc-tilt), but up to date for Nanoc 4.

### To do

Soon:

* Release

### Related issues

n/a