### PR TITLE
feat: show use of 'passthrough' in default config

### DIFF
--- a/nanoc-cli/lib/nanoc/cli/commands/create-site.rb
+++ b/nanoc-cli/lib/nanoc/cli/commands/create-site.rb
@@ -60,9 +60,7 @@ module Nanoc::CLI::Commands
       #  end
       #end
 
-      compile '/**/*' do
-        write item.identifier.to_s
-      end
+      passthrough '/**/*'
 
       layout '/**/*', :erb
     EOS


### PR DESCRIPTION
### Detailed description

Replace the "fallthrough" rule with the convenience method `passthrough` to demonstrate its use and make the default rules shorter.

### To do

* [ ] Tests?
* [ ] Documentation (probably not necessary?)
* [ ] Feature flags?
* [ ] spec?

Sorry, I have no idea whether any of this will be necessary for this change.

### Related issues

None I’m aware of.