### PR TITLE
Use rubygems version 3.4.9 on CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
+          rubygems: 3.4.9 # https://github.com/ruby/psych/discussions/607
           bundler-cache: true
 
       - name: Test style

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,15 +24,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-
-      - uses: actions/cache@v3
-        with:
-          path: vendor/bundle
-          key: bundler-b-${{ runner.os }}-${{ matrix.ruby-version }}-${{ hashFiles('Gemfile') }}
-
-      - run: |
-          bundle config set --local path 'vendor/bundle'
-          bundle install --jobs "$(nproc)"
+          bundler-cache: true
 
       - name: Test style
         if: ${{ matrix.ruby-version == '3.1' }}


### PR DESCRIPTION
### Detailed description
Ruby 3.1 and the prior versions have to use rubygems v3.4.9 or later to build native extension. The most concise instruction I've found is here: https://github.com/ruby/psych/discussions/607#discussioncomment-7233953.

In this nanoc/nanoc repository, this issue has not been made apparent since it has apparently been referencing cached installations in the CI, until #1679 sees the following error (quoted from https://github.com/nanoc/nanoc/actions/runs/7328290703/job/19956352783?pr=1679)

<details>
<summary>Details</summary>

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

current directory:
/home/runner/work/nanoc/nanoc/vendor/bundle/ruby/2.7.0/gems/mini_racer-0.6.4/ext/mini_racer_extension
/opt/hostedtoolcache/Ruby/2.7.8/x64/bin/ruby -I
/opt/hostedtoolcache/Ruby/2.7.8/x64/lib/ruby/2.7.0 -r
./siteconf20231226-1795-wpoysp.rb extconf.rb
checking for -lpthread... yes
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/opt/hostedtoolcache/Ruby/2.7.8/x64/bin/$(RUBY_BASE_NAME)
	--with-pthread-dir
	--without-pthread-dir
	--with-pthread-include
	--without-pthread-include=${pthread-dir}/include
	--with-pthread-lib
	--without-pthread-lib=${pthread-dir}/lib
	--with-pthreadlib
	--without-pthreadlib
	--enable-debug
	--disable-debug
	--enable-asan
	--disable-asan
/opt/hostedtoolcache/Ruby/2.7.8/x64/lib/ruby/2.7.0/psych.rb:456:in
`parse_stream': undefined method `parse' for #<Psych::Parser:0x0000557992bc3728>
(NoMethodError)
...
An error occurred while installing mini_racer (0.6.4), and Bundler cannot
continue.

In Gemfile:
  mini_racer
```

</details>

This PR fixes it by pinning the version of rubygems to v3.4.9 just as instructed in https://github.com/ruby/psych/discussions/607, configuring it through ruby/setup-ruby's definition.

Also, in the previous definition the installed gems were cached through lines of configurations, which can be replaced with inline `bundler-cache: true`, so I did it too to favor simplicity.

### To do
None.

### Related issues
Not directly but related to #1679
