### PR TITLE
Update for breaking change in sass-embedded 1.68.0

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -317,7 +317,7 @@ RSpec/ExpectOutput:
 # Offense count: 7
 # Configuration parameters: Include, CustomTransform, IgnoreMethods, SpecSuffixOnly.
 # Include: **/*_spec*rb*, **/spec/**/*
-RSpec/FilePath:
+RSpec/SpecFilePathFormat:
   Exclude:
     - 'guard-nanoc/spec/lib/guard/nanoc/live_command_spec.rb'
     - 'nanoc-external/spec/filter_spec.rb'

--- a/nanoc-dart-sass/lib/nanoc/dart_sass/filter.rb
+++ b/nanoc-dart-sass/lib/nanoc/dart_sass/filter.rb
@@ -31,7 +31,7 @@ module Nanoc
           @source_item = source_item
         end
 
-        def canonicalize(url, **)
+        def canonicalize(url, *, **)
           # Construct proper URL with `nanoc:` prefix if needed
           if url.start_with?('nanoc:')
             url


### PR DESCRIPTION
### Detailed description

In sass-embedded 1.68.0, there is a breaking change in importer function signature.

See: https://github.com/ntkme/sass-embedded-host-ruby/pull/156