### PR TITLE
Add base64 as a gem dependency

### DIFF
--- a/nanoc-core/lib/nanoc/core.rb
+++ b/nanoc-core/lib/nanoc/core.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # Ruby stdlib
+require 'base64'
 require 'fiber'
 require 'find'
 require 'pstore'

--- a/nanoc-core/nanoc-core.gemspec
+++ b/nanoc-core/nanoc-core.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.7'
 
+  s.add_runtime_dependency('base64', '~> 0.2')
   s.add_runtime_dependency('concurrent-ruby', '~> 1.1')
   s.add_runtime_dependency('ddmetrics', '~> 1.0')
   s.add_runtime_dependency('ddplugin', '~> 1.0')

--- a/nanoc/lib/nanoc.rb
+++ b/nanoc/lib/nanoc.rb
@@ -11,7 +11,6 @@ module Nanoc
 end
 
 # Load general requirements
-require 'base64'
 require 'cgi'
 require 'digest'
 require 'English'


### PR DESCRIPTION
### Detailed description

Ruby 3.3 still comes with `base64` as a gem, but future versions of Ruby won’t. This adds the `base64` gem as a dependency, and so Nanoc is future-proofed.

### To do

n/a

### Related issues

n/a