### PR TITLE
Let Store compress data

### DIFF
--- a/nanoc-core/lib/nanoc/core.rb
+++ b/nanoc-core/lib/nanoc/core.rb
@@ -7,6 +7,7 @@ require 'pstore'
 require 'singleton'
 require 'tmpdir'
 require 'yaml'
+require 'zlib'
 
 # External gems
 require 'concurrent-ruby'

--- a/nanoc-core/lib/nanoc/core/action_sequence_store.rb
+++ b/nanoc-core/lib/nanoc/core/action_sequence_store.rb
@@ -11,7 +11,7 @@ module Nanoc
 
       contract C::KeywordArgs[config: Nanoc::Core::Configuration] => C::Any
       def initialize(config:)
-        super(Nanoc::Core::Store.tmp_path_for(config: config, store_name: 'rule_memory'), 1)
+        super(Nanoc::Core::Store.tmp_path_for(config: config, store_name: 'rule_memory'), 2)
 
         @action_sequences = {}
       end

--- a/nanoc-core/lib/nanoc/core/binary_compiled_content_cache.rb
+++ b/nanoc-core/lib/nanoc/core/binary_compiled_content_cache.rb
@@ -11,7 +11,7 @@ module Nanoc
 
       contract C::KeywordArgs[config: Nanoc::Core::Configuration] => C::Any
       def initialize(config:)
-        super(Nanoc::Core::Store.tmp_path_for(config: config, store_name: 'binary_content'), 2)
+        super(Nanoc::Core::Store.tmp_path_for(config: config, store_name: 'binary_content'), 3)
 
         @cache = {}
       end

--- a/nanoc-core/lib/nanoc/core/checksum_store.rb
+++ b/nanoc-core/lib/nanoc/core/checksum_store.rb
@@ -16,7 +16,7 @@ module Nanoc
 
       contract C::KeywordArgs[config: Nanoc::Core::Configuration, objects: C::IterOf[c_obj]] => C::Any
       def initialize(config:, objects:)
-        super(Nanoc::Core::Store.tmp_path_for(config: config, store_name: 'checksums'), 2)
+        super(Nanoc::Core::Store.tmp_path_for(config: config, store_name: 'checksums'), 3)
 
         @objects = objects
 

--- a/nanoc-core/lib/nanoc/core/dependency_store.rb
+++ b/nanoc-core/lib/nanoc/core/dependency_store.rb
@@ -42,7 +42,7 @@ module Nanoc
 
       contract Nanoc::Core::ItemCollection, Nanoc::Core::LayoutCollection, Nanoc::Core::Configuration => C::Any
       def initialize(items, layouts, config)
-        super(Nanoc::Core::Store.tmp_path_for(config: config, store_name: 'dependencies'), 5)
+        super(Nanoc::Core::Store.tmp_path_for(config: config, store_name: 'dependencies'), 6)
 
         @config = config
         @items = items

--- a/nanoc-core/lib/nanoc/core/outdatedness_store.rb
+++ b/nanoc-core/lib/nanoc/core/outdatedness_store.rb
@@ -8,7 +8,7 @@ module Nanoc
 
       contract C::KeywordArgs[config: Nanoc::Core::Configuration] => C::Any
       def initialize(config:)
-        super(Nanoc::Core::Store.tmp_path_for(config: config, store_name: 'outdatedness'), 1)
+        super(Nanoc::Core::Store.tmp_path_for(config: config, store_name: 'outdatedness'), 2)
 
         @outdated_refs = Set.new
       end

--- a/nanoc-core/lib/nanoc/core/store.rb
+++ b/nanoc-core/lib/nanoc/core/store.rb
@@ -130,11 +130,14 @@ module Nanoc
 
       def write_obj_to_file(filename, obj)
         data = Marshal.dump(obj)
-        write_data_to_file(filename, data)
+        compressed_data = Zlib::Deflate.deflate(data, Zlib::BEST_SPEED)
+        write_data_to_file(filename, compressed_data)
       end
 
       def read_obj_from_file(fn)
-        Marshal.load(File.binread(fn))
+        compressed_data = File.binread(fn)
+        data = Zlib::Inflate.inflate(compressed_data)
+        Marshal.load(data)
       end
 
       def version_filename

--- a/nanoc-core/lib/nanoc/core/textual_compiled_content_cache.rb
+++ b/nanoc-core/lib/nanoc/core/textual_compiled_content_cache.rb
@@ -11,7 +11,7 @@ module Nanoc
 
       contract C::KeywordArgs[config: Nanoc::Core::Configuration] => C::Any
       def initialize(config:)
-        super(Nanoc::Core::Store.tmp_path_for(config: config, store_name: 'compiled_content'), 3)
+        super(Nanoc::Core::Store.tmp_path_for(config: config, store_name: 'compiled_content'), 4)
 
         @cache = {}
       end


### PR DESCRIPTION
### Detailed description

This lets `Store` write/read compressed data, using Ruby’s built in [Zlib](https://ruby-doc.org/stdlib-3.1.2/libdoc/zlib/rdoc/Zlib.html).

The gains can be significant: for example, one site went from a 2+ GiB `compiled_content.data.db` to one that is 220 MiB.

I’ve opted not to have an upgrade path; the next version of Nanoc will ignore the files in `tmp/nanoc/` and do a full recompile. I think it’s not worth creating an upgrade path as these files are not meant to be permanent.

The performance hit seems to be negligible. Take a look at this:

```
git @ main

            Nanoc::Core::DependencyStore │ 5.38s
            Nanoc::Core::DependencyStore │ 3.57s

            Nanoc::Core::DependencyStore │ 5.37s
            Nanoc::Core::DependencyStore │ 3.47s

            Nanoc::Core::DependencyStore │ 5.57s
            Nanoc::Core::DependencyStore │ 3.55s

            Nanoc::Core::DependencyStore │ 5.82s
            Nanoc::Core::DependencyStore │ 3.60s

git @ denis/compress

            Nanoc::Core::DependencyStore │ 5.74s
            Nanoc::Core::DependencyStore │ 3.58s

            Nanoc::Core::DependencyStore │ 5.34s
            Nanoc::Core::DependencyStore │ 3.60s

            Nanoc::Core::DependencyStore │ 5.73s
            Nanoc::Core::DependencyStore │ 3.68s

            Nanoc::Core::DependencyStore │ 5.55s
            Nanoc::Core::DependencyStore │ 3.57s
```

Of each pair, the first is load (read), the second is store (write). I think they’re fairly evenly matched.

### To do

* [x] Tests

### Related issues

n/a