### PR TITLE
Disable RDiscount on clang 16

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,6 @@ group :plugins do
   gem 'pygments.rb', '~> 2.0', platforms: :ruby
   gem 'rack'
   gem 'rainpress'
-  gem 'rdiscount', '~> 2.2', platforms: :ruby
   gem 'redcarpet', '~> 3.4', platforms: :ruby
   gem 'RedCloth', platforms: :ruby
   gem 'rouge', '~> 3.1'
@@ -83,4 +82,10 @@ group :plugins do
   gem 'w3c_validators'
   gem 'wdm', '>= 0.1.0' if Gem.win_platform?
   gem 'yuicompressor'
+
+  # TODO: remove
+  # See https://github.com/davidfstr/rdiscount/issues/155
+  unless `clang --version`.match?(/clang version 16/)
+    gem 'rdiscount', '~> 2.2', platforms: :ruby
+  end
 end


### PR DESCRIPTION
### Detailed description

RDiscount does not compile with clang 16 (see https://github.com/davidfstr/rdiscount/issues/155). This disables RDiscount for now.

### To do

n/a

### Related issues

n/a