### PR TITLE
Make Checksummer faster and more correct

### DIFF
--- a/nanoc-core/spec/nanoc/core/action_sequence_spec.rb
+++ b/nanoc-core/spec/nanoc/core/action_sequence_spec.rb
@@ -147,9 +147,9 @@ describe Nanoc::Core::ActionSequence do
     example do
       expect(subject).to eql(
         [
-          [:filter, :erb, 'PeWUm2PtXYtqeHJdTqnY7kkwAow='],
+          [:filter, :erb, 'B1gmzMdP+iEDgTz7SylLoB6yLNw='],
           [:snapshot, [:bar], true, ['/foo.md']],
-          [:layout, '/default.erb', '97LAe1pYTLKczxBsu+x4MmvqdkU='],
+          [:layout, '/default.erb', 'QQW0vu/3fP4Ihc5xhQKuPer3xUc='],
         ],
       )
     end

--- a/nanoc-core/spec/nanoc/core/checksummer_spec.rb
+++ b/nanoc-core/spec/nanoc/core/checksummer_spec.rb
@@ -39,115 +39,115 @@ describe Nanoc::Core::Checksummer do
         described_class.calc_for_each_attribute_of(obj, Nanoc::Core::Checksummer::VerboseDigest)
       end
 
-      it { is_expected.to eq(foo: 'String<bar>') }
+      it { is_expected.to eq(foo: 'String#0<bar>') }
     end
   end
 
   context 'String' do
     let(:obj) { 'hello' }
 
-    it { is_expected.to eql('String<hello>') }
+    it { is_expected.to eql('String#0<hello>') }
   end
 
   context 'Symbol' do
     let(:obj) { :hello }
 
-    it { is_expected.to eql('Symbol<hello>') }
+    it { is_expected.to eql('Symbol#0<hello>') }
   end
 
   context 'nil' do
     let(:obj) { nil }
 
-    it { is_expected.to eql('NilClass<>') }
+    it { is_expected.to eql('NilClass#0<>') }
   end
 
   context 'true' do
     let(:obj) { true }
 
-    it { is_expected.to eql('TrueClass<>') }
+    it { is_expected.to eql('TrueClass#0<>') }
   end
 
   context 'false' do
     let(:obj) { false }
 
-    it { is_expected.to eql('FalseClass<>') }
+    it { is_expected.to eql('FalseClass#0<>') }
   end
 
   context 'Array' do
     let(:obj) { %w[hello goodbye] }
 
-    it { is_expected.to eql('Array<String<hello>,String<goodbye>,>') }
+    it { is_expected.to eql('Array#0<String#1<hello>,String#2<goodbye>,>') }
 
     context 'different order' do
       let(:obj) { %w[goodbye hello] }
 
-      it { is_expected.to eql('Array<String<goodbye>,String<hello>,>') }
+      it { is_expected.to eql('Array#0<String#1<goodbye>,String#2<hello>,>') }
     end
 
     context 'recursive' do
       let(:obj) { [].tap { |arr| arr << ['hello', arr] } }
 
-      it { is_expected.to eql('Array<Array<String<hello>,Array<recur>,>,>') }
+      it { is_expected.to eql('Array#0<Array#1<String#2<hello>,@0,>,>') }
     end
 
     context 'non-serializable' do
       let(:obj) { [-> {}] }
 
-      it { is_expected.to match(/\AArray<Proc<#<Proc:0x.*>>,>\z/) }
+      it { is_expected.to match(/\AArray#0<Proc#1<#<Proc:0x.*>>,>\z/) }
     end
   end
 
   context 'Set' do
     let(:obj) { Set.new(%w[hello goodbye]) }
 
-    it { is_expected.to eql('Set<String<goodbye>,String<hello>,>') }
+    it { is_expected.to eql('Set#0<String#1<goodbye>,String#2<hello>,>') }
 
     context 'different order' do
       let(:obj) { Set.new(%w[goodbye hello]) }
 
-      it { is_expected.to eql('Set<String<goodbye>,String<hello>,>') }
+      it { is_expected.to eql('Set#0<String#1<goodbye>,String#2<hello>,>') }
     end
 
     context 'recursive' do
       let(:obj) { Set.new.tap { |set| set << Set.new.add('hello').add(set) } }
 
-      it { is_expected.to eql('Set<Set<String<hello>,Set<recur>,>,>') }
+      it { is_expected.to eql('Set#0<Set#1<String#2<hello>,@0,>,>') }
     end
 
     context 'non-serializable' do
       let(:obj) { Set.new.add(-> {}) }
 
-      it { is_expected.to match(/\ASet<Proc<#<Proc:0x.*>>,>\z/) }
+      it { is_expected.to match(/\ASet#0<Proc#1<#<Proc:0x.*>>,>\z/) }
     end
   end
 
   context 'Hash' do
     let(:obj) { { 'a' => 'foo', 'b' => 'bar' } }
 
-    it { is_expected.to eql('Hash<String<a>=String<foo>,String<b>=String<bar>,>') }
+    it { is_expected.to eql('Hash#0<String#1<a>=String#2<foo>,String#3<b>=String#4<bar>,>') }
 
     context 'different order' do
       let(:obj) { { 'b' => 'bar', 'a' => 'foo' } }
 
-      it { is_expected.to eql('Hash<String<b>=String<bar>,String<a>=String<foo>,>') }
+      it { is_expected.to eql('Hash#0<String#1<b>=String#2<bar>,String#3<a>=String#4<foo>,>') }
     end
 
     context 'non-serializable' do
       let(:obj) { { 'a' => -> {} } }
 
-      it { is_expected.to match(/\AHash<String<a>=Proc<#<Proc:0x.*>>,>\z/) }
+      it { is_expected.to match(/\AHash#0<String#1<a>=Proc#2<#<Proc:0x.*>>,>\z/) }
     end
 
     context 'recursive values' do
       let(:obj) { {}.tap { |hash| hash['a'] = hash } }
 
-      it { is_expected.to eql('Hash<String<a>=Hash<recur>,>') }
+      it { is_expected.to eql('Hash#0<String#1<a>=@0,>') }
     end
 
     context 'recursive keys' do
       let(:obj) { {}.tap { |hash| hash[hash] = 'hello' } }
 
-      it { is_expected.to eql('Hash<Hash<recur>=String<hello>,>') }
+      it { is_expected.to eql('Hash#0<@0=String#1<hello>,>') }
     end
   end
 
@@ -164,57 +164,57 @@ describe Nanoc::Core::Checksummer do
       File.utime(mtime, mtime, filename)
     end
 
-    it { is_expected.to eql('Pathname<6-200>') }
+    it { is_expected.to eql('Pathname#0<6-200>') }
 
     context 'does not exist' do
       before do
         FileUtils.rm_rf(filename)
       end
 
-      it { is_expected.to eql('Pathname<???>') }
+      it { is_expected.to eql('Pathname#0<???>') }
     end
 
     context 'different data' do
       let(:data) { 'other stuffs :o' }
 
-      it { is_expected.to eql('Pathname<15-200>') }
+      it { is_expected.to eql('Pathname#0<15-200>') }
     end
   end
 
   context 'Time' do
     let(:obj) { Time.at(111_223) }
 
-    it { is_expected.to eql('Time<111223>') }
+    it { is_expected.to eql('Time#0<111223>') }
   end
 
   context 'Float' do
     let(:obj) { 3.14 }
 
-    it { is_expected.to eql('Float<3.14>') }
+    it { is_expected.to eql('Float#0<3.14>') }
   end
 
   context 'Fixnum/Integer' do
     let(:obj) { 3 }
 
-    it { is_expected.to match(/\A(Integer|Fixnum)<3>\z/) }
+    it { is_expected.to match(/\A(Integer|Fixnum)#0<3>\z/) }
   end
 
   context 'Nanoc::Core::Identifier' do
     let(:obj) { Nanoc::Core::Identifier.new('/foo.md') }
 
-    it { is_expected.to eql('Nanoc::Core::Identifier<String</foo.md>>') }
+    it { is_expected.to eql('Nanoc::Core::Identifier#0<String#1</foo.md>>') }
   end
 
   context 'Nanoc::Core::Configuration' do
     let(:obj) { Nanoc::Core::Configuration.new(dir: Dir.getwd, hash: { 'foo' => 'bar' }) }
 
-    it { is_expected.to eql('Nanoc::Core::Configuration<Symbol<foo>=String<bar>,>') }
+    it { is_expected.to eql('Nanoc::Core::Configuration#0<Symbol#1<foo>=String#2<bar>,>') }
   end
 
   context 'Nanoc::Core::Item' do
     let(:obj) { Nanoc::Core::Item.new('asdf', { 'foo' => 'bar' }, '/foo.md') }
 
-    it { is_expected.to eql('Nanoc::Core::Item<content=Nanoc::Core::TextualContent<String<asdf>>,attributes=Hash<Symbol<foo>=String<bar>,>,identifier=Nanoc::Core::Identifier<String</foo.md>>>') }
+    it { is_expected.to eql('Nanoc::Core::Item#0<content=Nanoc::Core::TextualContent#1<String#2<asdf>>,attributes=Hash#3<Symbol#4<foo>=String#5<bar>,>,identifier=Nanoc::Core::Identifier#6<String#7</foo.md>>>') }
 
     context 'binary' do
       let(:filename) { File.expand_path('foo.dat') }
@@ -229,7 +229,7 @@ describe Nanoc::Core::Checksummer do
         File.utime(mtime, mtime, content.filename)
       end
 
-      it { is_expected.to eql('Nanoc::Core::Item<content=Nanoc::Core::BinaryContent<Pathname<6-200>>,attributes=Hash<Symbol<foo>=String<bar>,>,identifier=Nanoc::Core::Identifier<String</foo.md>>>') }
+      it { is_expected.to eql('Nanoc::Core::Item#0<content=Nanoc::Core::BinaryContent#1<Pathname#2<6-200>>,attributes=Hash#3<Symbol#4<foo>=String#5<bar>,>,identifier=Nanoc::Core::Identifier#6<String#7</foo.md>>>') }
     end
 
     context 'recursive attributes' do
@@ -237,45 +237,45 @@ describe Nanoc::Core::Checksummer do
         obj.attributes[:foo] = obj
       end
 
-      it { is_expected.to eql('Nanoc::Core::Item<content=Nanoc::Core::TextualContent<String<asdf>>,attributes=Hash<Symbol<foo>=Nanoc::Core::Item<recur>,>,identifier=Nanoc::Core::Identifier<String</foo.md>>>') }
+      it { is_expected.to eql('Nanoc::Core::Item#0<content=Nanoc::Core::TextualContent#1<String#2<asdf>>,attributes=Hash#3<Symbol#4<foo>=@0,>,identifier=Nanoc::Core::Identifier#5<String#6</foo.md>>>') }
     end
 
     context 'with checksum' do
       let(:obj) { Nanoc::Core::Item.new('asdf', { 'foo' => 'bar' }, '/foo.md', checksum_data: 'abcdef') }
 
-      it { is_expected.to eql('Nanoc::Core::Item<checksum_data=abcdef>') }
+      it { is_expected.to eql('Nanoc::Core::Item#0<checksum_data=abcdef>') }
     end
 
     context 'with content checksum' do
       let(:obj) { Nanoc::Core::Item.new('asdf', { 'foo' => 'bar' }, '/foo.md', content_checksum_data: 'con-cs') }
 
-      it { is_expected.to eql('Nanoc::Core::Item<content_checksum_data=con-cs,attributes=Hash<Symbol<foo>=String<bar>,>,identifier=Nanoc::Core::Identifier<String</foo.md>>>') }
+      it { is_expected.to eql('Nanoc::Core::Item#0<content_checksum_data=con-cs,attributes=Hash#1<Symbol#2<foo>=String#3<bar>,>,identifier=Nanoc::Core::Identifier#4<String#5</foo.md>>>') }
     end
 
     context 'with attributes checksum' do
       let(:obj) { Nanoc::Core::Item.new('asdf', { 'foo' => 'bar' }, '/foo.md', attributes_checksum_data: 'attr-cs') }
 
-      it { is_expected.to eql('Nanoc::Core::Item<content=Nanoc::Core::TextualContent<String<asdf>>,attributes_checksum_data=attr-cs,identifier=Nanoc::Core::Identifier<String</foo.md>>>') }
+      it { is_expected.to eql('Nanoc::Core::Item#0<content=Nanoc::Core::TextualContent#1<String#2<asdf>>,attributes_checksum_data=attr-cs,identifier=Nanoc::Core::Identifier#3<String#4</foo.md>>>') }
     end
   end
 
   context 'Nanoc::Core::Layout' do
     let(:obj) { Nanoc::Core::Layout.new('asdf', { 'foo' => 'bar' }, '/foo.md') }
 
-    it { is_expected.to eql('Nanoc::Core::Layout<content=Nanoc::Core::TextualContent<String<asdf>>,attributes=Hash<Symbol<foo>=String<bar>,>,identifier=Nanoc::Core::Identifier<String</foo.md>>>') }
+    it { is_expected.to eql('Nanoc::Core::Layout#0<content=Nanoc::Core::TextualContent#1<String#2<asdf>>,attributes=Hash#3<Symbol#4<foo>=String#5<bar>,>,identifier=Nanoc::Core::Identifier#6<String#7</foo.md>>>') }
 
     context 'recursive attributes' do
       before do
         obj.attributes[:foo] = obj
       end
 
-      it { is_expected.to eql('Nanoc::Core::Layout<content=Nanoc::Core::TextualContent<String<asdf>>,attributes=Hash<Symbol<foo>=Nanoc::Core::Layout<recur>,>,identifier=Nanoc::Core::Identifier<String</foo.md>>>') }
+      it { is_expected.to eql('Nanoc::Core::Layout#0<content=Nanoc::Core::TextualContent#1<String#2<asdf>>,attributes=Hash#3<Symbol#4<foo>=@0,>,identifier=Nanoc::Core::Identifier#5<String#6</foo.md>>>') }
     end
 
     context 'with checksum' do
       let(:obj) { Nanoc::Core::Layout.new('asdf', { 'foo' => 'bar' }, '/foo.md', checksum_data: 'abcdef') }
 
-      it { is_expected.to eql('Nanoc::Core::Layout<checksum_data=abcdef>') }
+      it { is_expected.to eql('Nanoc::Core::Layout#0<checksum_data=abcdef>') }
     end
   end
 
@@ -283,26 +283,26 @@ describe Nanoc::Core::Checksummer do
     let(:obj) { Nanoc::Core::ItemRep.new(item, :pdf) }
     let(:item) { Nanoc::Core::Item.new('asdf', {}, '/foo.md') }
 
-    it { is_expected.to eql('Nanoc::Core::ItemRep<item=Nanoc::Core::Item<content=Nanoc::Core::TextualContent<String<asdf>>,attributes=Hash<>,identifier=Nanoc::Core::Identifier<String</foo.md>>>,name=Symbol<pdf>>') }
+    it { is_expected.to eql('Nanoc::Core::ItemRep#0<item=Nanoc::Core::Item#1<content=Nanoc::Core::TextualContent#2<String#3<asdf>>,attributes=Hash#4<>,identifier=Nanoc::Core::Identifier#5<String#6</foo.md>>>,name=Symbol#7<pdf>>') }
   end
 
   context 'Nanoc::Core::Context' do
     let(:obj) { Nanoc::Core::Context.new(foo: 123) }
 
-    it { is_expected.to match(/\ANanoc::Core::Context<@foo=(Fixnum|Integer)<123>,>\z/) }
+    it { is_expected.to match(/\ANanoc::Core::Context#0<@foo=(Fixnum|Integer)#1<123>,>\z/) }
   end
 
   context 'Nanoc::Core::CodeSnippet' do
     let(:obj) { Nanoc::Core::CodeSnippet.new('asdf', '/bob.rb') }
 
-    it { is_expected.to eql('Nanoc::Core::CodeSnippet<String<asdf>>') }
+    it { is_expected.to eql('Nanoc::Core::CodeSnippet#0<String#1<asdf>>') }
   end
 
   context 'Nanoc::Core::CompilationItemView' do
     let(:obj) { Nanoc::Core::CompilationItemView.new(item, nil) }
     let(:item) { Nanoc::Core::Item.new('asdf', {}, '/foo.md') }
 
-    it { is_expected.to eql('Nanoc::Core::CompilationItemView<Nanoc::Core::Item<content=Nanoc::Core::TextualContent<String<asdf>>,attributes=Hash<>,identifier=Nanoc::Core::Identifier<String</foo.md>>>>') }
+    it { is_expected.to eql('Nanoc::Core::CompilationItemView#0<Nanoc::Core::Item#1<content=Nanoc::Core::TextualContent#2<String#3<asdf>>,attributes=Hash#4<>,identifier=Nanoc::Core::Identifier#5<String#6</foo.md>>>>') }
   end
 
   context 'Nanoc::Core::BasicItemRepView' do
@@ -310,7 +310,7 @@ describe Nanoc::Core::Checksummer do
     let(:rep) { Nanoc::Core::ItemRep.new(item, :pdf) }
     let(:item) { Nanoc::Core::Item.new('asdf', {}, '/foo.md') }
 
-    it { is_expected.to eql('Nanoc::Core::BasicItemRepView<Nanoc::Core::ItemRep<item=Nanoc::Core::Item<content=Nanoc::Core::TextualContent<String<asdf>>,attributes=Hash<>,identifier=Nanoc::Core::Identifier<String</foo.md>>>,name=Symbol<pdf>>>') }
+    it { is_expected.to eql('Nanoc::Core::BasicItemRepView#0<Nanoc::Core::ItemRep#1<item=Nanoc::Core::Item#2<content=Nanoc::Core::TextualContent#3<String#4<asdf>>,attributes=Hash#5<>,identifier=Nanoc::Core::Identifier#6<String#7</foo.md>>>,name=Symbol#8<pdf>>>') }
   end
 
   context 'Nanoc::Core::CompilationItemRepView' do
@@ -318,28 +318,28 @@ describe Nanoc::Core::Checksummer do
     let(:rep) { Nanoc::Core::ItemRep.new(item, :pdf) }
     let(:item) { Nanoc::Core::Item.new('asdf', {}, '/foo.md') }
 
-    it { is_expected.to eql('Nanoc::Core::CompilationItemRepView<Nanoc::Core::ItemRep<item=Nanoc::Core::Item<content=Nanoc::Core::TextualContent<String<asdf>>,attributes=Hash<>,identifier=Nanoc::Core::Identifier<String</foo.md>>>,name=Symbol<pdf>>>') }
+    it { is_expected.to eql('Nanoc::Core::CompilationItemRepView#0<Nanoc::Core::ItemRep#1<item=Nanoc::Core::Item#2<content=Nanoc::Core::TextualContent#3<String#4<asdf>>,attributes=Hash#5<>,identifier=Nanoc::Core::Identifier#6<String#7</foo.md>>>,name=Symbol#8<pdf>>>') }
   end
 
   context 'Nanoc::Core::BasicItemView' do
     let(:obj) { Nanoc::Core::BasicItemView.new(item, nil) }
     let(:item) { Nanoc::Core::Item.new('asdf', {}, '/foo.md') }
 
-    it { is_expected.to eql('Nanoc::Core::BasicItemView<Nanoc::Core::Item<content=Nanoc::Core::TextualContent<String<asdf>>,attributes=Hash<>,identifier=Nanoc::Core::Identifier<String</foo.md>>>>') }
+    it { is_expected.to eql('Nanoc::Core::BasicItemView#0<Nanoc::Core::Item#1<content=Nanoc::Core::TextualContent#2<String#3<asdf>>,attributes=Hash#4<>,identifier=Nanoc::Core::Identifier#5<String#6</foo.md>>>>') }
   end
 
   context 'Nanoc::Core::LayoutView' do
     let(:obj) { Nanoc::Core::LayoutView.new(layout, nil) }
     let(:layout) { Nanoc::Core::Layout.new('asdf', {}, '/foo.md') }
 
-    it { is_expected.to eql('Nanoc::Core::LayoutView<Nanoc::Core::Layout<content=Nanoc::Core::TextualContent<String<asdf>>,attributes=Hash<>,identifier=Nanoc::Core::Identifier<String</foo.md>>>>') }
+    it { is_expected.to eql('Nanoc::Core::LayoutView#0<Nanoc::Core::Layout#1<content=Nanoc::Core::TextualContent#2<String#3<asdf>>,attributes=Hash#4<>,identifier=Nanoc::Core::Identifier#5<String#6</foo.md>>>>') }
   end
 
   context 'Nanoc::Core::ConfigView' do
     let(:obj) { Nanoc::Core::ConfigView.new(config, nil) }
     let(:config) { Nanoc::Core::Configuration.new(dir: Dir.getwd, hash: { 'foo' => 'bar' }) }
 
-    it { is_expected.to eql('Nanoc::Core::ConfigView<Nanoc::Core::Configuration<Symbol<foo>=String<bar>,>>') }
+    it { is_expected.to eql('Nanoc::Core::ConfigView#0<Nanoc::Core::Configuration#1<Symbol#2<foo>=String#3<bar>,>>') }
   end
 
   context 'Nanoc::Core::ItemCollectionWithRepsView' do
@@ -352,12 +352,12 @@ describe Nanoc::Core::Checksummer do
         config,
         [
           Nanoc::Core::Item.new('foo', {}, '/foo.md'),
-          Nanoc::Core::Item.new('bar', {}, '/foo.md'),
+          Nanoc::Core::Item.new('bar', {}, '/bar.md'),
         ],
       )
     end
 
-    it { is_expected.to eql('Nanoc::Core::ItemCollectionWithRepsView<Nanoc::Core::ItemCollection<Nanoc::Core::Item<content=Nanoc::Core::TextualContent<String<foo>>,attributes=Hash<>,identifier=Nanoc::Core::Identifier<String</foo.md>>>,Nanoc::Core::Item<content=Nanoc::Core::TextualContent<String<bar>>,attributes=Hash<>,identifier=Nanoc::Core::Identifier<String</foo.md>>>,>>') }
+    it { is_expected.to eql('Nanoc::Core::ItemCollectionWithRepsView#0<Nanoc::Core::ItemCollection#1<Nanoc::Core::Item#2<content=Nanoc::Core::TextualContent#3<String#4<foo>>,attributes=Hash#5<>,identifier=Nanoc::Core::Identifier#6<String#7</foo.md>>>,Nanoc::Core::Item#8<content=Nanoc::Core::TextualContent#9<String#10<bar>>,attributes=@5,identifier=Nanoc::Core::Identifier#11<String#12</bar.md>>>,>>') }
   end
 
   context 'Nanoc::Core::ItemCollectionWithoutRepsView' do
@@ -370,12 +370,12 @@ describe Nanoc::Core::Checksummer do
         config,
         [
           Nanoc::Core::Item.new('foo', {}, '/foo.md'),
-          Nanoc::Core::Item.new('bar', {}, '/foo.md'),
+          Nanoc::Core::Item.new('bar', {}, '/bar.md'),
         ],
       )
     end
 
-    it { is_expected.to eql('Nanoc::Core::ItemCollectionWithoutRepsView<Nanoc::Core::ItemCollection<Nanoc::Core::Item<content=Nanoc::Core::TextualContent<String<foo>>,attributes=Hash<>,identifier=Nanoc::Core::Identifier<String</foo.md>>>,Nanoc::Core::Item<content=Nanoc::Core::TextualContent<String<bar>>,attributes=Hash<>,identifier=Nanoc::Core::Identifier<String</foo.md>>>,>>') }
+    it { is_expected.to eql('Nanoc::Core::ItemCollectionWithoutRepsView#0<Nanoc::Core::ItemCollection#1<Nanoc::Core::Item#2<content=Nanoc::Core::TextualContent#3<String#4<foo>>,attributes=Hash#5<>,identifier=Nanoc::Core::Identifier#6<String#7</foo.md>>>,Nanoc::Core::Item#8<content=Nanoc::Core::TextualContent#9<String#10<bar>>,attributes=@5,identifier=Nanoc::Core::Identifier#11<String#12</bar.md>>>,>>') }
   end
 
   context 'other marshal-able classes' do
@@ -389,12 +389,12 @@ describe Nanoc::Core::Checksummer do
       end
     end
 
-    it { is_expected.to match(/\A#<Class:0x[0-9a-f]+><.*>\z/) }
+    it { is_expected.to match(/\A#<Class:0x[0-9a-f]+>#0<.*>\z/) }
   end
 
   context 'other non-marshal-able classes' do
     let(:obj) { proc {} }
 
-    it { is_expected.to match(/\AProc<#<Proc:0x.*>>\z/) }
+    it { is_expected.to match(/\AProc#0<#<Proc:0x.*>>\z/) }
   end
 end

--- a/nanoc-core/spec/nanoc/core/processing_actions/filter_spec.rb
+++ b/nanoc-core/spec/nanoc/core/processing_actions/filter_spec.rb
@@ -6,7 +6,7 @@ describe Nanoc::Core::ProcessingActions::Filter do
   describe '#serialize' do
     subject { action.serialize }
 
-    it { is_expected.to eql([:filter, :foo, 'sJYzLjHGo1e4ytuDfnOLkqrt9QE=']) }
+    it { is_expected.to eql([:filter, :foo, 'v+eiDx9FKFH7+UBdX93/FK7/pRM=']) }
   end
 
   describe '#to_s' do
@@ -18,7 +18,7 @@ describe Nanoc::Core::ProcessingActions::Filter do
   describe '#inspect' do
     subject { action.inspect }
 
-    it { is_expected.to eql('<Nanoc::Core::ProcessingActions::Filter :foo, "sJYzLjHGo1e4ytuDfnOLkqrt9QE=">') }
+    it { is_expected.to eql('<Nanoc::Core::ProcessingActions::Filter :foo, "v+eiDx9FKFH7+UBdX93/FK7/pRM=">') }
   end
 
   describe '#== and #eql?' do

--- a/nanoc-core/spec/nanoc/core/processing_actions/layout_spec.rb
+++ b/nanoc-core/spec/nanoc/core/processing_actions/layout_spec.rb
@@ -6,7 +6,7 @@ describe Nanoc::Core::ProcessingActions::Layout do
   describe '#serialize' do
     subject { action.serialize }
 
-    it { is_expected.to eql([:layout, '/foo.erb', 'sJYzLjHGo1e4ytuDfnOLkqrt9QE=']) }
+    it { is_expected.to eql([:layout, '/foo.erb', 'v+eiDx9FKFH7+UBdX93/FK7/pRM=']) }
   end
 
   describe '#to_s' do
@@ -18,7 +18,7 @@ describe Nanoc::Core::ProcessingActions::Layout do
   describe '#inspect' do
     subject { action.inspect }
 
-    it { is_expected.to eql('<Nanoc::Core::ProcessingActions::Layout "/foo.erb", "sJYzLjHGo1e4ytuDfnOLkqrt9QE=">') }
+    it { is_expected.to eql('<Nanoc::Core::ProcessingActions::Layout "/foo.erb", "v+eiDx9FKFH7+UBdX93/FK7/pRM=">') }
   end
 
   describe '#== and #eql?' do

--- a/nanoc/spec/nanoc/core/checksummer_spec.rb
+++ b/nanoc/spec/nanoc/core/checksummer_spec.rb
@@ -12,7 +12,7 @@ describe Nanoc::Core::Checksummer do
 
     let(:data) { 'STUFF!' }
 
-    it { is_expected.to eql('Nanoc::RuleDSL::RulesCollection<String<STUFF!>>') }
+    it { is_expected.to eql('Nanoc::RuleDSL::RulesCollection#0<String#1<STUFF!>>') }
   end
 
   context 'Nanoc::RuleDSL::CompilationRuleContext' do
@@ -37,24 +37,24 @@ describe Nanoc::Core::Checksummer do
     let(:recorder) { Nanoc::RuleDSL::ActionRecorder.new(rep) }
     let(:view_context) { Nanoc::Core::ViewContextForPreCompilation.new(items: items) }
 
-    let(:expected_item_checksum) { 'Nanoc::Core::Item<content=Nanoc::Core::TextualContent<String<stuff>>,attributes=Hash<>,identifier=Nanoc::Core::Identifier<String</stuff.md>>>' }
-    let(:expected_item_rep_checksum) { 'Nanoc::Core::ItemRep<item=' + expected_item_checksum + ',name=Symbol<pdf>>' }
-    let(:expected_layout_checksum) { 'Nanoc::Core::Layout<content=Nanoc::Core::TextualContent<String<asdf>>,attributes=Hash<>,identifier=Nanoc::Core::Identifier<String</foo.md>>>' }
-    let(:expected_config_checksum) { 'Nanoc::Core::Configuration<Symbol<foo>=String<bar>,>' }
+    let(:expected_item_checksum) { 'Nanoc::Core::Item#2<content=Nanoc::Core::TextualContent#3<String#4<stuff>>,attributes=Hash#5<>,identifier=Nanoc::Core::Identifier#6<String#7</stuff.md>>>' }
+    let(:expected_item_rep_checksum) { 'Nanoc::Core::ItemRep#9<item=@2,name=Symbol#10<pdf>>' }
+    let(:expected_layout_checksum) { 'Nanoc::Core::Layout#15<content=Nanoc::Core::TextualContent#16<String#17<asdf>>,attributes=@5,identifier=Nanoc::Core::Identifier#18<String#19</foo.md>>>' }
+    let(:expected_config_checksum) { 'Nanoc::Core::Configuration#21<Symbol#22<foo>=String#23<bar>,>' }
 
     let(:expected_checksum) do
       [
-        'Nanoc::RuleDSL::CompilationRuleContext<',
+        'Nanoc::RuleDSL::CompilationRuleContext#0<',
         'item=',
-        'Nanoc::Core::BasicItemView<' + expected_item_checksum + '>',
+        'Nanoc::Core::BasicItemView#1<' + expected_item_checksum + '>',
         ',rep=',
-        'Nanoc::Core::BasicItemRepView<' + expected_item_rep_checksum + '>',
+        'Nanoc::Core::BasicItemRepView#8<' + expected_item_rep_checksum + '>',
         ',items=',
-        'Nanoc::Core::ItemCollectionWithoutRepsView<Nanoc::Core::ItemCollection<' + expected_item_checksum + ',>>',
+        'Nanoc::Core::ItemCollectionWithoutRepsView#11<Nanoc::Core::ItemCollection#12<@2,>>',
         ',layouts=',
-        'Nanoc::Core::LayoutCollectionView<Nanoc::Core::LayoutCollection<' + expected_layout_checksum + ',>>',
+        'Nanoc::Core::LayoutCollectionView#13<Nanoc::Core::LayoutCollection#14<' + expected_layout_checksum + ',>>',
         ',config=',
-        'Nanoc::Core::ConfigView<' + expected_config_checksum + '>',
+        'Nanoc::Core::ConfigView#20<' + expected_config_checksum + '>',
         '>',
       ].join('')
     end
@@ -67,6 +67,6 @@ describe Nanoc::Core::Checksummer do
 
     before { require 'sass' }
 
-    it { is_expected.to match(%r{\ASass::Importers::Filesystem<root=(C:)?/foo>\z}) }
+    it { is_expected.to match(%r{\ASass::Importers::Filesystem#0<root=(C:)?/foo>\z}) }
   end
 end


### PR DESCRIPTION
### Detailed description

The new implementation is faster because of two reasons:

- It more aggressively avoids calculating checksums of already-calculated items
- It effectfully updates a hash rather than using Immutable::Set

Preliminary tests suggest a 30% speedup, but I have not at all tested this out properly.

It is also more correct because it replaces use of <recur> with a numerical reference to a previously-seen object.

Each newly checksummed object will have a number suffix, e.g. `Array#5<…>`. Each previously seen object will have an @-reference, e.g. `Array#9<@4,@5,>`.

This will invalidate existing stored checksums in Nanoc sites, but it is unavoidable and worth the tradeoff.

### To do

* [x] Tests

### Related issues

This does not fix #1692 yet, but it brings the checksummer in a better state to handle it.
