### PR TITLE
Strip drive identifier from File.expand_path on Windows

### DIFF
--- a/nanoc-core/lib/nanoc/core/utils.rb
+++ b/nanoc-core/lib/nanoc/core/utils.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# .sub(/^[A-Z]:/,'')
+
+module Nanoc
+  module Core
+    # Utilities that don’t fit anywhere else.
+    #
+    # @api private
+    module Utils
+      # Same as File.expand_path, but does not add a drive identifier on
+      # Windows. This is necessary in case the path is a Nanoc path, rather than
+      # a filesystem path.
+      def self.expand_path_without_drive_identifier(file_name, dir_string)
+        res = File.expand_path(file_name, dir_string)
+
+        if Nanoc::Core.on_windows?
+          # On Windows, strip the drive identifier, e.g. `C:`.
+          res = res.sub(/^[A-Z]:/, '')
+        end
+
+        res
+      end
+    end
+  end
+end

--- a/nanoc-core/nanoc-core.manifest
+++ b/nanoc-core/nanoc-core.manifest
@@ -136,6 +136,7 @@ lib/nanoc/core/temp_filename_factory.rb
 lib/nanoc/core/textual_compiled_content_cache.rb
 lib/nanoc/core/textual_content.rb
 lib/nanoc/core/trivial_error.rb
+lib/nanoc/core/utils.rb
 lib/nanoc/core/view_context_for_compilation.rb
 lib/nanoc/core/view_context_for_pre_compilation.rb
 lib/nanoc/core/view_context_for_shell.rb

--- a/nanoc-core/spec/nanoc/core/utils_spec.rb
+++ b/nanoc-core/spec/nanoc/core/utils_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+describe Nanoc::Core::Utils do
+  describe '.expand_path_without_drive_identifier' do
+    # TODO: Test on Windows
+
+    subject { described_class.expand_path_without_drive_identifier('foo.html', '/home/denis') }
+
+    it { is_expected.to eq('/home/denis/foo.html') }
+  end
+end

--- a/nanoc-dart-sass/lib/nanoc/dart_sass/filter.rb
+++ b/nanoc-dart-sass/lib/nanoc/dart_sass/filter.rb
@@ -62,7 +62,7 @@ module Nanoc
               pat
             else
               dirname = File.dirname(@source_item.identifier.to_s)
-              File.expand_path(pat, dirname)
+              Nanoc::Core::Utils.expand_path_without_drive_identifier(pat, dirname)
             end
 
           items = collect_items(pat, is_extension_given)

--- a/nanoc/lib/nanoc/data_sources/filesystem/tools.rb
+++ b/nanoc/lib/nanoc/data_sources/filesystem/tools.rb
@@ -141,7 +141,7 @@ class Nanoc::DataSources::Filesystem < Nanoc::DataSource
     #   detected (something other than file, directory or link)
     def resolve_symlink(filename, recursion_limit = 5)
       target = File.readlink(filename)
-      absolute_target = File.expand_path(target, File.dirname(filename))
+      absolute_target = Nanoc::Core::Utils.expand_path_without_drive_identifier(target, File.dirname(filename))
 
       case File.ftype(absolute_target)
       when 'link'


### PR DESCRIPTION
### Detailed description

On Windows, `File.expand_path` adds a drive identifier to the beginning (e.g. `C:`) which breaks things when a Nanoc path is expected (one that starts with a slash).

The fix isn’t particulary pretty, but I cannot come up with a better solution.

:warning: I also was not able to test this on Windows yet.

### To do

* [x] Tests

### Related issues

Fixes #1703.
