### PR TITLE
Add :id_proc to Blogging helper

### DIFF
--- a/nanoc/lib/nanoc/helpers/blogging.rb
+++ b/nanoc/lib/nanoc/helpers/blogging.rb
@@ -37,6 +37,7 @@ module Nanoc::Helpers
       attr_accessor :content_proc
       attr_accessor :excerpt_proc
       attr_accessor :title_proc
+      attr_accessor :id_proc
       attr_accessor :title
       attr_accessor :author_name
       attr_accessor :author_uri
@@ -147,7 +148,7 @@ module Nanoc::Helpers
 
         xml.entry do
           # Add primary attributes
-          xml.id atom_tag_for(article)
+          xml.id id_proc.call(article)
           xml.title title_proc.call(article), type: 'html'
 
           # Add dates
@@ -179,6 +180,7 @@ module Nanoc::Helpers
     # @option params [Proc] :content_proc
     # @option params [Proc] :excerpt_proc
     # @option params [Proc] :title_proc
+    # @option params [Proc] :id_proc
     # @option params [String] :alt_link
     # @option params [String] :id
     # @option params [String] :title
@@ -203,6 +205,7 @@ module Nanoc::Helpers
       builder.content_proc      = params[:content_proc] || ->(a) { a.compiled_content(snapshot: :pre) }
       builder.excerpt_proc      = params[:excerpt_proc] || ->(a) { a[:excerpt] }
       builder.title_proc        = params[:title_proc] || ->(a) { a[:title] }
+      builder.id_proc           = params[:id_proc] || ->(a) { atom_tag_for(a) }
       builder.title             = params[:title] || @item[:title] || @config[:title]
       builder.author_name       = params[:author_name] || @item[:author_name] || @config[:author_name]
       builder.author_uri        = params[:author_uri] || @item[:author_uri] || @config[:author_uri]

--- a/nanoc/test/helpers/test_blogging.rb
+++ b/nanoc/test/helpers/test_blogging.rb
@@ -617,6 +617,28 @@ class Nanoc::Helpers::BloggingTest < Nanoc::TestCase
     assert_match 'foobar!</title>', result
   end
 
+  def test_atom_feed_with_id_proc_param
+    # Mock article
+    @items = [mock_article]
+
+    # Mock site
+    config = Nanoc::Core::Configuration.new(hash: { base_url: 'http://example.com' }, dir: Dir.getwd)
+    @config = Nanoc::Core::ConfigView.new(config, @view_context)
+
+    # Create feed item
+    @item = mock
+    @item.stubs(:identifier).returns('/abc.md')
+    @item.stubs(:[]).with(:title).returns('My Blog Or Something')
+    @item.stubs(:[]).with(:author_name).returns('J. Doe')
+    @item.stubs(:[]).with(:author_uri).returns('http://example.com/~jdoe')
+    @item.stubs(:[]).with(:[]).with(:feed_url).returns('http://example.com/feed')
+
+    # Check
+    result = atom_feed id_proc: ->(_a) { "example.com/xyzzy,2000-01-01,#{@item.identifier}" }
+
+    assert_match '<id>example.com/xyzzy,2000-01-01,/abc.md</id>', result
+  end
+
   def test_atom_feed_with_icon_param
     # Mock article
     @items = [mock_article]


### PR DESCRIPTION
### Detailed description

This allows passing an `id_proc` argument to the blogging helper, to customize the ID generation. This is useful for when more control is required, e.g. when renaming items, or routing them to a different output location.

### To do

* [x] Tests
* [ ] ~~Documentation~~ **will do later on nanoc.app**
