### PR TITLE
Run checks in parallel

### DIFF
--- a/nanoc/spec/nanoc/regressions/gh_809_spec.rb
+++ b/nanoc/spec/nanoc/regressions/gh_809_spec.rb
@@ -13,7 +13,7 @@ EOS
   specify 'stale check does not consider output/greeting.tmp as stale' do
     Nanoc::CLI.run(['compile'])
 
-    regex = /Running check stale…   (\e\[32m)?ok(\e\[0m)?/
+    regex = /\r  stale  ok\e\[K/
     expect { Nanoc::CLI.run(%w[check stale]) }.to output(regex).to_stdout
   end
 end


### PR DESCRIPTION
### Detailed description

Similar to #1734: runs checks in parallel. This is what it looks like:

https://github.com/user-attachments/assets/aa9af20c-187a-425a-8ce0-ef07a00f3c70

Parallelism is currently set to 5, but is configurable. (I think it’s good to have a limit, but I’m not sure what it should be.)

I can’t imagine individual checks sharing state, so parallelising this should be possible without side effects. For that reason, like in ##1734, I think a feature flag wouldn’t be useful.

### To do

* [x] Tests
* [ ] ~~Documentation~~
* [ ] ~~Feature flags~~

### Related issues

See #1734.
