### PR TITLE
Let #[] create single-item dependencies if possible

### DIFF
--- a/nanoc-cli/spec/spec_helper.rb
+++ b/nanoc-cli/spec/spec_helper.rb
@@ -38,7 +38,7 @@ Class.new(Nanoc::Core::ActionProvider) do
   end
 
   def preprocess(site)
-    item = site.items['/hello.*']
+    item = site.items.object_matching_glob('/hello.*')
 
     if item
       item.content = Nanoc::Core::TextualContent.new('Better hello!')

--- a/nanoc-core/lib/nanoc/core/basic_item_view.rb
+++ b/nanoc-core/lib/nanoc/core/basic_item_view.rb
@@ -34,7 +34,7 @@ module Nanoc
         parent_identifier = '/' + _unwrap.identifier.components[0..-2].join('/') + '/'
         parent_identifier = '/' if parent_identifier == '//'
 
-        parent = @context.items[parent_identifier]
+        parent = @context.items.object_with_identifier(parent_identifier)
 
         parent && self.class.new(parent, @context)
       end

--- a/nanoc-core/lib/nanoc/core/executor.rb
+++ b/nanoc-core/lib/nanoc/core/executor.rb
@@ -90,10 +90,11 @@ module Nanoc
 
       def find_layout(arg)
         req_id = arg.__nanoc_cleaned_identifier
-        layout = layouts[req_id]
+        layout = layouts.object_with_identifier(req_id)
         return layout if layout
 
         if use_globs?
+          # TODO: use object_matching_glob instead
           pat = Nanoc::Core::Pattern.from(arg)
           layout = layouts.find { |l| pat.match?(l.identifier) }
           return layout if layout

--- a/nanoc-core/lib/nanoc/core/identifiable_collection.rb
+++ b/nanoc-core/lib/nanoc/core/identifiable_collection.rb
@@ -37,17 +37,6 @@ module Nanoc
         super
       end
 
-      # contract C::Any => C::Maybe[C::RespondTo[:identifier]]
-      def [](arg)
-        # TODO: remove
-
-        if frozen?
-          get_memoized(arg)
-        else
-          get_unmemoized(arg)
-        end
-      end
-
       # contract C::Any => C::IterOf[C::RespondTo[:identifier]]
       def find_all(arg)
         if frozen?

--- a/nanoc-core/lib/nanoc/core/identifiable_collection.rb
+++ b/nanoc-core/lib/nanoc/core/identifiable_collection.rb
@@ -68,9 +68,9 @@ module Nanoc
 
       def object_with_identifier(identifier)
         if frozen?
-          object_with_identifier_memoized(identifier)
+          @mapping[identifier.to_s]
         else
-          object_with_identifier_unmemoized(identifier)
+          find { |i| i.identifier == identifier }
         end
       end
 
@@ -83,19 +83,6 @@ module Nanoc
       end
 
       protected
-
-      def object_with_identifier_memoized(identifier)
-        object_with_identifier_unmemoized(identifier)
-      end
-      memo_wise :object_with_identifier_memoized
-
-      def object_with_identifier_unmemoized(identifier)
-        if frozen?
-          @mapping[identifier.to_s]
-        else
-          find { |i| i.identifier == identifier }
-        end
-      end
 
       def object_matching_glob_memoized(glob)
         object_matching_glob_unmemoized(glob)

--- a/nanoc-core/lib/nanoc/core/item_collection.rb
+++ b/nanoc-core/lib/nanoc/core/item_collection.rb
@@ -9,12 +9,6 @@ module Nanoc
         initialize_basic(config, objects, 'items')
       end
 
-      # contract C::Any => C::Maybe[C::RespondTo[:identifier]]
-      def get_memoized(arg)
-        get_unmemoized(arg)
-      end
-      memo_wise :get_memoized
-
       def reference
         'items'
       end

--- a/nanoc-core/lib/nanoc/core/layout_collection.rb
+++ b/nanoc-core/lib/nanoc/core/layout_collection.rb
@@ -9,12 +9,6 @@ module Nanoc
         initialize_basic(config, objects, 'layouts')
       end
 
-      # contract C::Any => C::Maybe[C::RespondTo[:identifier]]
-      def get_memoized(arg)
-        get_unmemoized(arg)
-      end
-      memo_wise :get_memoized
-
       def reference
         'layouts'
       end

--- a/nanoc-core/lib/nanoc/core/outdatedness_rules/rules_modified.rb
+++ b/nanoc-core/lib/nanoc/core/outdatedness_rules/rules_modified.rb
@@ -34,9 +34,11 @@ module Nanoc
           actions = basic_outdatedness_checker.action_sequence_store[obj]
           layout_actions = actions.select { |a| a.first == :layout }
 
+          layouts = basic_outdatedness_checker.site.layouts
+
           layout_actions.map do |layout_action|
             layout_pattern = layout_action[1]
-            basic_outdatedness_checker.site.layouts[layout_pattern]
+            layouts.object_with_identifier(layout_pattern) || layouts.object_matching_glob(layout_pattern)
           end.compact
         end
       end

--- a/nanoc-core/spec/nanoc/core/identifiable_collection_spec.rb
+++ b/nanoc-core/spec/nanoc/core/identifiable_collection_spec.rb
@@ -19,62 +19,6 @@ describe Nanoc::Core::IdentifiableCollection do
       it { is_expected.to eq("<#{described_class}>") }
     end
 
-    describe '#[]' do
-      let(:objects) do
-        [
-          Nanoc::Core::Item.new('asdf', {}, Nanoc::Core::Identifier.new('/one')),
-          Nanoc::Core::Item.new('asdf', {}, Nanoc::Core::Identifier.new('/two')),
-        ]
-      end
-
-      context 'string pattern style is glob' do
-        let(:config) { Nanoc::Core::Configuration.new(dir: Dir.getwd).with_defaults }
-
-        it 'handles glob' do
-          expect(identifiable_collection['/on*']).to equal(objects[0])
-          expect(identifiable_collection['/*wo']).to equal(objects[1])
-        end
-      end
-
-      context 'string pattern style is glob' do
-        let(:config) { Nanoc::Core::Configuration.new(dir: Dir.getwd) }
-
-        it 'does not handle glob' do
-          expect(identifiable_collection['/on*']).to be_nil
-          expect(identifiable_collection['/*wo']).to be_nil
-        end
-      end
-
-      it 'handles identifier' do
-        expect(identifiable_collection['/one']).to equal(objects[0])
-        expect(identifiable_collection['/two']).to equal(objects[1])
-      end
-
-      it 'handles malformed identifier' do
-        expect(identifiable_collection['one/']).to be_nil
-        expect(identifiable_collection['/one/']).to be_nil
-        expect(identifiable_collection['one']).to be_nil
-        expect(identifiable_collection['//one']).to be_nil
-        expect(identifiable_collection['/one//']).to be_nil
-      end
-
-      it 'handles regex' do
-        expect(identifiable_collection[/one/]).to equal(objects[0])
-        expect(identifiable_collection[/on/]).to equal(objects[0])
-        expect(identifiable_collection[/\/o/]).to equal(objects[0])
-        expect(identifiable_collection[/e$/]).to equal(objects[0])
-      end
-
-      context 'frozen' do
-        before { identifiable_collection.freeze }
-
-        example do
-          expect(identifiable_collection['/one']).to equal(objects[0])
-          expect(identifiable_collection['/fifty']).to be_nil
-        end
-      end
-    end
-
     describe '#find_all' do
       subject { identifiable_collection.find_all(arg) }
 
@@ -177,14 +121,14 @@ describe Nanoc::Core::IdentifiableCollection do
 
       it 'makes /foo nil' do
         expect { subject }
-          .to change { identifiable_collection['/foo'] }
+          .to change { identifiable_collection.object_with_identifier('/foo') }
           .from(objects[0])
           .to(nil)
       end
 
       it 'makes /bar non-nil' do
         expect { subject }
-          .to change { identifiable_collection['/bar'] }
+          .to change { identifiable_collection.object_with_identifier('/bar') }
           .from(nil)
           .to(objects[0])
       end

--- a/nanoc-core/spec/nanoc/core/identifiable_collection_spec.rb
+++ b/nanoc-core/spec/nanoc/core/identifiable_collection_spec.rb
@@ -19,6 +19,118 @@ describe Nanoc::Core::IdentifiableCollection do
       it { is_expected.to eq("<#{described_class}>") }
     end
 
+    describe '#object_with_identifier' do
+      subject(:object_with_identifier) { identifiable_collection.object_with_identifier(arg) }
+
+      let(:objects) do
+        [
+          Nanoc::Core::Item.new('Foo', {}, '/foo.md'),
+          Nanoc::Core::Item.new('Bar', {}, '/bar.md'),
+          Nanoc::Core::Item.new('Quz', {}, '/qux.md'),
+        ]
+      end
+
+      shared_examples 'object_with_identifier' do
+        context 'when given an identifier' do
+          context 'when object does not exist' do
+            let(:arg) { Nanoc::Core::Identifier.new('/nope.md') }
+
+            it 'returns nil' do
+              expect(object_with_identifier).to be_nil
+            end
+          end
+
+          context 'when object exist' do
+            let(:arg) { Nanoc::Core::Identifier.new('/foo.md') }
+
+            it 'returns object' do
+              expect(object_with_identifier).to eq(objects[0])
+            end
+          end
+        end
+
+        context 'when given a string' do
+          context 'when object does not exist' do
+            let(:arg) { '/nope.md' }
+
+            it 'returns nil' do
+              expect(object_with_identifier).to be_nil
+            end
+          end
+
+          context 'when object exist' do
+            let(:arg) { '/foo.md' }
+
+            it 'returns object' do
+              expect(object_with_identifier).to eq(objects[0])
+            end
+          end
+        end
+      end
+
+      context 'when frozen' do
+        before { identifiable_collection.freeze }
+
+        include_examples 'object_with_identifier'
+      end
+
+      context 'when not frozen' do
+        include_examples 'object_with_identifier'
+      end
+    end
+
+    describe '#object_matching_glob' do
+      subject(:object_matching_glob) { identifiable_collection.object_matching_glob(arg) }
+
+      let(:objects) do
+        [
+          Nanoc::Core::Item.new('Foo', {}, '/foo.md'),
+          Nanoc::Core::Item.new('Bar', {}, '/bar.md'),
+          Nanoc::Core::Item.new('Quz', {}, '/qux.md'),
+        ]
+      end
+
+      shared_examples 'object_matching_glob' do
+        context 'when object does not exist' do
+          let(:arg) { '/nope.*' }
+
+          it 'returns nil' do
+            expect(object_matching_glob).to be_nil
+          end
+        end
+
+        context 'when object exist' do
+          let(:arg) { '/foo.*' }
+
+          context 'when globs are enabled' do
+            let(:config) { super().merge(string_pattern_type: 'glob') }
+
+            it 'returns object' do
+              expect(object_matching_glob).to eq(objects[0])
+            end
+          end
+
+          context 'when globs are disabled' do
+            let(:config) { super().merge(string_pattern_type: 'legacy') }
+
+            it 'returns nil' do
+              expect(object_matching_glob).to be_nil
+            end
+          end
+        end
+      end
+
+      context 'when frozen' do
+        before { identifiable_collection.freeze }
+
+        include_examples 'object_matching_glob'
+      end
+
+      context 'when not frozen' do
+        include_examples 'object_matching_glob'
+      end
+    end
+
     describe '#find_all' do
       subject { identifiable_collection.find_all(arg) }
 

--- a/nanoc-core/spec/nanoc/core/item_collection_with_reps_view_spec.rb
+++ b/nanoc-core/spec/nanoc/core/item_collection_with_reps_view_spec.rb
@@ -6,7 +6,9 @@ describe Nanoc::Core::ItemCollectionWithRepsView do
   let(:view_class) { Nanoc::Core::CompilationItemView }
   let(:collection_class) { Nanoc::Core::ItemCollection }
 
-  it_behaves_like 'an identifiable collection view'
+  it_behaves_like 'an identifiable collection view' do
+    let(:element_class) { Nanoc::Core::Item }
+  end
 
   describe '#inspect' do
     subject { view.inspect }

--- a/nanoc-core/spec/nanoc/core/item_collection_without_reps_view_spec.rb
+++ b/nanoc-core/spec/nanoc/core/item_collection_without_reps_view_spec.rb
@@ -6,7 +6,9 @@ describe Nanoc::Core::ItemCollectionWithoutRepsView do
   let(:view_class) { Nanoc::Core::BasicItemView }
   let(:collection_class) { Nanoc::Core::ItemCollection }
 
-  it_behaves_like 'an identifiable collection view'
+  it_behaves_like 'an identifiable collection view' do
+    let(:element_class) { Nanoc::Core::Item }
+  end
 
   describe '#inspect' do
     subject { view.inspect }

--- a/nanoc-core/spec/nanoc/core/layout_collection_view_spec.rb
+++ b/nanoc-core/spec/nanoc/core/layout_collection_view_spec.rb
@@ -6,7 +6,9 @@ describe Nanoc::Core::LayoutCollectionView do
   let(:view_class) { Nanoc::Core::LayoutView }
   let(:collection_class) { Nanoc::Core::LayoutCollection }
 
-  it_behaves_like 'an identifiable collection view'
+  it_behaves_like 'an identifiable collection view' do
+    let(:element_class) { Nanoc::Core::Layout }
+  end
 
   describe '#inspect' do
     subject { view.inspect }

--- a/nanoc-core/spec/nanoc/core/mutable_item_collection_view_spec.rb
+++ b/nanoc-core/spec/nanoc/core/mutable_item_collection_view_spec.rb
@@ -30,14 +30,14 @@ describe Nanoc::Core::MutableItemCollectionView do
       view.create('new content', { title: 'New Page' }, '/new')
 
       expect(view._unwrap.size).to eq(2)
-      expect(view._unwrap['/new'].content.string).to eq('new content')
+      expect(view._unwrap.object_with_identifier('/new').content.string).to eq('new content')
     end
 
     it 'does not update wrapped' do
       view.create('new content', { title: 'New Page' }, '/new')
 
       expect(wrapped.size).to eq(1)
-      expect(wrapped['/new']).to be_nil
+      expect(wrapped.object_with_identifier('/new')).to be_nil
     end
 
     it 'returns self' do

--- a/nanoc-core/spec/nanoc/core/mutable_item_collection_view_spec.rb
+++ b/nanoc-core/spec/nanoc/core/mutable_item_collection_view_spec.rb
@@ -10,7 +10,9 @@ describe Nanoc::Core::MutableItemCollectionView do
     { string_pattern_type: 'glob' }
   end
 
-  it_behaves_like 'an identifiable collection view'
+  it_behaves_like 'an identifiable collection view' do
+    let(:element_class) { Nanoc::Core::Item }
+  end
   it_behaves_like 'a mutable identifiable collection view'
 
   describe '#create' do

--- a/nanoc-core/spec/nanoc/core/mutable_layout_collection_view_spec.rb
+++ b/nanoc-core/spec/nanoc/core/mutable_layout_collection_view_spec.rb
@@ -31,14 +31,14 @@ describe Nanoc::Core::MutableLayoutCollectionView do
       view.create('new content', { title: 'New Page' }, '/new')
 
       expect(view._unwrap.size).to eq(2)
-      expect(view._unwrap['/new'].content.string).to eq('new content')
+      expect(view._unwrap.object_with_identifier('/new').content.string).to eq('new content')
     end
 
     it 'does not update wrapped' do
       view.create('new content', { title: 'New Page' }, '/new')
 
       expect(wrapped.size).to eq(1)
-      expect(wrapped['/new']).to be_nil
+      expect(wrapped.object_with_identifier('/new')).to be_nil
     end
 
     it 'returns self' do

--- a/nanoc-core/spec/nanoc/core/mutable_layout_collection_view_spec.rb
+++ b/nanoc-core/spec/nanoc/core/mutable_layout_collection_view_spec.rb
@@ -10,7 +10,10 @@ describe Nanoc::Core::MutableLayoutCollectionView do
     { string_pattern_type: 'glob' }
   end
 
-  it_behaves_like 'an identifiable collection view'
+  it_behaves_like 'an identifiable collection view' do
+    let(:element_class) { Nanoc::Core::Layout }
+  end
+
   it_behaves_like 'a mutable identifiable collection view'
 
   describe '#create' do

--- a/nanoc-core/spec/nanoc/core/site_loader_spec.rb
+++ b/nanoc-core/spec/nanoc/core/site_loader_spec.rb
@@ -39,16 +39,22 @@ describe Nanoc::Core::SiteLoader do
 
       it 'has an item' do
         expect(subject.items.size).to eq(1)
-        expect(subject.items['/about.md'].content).to be_a(Nanoc::Core::TextualContent)
-        expect(subject.items['/about.md'].content.string).to eq('I am Denis!')
-        expect(subject.items['/about.md'].identifier.to_s).to eq('/about.md')
+        expect(subject.items.object_with_identifier('/about.md').content)
+          .to be_a(Nanoc::Core::TextualContent)
+        expect(subject.items.object_with_identifier('/about.md').content.string)
+          .to eq('I am Denis!')
+        expect(subject.items.object_with_identifier('/about.md').identifier.to_s)
+          .to eq('/about.md')
       end
 
       it 'has a layout' do
         expect(subject.layouts.size).to eq(1)
-        expect(subject.layouts['/page.erb'].content).to be_a(Nanoc::Core::TextualContent)
-        expect(subject.layouts['/page.erb'].content.string).to eq('<html><%= yield %></html>')
-        expect(subject.layouts['/page.erb'].identifier.to_s).to eq('/page.erb')
+        expect(subject.layouts.object_with_identifier('/page.erb').content)
+          .to be_a(Nanoc::Core::TextualContent)
+        expect(subject.layouts.object_with_identifier('/page.erb').content.string)
+          .to eq('<html><%= yield %></html>')
+        expect(subject.layouts.object_with_identifier('/page.erb').identifier.to_s)
+          .to eq('/page.erb')
       end
 
       context 'some items, layouts, and code snippets' do
@@ -149,10 +155,14 @@ describe Nanoc::Core::SiteLoader do
 
       it 'loads code snippets before items/layouts' do
         expect(subject.items.size).to eq(1)
-        expect(subject.items['/generated.txt'].content).to be_a(Nanoc::Core::TextualContent)
-        expect(subject.items['/generated.txt'].content.string).to eq('Generated content!')
-        expect(subject.items['/generated.txt'].attributes).to eq(generated: true)
-        expect(subject.items['/generated.txt'].identifier.to_s).to eq('/generated.txt')
+        expect(subject.items.object_with_identifier('/generated.txt').content)
+          .to be_a(Nanoc::Core::TextualContent)
+        expect(subject.items.object_with_identifier('/generated.txt').content.string)
+          .to eq('Generated content!')
+        expect(subject.items.object_with_identifier('/generated.txt').attributes)
+          .to eq(generated: true)
+        expect(subject.items.object_with_identifier('/generated.txt').identifier.to_s)
+          .to eq('/generated.txt')
       end
     end
   end

--- a/nanoc-core/spec/nanoc/core/support/identifiable_collection_view_examples.rb
+++ b/nanoc-core/spec/nanoc/core/support/identifiable_collection_view_examples.rb
@@ -156,11 +156,11 @@ shared_examples 'an identifiable collection view' do
     subject { view[arg] }
 
     let(:page_object) do
-      double(:identifiable, identifier: Nanoc::Core::Identifier.new('/page.erb'))
+      element_class.new('content', {}, Nanoc::Core::Identifier.new('/page.erb'))
     end
 
     let(:home_object) do
-      double(:identifiable, identifier: Nanoc::Core::Identifier.new('/home.erb'))
+      element_class.new('content', {}, Nanoc::Core::Identifier.new('/home.erb'))
     end
 
     let(:wrapped) do
@@ -184,11 +184,11 @@ shared_examples 'an identifiable collection view' do
       end
     end
 
-    context 'string' do
+    context 'string, with exact match' do
       let(:arg) { '/home.erb' }
 
-      it 'creates dependency' do
-        expect(dependency_tracker).to receive(:bounce).with(wrapped, raw_content: ['/home.erb'])
+      it 'does not create dependency' do
+        expect(dependency_tracker).not_to receive(:bounce)
         subject
       end
 
@@ -205,8 +205,8 @@ shared_examples 'an identifiable collection view' do
     context 'identifier' do
       let(:arg) { Nanoc::Core::Identifier.new('/home.erb') }
 
-      it 'creates dependency' do
-        expect(dependency_tracker).to receive(:bounce).with(wrapped, raw_content: ['/home.erb'])
+      it 'does not create dependency' do
+        expect(dependency_tracker).not_to receive(:bounce)
         subject
       end
 

--- a/nanoc/spec/nanoc/helpers/rendering_spec.rb
+++ b/nanoc/spec/nanoc/helpers/rendering_spec.rb
@@ -34,9 +34,6 @@ describe Nanoc::Helpers::Rendering, helper: true do
 
           it 'tracks proper dependencies' do
             expect(ctx.dependency_tracker).to receive(:enter)
-              .with(an_instance_of(Nanoc::Core::LayoutCollection), raw_content: ['/partial/'], attributes: false, compiled_content: false, path: false)
-              .ordered
-            expect(ctx.dependency_tracker).to receive(:enter)
               .with(layout, raw_content: true, attributes: false, compiled_content: false, path: false)
               .ordered
 

--- a/nanoc/spec/nanoc/orig_cli/commands/show_rules_spec.rb
+++ b/nanoc/spec/nanoc/orig_cli/commands/show_rules_spec.rb
@@ -37,11 +37,11 @@ describe Nanoc::OrigCLI::Commands::ShowRules, site: true, stdio: true do
 
     let(:reps) do
       Nanoc::Core::ItemRepRepo.new.tap do |reps|
-        reps << Nanoc::Core::ItemRep.new(items['/about.md'], :default)
-        reps << Nanoc::Core::ItemRep.new(items['/about.md'], :text)
-        reps << Nanoc::Core::ItemRep.new(items['/dog.md'], :default)
-        reps << Nanoc::Core::ItemRep.new(items['/dog.md'], :text)
-        reps << Nanoc::Core::ItemRep.new(items['/other.dat'], :default)
+        reps << Nanoc::Core::ItemRep.new(items.object_with_identifier('/about.md'), :default)
+        reps << Nanoc::Core::ItemRep.new(items.object_with_identifier('/about.md'), :text)
+        reps << Nanoc::Core::ItemRep.new(items.object_with_identifier('/dog.md'), :default)
+        reps << Nanoc::Core::ItemRep.new(items.object_with_identifier('/dog.md'), :text)
+        reps << Nanoc::Core::ItemRep.new(items.object_with_identifier('/other.dat'), :default)
       end
     end
 

--- a/nanoc/test/rule_dsl/test_action_provider.rb
+++ b/nanoc/test/rule_dsl/test_action_provider.rb
@@ -48,7 +48,7 @@ class Nanoc::RuleDSL::ActionProviderTest < Nanoc::TestCase
       # Apply preprocess blocks
       action_provider.preprocess(site)
 
-      assert site.items['/index.*'].attributes[:preprocessed]
+      assert site.items.object_matching_glob('/index.*').attributes[:preprocessed]
     end
   end
 


### PR DESCRIPTION
### Detailed description

This changes `@items[]` so that if there is a single exact match, no dependency on the item collection is created.

(Same for layouts.)

See source comments for details.

This PR can be a bit tough to review, but you can look through the commits individually. The first commit is the actual change of letting `#[]` not create dependencies on the item/laout collection, while the second commit removes `IdentifiableCollection#[]`, which is no longer needed and probably should not be used anyway.

### To do

* Add tests for `IdentifiableCollection`’s `#object_matching_glob` and `#object_with_identifier` methods (since `#[]` is gone).

### Related issues

Fixes, hopefully, #1605.