### PR TITLE
Make `delete` log lines use relative paths

### DIFF
--- a/nanoc-cli/lib/nanoc/cli/compile_listeners/file_action_printer.rb
+++ b/nanoc-cli/lib/nanoc/cli/compile_listeners/file_action_printer.rb
@@ -55,6 +55,7 @@ module Nanoc::CLI::CompileListeners
             :low
           end
 
+        # Make path relative (to current working directory)
         # FIXME: do not depend on working directory
         if path.start_with?(Dir.getwd)
           path = path[(Dir.getwd.size + 1)..path.size]
@@ -64,10 +65,22 @@ module Nanoc::CLI::CompileListeners
       end
 
       on(:file_pruned) do |path|
+        # Make path relative (to current working directory)
+        # FIXME: do not depend on working directory
+        if path.start_with?(Dir.getwd)
+          path = path[(Dir.getwd.size + 1)..path.size]
+        end
+
         Nanoc::CLI::Logger.instance.file(:high, :delete, path)
       end
 
       on(:file_listed_for_pruning) do |path|
+        # Make path relative (to current working directory)
+        # FIXME: do not depend on working directory
+        if path.start_with?(Dir.getwd)
+          path = path[(Dir.getwd.size + 1)..path.size]
+        end
+
         Nanoc::CLI::Logger.instance.file(:high, :delete, '(dry run) ' + path)
       end
     end

--- a/nanoc/test/orig_cli/commands/test_prune.rb
+++ b/nanoc/test/orig_cli/commands/test_prune.rb
@@ -45,7 +45,11 @@ class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
       File.write('output2/foo.html', 'this is a foo.')
       File.write('output2/index.html', 'this is a index.')
 
-      Nanoc::CLI.run %w[prune --yes]
+      io = capturing_stdio do
+        Nanoc::CLI.run %w[prune --yes]
+      end
+
+      assert_match %r{^\s+delete  output2/foo\.html$}, io[:stdout]
 
       assert File.file?('output2/index.html')
       refute File.file?('output2/foo.html')
@@ -69,8 +73,8 @@ class Nanoc::CLI::Commands::PruneTest < Nanoc::TestCase
         Nanoc::CLI.run %w[prune --dry-run]
       end
 
-      assert_match %r{^\s+delete\s+\(dry run\) .*/output2/index\.html$}, io[:stdout]
-      assert_match %r{^\s+delete\s+\(dry run\) .*/output2/foo\.html$}, io[:stdout]
+      assert_match %r{^\s+delete  \(dry run\) output2/index\.html$}, io[:stdout]
+      assert_match %r{^\s+delete  \(dry run\) output2/foo\.html$}, io[:stdout]
 
       assert File.file?('output2/index.html')
       assert File.file?('output2/foo.html')


### PR DESCRIPTION
### Detailed description

This changes the `delete` lines, emitted when pruning stale files from the output directory, to have relative paths, rather than absolute ones:

```
      delete  output/assets/style/typewritten_r7cl9-xmrxt-fnmvv.css
```

This is consistent with the other emitted lines.

### To do

n/a

### Related issues

n/a