### PR TITLE
Make error handler print #full_message if available

### DIFF
--- a/nanoc-cli/lib/nanoc/cli/error_handler.rb
+++ b/nanoc-cli/lib/nanoc/cli/error_handler.rb
@@ -115,6 +115,7 @@ module Nanoc::CLI
       stream.puts 'Captain! We’ve been hit!'
 
       write_error_message(stream, error)
+      write_error_detail(stream, error)
       write_item_rep(stream, error)
       write_stack_trace(stream, error)
 
@@ -133,6 +134,7 @@ module Nanoc::CLI
       stream.puts "Crashlog created at #{Time.now}"
 
       write_error_message(stream, error, verbose: true)
+      write_error_detail(stream, error)
       write_item_rep(stream, error, verbose: true)
       write_stack_trace(stream, error, verbose: true)
       write_version_information(stream, verbose: true)
@@ -289,6 +291,15 @@ module Nanoc::CLI
         "\n" + error.errors.map { |e| "  * #{e.pointer}: #{e.message}" }.join("\n")
       else
         error.message
+      end
+    end
+
+    def write_error_detail(stream, error)
+      error = unwrap_error(error)
+
+      if error.respond_to?(:full_message)
+        stream.puts
+        stream.puts error.full_message
       end
     end
 

--- a/nanoc-cli/spec/nanoc/cli/error_handler_spec.rb
+++ b/nanoc-cli/spec/nanoc/cli/error_handler_spec.rb
@@ -118,6 +118,34 @@ describe Nanoc::CLI::ErrorHandler, stdio: true do
         end
       end
 
+      context 'when error implements #full_message', stdio: true do
+        let(:klass) do
+          Class.new(StandardError) do
+            def self.to_s
+              'SubclassOfStandardError'
+            end
+
+            def full_message
+              "okay so what I mean is that #{message}"
+            end
+          end
+        end
+
+        let(:error) do
+          raise klass.new('it is broken')
+        rescue => e
+          return e
+        end
+
+        it 'prints error message followed by error detail' do
+          subject
+
+          expect($stderr.string).to match(
+            %r{SubclassOfStandardError: it is broken.*okay so what I mean is that it is broken}m,
+          )
+        end
+      end
+
       context 'non-trivial error' do
         # …
       end

--- a/nanoc-dart-sass/lib/nanoc/dart_sass/filter.rb
+++ b/nanoc-dart-sass/lib/nanoc/dart_sass/filter.rb
@@ -23,9 +23,6 @@ module Nanoc
           syntax: syntax,
         )
         result.css
-      rescue StandardError => e # rubocop:disable Lint/UselessRescue
-        # TODO: use full_message for syntax errors
-        raise e
       end
 
       class NanocImporter


### PR DESCRIPTION
### Detailed description

If an error implements `#full_message`, it will be printed after the error detail. This makes the `nanoc-dart-sass` errors much more interesting:

```
Captain! We’ve been hit!

Sass::CompileError: Undefined mixin.

Error: Undefined mixin.
  ╷
9 │   @include oops;
  │   ^^^^^^^^^^^^^
  ╵
  nanoc:/assets/style/_2021q4_common.* 9:3  @use
  - 7:1                                     root stylesheet

Current item: /assets/style/2021q4.scss (:default representation)
```

### To do

* [x] Tests

### Related issues

n/a