### PR TITLE
Clean up priority queue implementation

### DIFF
--- a/nanoc-core/lib/nanoc/core/item_rep_selector.rb
+++ b/nanoc-core/lib/nanoc/core/item_rep_selector.rb
@@ -13,7 +13,7 @@ module Nanoc
       class ItemRepPriorityQueue
         def initialize(reps)
           # Prio A: most important; prio C: least important.
-          @prio_a = []
+          @prio_a = nil
           @prio_b = reps.dup
           @prio_c = []
 
@@ -32,8 +32,9 @@ module Nanoc
 
         def next
           # Read prio A
-          @this = @prio_a.pop
+          @this = @prio_a
           if @this
+            @prio_a = nil
             return @this
           end
 
@@ -70,7 +71,7 @@ module Nanoc
 
           # Put `dep` (item rep that needs to be compiled first, before
           # `@this`) into priority A (highest prio).
-          @prio_a.push(dep)
+          @prio_a = dep
 
           # Remember that we’ve prioritised `dep`. This particular element will
           # come from @prio_b at some point in the future, so we’ll have to skip

--- a/nanoc-core/lib/nanoc/core/item_rep_selector.rb
+++ b/nanoc-core/lib/nanoc/core/item_rep_selector.rb
@@ -8,27 +8,13 @@ module Nanoc
         @reps = reps
       end
 
-      # An iterator (FIFO) over an array, with ability to ignore certain
-      # elements.
-      class ItemRepIgnorableIterator
-        def initialize(array)
-          @array = array.dup
-        end
-
-        def next_ignoring(ignored)
-          elem = @array.shift
-          elem = @array.shift while ignored.include?(elem)
-          elem
-        end
-      end
-
       # A priority queue that tracks dependencies and can detect circular
       # dependencies.
       class ItemRepPriorityQueue
         def initialize(reps)
           # Prio A: most important; prio C: least important.
           @prio_a = []
-          @prio_b = ItemRepIgnorableIterator.new(reps)
+          @prio_b = reps.dup
           @prio_c = []
 
           # List of reps that we’ve already seen. Reps from `reps` will end up
@@ -52,7 +38,8 @@ module Nanoc
           end
 
           # Read prio B
-          @this = @prio_b.next_ignoring(@seen)
+          @this = @prio_b.shift
+          @this = @prio_b.shift while @seen.include?(@this)
           if @this
             return @this
           end

--- a/nanoc-core/spec/nanoc/core/item_rep_selector/item_rep_priority_queue_spec.rb
+++ b/nanoc-core/spec/nanoc/core/item_rep_selector/item_rep_priority_queue_spec.rb
@@ -39,6 +39,8 @@ describe Nanoc::Core::ItemRepSelector::ItemRepPriorityQueue do
 
       expect(micro_graph.next).to eq(reps[4])
       micro_graph.mark_ok
+
+      expect(micro_graph.next).to be_nil
     end
   end
 
@@ -61,6 +63,8 @@ describe Nanoc::Core::ItemRepSelector::ItemRepPriorityQueue do
 
       expect(micro_graph.next).to eq(reps[0])
       micro_graph.mark_ok
+
+      expect(micro_graph.next).to be_nil
     end
   end
 
@@ -86,6 +90,8 @@ describe Nanoc::Core::ItemRepSelector::ItemRepPriorityQueue do
 
       expect(micro_graph.next).to eq(reps[0])
       micro_graph.mark_ok
+
+      expect(micro_graph.next).to be_nil
     end
   end
 
@@ -153,6 +159,8 @@ describe Nanoc::Core::ItemRepSelector::ItemRepPriorityQueue do
 
       expect(micro_graph.next).to eq(reps[0])
       micro_graph.mark_ok
+
+      expect(micro_graph.next).to be_nil
     end
   end
 
@@ -201,6 +209,8 @@ describe Nanoc::Core::ItemRepSelector::ItemRepPriorityQueue do
 
       expect(micro_graph.next).to eq(reps[0])
       micro_graph.mark_ok
+
+      expect(micro_graph.next).to be_nil
     end
   end
 
@@ -238,6 +248,8 @@ describe Nanoc::Core::ItemRepSelector::ItemRepPriorityQueue do
 
       expect(micro_graph.next).to eq(reps[0])
       micro_graph.mark_ok
+
+      expect(micro_graph.next).to be_nil
     end
   end
 


### PR DESCRIPTION
### Detailed description

* `ItemRepIgnorableIterator` is not a useful abstraction (it barely does anything), so away it goes.

* `@prio_a` only ever contains one or two elements, so having it as an array is not worth it.

* Some `expect(micro_graph.next).to be_nil` were missing.

### To do

* [x] Tests

### Related issues

n/a