### PR TITLE
Add --focus option

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -106,6 +106,10 @@ Style/GlobalVars:
     - "*/test/**/*.rb"
     - "*/spec/**/*.rb"
 
+# This interferes with variables named `focus`.
+RSpec/Focus:
+  Enabled: false
+
 # ----- ENABLED (new cops not enabled by default) -----
 
 Layout/EmptyLinesAroundAttributeAccessor:

--- a/nanoc-cli/lib/nanoc/cli/commands/compile.rb
+++ b/nanoc-cli/lib/nanoc/cli/commands/compile.rb
@@ -9,6 +9,7 @@ no_params
 
 flag nil, :diff, 'generate diff'
 flag :W, :watch, 'watch for changes and recompile when needed'
+option nil, :focus, 'compile only items matching the given pattern', argument: :required, multiple: true
 
 module Nanoc::CLI::Commands
   class Compile < ::Nanoc::CLI::CommandRunner
@@ -26,7 +27,7 @@ module Nanoc::CLI::Commands
 
     def run_repeat
       require 'nanoc/live'
-      Nanoc::Live::LiveRecompiler.new(command_runner: self).run
+      Nanoc::Live::LiveRecompiler.new(command_runner: self, focus: options[:focus]).run
     end
 
     def run_once
@@ -35,7 +36,7 @@ module Nanoc::CLI::Commands
       @site = load_site
 
       puts 'Compiling site…'
-      compiler = Nanoc::Core::Compiler.new_for(@site)
+      compiler = Nanoc::Core::Compiler.new_for(@site, focus: options[:focus])
       listener = Nanoc::CLI::CompileListeners::Aggregate.new(
         command_runner: self,
         site: @site,
@@ -48,6 +49,11 @@ module Nanoc::CLI::Commands
       time_after = Time.now
       puts
       puts "Site compiled in #{format('%.2f', time_after - time_before)}s."
+
+      if options[:focus]
+        warn 'CAUTION: A --focus option is specified. Not the entire site has been compiled.'
+        warn 'Re-run without --focus to compile the entire site.'
+      end
     end
   end
 end

--- a/nanoc-core/lib/nanoc/core/compiler.rb
+++ b/nanoc-core/lib/nanoc/core/compiler.rb
@@ -6,16 +6,16 @@ module Nanoc
       include Nanoc::Core::ContractsSupport
 
       contract Nanoc::Core::Site => C::Any
-      def self.compile(site)
-        new_for(site).run_until_end
+      def self.compile(site, focus: nil)
+        new_for(site, focus:).run_until_end
       end
 
       contract Nanoc::Core::Site => Nanoc::Core::Compiler
-      def self.new_for(site)
-        Nanoc::Core::CompilerLoader.new.load(site)
+      def self.new_for(site, focus: nil)
+        Nanoc::Core::CompilerLoader.new.load(site, focus:)
       end
 
-      def initialize(site, compiled_content_cache:, checksum_store:, action_sequence_store:, action_provider:, dependency_store:, outdatedness_store:)
+      def initialize(site, compiled_content_cache:, checksum_store:, action_sequence_store:, action_provider:, dependency_store:, outdatedness_store:, focus:)
         @site = site
 
         # Needed because configuration is mutable :(
@@ -27,6 +27,7 @@ module Nanoc
         @dependency_store       = dependency_store
         @action_provider        = action_provider
         @outdatedness_store     = outdatedness_store
+        @focus                  = focus
 
         @compiled_content_store = Nanoc::Core::CompiledContentStore.new
       end
@@ -184,6 +185,7 @@ module Nanoc
           action_sequences:,
           compilation_context: compilation_context(reps:),
           compiled_content_cache: @compiled_content_cache,
+          focus: @focus,
         )
       end
 

--- a/nanoc-core/lib/nanoc/core/compiler_loader.rb
+++ b/nanoc-core/lib/nanoc/core/compiler_loader.rb
@@ -4,7 +4,7 @@ module Nanoc
   module Core
     # @api private
     class CompilerLoader
-      def load(site, action_provider: nil)
+      def load(site, focus: nil, action_provider: nil)
         action_sequence_store = Nanoc::Core::ActionSequenceStore.new(config: site.config)
 
         dependency_store =
@@ -30,6 +30,7 @@ module Nanoc
           dependency_store:,
           action_provider:,
           outdatedness_store:,
+          focus:,
         }
 
         Nanoc::Core::Compiler.new(site, **params)

--- a/nanoc-core/spec/nanoc/core/compiler_spec.rb
+++ b/nanoc-core/spec/nanoc/core/compiler_spec.rb
@@ -19,6 +19,7 @@ describe Nanoc::Core::Compiler do
       action_provider:,
       dependency_store:,
       outdatedness_store:,
+      focus: nil,
     )
   end
 

--- a/nanoc-live/lib/nanoc/live/command_runners/live.rb
+++ b/nanoc-live/lib/nanoc/live/command_runners/live.rb
@@ -29,7 +29,7 @@ module Nanoc
             Nanoc::CLI::Commands::View.new(view_options, [], self).run
           end
 
-          Nanoc::Live::LiveRecompiler.new(command_runner: self).run
+          Nanoc::Live::LiveRecompiler.new(command_runner: self, focus: options[:focus]).run
         end
       end
     end

--- a/nanoc-live/lib/nanoc/live/commands/live.rb
+++ b/nanoc-live/lib/nanoc/live/commands/live.rb
@@ -8,9 +8,10 @@ description <<~EOS
   static web server requires `adsf` (not `asdf`!).
 EOS
 
-option :H, :handler, 'specify the handler to use (webrick/puma/...)', argument: :required
-option :o, :host,    'specify the host to listen on', default: '127.0.0.1', argument: :required
-option :p, :port,    'specify the port to listen on', transform: Nanoc::CLI::Transform::Port, default: 3000, argument: :required
+option :H,  :handler, 'specify the handler to use (webrick/puma/...)', argument: :required
+option :o,  :host,    'specify the host to listen on', default: '127.0.0.1', argument: :required
+option :p,  :port,    'specify the port to listen on', transform: Nanoc::CLI::Transform::Port, default: 3000, argument: :required
+option nil, :focus,   'compile only items matching the given pattern', argument: :required, multiple: true
 no_params
 
 runner Nanoc::Live::CommandRunners::Live

--- a/nanoc-live/spec/nanoc/live/live_recompiler_spec.rb
+++ b/nanoc-live/spec/nanoc/live/live_recompiler_spec.rb
@@ -5,10 +5,13 @@ describe Nanoc::Live::LiveRecompiler, fork: true, site: true, stdio: true do
     Nanoc::CLI::ErrorHandler.enable
   end
 
+  # TODO: vary
+  let(:focus) { nil }
+
   it 'detects content changes' do
     command = nil
     command_runner = Nanoc::CLI::CommandRunner.new({}, [], command)
-    live_recompiler = described_class.new(command_runner:)
+    live_recompiler = described_class.new(command_runner:, focus:)
 
     pid = fork do
       trap(:INT) { exit(0) }
@@ -34,7 +37,7 @@ describe Nanoc::Live::LiveRecompiler, fork: true, site: true, stdio: true do
   it 'detects rules changes' do
     command = nil
     command_runner = Nanoc::CLI::CommandRunner.new({}, [], command)
-    live_recompiler = described_class.new(command_runner:)
+    live_recompiler = described_class.new(command_runner:, focus:)
 
     pid = fork do
       trap(:INT) { exit(0) }
@@ -65,7 +68,7 @@ describe Nanoc::Live::LiveRecompiler, fork: true, site: true, stdio: true do
   it 'detects lib changes' do
     command = nil
     command_runner = Nanoc::CLI::CommandRunner.new({}, [], command)
-    live_recompiler = described_class.new(command_runner:)
+    live_recompiler = described_class.new(command_runner:, focus:)
 
     File.write('nanoc.yaml', 'site_name: Oldz')
     File.write('content/lol.html', '<%= @config[:site_name] %>')
@@ -99,7 +102,7 @@ describe Nanoc::Live::LiveRecompiler, fork: true, site: true, stdio: true do
   it 'detects lib changes' do
     command = nil
     command_runner = Nanoc::CLI::CommandRunner.new({}, [], command)
-    live_recompiler = described_class.new(command_runner:)
+    live_recompiler = described_class.new(command_runner:, focus:)
 
     FileUtils.mkdir_p('lib')
     File.write('lib/lol.rb', 'def greeting; "hi"; end')
@@ -145,7 +148,7 @@ describe Nanoc::Live::LiveRecompiler, fork: true, site: true, stdio: true do
 
       command = nil
       command_runner = Nanoc::CLI::CommandRunner.new({}, [], command)
-      live_recompiler = described_class.new(command_runner:)
+      live_recompiler = described_class.new(command_runner:, focus:)
 
       live_recompiler.run
     end

--- a/nanoc/spec/nanoc/integration/compile_command_spec.rb
+++ b/nanoc/spec/nanoc/integration/compile_command_spec.rb
@@ -47,8 +47,7 @@ describe 'Compile command', site: true, stdio: true do
     end
 
     # Compile
-    site = Nanoc::Core::SiteLoader.new.new_from_cwd
-    Nanoc::Core::Compiler.compile(site)
+    Nanoc::CLI.run(%w[compile])
 
     # Check
     expect(File.read('output/index.html')).to eq('<h1>A</h1>')
@@ -64,10 +63,29 @@ describe 'Compile command', site: true, stdio: true do
     end
 
     # Compile
-    site = Nanoc::Core::SiteLoader.new.new_from_cwd
-    Nanoc::Core::Compiler.compile(site)
+    Nanoc::CLI.run(%w[compile])
 
     # Check
     expect(File.read('output/index.html')).to eq('<h1>B</h1>')
+  end
+
+  it 'recompiles only items under focus' do
+    # Create items
+    File.write('content/a.html', '<h1>A</h1>')
+    File.write('content/b.html', '<h1>B</h1>')
+
+    # Create routes
+    File.write('Rules', <<~RULES)
+      compile '/**/*' do
+        write ext: '.html'
+      end
+    RULES
+
+    # Compile
+    Nanoc::CLI.run(%w[compile --focus /a.*])
+
+    # Check
+    expect(File.read('output/a.html')).to eq('<h1>A</h1>')
+    expect(File.file?('output/b.html')).to be(false)
   end
 end


### PR DESCRIPTION
### Detailed description

This adds a `--focus` option to the `compile` and `live` commands, which take a pattern that specifies which items to compile. For example:

```bash
$ bundle exec nanoc compile --focus="/assets/style/**/*"
```

```bash
$ bundle exec nanoc live --focus="/assets/style/**/*"
```

When `--focus` is specified, a caution message will be printed, to make it clear that *only part* of the site is compiled:

```
CAUTION: A --focus option is specified. Not the entire site has been compiled.
Re-run without --focus to compile the entire site.
```

### To do

* [x] Multiple `--focus` options (`multiple: true` in cri)
* [x] Tests
* [ ] Documentation
* [ ] Feature flags

### Related issues

n/a