### PR TITLE
Remove redundant Pattern.from

### DIFF
--- a/nanoc-core/lib/nanoc/core/outdatedness_checker.rb
+++ b/nanoc-core/lib/nanoc/core/outdatedness_checker.rb
@@ -149,8 +149,7 @@ module Nanoc
           when Enumerable
             # If the `raw_content` dependency prop is a collection, then this
             # is a dependency on specific objects, given by the patterns.
-            patterns = raw_content_prop.map { |r| Nanoc::Core::Pattern.from(r) }
-            patterns.flat_map { |pat| objects.find_all(pat) }
+            raw_content_prop.flat_map { |pat| objects.find_all(pat) }
           else
             raise(
               Nanoc::Core::Errors::InternalInconsistency,


### PR DESCRIPTION
### Detailed description

This call will break memoization of #find_all, as a Pattern is not memoizable well (it should really implement #eql? and #== etc, but does not at the moment).

This should speed things up slightly. Or a lot. To be seen.

### To do

* Open question: Does it make sense to make `Pattern` memoizable, by implementing `#==` etc? This would’ve avoided this issue…

### Related issues

Fixes, or at least improves #1605.
