### PR TITLE
Set minimum Ruby version to 3.1

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["3.0", "3.1", "3.2", "3.3"]
+        ruby-version: ["3.1", "3.2", "3.3"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,12 @@ inherit_from: .rubocop_todo.yml
 # ----- CONFIGURED -----
 
 AllCops:
+  # TODO: Change to 3.1
   TargetRubyVersion: 2.7
+
+# TODO: enable once `TargetRubyVersion` is set to 3.1.
+Gemspec/RequiredRubyVersion:
+  Enabled: false
 
 require:
   - rubocop-minitest

--- a/guard-nanoc/guard-nanoc.gemspec
+++ b/guard-nanoc/guard-nanoc.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.author        = 'Denis Defreyne'
   s.email         = 'denis.defreyne@stoneship.org'
 
-  s.required_ruby_version = '>= 2.7'
+  s.required_ruby_version = '>= 3.1'
 
   s.add_dependency 'guard', '~> 2.8'
   s.add_dependency 'guard-compat', '~> 1.0'

--- a/nanoc-checking/nanoc-checking.gemspec
+++ b/nanoc-checking/nanoc-checking.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files         = ['NEWS.md', 'README.md'] + Dir['lib/**/*.rb']
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.7'
+  s.required_ruby_version = '>= 3.1'
 
   s.add_runtime_dependency('nanoc-cli', '~> 4.12', '>= 4.12.5')
   s.add_runtime_dependency('nanoc-core', '~> 4.12', '>= 4.12.5')

--- a/nanoc-cli/nanoc-cli.gemspec
+++ b/nanoc-cli/nanoc-cli.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files         = ['NEWS.md', 'README.md'] + Dir['lib/**/*.rb']
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.7'
+  s.required_ruby_version = '>= 3.1'
 
   s.add_runtime_dependency('cri', '~> 2.15')
   s.add_runtime_dependency('diff-lcs', '~> 1.3')

--- a/nanoc-core/nanoc-core.gemspec
+++ b/nanoc-core/nanoc-core.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files         = ['NEWS.md', 'README.md'] + Dir['lib/**/*.rb'] + Dir['lib/**/*-schema.json']
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.7'
+  s.required_ruby_version = '>= 3.1'
 
   s.add_runtime_dependency('base64', '~> 0.2')
   s.add_runtime_dependency('concurrent-ruby', '~> 1.1')

--- a/nanoc-dart-sass/nanoc-dart-sass.gemspec
+++ b/nanoc-dart-sass/nanoc-dart-sass.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files         = ['NEWS.md', 'README.md'] + Dir['lib/**/*.rb']
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.7'
+  s.required_ruby_version = '>= 3.1'
 
   s.add_runtime_dependency('nanoc-core', '~> 4.12')
   s.add_runtime_dependency('sass-embedded', '~> 1.56')

--- a/nanoc-deploying/nanoc-deploying.gemspec
+++ b/nanoc-deploying/nanoc-deploying.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files         = ['NEWS.md', 'README.md'] + Dir['lib/**/*.rb']
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.7'
+  s.required_ruby_version = '>= 3.1'
 
   s.add_runtime_dependency('nanoc-checking', '~> 1.0')
   s.add_runtime_dependency('nanoc-cli', '~> 4.11', '>= 4.11.15')

--- a/nanoc-external/nanoc-external.gemspec
+++ b/nanoc-external/nanoc-external.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files         = ['NEWS.md', 'README.md'] + Dir['lib/**/*.rb']
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.7'
+  s.required_ruby_version = '>= 3.1'
 
   s.add_runtime_dependency('nanoc-core', '~> 4.11', '>= 4.11.14')
   s.metadata = {

--- a/nanoc-live/nanoc-live.gemspec
+++ b/nanoc-live/nanoc-live.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files         = ['NEWS.md', 'README.md'] + Dir['lib/**/*.rb']
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.7'
+  s.required_ruby_version = '>= 3.1'
 
   s.add_runtime_dependency('adsf-live', '~> 1.4')
   s.add_runtime_dependency('listen', '~> 3.0')

--- a/nanoc-org-mode/nanoc-org-mode.gemspec
+++ b/nanoc-org-mode/nanoc-org-mode.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files         = ['NEWS.md', 'README.md'] + Dir['lib/**/*.rb']
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.7'
+  s.required_ruby_version = '>= 3.1'
 
   s.add_runtime_dependency('nanoc-core', '~> 4.12')
   s.add_runtime_dependency('org-ruby', '~> 0.9')

--- a/nanoc-spec/nanoc-spec.gemspec
+++ b/nanoc-spec/nanoc-spec.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files         = ['NEWS.md', 'README.md'] + Dir['lib/**/*.rb']
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.7'
+  s.required_ruby_version = '>= 3.1'
 
   s.add_runtime_dependency('nanoc-core', '~> 4.11', '>= 4.11.13')
   s.metadata = {

--- a/nanoc-tilt/nanoc-tilt.gemspec
+++ b/nanoc-tilt/nanoc-tilt.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files         = ['NEWS.md', 'README.md'] + Dir['lib/**/*.rb']
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.7'
+  s.required_ruby_version = '>= 3.1'
 
   s.add_runtime_dependency('nanoc-core', '~> 4.11', '>= 4.11.14')
   s.add_runtime_dependency('tilt', '~> 2.0')

--- a/nanoc/nanoc.gemspec
+++ b/nanoc/nanoc.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables        = ['nanoc']
   s.require_paths      = ['lib']
 
-  s.required_ruby_version = '>= 2.7'
+  s.required_ruby_version = '>= 3.1'
 
   s.add_runtime_dependency('addressable', '~> 2.5')
   s.add_runtime_dependency('colored', '~> 1.2')


### PR DESCRIPTION
### Detailed description

The minimum Ruby version can be set to 3.1, because Ruby 2.7 and 3.0 are both end-of-life.

### To do

n/a

### Related issues

n/a
