### PR TITLE
Return of the YAML aliases :)

### DIFF
--- a/nanoc-core/lib/nanoc/core/config_loader.rb
+++ b/nanoc-core/lib/nanoc/core/config_loader.rb
@@ -56,7 +56,7 @@ module Nanoc
       end
 
       def load_file(filename)
-        YAML.safe_load_file(filename, permitted_classes: PERMITTED_YAML_CLASSES)
+        YAML.safe_load_file(filename, permitted_classes: PERMITTED_YAML_CLASSES, aliases: true)
       end
 
       # @api private

--- a/nanoc-core/lib/nanoc/core/config_loader.rb
+++ b/nanoc-core/lib/nanoc/core/config_loader.rb
@@ -4,8 +4,6 @@ module Nanoc
   module Core
     # @api private
     class ConfigLoader
-      PERMITTED_YAML_CLASSES = [Symbol, Date, Time].freeze
-
       class NoConfigFileFoundError < ::Nanoc::Core::Error
         def initialize
           super('No configuration file found')
@@ -56,7 +54,7 @@ module Nanoc
       end
 
       def load_file(filename)
-        YAML.safe_load_file(filename, permitted_classes: PERMITTED_YAML_CLASSES, aliases: true)
+        YamlLoader.load_file(filename)
       end
 
       # @api private

--- a/nanoc-core/lib/nanoc/core/yaml_loader.rb
+++ b/nanoc-core/lib/nanoc/core/yaml_loader.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Nanoc
+  module Core
+    # @api private
+    module YamlLoader
+      OPTIONS = {
+        permitted_classes: [Symbol, Date, Time].freeze,
+        aliases: true,
+      }.freeze
+
+      private_constant :OPTIONS
+
+      def self.load(yaml_string)
+        YAML.safe_load(yaml_string, **OPTIONS)
+      end
+
+      def self.load_file(filename)
+        YAML.safe_load_file(filename, **OPTIONS)
+      end
+    end
+  end
+end

--- a/nanoc-core/nanoc-core.manifest
+++ b/nanoc-core/nanoc-core.manifest
@@ -140,3 +140,4 @@ lib/nanoc/core/view_context_for_compilation.rb
 lib/nanoc/core/view_context_for_pre_compilation.rb
 lib/nanoc/core/view_context_for_shell.rb
 lib/nanoc/core/view.rb
+lib/nanoc/core/yaml_loader.rb

--- a/nanoc-core/spec/nanoc/core/yaml_loader_spec.rb
+++ b/nanoc-core/spec/nanoc/core/yaml_loader_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+describe Nanoc::Core::YamlLoader do
+  subject(:loader) { described_class }
+  let(:yaml_input) do
+    <<~YAML
+    point: &point_data
+      x: 42
+      y: 43
+    rect:
+      origin: *point_data
+      extent: {w: 10, h: 11}
+    YAML
+  end
+  let(:expected_output) do
+    {
+      'point' => {'x' => 42, 'y' => 43},
+      'rect' => {
+        'origin' => {'x' => 42, 'y' => 43},
+        'extent' => {'w' => 10, 'h' => 11},
+      }
+    }
+  end
+
+  describe 'load' do
+    it 'accepts YAML aliases' do
+      expect(loader.load yaml_input).to eq expected_output
+    end
+  end
+end

--- a/nanoc/lib/nanoc/data_sources/filesystem.rb
+++ b/nanoc/lib/nanoc/data_sources/filesystem.rb
@@ -48,8 +48,6 @@ module Nanoc::DataSources
   #
   # @api private
   class Filesystem < Nanoc::DataSource
-    PERMITTED_YAML_CLASSES = Nanoc::Core::ConfigLoader::PERMITTED_YAML_CLASSES
-
     class AmbiguousMetadataAssociationError < ::Nanoc::Core::Error
       def initialize(content_filenames, meta_filename)
         super("There are multiple content files (#{content_filenames.sort.join(', ')}) that could match the file containing metadata (#{meta_filename}).")
@@ -154,7 +152,7 @@ module Nanoc::DataSources
       is_binary = content_filename && !@site_config[:text_extensions].include?(File.extname(content_filename)[1..])
 
       if is_binary && klass == Nanoc::Core::Item
-        meta = (meta_filename && YAML.safe_load_file(meta_filename, permitted_classes: PERMITTED_YAML_CLASSES, aliases: true)) || {}
+        meta = (meta_filename && Nanoc::Core::YamlLoader.load_file(meta_filename)) || {}
 
         ProtoDocument.new(is_binary: true, filename: content_filename, attributes: meta)
       elsif is_binary && klass == Nanoc::Core::Layout

--- a/nanoc/lib/nanoc/data_sources/filesystem.rb
+++ b/nanoc/lib/nanoc/data_sources/filesystem.rb
@@ -154,7 +154,7 @@ module Nanoc::DataSources
       is_binary = content_filename && !@site_config[:text_extensions].include?(File.extname(content_filename)[1..])
 
       if is_binary && klass == Nanoc::Core::Item
-        meta = (meta_filename && YAML.safe_load_file(meta_filename, permitted_classes: PERMITTED_YAML_CLASSES)) || {}
+        meta = (meta_filename && YAML.safe_load_file(meta_filename, permitted_classes: PERMITTED_YAML_CLASSES, aliases: true)) || {}
 
         ProtoDocument.new(is_binary: true, filename: content_filename, attributes: meta)
       elsif is_binary && klass == Nanoc::Core::Layout

--- a/nanoc/lib/nanoc/data_sources/filesystem/parser.rb
+++ b/nanoc/lib/nanoc/data_sources/filesystem/parser.rb
@@ -61,7 +61,7 @@ class Nanoc::DataSources::Filesystem
     # @return [Hash]
     def parse_metadata(data, filename)
       begin
-        meta = YAML.safe_load(data, permitted_classes: PERMITTED_YAML_CLASSES) || {}
+        meta = YAML.safe_load(data, permitted_classes: PERMITTED_YAML_CLASSES, aliases: true) || {}
       rescue => e
         raise Errors::UnparseableMetadata.new(filename, e)
       end

--- a/nanoc/lib/nanoc/data_sources/filesystem/parser.rb
+++ b/nanoc/lib/nanoc/data_sources/filesystem/parser.rb
@@ -4,7 +4,6 @@
 class Nanoc::DataSources::Filesystem
   class Parser
     SEPARATOR = /(-{5}|-{3})/.source
-    PERMITTED_YAML_CLASSES = Nanoc::Core::ConfigLoader::PERMITTED_YAML_CLASSES
 
     class ParseResult
       attr_reader :content
@@ -61,7 +60,7 @@ class Nanoc::DataSources::Filesystem
     # @return [Hash]
     def parse_metadata(data, filename)
       begin
-        meta = YAML.safe_load(data, permitted_classes: PERMITTED_YAML_CLASSES, aliases: true) || {}
+        meta = Nanoc::Core::YamlLoader.load(data) || {}
       rescue => e
         raise Errors::UnparseableMetadata.new(filename, e)
       end


### PR DESCRIPTION
Hi @denisdefreyne, it's been a long time since we've last been in touch. How are you? :)

### Detailed description

This is the fix for #1676. See details there.

FYI, the last commit is solely a refactoring to establish single responsibility for YAML parser invocations, while the prior commits fix the invocations in the multiple places where they occurred.

3 commits:

- commit 1: Fix YAML invocation for `nanoc.yaml`
- commit 2: Fix YAML invocations in other places
- commit 3: Factor out business rules for YAML invocation
  => single responsibility, less verbose YAML access, centrally testable (test included)
