### PR TITLE
Remove redundant defaults in command descriptions

### DIFF
--- a/guard-nanoc/lib/guard/nanoc/live_command.rb
+++ b/guard-nanoc/lib/guard/nanoc/live_command.rb
@@ -9,8 +9,8 @@ description <<~EOS
 EOS
 
 required :H, :handler,       'specify the handler to use (webrick/puma/...)'
-required :o, :host,          'specify the host to listen on (default: 0.0.0.0)', default: '127.0.0.1'
-required :p, :port,          'specify the port to listen on (default: 3000)', transform: Nanoc::CLI::Transform::Port, default: 3000
+required :o, :host,          'specify the host to listen on', default: '127.0.0.1'
+required :p, :port,          'specify the port to listen on', transform: Nanoc::CLI::Transform::Port, default: 3000
 flag     :L, :'live-reload', 'reload on changes'
 
 module Guard

--- a/nanoc-cli/lib/nanoc/cli/commands/view.rb
+++ b/nanoc-cli/lib/nanoc/cli/commands/view.rb
@@ -9,8 +9,8 @@ description <<~EOS
 EOS
 
 required :H, :handler, 'specify the handler to use (webrick/puma/...)'
-required :o, :host,    'specify the host to listen on (default: 127.0.0.1)', default: '127.0.0.1'
-required :p, :port,    'specify the port to listen on (default: 3000)', transform: Nanoc::CLI::Transform::Port, default: 3000
+required :o, :host,    'specify the host to listen on', default: '127.0.0.1'
+required :p, :port,    'specify the port to listen on', transform: Nanoc::CLI::Transform::Port, default: 3000
 flag :L, :'live-reload', 'reload on changes'
 no_params
 

--- a/nanoc-live/lib/nanoc/live/commands/live.rb
+++ b/nanoc-live/lib/nanoc/live/commands/live.rb
@@ -9,8 +9,8 @@ description <<~EOS
 EOS
 
 required :H, :handler, 'specify the handler to use (webrick/puma/...)'
-required :o, :host,    'specify the host to listen on (default: 127.0.0.1)', default: '127.0.0.1'
-required :p, :port,    'specify the port to listen on (default: 3000)', transform: Nanoc::CLI::Transform::Port, default: 3000
+required :o, :host,    'specify the host to listen on', default: '127.0.0.1'
+required :p, :port,    'specify the port to listen on', transform: Nanoc::CLI::Transform::Port, default: 3000
 no_params
 
 runner Nanoc::Live::CommandRunners::Live


### PR DESCRIPTION
### Detailed description

When a `:default` is specified, it is automatically added to the command description, so it does not need to be specified in the command description manually. In fact, adding it to the command description manually makes it appear twice:

```
    -o --host=<value>         specify the host to listen on (default:
                              127.0.0.1) (default: 127.0.0.1)
```

### To do

* [x] Tests

### Related issues

n/a