### PR TITLE
Do cleanup on SIGINT/SIGTERM

### DIFF
--- a/nanoc-cli/spec/nanoc/cli/error_handler_spec.rb
+++ b/nanoc-cli/spec/nanoc/cli/error_handler_spec.rb
@@ -178,4 +178,14 @@ describe Nanoc::CLI::ErrorHandler, stdio: true do
       expect(missing).to be_empty
     end
   end
+
+  describe '#handle_while' do
+    it 'makes #exit bubble up a SystemExit' do
+      expect do
+        error_handler.handle_while(exit_on_error: false) do
+          exit(0)
+        end
+      end.to raise_error(SystemExit)
+    end
+  end
 end


### PR DESCRIPTION
### Detailed description

SIGINT and SIGTERM would make Nanoc exit immediately without going through the proper shutdown process. The outdatedness information was not written to disk properly, which means that re-running `nanoc compile` after an interrupt would yield incorrect results.

`#exit!` exits immediately, while `#exit` raises an exception which Nanoc can (and should) handle.

In addition, this makes interrupts exit with status code 1, which should’ve been the case before already anyway.

Testing out this solution properly is cumbersome: I could not figure out a good way to test this in an automated way.

This is not the ideal solution, because Nanoc ideally would be written in a way that a sudden kill (e.g. also SIGKILL) would leave the state information consistent and usable. Such a change would require some rethinking of Nanoc’s core flows though, and is out of scope of this PR.

### To do

* [x] Tests

### Related issues

Fixes #1641.
