### PR TITLE
Optimize item rep selection

### DIFF
--- a/nanoc-core/lib/nanoc/core/item_rep_selector.rb
+++ b/nanoc-core/lib/nanoc/core/item_rep_selector.rb
@@ -8,23 +8,73 @@ module Nanoc
         @reps = reps
       end
 
-      class MicroGraph
-        def initialize(reps)
-          @reps = Set.new(reps)
-          @stack = []
+      # An iterator (FIFO) over an array, with ability to ignore certain
+      # elements.
+      class ItemRepIgnorableIterator
+        def initialize(array)
+          @array = array
+          @index = 0
         end
 
         def next
-          if @stack.any?
-            @stack.last
-          elsif @reps.any?
-            @reps.each { |rep| break rep }.tap do |rep|
-              @reps.delete(rep)
-              @stack.push(rep)
+          elem = @array[@index]
+          @index += 1
+          elem
+        end
+
+        def next_ignoring(ignored)
+          loop do
+            elem = self.next
+
+            unless ignored.include?(elem)
+              return elem
             end
-          else
-            nil
           end
+        end
+      end
+
+      # A priority queue that tracks dependencies and can detect circular
+      # dependencies.
+      class ItemRepPriorityQueue
+        def initialize(reps)
+          # Prio A: most important; prio C: least important.
+          @prio_a = []
+          @prio_b = ItemRepIgnorableIterator.new(reps)
+          @prio_c = []
+
+          # Stack of things that depend on each other. This is used for
+          # detecting and reporting circular dependencies.
+          @stack = []
+
+          # List of reps that we’ve already seen. Reps from `reps` will end up
+          # in here. Reps can end up in here even *before* they come from
+          # `reps`, when they are part of a dependency.
+          @seen = Set.new
+        end
+
+        def next
+          # Read prio A
+          @this = @prio_a.pop
+          if @this
+            @stack.push(@this)
+            return @this
+          end
+
+          # Read prio B
+          @this = @prio_b.next_ignoring(@seen)
+          if @this
+            @stack.push(@this)
+            return @this
+          end
+
+          # Read prio C
+          @this = @prio_c.pop
+          if @this
+            @stack.push(@this)
+            return @this
+          end
+
+          nil
         end
 
         def mark_ok
@@ -36,26 +86,39 @@ module Nanoc
             raise Nanoc::Core::Errors::DependencyCycle.new(@stack + [dep])
           end
 
-          @reps.delete(dep)
-          @stack.push(dep)
+          # `@this` depends on `dep`, so `dep` has to be compiled first. Thus,
+          # move `@this` into priority C, and `dep` into priority A.
+
+          # Put `@this` (item rep that needs `dep` to be compiled first) into
+          # priority C (lowest prio).
+          @prio_c.push(@this)
+
+          # Put `dep` (item rep that needs to be compiled first, before
+          # `@this`) into priority A (highest prio).
+          @prio_a.push(dep)
+
+          # Remember that we’ve prioritised `dep`. This particular element will
+          # come from @prio_b at some point in the future, so we’ll have to skip
+          # it then.
+          @seen << dep
         end
       end
 
       def each
-        mg = MicroGraph.new(@reps)
+        pq = ItemRepPriorityQueue.new(@reps)
 
         loop do
-          rep = mg.next
+          rep = pq.next
           break if rep.nil?
 
           begin
             yield(rep)
-            mg.mark_ok
+            pq.mark_ok
           rescue => e
             actual_error = e.is_a?(Nanoc::Core::Errors::CompilationError) ? e.unwrap : e
 
             if actual_error.is_a?(Nanoc::Core::Errors::UnmetDependency)
-              mg.mark_failed(actual_error.rep)
+              pq.mark_failed(actual_error.rep)
             else
               raise(e)
             end

--- a/nanoc-core/spec/meta_spec.rb
+++ b/nanoc-core/spec/meta_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 describe 'meta', chdir: false do
+  # rubocop:disable RSpec/ExampleLength
   it 'is covered by specs' do
     regular_files = Dir['lib/nanoc/core/**/*.rb']
     regular_file_base_names = regular_files.map { |fn| fn.gsub(/^lib\/nanoc\/core\/|\.rb$/, '') }
@@ -62,6 +63,7 @@ describe 'meta', chdir: false do
     ignored_spec_file_base_names = %w[
       errors/dependency_cycle
       outdatedness_rules
+      item_rep_selector/item_rep_priority_queue
     ]
 
     effective_regular_file_base_names =
@@ -88,4 +90,5 @@ describe 'meta', chdir: false do
       !content.match?(/\b(puts|warn)\b/) && !content.match?(/\$std(err|out)/)
     end)
   end
+  # rubocop:enable RSpec/ExampleLength
 end

--- a/nanoc-core/spec/nanoc/core/item_rep_selector/item_rep_priority_queue_spec.rb
+++ b/nanoc-core/spec/nanoc/core/item_rep_selector/item_rep_priority_queue_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Nanoc::Core::ItemRepSelector::MicroGraph do
+describe Nanoc::Core::ItemRepSelector::ItemRepPriorityQueue do
   subject(:micro_graph) { described_class.new(reps) }
 
   let(:items) do
@@ -50,9 +50,6 @@ describe Nanoc::Core::ItemRepSelector::MicroGraph do
       expect(micro_graph.next).to eq(reps[2])
       micro_graph.mark_ok
 
-      expect(micro_graph.next).to eq(reps[0])
-      micro_graph.mark_ok
-
       expect(micro_graph.next).to eq(reps[1])
       micro_graph.mark_ok
 
@@ -60,6 +57,9 @@ describe Nanoc::Core::ItemRepSelector::MicroGraph do
       micro_graph.mark_ok
 
       expect(micro_graph.next).to eq(reps[4])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[0])
       micro_graph.mark_ok
     end
   end
@@ -75,16 +75,16 @@ describe Nanoc::Core::ItemRepSelector::MicroGraph do
       expect(micro_graph.next).to eq(reps[4])
       micro_graph.mark_ok
 
-      expect(micro_graph.next).to eq(reps[2])
-      micro_graph.mark_ok
-
-      expect(micro_graph.next).to eq(reps[0])
-      micro_graph.mark_ok
-
       expect(micro_graph.next).to eq(reps[1])
       micro_graph.mark_ok
 
       expect(micro_graph.next).to eq(reps[3])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[2])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[0])
       micro_graph.mark_ok
     end
   end

--- a/nanoc-core/spec/nanoc/core/item_rep_selector/micro_graph_spec.rb
+++ b/nanoc-core/spec/nanoc/core/item_rep_selector/micro_graph_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+describe Nanoc::Core::ItemRepSelector::MicroGraph do
+  subject(:micro_graph) { described_class.new(reps) }
+
+  let(:items) do
+    [
+      Nanoc::Core::Item.new('item A', {}, '/a.md'),
+      Nanoc::Core::Item.new('item B', {}, '/b.md'),
+      Nanoc::Core::Item.new('item C', {}, '/c.md'),
+      Nanoc::Core::Item.new('item D', {}, '/d.md'),
+      Nanoc::Core::Item.new('item E', {}, '/e.md'),
+    ]
+  end
+
+  let(:reps) do
+    [
+      Nanoc::Core::ItemRep.new(items[0], :default),
+      Nanoc::Core::ItemRep.new(items[1], :default),
+      Nanoc::Core::ItemRep.new(items[2], :default),
+      Nanoc::Core::ItemRep.new(items[3], :default),
+      Nanoc::Core::ItemRep.new(items[4], :default),
+    ]
+  end
+
+  context 'when there are no dependencies' do
+    it 'runs through reps in order' do
+      expect(micro_graph.next).to eq(reps[0])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[1])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[2])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[3])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[4])
+      micro_graph.mark_ok
+    end
+  end
+
+  context 'when is a simple dependency' do
+    it 'schedules the dependency next up' do
+      expect(micro_graph.next).to eq(reps[0])
+      micro_graph.mark_failed(reps[2])
+
+      expect(micro_graph.next).to eq(reps[2])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[0])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[1])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[3])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[4])
+      micro_graph.mark_ok
+    end
+  end
+
+  context 'when is a transitive dependency' do
+    it 'schedules the dependency next up' do
+      expect(micro_graph.next).to eq(reps[0])
+      micro_graph.mark_failed(reps[2])
+
+      expect(micro_graph.next).to eq(reps[2])
+      micro_graph.mark_failed(reps[4])
+
+      expect(micro_graph.next).to eq(reps[4])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[2])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[0])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[1])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[3])
+      micro_graph.mark_ok
+    end
+  end
+
+  context 'when is a circular dependency of size 2' do
+    it 'schedules the dependency next up' do
+      expect(micro_graph.next).to eq(reps[0])
+      micro_graph.mark_failed(reps[2])
+
+      expect(micro_graph.next).to eq(reps[2])
+      expect { micro_graph.mark_failed(reps[0]) }
+        .to raise_error(Nanoc::Core::Errors::DependencyCycle)
+    end
+  end
+
+  context 'when is a circular dependency of size 3' do
+    it 'schedules the dependency next up' do
+      expect(micro_graph.next).to eq(reps[0])
+      micro_graph.mark_failed(reps[2])
+
+      expect(micro_graph.next).to eq(reps[2])
+      micro_graph.mark_failed(reps[4])
+
+      expect(micro_graph.next).to eq(reps[4])
+      expect { micro_graph.mark_failed(reps[0]) }
+        .to raise_error(Nanoc::Core::Errors::DependencyCycle)
+    end
+  end
+
+  context 'when is a circular dependency of size 4' do
+    it 'schedules the dependency next up' do
+      expect(micro_graph.next).to eq(reps[0])
+      micro_graph.mark_failed(reps[2])
+
+      expect(micro_graph.next).to eq(reps[2])
+      micro_graph.mark_failed(reps[4])
+
+      expect(micro_graph.next).to eq(reps[4])
+      micro_graph.mark_failed(reps[3])
+
+      expect(micro_graph.next).to eq(reps[3])
+      expect { micro_graph.mark_failed(reps[0]) }
+        .to raise_error(Nanoc::Core::Errors::DependencyCycle)
+    end
+  end
+end

--- a/nanoc-core/spec/nanoc/core/item_rep_selector_spec.rb
+++ b/nanoc-core/spec/nanoc/core/item_rep_selector_spec.rb
@@ -188,7 +188,7 @@ describe Nanoc::Core::ItemRepSelector do
 
       example do
         expect(successfully_yielded).to eq %i[b c d e a]
-        expect(tentatively_yielded).to eq %i[a b a c a d a e a]
+        expect(tentatively_yielded).to eq %i[a b c d e a]
       end
     end
 
@@ -217,8 +217,8 @@ describe Nanoc::Core::ItemRepSelector do
       end
 
       it 'picks prioritised roots' do
-        expect(successfully_yielded).to eq %i[d a e b c]
-        expect(tentatively_yielded).to eq %i[a d a b e b c]
+        expect(successfully_yielded).to eq %i[d e c b a]
+        expect(tentatively_yielded).to eq %i[a d b e c b a]
       end
     end
   end


### PR DESCRIPTION
### Detailed description

This modifies the item rep selection algorithm to favor item rep that are *not* known to have dependencies over item rep that have known dependencies. (Note: It’s important to distinguish “not known to have dependencies” from “known to not have dependencies” here.)

This helps for pages that have dependencies on large numbers of items, such as blog archive pages. Below is an example of a posts archive for three posts, `/posts/a.md`, `/posts/b.md` and `/posts/c.md`.

Before:

1. Nanoc compiles post archive, which has a compiled content dependency on all posts. Post archive fails to compile because of dependency on `/posts/a.md`.
2. Nanoc compiles `/posts/a.md`, successfully.
3. Nanoc compiles post archive again. Post archive again fails to compile, but now because of a dependency on `/posts/b.md`.
4. Nanoc compiles `/posts/b.md`, successfully.
5. Nanoc compiles post archive again. Post archive again fails to compile, but now because of a dependency on `/posts/c.md`.
6. Nanoc compiles `/posts/c.md`, successfully.
7. Nanoc compiles post archive again. Post archive now compiles properly.

After:

1. Nanoc compiles post archive, which has a compiled content dependency on all posts. Post archive fails to compile because of dependency on `/posts/a.md`.
2. Nanoc compiles `/posts/a.md`, successfully.
3. Nanoc compiles `/posts/b.md`, successfully.
4. Nanoc compiles `/posts/c.md`, successfully.
5. Nanoc compiles post archive again. Post archive now compiles properly.

Note how the posts archive compiled after all other reps that were not yet seen.

Future work could include reusing the dependency graph from the previous compilation to construct an order of compilation that by default would eliminate any failed compilations due to compiled content dependencies.

Initial rough performance measurements suggest a 20% speedup on a large site that exhibits pathologic behavior of Nanoc where it keeps trying prioritise recompiling archive pages.

### To do

* [x] Test more extensively
* [x] Do performance measurements

### Related issues

n/a