### PR TITLE
Specify pry as one of nanoc-cli's runtime dependencies

### DIFF
--- a/nanoc-cli/nanoc-cli.gemspec
+++ b/nanoc-cli/nanoc-cli.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('cri', '~> 2.15')
   s.add_runtime_dependency('diff-lcs', '~> 1.3')
   s.add_runtime_dependency('nanoc-core', "= #{Nanoc::CLI::VERSION}")
+  s.add_runtime_dependency('pry', '>= 0')
   s.add_runtime_dependency('zeitwerk', '~> 2.1')
   s.metadata = {
     'rubygems_mfa_required' => 'true',


### PR DESCRIPTION
### Detailed description
This PR adds a runtime dependency on pry to nanoc-cli so it does not fail when the application's Gemfile does not have pry.

I suppose that in the relatively old days pry was so prevalent that this was not thought of as a problem. Though nowadays irb is getting popularized again which sometimes displaces pry, when it becomes a problem.

### To do
None. 

### Related issues
Closes #1678.
