### PR TITLE
Forward CleaningStream#printf

### DIFF
--- a/nanoc-cli/lib/nanoc/cli/cleaning_stream.rb
+++ b/nanoc-cli/lib/nanoc/cli/cleaning_stream.rb
@@ -81,6 +81,11 @@ module Nanoc
         end
       end
 
+      # @see IO#printf
+      def printf(*args)
+        @stream.printf(*args)
+      end
+
       # @see IO#puts
       def puts(*str)
         _nanoc_swallow_broken_pipe_errors_while do

--- a/nanoc-cli/spec/nanoc/cli/cleaning_stream_spec.rb
+++ b/nanoc-cli/spec/nanoc/cli/cleaning_stream_spec.rb
@@ -20,7 +20,7 @@ describe Nanoc::CLI::CleaningStream do
   end
 
   it 'forwards methods' do
-    methods = %i[write << flush tell print puts string reopen exist? exists? close closed?]
+    methods = %i[write << flush tell print printf puts string reopen exist? exists? close closed?]
 
     s = stream_class.new
     cs = described_class.new(s)
@@ -30,6 +30,7 @@ describe Nanoc::CLI::CleaningStream do
     cs.flush
     cs.tell
     cs.print('cc')
+    cs.printf('cc')
     cs.puts('dd')
     cs.string
     cs.reopen('/dev/null', 'r')


### PR DESCRIPTION
### Detailed description

This fixes the following potential error:

```
NoMethodError: private method `printf' called for an instance of Nanoc::CLI::CleaningStream
```

### To do

* [x] Tests

### Related issues

n/a