### PR TITLE
Gracefully handle non-existant dir in `nanoc listen`

### DIFF
--- a/nanoc/lib/nanoc/data_sources/filesystem.rb
+++ b/nanoc/lib/nanoc/data_sources/filesystem.rb
@@ -94,9 +94,11 @@ module Nanoc::DataSources
       require 'listen'
 
       Nanoc::Core::ChangesStream.new do |cl|
-        if dir
+        full_dir = dir ? File.expand_path(dir) : nil
+
+        if full_dir && File.directory?(full_dir)
           listener =
-            Listen.to(File.expand_path(dir)) do |_modifieds, _addeds, _deleteds|
+            Listen.to(full_dir) do |_modifieds, _addeds, _deleteds|
               cl.unknown
             end
 


### PR DESCRIPTION
### Detailed description

When a directory given in the `filesystem` data source does not exist, `nanoc compile` will handle it fine, but `nanoc listen` will crash with a `…/gems/listen-3.7.1/lib/listen/adapter/config.rb:16:in `realpath': No such file or directory @ rb_check_realpath_internal` error.

This fix makes Nanoc ignore directories that do not exist.

One drawback is that if `nanoc live` is started *and then* the directory is created, `nanoc live` will still be ignoring the directory. That seems like an edge case though, but still something that might be improved later.

### To do

* [x] Tests

### Related issues

Fixes #1625.