### PR TITLE
Run nanoc checks in parallel

### DIFF
--- a/nanoc-checking/lib/nanoc/checking/runner.rb
+++ b/nanoc-checking/lib/nanoc/checking/runner.rb
@@ -53,6 +53,8 @@ module Nanoc
         run_check_classes(check_classes_named(check_class_names))
       end
 
+      ClassID = Struct.new(:identifier)
+
       private
 
       def loader
@@ -87,14 +89,13 @@ module Nanoc
         end
       end
 
-      ClassID = Struct.new(:identifier)
       def run_checks(classes)
         return [] if classes.empty?
 
         # TODO: remove me
         Nanoc::Core::Compiler.new_for(@site).run_until_reps_built
         length = classes.map { |c| c.identifier.to_s.length }.max + 18
-        if classes.size==1
+        if classes.size == 1
           print format("  %-#{length}s", "Running check #{classes.first.identifier}… ")
           check = classes.first.create(@site)
           check.run
@@ -104,11 +105,10 @@ module Nanoc
         Parallel.map(classes) do |klass|
           check = klass.create(@site)
           check.run
-          puts format("  %-#{length}s%s", "Check #{klass.identifier}: ",check.issues.empty? ? 'ok'.green : 'error'.red)
-          check.issues.map!{Nanoc::Checking::Issue.new(_1.description,_1.subject,ClassID.new(klass.identifier))}
+          puts format("  %-#{length}s%s", "Check #{klass.identifier}: ", check.issues.empty? ? 'ok'.green : 'error'.red)
+          check.issues.map! { Nanoc::Checking::Issue.new(_1.description, _1.subject, ClassID.new(klass.identifier)) }
           check.issues
         end.reduce(:union)
-
       end
 
       def subject_to_s(str)


### PR DESCRIPTION
### Detailed description

This speeds up nanoc checks by running them in parallel. We've used this on a large nanoc site with dozens of tests for over a year now, saving hours. If there is a single check it keeps the existing behaviour, because it allows for better feedback in case of a longrunning check (and that way no tests needed to be modified).

I used the parallel gem, because some parts of the check runner are not thread safe. This required me to replace the class that is passed into `Nanoc::Checking::Issue` with a Struct to allow it to serialize. It might be a bit cleaner to rewrite the Issue class to take a symbol rather than a class, but that would increase the scope of this PR further than I was comfortable with.

### To do

* [ ] Tests? The existing tests pass, I don't know how to test this better.
* [ ] Documentation
* [ ] Feature flag? If someone has a nanoc check that modifies state, like reformatting something in your site, then running the checks in parallel could cause undefined behaviour. I would consider this very bad practice, not sure if we need to take it into account.

### Related issues

https://github.com/nanoc/features/issues/47