### PR TITLE
Drop explicit dependency on psych

### DIFF
--- a/nanoc-core/nanoc-core.gemspec
+++ b/nanoc-core/nanoc-core.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('immutable-ruby', '~> 0.1')
   s.add_runtime_dependency('json_schema', '~> 0.19')
   s.add_runtime_dependency('memo_wise', '~> 1.5')
-  s.add_runtime_dependency('psych', '>= 4.0', '< 6.0')
   s.add_runtime_dependency('slow_enumerator_tools', '~> 1.0')
   s.add_runtime_dependency('tty-platform', '~> 0.2')
   s.add_runtime_dependency('zeitwerk', '~> 2.1')


### PR DESCRIPTION
### Detailed description

Ruby 3.1+ comes with at least psych 4.0, which makes this dependency obsolete.

(Nanoc still uses psych, but there is no more explicit gem dependency.)

### To do

n/a

### Related issues

Fixes #1712.