### PR TITLE
Support paths with spaces in internal_links check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,9 @@ gemspec path: 'nanoc-tilt'
 gemspec path: 'guard-nanoc'
 
 group :devel do
+  gem 'addressable', '~> 2.8'
   gem 'contracts', '~> 0.16'
+  gem 'debug', '~> 1.9'
   gem 'fuubar'
   gem 'guard-rake'
   gem 'json', '~> 2.1'

--- a/nanoc-checking/lib/nanoc/checking/checks/internal_links.rb
+++ b/nanoc-checking/lib/nanoc/checking/checks/internal_links.rb
@@ -43,7 +43,8 @@ module Nanoc
 
           output_dir = @config.output_dir
           output_dir += '/' unless output_dir.end_with?('/')
-          base_uri = URI("file://#{output_dir}")
+          # FIXME: escape is hacky
+          base_uri = URI("file://#{output_dir.gsub(' ', '%20')}")
           path = href.sub(/#{base_uri}/, '').sub(/file:\/{1,3}/, '')
 
           path = "/#{path}" unless path.start_with?('/')

--- a/nanoc-checking/lib/nanoc/checking/link_collector.rb
+++ b/nanoc-checking/lib/nanoc/checking/link_collector.rb
@@ -83,7 +83,8 @@ module ::Nanoc
 
       def uris_in_file(filename, tag_names)
         uris = Set.new
-        base_uri = URI("file://#{filename}")
+        # FIXME: escape is hacky
+        base_uri = URI("file://#{filename.gsub(' ', '%20')}")
         doc = Nokogiri::HTML(::File.read(filename))
         doc.traverse do |tag|
           next unless tag_names.nil? || tag_names.include?(tag.name)

--- a/nanoc-checking/lib/nanoc/checking/link_collector.rb
+++ b/nanoc-checking/lib/nanoc/checking/link_collector.rb
@@ -116,7 +116,8 @@ module ::Nanoc
             uri
           else
             begin
-              URI.join(base_uri, uri).to_s
+              # FIXME: escape is hacky
+              URI.join(base_uri, uri.gsub(' ', '%20')).to_s
             rescue
               uri
             end

--- a/nanoc-checking/spec/nanoc/checking/checks/external_links_spec.rb
+++ b/nanoc-checking/spec/nanoc/checking/checks/external_links_spec.rb
@@ -22,6 +22,13 @@ describe Nanoc::Checking::Checks::ExternalLinks do
   let(:items)         { Nanoc::Core::ItemCollection.new(config, []) }
   let(:layouts)       { Nanoc::Core::LayoutCollection.new(config, []) }
 
+  around do |ex|
+    FileUtils.mkdir('site with spaces')
+    Dir.chdir('site with spaces') do
+      ex.run
+    end
+  end
+
   before do
     FileUtils.mkdir_p('output')
     File.write('Rules', 'passthrough "/**/*"')

--- a/nanoc-checking/spec/nanoc/checking/checks/internal_links_spec.rb
+++ b/nanoc-checking/spec/nanoc/checking/checks/internal_links_spec.rb
@@ -16,6 +16,13 @@ describe Nanoc::Checking::Checks::InternalLinks do
   let(:items)         { Nanoc::Core::ItemCollection.new(config, []) }
   let(:layouts)       { Nanoc::Core::LayoutCollection.new(config, []) }
 
+  around do |ex|
+    FileUtils.mkdir('site with spaces')
+    Dir.chdir('site with spaces') do
+      ex.run
+    end
+  end
+
   before do
     FileUtils.mkdir_p('output')
     File.write('Rules', 'passthrough "/**/*"')

--- a/nanoc-checking/spec/nanoc/checking/checks/internal_links_spec.rb
+++ b/nanoc-checking/spec/nanoc/checking/checks/internal_links_spec.rb
@@ -21,10 +21,13 @@ describe Nanoc::Checking::Checks::InternalLinks do
     File.write('Rules', 'passthrough "/**/*"')
   end
 
+  # FIXME: deduplicate
   def path_to_file_uri(path, dir)
     output_dir = dir.is_a?(String) ? dir : dir.config.output_dir
     output_dir += '/' unless output_dir.end_with?('/')
-    URI.join("file://#{output_dir}", path).to_s
+
+    uri = Addressable::URI.convert_path(output_dir) + Addressable::URI.convert_path(path)
+    uri.to_s
   end
 
   it 'detects non-broken links' do

--- a/nanoc-checking/test/helper.rb
+++ b/nanoc-checking/test/helper.rb
@@ -9,6 +9,7 @@ require 'minitest/autorun'
 require 'mocha/minitest'
 require 'vcr'
 
+require 'debug'
 require 'tmpdir'
 require 'stringio'
 require 'yard'
@@ -222,10 +223,13 @@ module Nanoc
       File.absolute_path("#{__dir__}/..")
     end
 
+    # FIXME: deduplicate
     def path_to_file_uri(path, dir)
       output_dir = dir.is_a?(String) ? dir : dir.config.output_dir
       output_dir += '/' unless output_dir.end_with?('/')
-      URI.join("file://#{output_dir}", path).to_s
+
+      uri = Addressable::URI.convert_path(output_dir) + Addressable::URI.convert_path(path)
+      uri.to_s
     end
   end
 end

--- a/nanoc-checking/test/nanoc/checking/test_link_collector.rb
+++ b/nanoc-checking/test/nanoc/checking/test_link_collector.rb
@@ -13,7 +13,8 @@ module Nanoc
         File.open(file_a, 'w') do |io|
           io << %(<a href="http://example.com/">A 1</a>)
           io << %(<a href="https://example.com/">A 2</a>)
-          io << %(<a href="stuff/"A 3></a>)
+          io << %(<a href="stuff/">A 3</a>)
+          io << %(<a href="stuff with spaces/">A 3b</a>)
           io << %(<a name="href-less-anchor">A 4</a>)
           io << %(<a href="https://example.com/with-fragment#moo">A 5</a>)
         end
@@ -33,6 +34,7 @@ module Nanoc
         assert_includes hrefs, 'http://example.com/'
         assert_includes hrefs, 'https://example.com/'
         assert_includes hrefs, path_to_file_uri('stuff/', Dir.pwd)
+        assert_includes hrefs, path_to_file_uri('stuff with spaces/', Dir.pwd)
         refute_includes hrefs, 'https://example.com/with-fragment#moo'
         assert_includes hrefs, 'https://example.com/with-fragment'
         refute_includes hrefs, nil

--- a/nanoc-checking/test/nanoc/checking/test_link_collector.rb
+++ b/nanoc-checking/test/nanoc/checking/test_link_collector.rb
@@ -7,9 +7,9 @@ module Nanoc
     class LinkCollectorTest < Nanoc::TestCase
       def test_all
         # Create dummy data
-        FileUtils.mkdir_p('testdir')
+        FileUtils.mkdir_p('test dir')
         file_a = File.join(Dir.pwd, 'file-a.html')
-        file_b = File.join(Dir.pwd, 'testdir', 'file-b.html')
+        file_b = File.join(Dir.pwd, 'test dir', 'file-b.html')
         File.open(file_a, 'w') do |io|
           io << %(<a href="http://example.com/">A 1</a>)
           io << %(<a href="https://example.com/">A 2</a>)

--- a/nanoc/test/helper.rb
+++ b/nanoc/test/helper.rb
@@ -225,10 +225,13 @@ module Nanoc::TestHelpers
     File.absolute_path(__dir__ + '/..')
   end
 
+  # FIXME: deduplicate
   def path_to_file_uri(path, dir)
     output_dir = dir.is_a?(String) ? dir : dir.config.output_dir
     output_dir += '/' unless output_dir.end_with?('/')
-    URI.join("file://#{output_dir}", path).to_s
+
+    uri = Addressable::URI.convert_path(output_dir) + Addressable::URI.convert_path(path)
+    uri.to_s
   end
 end
 


### PR DESCRIPTION
### Detailed description

If there are spaces in the path to the Nanoc site or in any filename in the output directory, the `internal_links` check will fail with “bad URI” errors. This fixes that.

`addressable` is added as a development dependency for convenience, but it’s probably a good idea to use it as a replacement for `URI` to get rid of the hacky space handling and instead use `Addressable::URI.convert_path`. But that is for later.

### To do

* [x] Tests

### Related issues

n/a
