### PR TITLE
Optimise ItemRepIgnorableIterator

### DIFF
--- a/nanoc-core/lib/nanoc/core/item_rep_selector.rb
+++ b/nanoc-core/lib/nanoc/core/item_rep_selector.rb
@@ -12,24 +12,13 @@ module Nanoc
       # elements.
       class ItemRepIgnorableIterator
         def initialize(array)
-          @array = array
-          @index = 0
-        end
-
-        def next
-          elem = @array[@index]
-          @index += 1
-          elem
+          @array = array.dup
         end
 
         def next_ignoring(ignored)
-          loop do
-            elem = self.next
-
-            unless ignored.include?(elem)
-              return elem
-            end
-          end
+          elem = @array.shift
+          elem = @array.shift while ignored.include?(elem)
+          elem
         end
       end
 


### PR DESCRIPTION
### Detailed description

This changes `ItemRepIgnorableIterator`:

* It now uses `Array#shift`, which is faster than maintaining our own iteration index.
* It now uses `while` rather than `loop`, which is also significantly faster.

Probably a micro-optimisation.

I suppose that this shows that second-guessing Ruby is not a great idea!

### To do

n/a

### Related issues

n/a