### PR TITLE
Fix time/duration tests

### DIFF
--- a/nanoc-core/spec/nanoc/core/instrumentor_spec.rb
+++ b/nanoc-core/spec/nanoc/core/instrumentor_spec.rb
@@ -23,11 +23,19 @@ describe(Nanoc::Core::Instrumentor) do
       described_class.enable { ex.run }
     end
 
+    before do
+      a = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
+
+      allow(Process)
+        .to receive(:clock_gettime)
+        .with(Process::CLOCK_MONOTONIC, :nanosecond)
+        .and_return(a, a + 5_000_000_000)
+    end
+
     it 'sends notification' do
       expect do
         subject.call(:sample_notification, 'garbage', 123) do
-          # Go to a few seconds in the future
-          Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 5))
+          # pass time, as defined by the clock_gettime mock
         end
       end.to send_notification(:sample_notification, 5.0, 'garbage', 123)
     end


### PR DESCRIPTION
### Detailed description

This replaces `timecop` with mocking `Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)` directly, which seems more reliable.

I don’t know what happened to make timecop break, and my investigation hasn’t turned up anything.

Also: the `stage_ran` *does* need to be sent on error. I am not sure why that test passed in the past; the test likely was wrong (but no clear way to verify that).

### To do

n/a

### Related issues

(Add issue IDs for related issues here.)
