### PR TITLE
fix: wrong extension for non-index .md files

### DIFF
--- a/nanoc-cli/lib/nanoc/cli/commands/create-site.rb
+++ b/nanoc-cli/lib/nanoc/cli/commands/create-site.rb
@@ -54,7 +54,7 @@ module Nanoc::CLI::Commands
       #  layout '/default.*'
       #
       #  if item.identifier =~ '**/index.*'
-      #    write item.identifier.to_s
+      #    write item.identifier.without_ext + '.html'
       #  else
       #    write item.identifier.without_ext + '/index.html'
       #  end


### PR DESCRIPTION
### Detailed description

The initial rules file contains an example for handling `.md` files but doesn’t set the correct extension for the resulting `.html` file. This change strips the `.md` extension and adds a `.html` extension.

### To do

* Tests
