### PR TITLE
Improve store instrumentation

### DIFF
--- a/nanoc-cli/lib/nanoc/cli/compile_listeners/timing_recorder.rb
+++ b/nanoc-cli/lib/nanoc/cli/compile_listeners/timing_recorder.rb
@@ -21,6 +21,7 @@ module Nanoc::CLI::CompileListeners
       @outdatedness_rules_summary = DDMetrics::Summary.new
       @filters_summary = DDMetrics::Summary.new
       @load_stores_summary = DDMetrics::Summary.new
+      @store_stores_summary = DDMetrics::Summary.new
     end
 
     # @see Listener#start
@@ -52,6 +53,10 @@ module Nanoc::CLI::CompileListeners
 
       on(:store_loaded) do |duration, klass|
         @load_stores_summary.observe(duration, name: klass.to_s)
+      end
+
+      on(:store_stored) do |duration, klass|
+        @store_stores_summary.observe(duration, name: klass.to_s)
       end
 
       on(:compilation_suspended) do |rep, _target_rep, _snapshot_name|
@@ -145,6 +150,7 @@ module Nanoc::CLI::CompileListeners
       print_table_for_summary_duration(:stages, @stages_summary) if Nanoc::CLI.verbosity >= 2
       print_table_for_summary(:outdatedness_rules, @outdatedness_rules_summary) if Nanoc::CLI.verbosity >= 2
       print_table_for_summary_duration(:load_stores, @load_stores_summary) if Nanoc::CLI.verbosity >= 2
+      print_table_for_summary_duration(:store_stores, @store_stores_summary) if Nanoc::CLI.verbosity >= 2
     end
 
     def print_table_for_summary(name, summary)

--- a/nanoc-cli/spec/nanoc/cli/compile_listeners/timing_recorder_spec.rb
+++ b/nanoc-cli/spec/nanoc/cli/compile_listeners/timing_recorder_spec.rb
@@ -250,6 +250,13 @@ describe Nanoc::CLI::CompileListeners::TimingRecorder, stdio: true do
       .to output(/^\s*Nanoc::Core::ChecksumStore │ 1\.23s$/).to_stdout
   end
 
+  it 'prints store store durations' do
+    Nanoc::Core::NotificationCenter.post(:store_stored, 2.34, Nanoc::Core::ChecksumStore).sync
+
+    expect { listener.stop_safely }
+      .to output(/^\s*Nanoc::Core::ChecksumStore │ 2\.34s$/).to_stdout
+  end
+
   it 'skips printing empty metrics' do
     expect { listener.stop_safely }
       .not_to output(/filters|phases|stages/).to_stdout

--- a/nanoc-core/lib/nanoc/core/compilation_stages/load_stores.rb
+++ b/nanoc-core/lib/nanoc/core/compilation_stages/load_stores.rb
@@ -16,18 +16,11 @@ module Nanoc
 
         contract C::None => C::Any
         def run
-          load_store(@checksum_store)
-          load_store(@compiled_content_cache)
-          load_store(@dependency_store)
-          load_store(@action_sequence_store)
-          load_store(@outdatedness_store)
-        end
-
-        contract Nanoc::Core::Store => C::Any
-        def load_store(store)
-          Nanoc::Core::Instrumentor.call(:store_loaded, store.class) do
-            store.load
-          end
+          @checksum_store.load
+          @compiled_content_cache.load
+          @dependency_store.load
+          @action_sequence_store.load
+          @outdatedness_store.load
         end
       end
     end

--- a/nanoc-core/lib/nanoc/core/store.rb
+++ b/nanoc-core/lib/nanoc/core/store.rb
@@ -78,6 +78,12 @@ module Nanoc
       #
       # @return [void]
       def load
+        Nanoc::Core::Instrumentor.call(:store_loaded, self.class) do
+          load_uninstrumented
+        end
+      end
+
+      def load_uninstrumented
         return unless File.file?(filename)
 
         begin
@@ -88,7 +94,7 @@ module Nanoc
           end
         rescue
           FileUtils.rm_f(filename)
-          load
+          load_uninstrumented
         end
       end
 

--- a/nanoc-core/lib/nanoc/core/store.rb
+++ b/nanoc-core/lib/nanoc/core/store.rb
@@ -103,6 +103,14 @@ module Nanoc
       #
       # @return [void]
       def store
+        # NOTE: Yes, the “store stored” name is a little silly. Maybe stores
+        # need to be renamed to databases or so.
+        Nanoc::Core::Instrumentor.call(:store_stored, self.class) do
+          store_uninstrumented
+        end
+      end
+
+      def store_uninstrumented
         FileUtils.mkdir_p(File.dirname(filename))
 
         pstore.transaction do


### PR DESCRIPTION
### Detailed description

This adds instrumentation for `Store#store`.

As a refactoring, it also moves the existing instrumentation into `Store`. I think it makes more sense for `Store` instrumentation to live within `Store` itself!

### To do

Maybe the time has come to rename `Store#store`, e.g. to `Store#save`. The naming is *confusing*.

### Related issues

n/a