### PR TITLE
Use Marshal.{load,dump} instead of PStore

### DIFF
--- a/nanoc-core/lib/nanoc/core/store.rb
+++ b/nanoc-core/lib/nanoc/core/store.rb
@@ -90,11 +90,11 @@ module Nanoc
         begin
           # Check if store version is the expected version. If it is not, don’t
           # load.
-          read_version = Marshal.load(File.binread(version_filename))
+          read_version = read_obj_from_file(version_filename)
           return if read_version != version
 
           # Load data
-          self.data = Marshal.load(File.binread(data_filename))
+          self.data = read_obj_from_file(data_filename)
         rescue
           # An error occurred! Remove the database and try again
           FileUtils.rm_f(version_filename)
@@ -121,14 +121,22 @@ module Nanoc
       def store_uninstrumented
         FileUtils.mkdir_p(File.dirname(filename))
 
-        File.binwrite(version_filename, Marshal.dump(version))
-        File.binwrite(data_filename, Marshal.dump(data))
+        write_obj_to_file(version_filename, version)
+        write_obj_to_file(data_filename, data)
 
         # Remove old file (back from the PStore days), if there are any.
         FileUtils.rm_f(filename)
       end
 
       private
+
+      def write_obj_to_file(fn, obj)
+        File.binwrite(fn, Marshal.dump(obj))
+      end
+
+      def read_obj_from_file(fn)
+        Marshal.load(File.binread(fn))
+      end
 
       def version_filename
         "#{filename}.version.db"

--- a/nanoc-core/spec/nanoc/core/store_spec.rb
+++ b/nanoc-core/spec/nanoc/core/store_spec.rb
@@ -89,7 +89,7 @@ describe Nanoc::Core::Store do
   end
 
   it 'deletes and reloads on error' do
-    store = test_store_klass.new('test.db', 1)
+    store = test_store_klass.new('test', 1)
 
     # Create
     store.load
@@ -97,15 +97,15 @@ describe Nanoc::Core::Store do
     store.store
 
     # Test stored values
-    store = test_store_klass.new('test.db', 1)
+    store = test_store_klass.new('test', 1)
     store.load
     expect(store.data).to eq(fun: 'sure')
 
     # Mess up
-    File.write('test.db', 'Damn {}#}%@}$^)@&$&*^#@ broken stores!!!')
+    File.write('test.data.db', 'Damn {}#}%@}$^)@&$&*^#@ broken stores!!!')
 
     # Reload
-    store = test_store_klass.new('test.db', 1)
+    store = test_store_klass.new('test', 1)
     store.load
     expect(store.data).to be_nil
   end


### PR DESCRIPTION
### Detailed description

This removes use of `PStore` from the `Store` classes, and instead uses `Marshal.dump` and `Marshal.load` directly. This creates a tiny but measurable speedup, because `PStore#transaction` loads the data, even if the only purpose for the transaction is to replace all the data.

**NOTE:** This change will invalidate all data in everyone’s `tmp/nanoc` directory. I think that’s fine.

An example zero-change compilation, before:

```
load:
            Nanoc::Core::DependencyStore │ 5.85s

store:
            Nanoc::Core::DependencyStore │ 8.65s
```

An example zero-change compilation, after:

```
load:
            Nanoc::Core::DependencyStore │ 5.48s

store:
            Nanoc::Core::DependencyStore │ 3.49s
```

### To do

Nothing

### Related issues

n/a