### PR TITLE
Enable new Rubocop cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -785,6 +785,15 @@ RSpec/IsExpectedSpecify: # new in 2.27
 RSpec/RepeatedSubjectCall: # new in 2.27
   Enabled: true
 
+Style/MapIntoArray: # new in 1.63
+  Enabled: true
+
+RSpec/EmptyOutput: # new in 2.29
+  Enabled: true
+
+RSpec/UndescriptiveLiteralsDescription: # new in 2.29
+  Enabled: true
+
 # ----- TO ENABLE LATER -----
 
 # Valid cops, but fixing the offenses they report is non-trivial.

--- a/nanoc-core/lib/nanoc/core/core_ext/array.rb
+++ b/nanoc-core/lib/nanoc/core/core_ext/array.rb
@@ -10,19 +10,23 @@ module Nanoc
         #
         # @return [Array] The converted array
         def __nanoc_symbolize_keys_recursively
-          array = []
-          each do |element|
-            array << (element.respond_to?(:__nanoc_symbolize_keys_recursively) ? element.__nanoc_symbolize_keys_recursively : element)
+          map do |element|
+            if element.respond_to?(:__nanoc_symbolize_keys_recursively)
+              element.__nanoc_symbolize_keys_recursively
+            else
+              element
+            end
           end
-          array
         end
 
         def __nanoc_stringify_keys_recursively
-          array = []
-          each do |element|
-            array << (element.respond_to?(:__nanoc_stringify_keys_recursively) ? element.__nanoc_stringify_keys_recursively : element)
+          map do |element|
+            if element.respond_to?(:__nanoc_stringify_keys_recursively)
+              element.__nanoc_stringify_keys_recursively
+            else
+              element
+            end
           end
-          array
         end
 
         # Freezes the contents of the array, as well as all array elements. The

--- a/nanoc-core/spec/nanoc/core/action_sequence_spec.rb
+++ b/nanoc-core/spec/nanoc/core/action_sequence_spec.rb
@@ -111,8 +111,7 @@ describe Nanoc::Core::ActionSequence do
     end
 
     example do
-      actions = []
-      action_sequence.each { |a| actions << a }
+      actions = action_sequence.map { _1 }
       expect(actions.size).to eq(3)
     end
   end

--- a/nanoc-core/spec/nanoc/core/config_view_spec.rb
+++ b/nanoc-core/spec/nanoc/core/config_view_spec.rb
@@ -179,7 +179,10 @@ describe Nanoc::Core::ConfigView do
 
     example do
       res = []
+      # rubocop:disable Style/MapIntoArray
+      # (False positive: `view` does not implement #map)
       view.each { |k, v| res << [k, v] }
+      # rubocop:enable Style/MapIntoArray
 
       expect(res).to eql([[:output_dir, 'ootpoot/'], [:amount, 9000], [:animal, 'donkey'], [:foo, { bar: :baz }]])
     end

--- a/nanoc-core/spec/nanoc/core/identifiable_collection_spec.rb
+++ b/nanoc-core/spec/nanoc/core/identifiable_collection_spec.rb
@@ -255,8 +255,7 @@ describe Nanoc::Core::IdentifiableCollection do
       end
 
       it 'loops' do
-        res = []
-        identifiable_collection.each { |i| res << i.identifier.to_s }
+        res = identifiable_collection.map { _1.identifier.to_s }
         expect(res).to contain_exactly('/foo', '/bar')
       end
     end


### PR DESCRIPTION
### Detailed description

This enables new Rubocop cops that Rubocop complains about.

The `Style/MapIntoArray` cop needed some code changes, mostly sensible ones: no need to build arrays with `#each` when there is `#map`.

### To do

* [x] Tests

### Related issues

n/a
