### PR TITLE
Fix cycle detection in item rep selector

### DIFF
--- a/nanoc-core/lib/nanoc/core/errors.rb
+++ b/nanoc-core/lib/nanoc/core/errors.rb
@@ -72,10 +72,7 @@ module Nanoc
       # Error that is raised during site compilation when an item (directly or
       # indirectly) includes its own item content, leading to endless recursion.
       class DependencyCycle < ::Nanoc::Core::Error
-        def initialize(stack)
-          start_idx = stack.index(stack.last)
-          cycle = stack[start_idx..-2]
-
+        def initialize(cycle)
           msg_bits = []
           msg_bits << 'The site cannot be compiled because there is a dependency cycle:'
           msg_bits << ''

--- a/nanoc-core/spec/nanoc/core/errors/dependency_cycle_spec.rb
+++ b/nanoc-core/spec/nanoc/core/errors/dependency_cycle_spec.rb
@@ -1,16 +1,14 @@
 # frozen_string_literal: true
 
 describe Nanoc::Core::Errors::DependencyCycle do
-  subject(:error) { described_class.new(stack) }
+  subject(:error) { described_class.new(cycle) }
 
-  let(:stack) do
+  let(:cycle) do
     [
-      rep_a,
       rep_b,
       rep_c,
       rep_d,
       rep_e,
-      rep_b,
     ]
   end
 

--- a/nanoc-core/spec/nanoc/core/item_rep_selector/item_rep_priority_queue_spec.rb
+++ b/nanoc-core/spec/nanoc/core/item_rep_selector/item_rep_priority_queue_spec.rb
@@ -130,4 +130,114 @@ describe Nanoc::Core::ItemRepSelector::ItemRepPriorityQueue do
         .to raise_error(Nanoc::Core::Errors::DependencyCycle)
     end
   end
+
+  context 'when there are two regular dependencies' do
+    it 'schedules the dependency next up' do
+      expect(micro_graph.next).to eq(reps[0])
+      micro_graph.mark_failed(reps[2])
+
+      expect(micro_graph.next).to eq(reps[2])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[1])
+      micro_graph.mark_failed(reps[4])
+
+      expect(micro_graph.next).to eq(reps[4])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[3])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[1])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[0])
+      micro_graph.mark_ok
+    end
+  end
+
+  context 'when there is one regular dependency and one cyclical dependency' do
+    it 'schedules the dependency next up' do
+      expect(micro_graph.next).to eq(reps[0])
+      micro_graph.mark_failed(reps[2])
+
+      expect(micro_graph.next).to eq(reps[2])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[1])
+      micro_graph.mark_failed(reps[4])
+
+      expect(micro_graph.next).to eq(reps[4])
+      expect { micro_graph.mark_failed(reps[1]) }
+        .to raise_error(Nanoc::Core::Errors::DependencyCycle)
+    end
+  end
+
+  context 'when there is a transitive dependency' do
+    it 'schedules the dependency next up' do
+      expect(micro_graph.next).to eq(reps[0])
+      micro_graph.mark_failed(reps[1])
+
+      expect(micro_graph.next).to eq(reps[1])
+      micro_graph.mark_failed(reps[2])
+
+      expect(micro_graph.next).to eq(reps[2])
+      micro_graph.mark_failed(reps[3])
+
+      expect(micro_graph.next).to eq(reps[3])
+      micro_graph.mark_failed(reps[4])
+
+      expect(micro_graph.next).to eq(reps[4])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[3])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[2])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[1])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[0])
+      micro_graph.mark_ok
+    end
+  end
+
+  context 'when there is an item with dependencies on many other items that also have dependences' do
+    # 0 -> 2
+    # 2 -> 4
+    # 4 OK
+    # 1 -> 2
+    # 2 -> 3
+    # 3 OK
+    it 'schedules the dependency next up' do
+      expect(micro_graph.next).to eq(reps[0])
+      micro_graph.mark_failed(reps[2])
+
+      expect(micro_graph.next).to eq(reps[2])
+      micro_graph.mark_failed(reps[4])
+
+      expect(micro_graph.next).to eq(reps[4])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[1])
+      micro_graph.mark_failed(reps[2])
+
+      expect(micro_graph.next).to eq(reps[2])
+      micro_graph.mark_failed(reps[3])
+
+      expect(micro_graph.next).to eq(reps[3])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[1])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[2])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[0])
+      micro_graph.mark_ok
+    end
+  end
 end

--- a/nanoc-core/spec/nanoc/core/item_rep_selector_spec.rb
+++ b/nanoc-core/spec/nanoc/core/item_rep_selector_spec.rb
@@ -142,9 +142,9 @@ describe Nanoc::Core::ItemRepSelector do
         expect { subject }.to raise_error(Nanoc::Core::Errors::DependencyCycle, <<~EOS)
           The site cannot be compiled because there is a dependency cycle:
 
-              (1) item /foo.md, rep :a, uses compiled content of
-              (2) item /foo.md, rep :b, uses compiled content of
-              (3) item /foo.md, rep :c, uses compiled content of (1)
+              (1) item /foo.md, rep :c, uses compiled content of
+              (2) item /foo.md, rep :a, uses compiled content of
+              (3) item /foo.md, rep :b, uses compiled content of (1)
         EOS
       end
     end


### PR DESCRIPTION
### Detailed description

This replaces the stack-based dependency cycle detector with one that actually works. See the newly added specs for `ItemRepPriorityQueue` which demonstrate the #1619 regression.

### To do

* [x] It’s possible for the `ItemRepPriorityQueue` to yield an item even if it has already been yielded before and marked as OK. This isn’t the worst: it’s still correct, but certainly inefficient. Fix it anyway.

* [ ] (After merge) Update the [compilation order documentation](https://nanoc.app/doc/internals/#compilation-order) on the web site.

### Related issues

Fixes #1619.
