### PR TITLE
Adapt tests to rouge 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ group :plugins do
   gem 'rainpress'
   gem 'redcarpet', '~> 3.4', platforms: :ruby
   gem 'RedCloth', platforms: :ruby
-  gem 'rouge', '~> 3.1'
+  gem 'rouge', '~> 4.1'
   gem 'ruby-handlebars'
   gem 'rubypants'
   gem 'sass'

--- a/nanoc/spec/nanoc/filters/colorize_syntax/rouge_spec.rb
+++ b/nanoc/spec/nanoc/filters/colorize_syntax/rouge_spec.rb
@@ -86,8 +86,8 @@ describe Nanoc::Filters::ColorizeSyntax, filter: true do
           let(:output) do
             <<~EOS
               before
-              <pre><code class="language-ruby">  <span style="color: #000000;font-weight: bold">def</span> <span style="color: #990000;font-weight: bold">foo</span>
-                <span style="color: #000000;font-weight: bold">end</span></code></pre>
+              <pre><code class="language-ruby">  <span style="color: #cf222e">def</span> <span style="color: #8250df">foo</span>
+                <span style="color: #cf222e">end</span></code></pre>
               after
             EOS
           end


### PR DESCRIPTION
The exact contents produced by the GitHub theme in rouge 4 has been updated and this PR adapts the test to pass against rouge 4 (it will fail against rouge < 4 given the output is different).