### PR TITLE
nanoc-dart-sass: Replace @import with @use in tests

### DIFF
--- a/nanoc-dart-sass/spec/nanoc/dart_sass/filter_spec.rb
+++ b/nanoc-dart-sass/spec/nanoc/dart_sass/filter_spec.rb
@@ -71,10 +71,10 @@ describe Nanoc::DartSass::Filter, helper: true do
 
     let(:content) do
       <<~SCSS
-        @import '/defs.*';
+        @use '/defs.*';
 
         body {
-          color: $primary-color;
+          color: defs.$primary-color;
         }
       SCSS
     end
@@ -113,13 +113,13 @@ describe Nanoc::DartSass::Filter, helper: true do
 
     let(:content) do
       <<~SCSS
-        @import './defs1.*';
-        @import 'defs2.*';
-        @import 'defs3';
+        @use './defs1.*';
+        @use 'defs2.*';
+        @use 'defs3';
 
         body {
-          color: $fg-color;
-          background: $bg-color;
+          color: defs1.$fg-color;
+          background: defs2.$bg-color;
         }
       SCSS
     end


### PR DESCRIPTION
Dart Sass’ `@import` is deprecated and will start to function as regular CSS `@import` from Dart Sass 3.0 on.

No direct code changes are needed in Nanoc or the nanoc-dart-sass gem, but the tests emit a deprecation warning. This PR fixes that warning by switching to `@use` instead.

See https://sass-lang.com/documentation/breaking-changes/import/ for details.