### PR TITLE
Let CleaningStream forward #closed?

### DIFF
--- a/nanoc-cli/lib/nanoc/cli/cleaning_stream.rb
+++ b/nanoc-cli/lib/nanoc/cli/cleaning_stream.rb
@@ -103,6 +103,11 @@ module Nanoc
         @stream.close
       end
 
+      # @see IO#closed?
+      def closed?
+        @stream.closed?
+      end
+
       # @see File#exist?
       def exist?
         @stream.exist?

--- a/nanoc-cli/spec/nanoc/cli/cleaning_stream_spec.rb
+++ b/nanoc-cli/spec/nanoc/cli/cleaning_stream_spec.rb
@@ -20,7 +20,7 @@ describe Nanoc::CLI::CleaningStream do
   end
 
   it 'forwards methods' do
-    methods = %i[write << flush tell print puts string reopen exist? exists? close]
+    methods = %i[write << flush tell print puts string reopen exist? exists? close closed?]
 
     s = stream_class.new
     cs = described_class.new(s)
@@ -36,6 +36,7 @@ describe Nanoc::CLI::CleaningStream do
     cs.exist?
     cs.exists?
     cs.close
+    cs.closed?
 
     expect(s.called_methods).to eq(methods)
   end


### PR DESCRIPTION
### Detailed description

`$stdout`/`$stderr`, both instances of `CleaningStream`, should also respond to `#closed?` and forward it to the underlying stream.

### To do

* [x] Tests
* [~] Documentation
* [~] Feature flags

### Related issues

Part of a fix for #1631.