### PR TITLE
nanoc-dart-sass: somewhat hacky support for partials.

### DIFF
--- a/nanoc-dart-sass/lib/nanoc/dart_sass/filter.rb
+++ b/nanoc-dart-sass/lib/nanoc/dart_sass/filter.rb
@@ -71,7 +71,12 @@ module Nanoc
           item = @items[pat]
 
           unless item
-            raise "Could not find an item matching pattern `#{pat}`"
+            # Handle partials in a somewhat hacky way
+            pat_ = File.expand_path( "_"+File.basename(pat), File.dirname(pat) )
+            item = @items[pat_]
+            unless item
+              raise "Could not find an item matching pattern `#{pat}`"
+            end
           end
 
           item


### PR DESCRIPTION
### Detailed description

Current nanoc-dart-sass doesn't have support for partials (files starting with '_'). This is a quite ugly fix, but it does work. Feel free to close if you have a better solution or find it too ugly to merge.

### To do

* [x] Support for partials

### Related issues

#1690 
