### PR TITLE
Prevent double slash when using extra_files

### DIFF
--- a/nanoc/lib/nanoc/data_sources/filesystem/tools.rb
+++ b/nanoc/lib/nanoc/data_sources/filesystem/tools.rb
@@ -111,9 +111,9 @@ class Nanoc::DataSources::Filesystem < Nanoc::DataSource
         when nil
           []
         when String
-          ["#{dir_name}/#{extra_files}"]
+          ["#{dir_name}/#{extra_files.dup.delete_prefix('/')}"]
         when Array
-          extra_files.map { |extra_file| "#{dir_name}/#{extra_file}" }
+          extra_files.map { |extra_file| "#{dir_name}/#{extra_file.dup.delete_prefix('/')}" }
         else
           raise(
             Nanoc::Core::TrivialError,

--- a/nanoc/test/data_sources/test_filesystem_tools.rb
+++ b/nanoc/test/data_sources/test_filesystem_tools.rb
@@ -139,6 +139,28 @@ class Nanoc::DataSources::FilesystemToolsTest < Nanoc::TestCase
     assert_equal ['dir/.other', 'dir/.DS_Store'].sort, actual_files.sort
   end
 
+  def test_extra_files_string_with_leading_slash
+    # Write sample files
+    FileUtils.mkdir_p('dir')
+    File.write('dir/.other', 'o hai')
+    File.write('dir/.DS_Store', 'o hai')
+
+    actual_files = Nanoc::DataSources::Filesystem::Tools.all_files_in('dir', '/**/.DS_Store').sort
+
+    assert_equal ['dir/.DS_Store'].sort, actual_files.sort
+  end
+
+  def test_extra_files_array_with_leading_slash
+    # Write sample files
+    FileUtils.mkdir_p('dir')
+    File.write('dir/.other', 'o hai')
+    File.write('dir/.DS_Store', 'o hai')
+
+    actual_files = Nanoc::DataSources::Filesystem::Tools.all_files_in('dir', ['/**/.DS_Store']).sort
+
+    assert_equal ['dir/.DS_Store'].sort, actual_files.sort
+  end
+
   def test_unknown_pattern
     # Write sample files
     FileUtils.mkdir_p('dir')


### PR DESCRIPTION
### Detailed description

The Troubleshooting page gives instructions for what to do when [hidden files are ignored](https://nanoc.app/doc/troubleshooting/#hidden-files-are-ignored). The example given is as follows:

```yaml
data_sources:
  -
    type: filesystem
    extra_files:
      - "/.well-known/**/*"
      - "/.nojekyll"
```

However, this example is not currently working as intended: the extra files end up with double slashes at the beginning (e.g. `//.nojekyll`).

This PR fixes that.

### To do

* [x] Tests

The troubleshooting documentation could also be updated, though if both variants (starting with slash and not starting with slash) are supported, the documentation is fine anyway.

### Related issues

n/a