### PR TITLE
Set metadata source_code_uri

### DIFF
--- a/guard-nanoc/guard-nanoc.gemspec
+++ b/guard-nanoc/guard-nanoc.gemspec
@@ -22,5 +22,8 @@ Gem::Specification.new do |s|
 
   s.files         = Dir['[A-Z]*'] + Dir['lib/**/*'] + ['guard-nanoc.gemspec']
   s.require_paths = ['lib']
-  s.metadata['rubygems_mfa_required'] = 'true'
+  s.metadata = {
+    'rubygems_mfa_required' => 'true',
+    'source_code_uri' => "https://github.com/nanoc/nanoc/tree/#{s.name}-v#{s.version}/#{s.name}"
+  }
 end

--- a/nanoc-checking/nanoc-checking.gemspec
+++ b/nanoc-checking/nanoc-checking.gemspec
@@ -19,5 +19,8 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('nanoc-cli', '~> 4.12', '>= 4.12.5')
   s.add_runtime_dependency('nanoc-core', '~> 4.12', '>= 4.12.5')
-  s.metadata['rubygems_mfa_required'] = 'true'
+  s.metadata = {
+    'rubygems_mfa_required' => 'true',
+    'source_code_uri' => "https://github.com/nanoc/nanoc/tree/#{s.name}-v#{s.version}/#{s.name}"
+  }
 end

--- a/nanoc-cli/nanoc-cli.gemspec
+++ b/nanoc-cli/nanoc-cli.gemspec
@@ -21,5 +21,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('diff-lcs', '~> 1.3')
   s.add_runtime_dependency('nanoc-core', "= #{Nanoc::CLI::VERSION}")
   s.add_runtime_dependency('zeitwerk', '~> 2.1')
-  s.metadata['rubygems_mfa_required'] = 'true'
+  s.metadata = {
+    'rubygems_mfa_required' => 'true',
+    'source_code_uri' => "https://github.com/nanoc/nanoc/tree/#{s.name}-v#{s.version}/#{s.name}"
+  }
 end

--- a/nanoc-core/nanoc-core.gemspec
+++ b/nanoc-core/nanoc-core.gemspec
@@ -27,5 +27,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('slow_enumerator_tools', '~> 1.0')
   s.add_runtime_dependency('tty-platform', '~> 0.2')
   s.add_runtime_dependency('zeitwerk', '~> 2.1')
-  s.metadata['rubygems_mfa_required'] = 'true'
+  s.metadata = {
+    'rubygems_mfa_required' => 'true',
+    'source_code_uri' => "https://github.com/nanoc/nanoc/tree/#{s.name}-v#{s.version}/#{s.name}"
+  }
 end

--- a/nanoc-dart-sass/nanoc-dart-sass.gemspec
+++ b/nanoc-dart-sass/nanoc-dart-sass.gemspec
@@ -19,5 +19,8 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('nanoc-core', '~> 4.12')
   s.add_runtime_dependency('sass-embedded', '~> 1.56')
-  s.metadata['rubygems_mfa_required'] = 'true'
+  s.metadata = {
+    'rubygems_mfa_required' => 'true',
+    'source_code_uri' => "https://github.com/nanoc/nanoc/tree/#{s.name}-v#{s.version}/#{s.name}"
+  }
 end

--- a/nanoc-deploying/nanoc-deploying.gemspec
+++ b/nanoc-deploying/nanoc-deploying.gemspec
@@ -20,5 +20,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('nanoc-checking', '~> 1.0')
   s.add_runtime_dependency('nanoc-cli', '~> 4.11', '>= 4.11.15')
   s.add_runtime_dependency('nanoc-core', '~> 4.11', '>= 4.11.15')
-  s.metadata['rubygems_mfa_required'] = 'true'
+  s.metadata = {
+    'rubygems_mfa_required' => 'true',
+    'source_code_uri' => "https://github.com/nanoc/nanoc/tree/#{s.name}-v#{s.version}/#{s.name}"
+  }
 end

--- a/nanoc-external/nanoc-external.gemspec
+++ b/nanoc-external/nanoc-external.gemspec
@@ -18,5 +18,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.7'
 
   s.add_runtime_dependency('nanoc-core', '~> 4.11', '>= 4.11.14')
-  s.metadata['rubygems_mfa_required'] = 'true'
+  s.metadata = {
+    'rubygems_mfa_required' => 'true',
+    'source_code_uri' => "https://github.com/nanoc/nanoc/tree/#{s.name}-v#{s.version}/#{s.name}"
+  }
 end

--- a/nanoc-live/nanoc-live.gemspec
+++ b/nanoc-live/nanoc-live.gemspec
@@ -21,5 +21,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('listen', '~> 3.0')
   s.add_runtime_dependency('nanoc-cli', '~> 4.11', '>= 4.11.14')
   s.add_runtime_dependency('nanoc-core', '~> 4.11', '>= 4.11.14')
-  s.metadata['rubygems_mfa_required'] = 'true'
+  s.metadata = {
+    'rubygems_mfa_required' => 'true',
+    'source_code_uri' => "https://github.com/nanoc/nanoc/tree/#{s.name}-v#{s.version}/#{s.name}"
+  }
 end

--- a/nanoc-spec/nanoc-spec.gemspec
+++ b/nanoc-spec/nanoc-spec.gemspec
@@ -18,5 +18,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.7'
 
   s.add_runtime_dependency('nanoc-core', '~> 4.11', '>= 4.11.13')
-  s.metadata['rubygems_mfa_required'] = 'true'
+  s.metadata = {
+    'rubygems_mfa_required' => 'true',
+    'source_code_uri' => "https://github.com/nanoc/nanoc/tree/#{s.name}-v#{s.version}/#{s.name}"
+  }
 end

--- a/nanoc-tilt/nanoc-tilt.gemspec
+++ b/nanoc-tilt/nanoc-tilt.gemspec
@@ -19,5 +19,8 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('nanoc-core', '~> 4.11', '>= 4.11.14')
   s.add_runtime_dependency('tilt', '~> 2.0')
-  s.metadata['rubygems_mfa_required'] = 'true'
+  s.metadata = {
+    'rubygems_mfa_required' => 'true',
+    'source_code_uri' => "https://github.com/nanoc/nanoc/tree/#{s.name}-v#{s.version}/#{s.name}"
+  }
 end

--- a/nanoc/nanoc.gemspec
+++ b/nanoc/nanoc.gemspec
@@ -28,5 +28,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('parallel', '~> 1.12')
   s.add_runtime_dependency('tty-command', '~> 0.8')
   s.add_runtime_dependency('tty-which', '~> 0.4')
-  s.metadata['rubygems_mfa_required'] = 'true'
+  s.metadata = {
+    'rubygems_mfa_required' => 'true',
+    'source_code_uri' => "https://github.com/nanoc/nanoc/tree/#{s.name}-v#{s.version}/#{s.name}"
+  }
 end


### PR DESCRIPTION
This commit adds 'source_code_uri' key to gemspec's metadata, which makes nanoc and the plugins compatible with  [gem-src](https://rubygems.org/gems/gem-src)'s functionality: without it there is no way to detect the source repo unless actually opening the homepage and navigate through it, which I believe is rather tedious.

The 'source_code_uri' item in gemspec's metadata is described in [the guideline rubygems.org publishes](https://guides.rubygems.org/specification-reference/#metadata), and it is [what gem-src uses to prioritize when inferring which repo to clone](https://github.com/amatsuda/gem-src/blob/v0.10.2/lib/rubygems_plugin.rb#L38).

I guess there are not many who have come across this issue, but what do you think of it anyway?

And last but not least, thanks for letting me have a chance to touch your product. I have had a lot of fun and I appreciate your effort 🤝 