### PR TITLE
Add missing _erbout binding to Haml filter

### DIFF
--- a/nanoc/lib/nanoc/filters/haml.rb
+++ b/nanoc/lib/nanoc/filters/haml.rb
@@ -15,7 +15,11 @@ module Nanoc::Filters
     # @return [String] The filtered content
     def run(content, params = {})
       # Get options
-      options = params.merge(filename:)
+      options = params.merge(
+        filename:,
+        outvar: '_erbout',
+        disable_capture: true,
+      )
 
       # Create context
       context = ::Nanoc::Core::Context.new(assigns)


### PR DESCRIPTION
### Detailed description

This makes the Haml filter compatible with the Rendering helper.

### To do

* [x] Tests

### Related issues

Fixes #1639.
