### PR TITLE
Don’t let ItemRepPriorityQueue yield items more than once

### DIFF
--- a/nanoc-core/lib/nanoc/core/item_rep_selector.rb
+++ b/nanoc-core/lib/nanoc/core/item_rep_selector.rb
@@ -36,6 +36,10 @@ module Nanoc
           # `reps`, when they are part of a dependency.
           @seen = Set.new
 
+          # List of reps that have already been completed (yielded followed by
+          # `#mark_ok`).
+          @completed = Set.new
+
           # Record (hard) dependencies. Used for detecting cycles.
           @dependencies = Hash.new { |hash, key| hash[key] = Set.new }
         end
@@ -55,6 +59,7 @@ module Nanoc
 
           # Read prio C
           @this = @prio_c.pop
+          @this = @prio_c.pop while @completed.include?(@this)
           if @this
             return @this
           end
@@ -63,7 +68,7 @@ module Nanoc
         end
 
         def mark_ok
-          # Nothing to do
+          @completed << @this
         end
 
         def mark_failed(dep)

--- a/nanoc-core/spec/nanoc/core/item_rep_selector/item_rep_priority_queue_spec.rb
+++ b/nanoc-core/spec/nanoc/core/item_rep_selector/item_rep_priority_queue_spec.rb
@@ -240,4 +240,35 @@ describe Nanoc::Core::ItemRepSelector::ItemRepPriorityQueue do
       micro_graph.mark_ok
     end
   end
+
+  context 'when there is an item with dependencies on an item that was delayed due to another dependency' do
+    # 0 -> 3
+    # 3 OK
+    # 1 -> 0
+    # 0 OK
+    it 'schedules the dependency next up' do
+      expect(micro_graph.next).to eq(reps[0])
+      micro_graph.mark_failed(reps[3])
+
+      expect(micro_graph.next).to eq(reps[3])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[1])
+      micro_graph.mark_failed(reps[0])
+
+      expect(micro_graph.next).to eq(reps[0])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[2])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[4])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to eq(reps[1])
+      micro_graph.mark_ok
+
+      expect(micro_graph.next).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
### Detailed description

It is possible, though unlikely, for the `ItemRepPriorityQueue` to yield an item more than once.

This happens when an item rep has a dependency on an item that was previously yielded but could not be compiled due to a dependency it had itself. For example, given items A to E:

* item A depends on item D
* item B depends on item A

The order of yielding should be:

1. item A (regular prio; outcome=failure due to dependency on item D)
2. item D (prioritised; ok)
3. item B (regular prio; outcome=failure due to dependency on item A)
4. item A (prioritised; outcome=ok)
5. item C (regular prio; ok)
6. item E (regular prio; ok)
7. item B (least prio)

Previously, item A would be yielded twice: once in step 4 (when it was prioritised) and once near the end (in step 7 or 8). This is because item A ended up being deprioritised (in step 1) but it wasn’t taken into account that in the mean time, it could have been a dependency of some other item, and thus be compiled before ending up in step 7 or 8.

This is a bit mind-bending to wrap one’s head around, which is why there is a test case for this now.

### To do

* [x] Tests
* [~] Documentation
* [~] Feature flags

Future improvements could probably include folding `@seen` and `@completed` into one, and making `@prio_a` a nullable object instead of an array.

### Related issues

This is a likely fix for #1631.