### PR TITLE
Clean up Store implementation

### DIFF
--- a/nanoc-core/lib/nanoc/core/store.rb
+++ b/nanoc-core/lib/nanoc/core/store.rb
@@ -83,17 +83,6 @@ module Nanoc
         end
       end
 
-      def load_uninstrumented
-        unsafe_load_uninstrumented
-      rescue
-        # An error occurred! Remove the database and try again
-        FileUtils.rm_f(version_filename)
-        FileUtils.rm_f(data_filename)
-
-        # Try again
-        unsafe_load_uninstrumented
-      end
-
       # Stores the data contained in memory to the filesystem. This method will
       #   use the {#data} method to fetch the data that should be written.
       #
@@ -106,6 +95,19 @@ module Nanoc
         end
       end
 
+      private
+
+      def load_uninstrumented
+        unsafe_load_uninstrumented
+      rescue
+        # An error occurred! Remove the database and try again
+        FileUtils.rm_f(version_filename)
+        FileUtils.rm_f(data_filename)
+
+        # Try again
+        unsafe_load_uninstrumented
+      end
+
       def store_uninstrumented
         FileUtils.mkdir_p(File.dirname(filename))
 
@@ -115,8 +117,6 @@ module Nanoc
         # Remove old file (back from the PStore days), if there are any.
         FileUtils.rm_f(filename)
       end
-
-      private
 
       # Unsafe, because it can throw exceptions.
       def unsafe_load_uninstrumented


### PR DESCRIPTION
### Detailed description

* Make `#load_uninstrumented` and `#store_uninstrumented` private. These aren’t supposed to be part of the class’ public API.

* Let `#load_uninstrumented` only retry errors once. If an error occurs the second time, then something else is wrong.

### To do

* Ideally, tests for `#load_uninstrumented` that it only retries errors once. However, this is tough to test because these errors are hard to test -- they’re really there more for preventing future programming errors.

### Related issues

n/a