### PR TITLE
Don’t refer to Nanoc:: from nanoc-cli gem

### DIFF
--- a/nanoc-cli/lib/nanoc/cli/commands/create-site.rb
+++ b/nanoc-cli/lib/nanoc/cli/commands/create-site.rb
@@ -23,7 +23,7 @@ module Nanoc::CLI::Commands
 
       source 'https://rubygems.org'
 
-      gem 'nanoc', '~> #{Nanoc::VERSION.split('.').take(2).join('.')}'
+      gem 'nanoc', '~> #{Nanoc::CLI::VERSION.split('.').take(2).join('.')}'
     EOS
 
     DEFAULT_CONFIG = <<~EOS unless defined? DEFAULT_CONFIG


### PR DESCRIPTION
### Detailed description

The `nanoc-cli` gem doesn’t depend on the `nanoc` gem (but the other way around) so it shouldn’t be using `Nanoc::`.

### To do

n/a

### Related issues

This fixes #1670.
