### PR TITLE
nanoc-checking: Handle javascript: URLs

### DIFF
--- a/nanoc-checking/lib/nanoc/checking/checks/external_links.rb
+++ b/nanoc-checking/lib/nanoc/checking/checks/external_links.rb
@@ -43,6 +43,13 @@ module Nanoc
         end
 
         def validate(href)
+          # Skip javascript: URLs
+          #
+          # This needs to be handled explicitly, because URI.parse does not
+          # like `javascript:` URLs -- presumably because those are not
+          # technically valid URLs.
+          return nil if href.start_with?('javascript:')
+
           # Parse
           url = nil
           begin

--- a/nanoc-checking/spec/nanoc/checking/checks/external_links_spec.rb
+++ b/nanoc-checking/spec/nanoc/checking/checks/external_links_spec.rb
@@ -138,6 +138,21 @@ describe Nanoc::Checking::Checks::ExternalLinks do
     end
   end
 
+  context 'javascript URL' do
+    before do
+      File.write('output/hi.html', %[<a href="javascript:window.scrollTo({top:0,behavior: 'smooth'})">scroll to top</a>])
+    end
+
+    let(:check) do
+      described_class.create(site)
+    end
+
+    it 'has no issues' do
+      check.run
+      expect(check.issues.size).to eq(0)
+    end
+  end
+
   context 'with some patterns excluded' do
     let(:config) do
       super().merge(


### PR DESCRIPTION
### Detailed description

This makes the `external_links` check not error on `javascript:` URLs.

### To do

* [x] Tests

### Related issues

Fixes #1689.
