### PR TITLE
Fix broken {Item,Layout}#reference

### DIFF
--- a/nanoc-core/lib/nanoc/core/item.rb
+++ b/nanoc-core/lib/nanoc/core/item.rb
@@ -6,6 +6,13 @@ module Nanoc
       def reference
         @_reference ||= "item:#{identifier}"
       end
+
+      def identifier=(new_identifier)
+        super(new_identifier)
+
+        # Invalidate memoization cache
+        @_reference = nil
+      end
     end
   end
 end

--- a/nanoc-core/lib/nanoc/core/layout.rb
+++ b/nanoc-core/lib/nanoc/core/layout.rb
@@ -6,6 +6,13 @@ module Nanoc
       def reference
         @_reference ||= "layout:#{identifier}"
       end
+
+      def identifier=(new_identifier)
+        super(new_identifier)
+
+        # Invalidate memoization cache
+        @_reference = nil
+      end
     end
   end
 end

--- a/nanoc-core/spec/nanoc/core/item_spec.rb
+++ b/nanoc-core/spec/nanoc/core/item_spec.rb
@@ -9,5 +9,12 @@ describe Nanoc::Core::Item do
     it 'has the proper reference' do
       expect(item.reference).to eql('item:/foo.md')
     end
+
+    it 'updates reference after updating identifier' do
+      expect { item.identifier = '/foo2.md' }
+        .to change(item, :reference)
+        .from('item:/foo.md')
+        .to('item:/foo2.md')
+    end
   end
 end

--- a/nanoc-core/spec/nanoc/core/layout_spec.rb
+++ b/nanoc-core/spec/nanoc/core/layout_spec.rb
@@ -9,5 +9,12 @@ describe Nanoc::Core::Layout do
     it 'has the proper reference' do
       expect(layout.reference).to eql('layout:/foo.md')
     end
+
+    it 'updates reference after updating identifier' do
+      expect { layout.identifier = '/foo2.md' }
+        .to change(layout, :reference)
+        .from('layout:/foo.md')
+        .to('layout:/foo2.md')
+    end
   end
 end


### PR DESCRIPTION
### Detailed description

This fixes the implementation of `Item#reference` and `Layout#reference` so that those methods return the correct value even after their `identifier` has changed.

Executing `@_reference = nil` isn’t really the cleanest solution, but it fixes the problem.

### To do

* [x] Tests

### Related issues

This likely fixes #1640.

Bug introduced in https://github.com/nanoc/nanoc/pull/1603.
