### PR TITLE
nanoc-dart-sass: Support partial and directory imports

### DIFF
--- a/nanoc-dart-sass/lib/nanoc/dart_sass/filter.rb
+++ b/nanoc-dart-sass/lib/nanoc/dart_sass/filter.rb
@@ -68,13 +68,24 @@ module Nanoc
               File.expand_path(pat, dirname)
             end
 
-          item = @items[pat]
+          items = []
 
-          unless item
+          # Try as a regular path
+          items << @items[pat]
+
+          # Try as a partial
+          partial_pat = File.join(File.dirname(pat), "_#{File.basename(pat)}")
+          items << @items[partial_pat]
+
+          items = items.compact
+          case items.size
+          when 0
             raise "Could not find an item matching pattern `#{pat}`"
+          when 1
+            items.first
+          else
+            raise "It is not clear which item to import. Multiple items match `#{pat}`: #{items.map { _1.identifier.to_s }.join(', ')}"
           end
-
-          item
         end
       end
 

--- a/nanoc-dart-sass/lib/nanoc/dart_sass/filter.rb
+++ b/nanoc-dart-sass/lib/nanoc/dart_sass/filter.rb
@@ -65,6 +65,24 @@ module Nanoc
               File.expand_path(pat, dirname)
             end
 
+          items = collect_items(pat, is_extension_given)
+
+          # Get the single matching item, or error if there isn’t exactly one
+          items = items.compact
+          case items.size
+          when 0
+            raise "Could not find an item matching pattern `#{pat}`"
+          when 1
+            items.first
+          else
+            raise "It is not clear which item to import. Multiple items match `#{pat}`: #{items.map { _1.identifier.to_s }.sort.join(', ')}"
+          end
+        end
+
+        # Given a pattern, return a collection of items that match this pattern.
+        # This goes beyond what Nanoc patterns typically support by e.g.
+        # supporting partials and index imports.
+        def collect_items(pat, is_extension_given)
           items = []
 
           # Try as a regular path
@@ -80,15 +98,7 @@ module Nanoc
             items.concat(@items.find_all(File.join(pat, '/_index.*')))
           end
 
-          items = items.compact
-          case items.size
-          when 0
-            raise "Could not find an item matching pattern `#{pat}`"
-          when 1
-            items.first
-          else
-            raise "It is not clear which item to import. Multiple items match `#{pat}`: #{items.map { _1.identifier.to_s }.sort.join(', ')}"
-          end
+          items
         end
 
         def try_pat(pat, is_extension_given)

--- a/nanoc-dart-sass/lib/nanoc/dart_sass/filter.rb
+++ b/nanoc-dart-sass/lib/nanoc/dart_sass/filter.rb
@@ -68,16 +68,16 @@ module Nanoc
           items = []
 
           # Try as a regular path
-          items << try_pat(pat, is_extension_given)
+          items.concat(try_pat(pat, is_extension_given))
 
           # Try as a partial
           partial_pat = File.join(File.dirname(pat), "_#{File.basename(pat)}")
-          items << try_pat(partial_pat, is_extension_given)
+          items.concat(try_pat(partial_pat, is_extension_given))
 
           # Try as index
           unless is_extension_given
-            items << @items[File.join(pat, '/index.*')]
-            items << @items[File.join(pat, '/_index.*')]
+            items.concat(@items.find_all(File.join(pat, '/index.*')))
+            items.concat(@items.find_all(File.join(pat, '/_index.*')))
           end
 
           items = items.compact
@@ -87,15 +87,15 @@ module Nanoc
           when 1
             items.first
           else
-            raise "It is not clear which item to import. Multiple items match `#{pat}`: #{items.map { _1.identifier.to_s }.join(', ')}"
+            raise "It is not clear which item to import. Multiple items match `#{pat}`: #{items.map { _1.identifier.to_s }.sort.join(', ')}"
           end
         end
 
         def try_pat(pat, is_extension_given)
           if is_extension_given
-            @items[pat]
+            @items.find_all(pat)
           else
-            @items["#{pat}.*"]
+            @items.find_all("#{pat}.*")
           end
         end
       end

--- a/nanoc-dart-sass/spec/nanoc/dart_sass/filter/nanoc_importer_spec.rb
+++ b/nanoc-dart-sass/spec/nanoc/dart_sass/filter/nanoc_importer_spec.rb
@@ -82,7 +82,7 @@ describe Nanoc::DartSass::Filter::NanocImporter do
   end
 
   describe '#load' do
-    subject { importer.load(url) }
+    subject(:load_call) { importer.load(url) }
 
     context 'when importing absolute path with extension' do
       let(:url) { '/assets/style/colors.scss' }
@@ -132,7 +132,58 @@ describe Nanoc::DartSass::Filter::NanocImporter do
       it { is_expected.to eq({ contents: 'partial content here', syntax: :scss }) }
     end
 
+    context 'with index (not a partial)' do
+      let(:foundation_item) { Nanoc::Core::Item.new('foundation/index content here', {}, '/assets/style/foundation/index.scss') }
+      let(:source_item) { screen_item }
+
+      let(:items_array) do
+        [
+          screen_item,
+          foundation_item,
+        ]
+      end
+
+      context 'when importing index with relative path without dot without extension' do
+        let(:url) { 'foundation' }
+
+        it { is_expected.to eq({ contents: 'foundation/index content here', syntax: :scss }) }
+      end
+
+      context 'when importing index with relative path with dot with extension' do
+        let(:url) { 'foundation.*' }
+
+        it 'raises' do
+          expect { load_call }.to raise_error('Could not find an item matching pattern `/assets/style/foundation.*`')
+        end
+      end
+    end
+
+    context 'with index (partial)' do
+      let(:foundation_item) { Nanoc::Core::Item.new('foundation/index content here', {}, '/assets/style/foundation/_index.scss') }
+      let(:source_item) { screen_item }
+
+      let(:items_array) do
+        [
+          screen_item,
+          foundation_item,
+        ]
+      end
+
+      context 'when importing index with relative path without dot without extension' do
+        let(:url) { 'foundation' }
+
+        it { is_expected.to eq({ contents: 'foundation/index content here', syntax: :scss }) }
+      end
+
+      context 'when importing index with relative path with dot with extension' do
+        let(:url) { 'foundation.*' }
+
+        it 'raises' do
+          expect { load_call }.to raise_error('Could not find an item matching pattern `/assets/style/foundation.*`')
+        end
+      end
+    end
+
     # TODO: test ambiguous import
-    # TODO: test index (directory import)
   end
 end

--- a/nanoc-dart-sass/spec/nanoc/dart_sass/filter/nanoc_importer_spec.rb
+++ b/nanoc-dart-sass/spec/nanoc/dart_sass/filter/nanoc_importer_spec.rb
@@ -54,14 +54,14 @@ describe Nanoc::DartSass::Filter::NanocImporter do
 
   let(:screen_item) { Nanoc::Core::Item.new('screen content here', {}, '/assets/style/screen.scss') }
   let(:colors_item) { Nanoc::Core::Item.new('colors content here', {}, '/assets/style/colors.scss') }
-  let(:fonts_item) { Nanoc::Core::Item.new('fonts content here', {}, '/assets/fonts.scss') }
+  let(:partial_item) { Nanoc::Core::Item.new('partial content here', {}, '/assets/style/_partial.scss') }
   let(:source_item) { screen_item }
 
   let(:items_array) do
     [
       screen_item,
       colors_item,
-      fonts_item,
+      partial_item,
     ]
   end
 
@@ -119,5 +119,20 @@ describe Nanoc::DartSass::Filter::NanocImporter do
 
       it { is_expected.to eq({ contents: 'colors content here', syntax: :scss }) }
     end
+
+    context 'when importing partial with relative path without dot with extension' do
+      let(:url) { 'partial.scss' }
+
+      it { is_expected.to eq({ contents: 'partial content here', syntax: :scss }) }
+    end
+
+    context 'when importing partial with relative path without dot without extension' do
+      let(:url) { 'partial' }
+
+      it { is_expected.to eq({ contents: 'partial content here', syntax: :scss }) }
+    end
+
+    # TODO: test ambiguous import
+    # TODO: test index (directory import)
   end
 end

--- a/nanoc-dart-sass/spec/nanoc/dart_sass/filter/nanoc_importer_spec.rb
+++ b/nanoc-dart-sass/spec/nanoc/dart_sass/filter/nanoc_importer_spec.rb
@@ -184,6 +184,24 @@ describe Nanoc::DartSass::Filter::NanocImporter do
       end
     end
 
-    # TODO: test ambiguous import
+    context 'with ambiguous import' do
+      let(:color_scss_item) { Nanoc::Core::Item.new('foundation/index content here', {}, '/assets/style/color.scss') }
+      let(:color_sass_item) { Nanoc::Core::Item.new('foundation/index content here', {}, '/assets/style/color.sass') }
+      let(:source_item) { screen_item }
+
+      let(:items_array) do
+        [
+          screen_item,
+          color_scss_item,
+          color_sass_item,
+        ]
+      end
+
+      let(:url) { 'color.*' }
+
+      it 'raises' do
+        expect { load_call }.to raise_error('It is not clear which item to import. Multiple items match `/assets/style/color.*`: /assets/style/color.sass, /assets/style/color.scss')
+      end
+    end
   end
 end


### PR DESCRIPTION
### Detailed description

This makes nanoc-dart-sass support importing partials (e.g. `@import 'foundation';` loads `_foundation.scss`) and directory imports (e.g. `@import 'foundation';` loads `foundation/_index.scss`).

It also handles ambiguous better: if multiple items match, an error is raised.

It was tough to reuse [the existing `sass-embedded-shim-ruby` implementation](https://github.com/sass-contrib/sassc-embedded-shim-ruby/blob/72399fda8dcc3eb511d7914fedf6e9d4a705d073/lib/sassc/embedded.rb#L226-L295) because nanoc-dart-sass allows Nanoc-style patterns in its imports, which regular dart-sass doesn’t do. It’s both a drawback and an advantage.

### To do

* [x] Tests

### Related issues

- #1690
- #1691
