### PR TITLE
Make clonefile a hard dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,6 @@ group :plugins do
   gem 'asciidoctor'
   gem 'bluecloth', platforms: :ruby
   gem 'builder'
-  gem 'clonefile', '~> 0.5.2'
   gem 'coderay'
   gem 'coffee-script'
   gem 'erubi'

--- a/nanoc-core/lib/nanoc/core.rb
+++ b/nanoc-core/lib/nanoc/core.rb
@@ -10,6 +10,7 @@ require 'yaml'
 require 'zlib'
 
 # External gems
+require 'clonefile'
 require 'concurrent-ruby'
 require 'json_schema'
 require 'ddmetrics'
@@ -19,13 +20,6 @@ require 'memo_wise'
 require 'slow_enumerator_tools'
 require 'tty-platform'
 require 'zeitwerk'
-
-# External gems (optional)
-begin
-  require 'clonefile'
-rescue LoadError
-  # ignore
-end
 
 module Nanoc
   module Core

--- a/nanoc-core/lib/nanoc/core/binary_compiled_content_cache.rb
+++ b/nanoc-core/lib/nanoc/core/binary_compiled_content_cache.rb
@@ -92,10 +92,6 @@ module Nanoc
         end
       end
 
-      def use_clonefile?
-        defined?(Clonefile)
-      end
-
       private
 
       def dirname
@@ -136,13 +132,11 @@ module Nanoc
         # changed outside of Nanoc.
 
         # Try clonefile
-        if use_clonefile?
-          FileUtils.rm_f(to)
-          begin
-            res = Clonefile.always(from, to)
-            return if res
-          rescue Clonefile::UnsupportedPlatform, Errno::ENOTSUP, Errno::EXDEV, Errno::EINVAL
-          end
+        FileUtils.rm_f(to)
+        begin
+          res = Clonefile.always(from, to)
+          return if res
+        rescue Clonefile::UnsupportedPlatform, Errno::ENOTSUP, Errno::EXDEV, Errno::EINVAL
         end
 
         # Fall back to old-school copy

--- a/nanoc-core/lib/nanoc/core/item_rep_writer.rb
+++ b/nanoc-core/lib/nanoc/core/item_rep_writer.rb
@@ -79,13 +79,11 @@ module Nanoc
 
       def smart_cp(from, to)
         # Try clonefile
-        if defined?(Clonefile)
-          FileUtils.rm_f(to)
-          begin
-            res = Clonefile.always(from, to)
-            return if res
-          rescue Clonefile::UnsupportedPlatform, Errno::ENOTSUP, Errno::EXDEV, Errno::EINVAL
-          end
+        FileUtils.rm_f(to)
+        begin
+          res = Clonefile.always(from, to)
+          return if res
+        rescue Clonefile::UnsupportedPlatform, Errno::ENOTSUP, Errno::EXDEV, Errno::EINVAL
         end
 
         # Try with hardlink

--- a/nanoc-core/nanoc-core.gemspec
+++ b/nanoc-core/nanoc-core.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.1'
 
   s.add_dependency('base64', '~> 0.2')
+  s.add_dependency('clonefile', '~> 0.5.3')
   s.add_dependency('concurrent-ruby', '~> 1.1')
   s.add_dependency('ddmetrics', '~> 1.0')
   s.add_dependency('ddplugin', '~> 1.0')

--- a/nanoc/spec/nanoc/regressions/gh_1572_spec.rb
+++ b/nanoc/spec/nanoc/regressions/gh_1572_spec.rb
@@ -4,10 +4,6 @@ describe 'GH-1572', site: true, stdio: true do
   example do
     FileUtils.mkdir_p('content')
 
-    allow_any_instance_of(Nanoc::Core::BinaryCompiledContentCache)
-      .to receive(:use_clonefile?)
-      .and_return(false)
-
     File.write('content/repro.jpg', '<data>')
     File.chmod(0o400, 'content/repro.jpg')
     expect(File.stat('content/repro.jpg').mode).to eq(0o100400)


### PR DESCRIPTION
### Detailed description

`clonefile`, which is a good idea in general, should now be well supported across all operating systems. The compatibility issues should be a thing of the past.

### To do

* [x] Tests

### See also

- #1511 
- https://codeberg.org/da/ruby-clonefile