### PR TITLE
Add Pattern#=== and export it

### DIFF
--- a/nanoc-core/lib/nanoc/core/pattern.rb
+++ b/nanoc-core/lib/nanoc/core/pattern.rb
@@ -29,6 +29,11 @@ module Nanoc
         raise NotImplementedError
       end
 
+      contract C::Any => C::Bool
+      def ===(other)
+        match?(other)
+      end
+
       def captures(_identifier)
         raise NotImplementedError
       end

--- a/nanoc-core/spec/nanoc/core/string_pattern_spec.rb
+++ b/nanoc-core/spec/nanoc/core/string_pattern_spec.rb
@@ -42,4 +42,32 @@ describe Nanoc::Core::StringPattern do
       expect(subject).to eq('/foo/*/bar/**/*.animal')
     end
   end
+
+  describe 'case equality' do
+    it 'can match strings' do
+      input = '/software/nanoc.md'
+
+      result =
+        case input
+        when described_class.from('/software/*')
+          true
+        else
+          false
+        end
+
+      expect(result).to be(true)
+    end
+
+    it 'can match identifiers' do
+      result =
+        case Nanoc::Core::Identifier.new('/software/nanoc.md')
+        when described_class.from('/software/*')
+          true
+        else
+          false
+        end
+
+      expect(result).to be(true)
+    end
+  end
 end

--- a/nanoc/lib/nanoc.rb
+++ b/nanoc/lib/nanoc.rb
@@ -43,6 +43,7 @@ Nanoc::DataSource = Nanoc::Core::DataSource
 Nanoc::Filter = Nanoc::Core::Filter
 Nanoc::Error = Nanoc::Core::Error
 Nanoc::Check = Nanoc::Checking::Check
+Nanoc::Pattern = Nanoc::Core::Pattern
 
 # Load Nanoc
 require 'nanoc/version'


### PR DESCRIPTION
### Detailed description

This adds `Nanoc::Core::Patern#===` which makes it possible to use it in `case`/`when`:

```ruby
case s
when Nanoc::Pattern.from("/software/*")
  # …
when Nanoc::Pattern.from("/fiction/*")
  # …
end
```

In addition, this export `Nanoc::Core::Pattern` as `Nanoc::Pattern`. This needs documentation (the pattern class has been private/internal until now).

### To do

* [x] Tests
* [ ] ~~Documentation~~ — **will update on nanoc.app later**
