### PR TITLE
Provide helper to check only changed files

### DIFF
--- a/nanoc-checking/lib/nanoc/checking/runner.rb
+++ b/nanoc-checking/lib/nanoc/checking/runner.rb
@@ -118,7 +118,7 @@ module Nanoc
 
           check.run
 
-          state = check.issues.empty? ? colorizer.c('ok', :green) : colorizer.c('error', :red)
+          state = check.ok? ? colorizer.c('ok', :green) : colorizer.c('error', :red)
           log_check(index:, topic: format("  %-#{length}s", check.class.identifier.to_s), state:)
         end
 


### PR DESCRIPTION
This PR provides a helper method that filters `output_filenames` into `output_changed_filenames`, containing only the files that changed since the last successful run.

### Detailed description

Many checks, such as HTML5 validation and spelling checks, can be greatly sped up by skipping all files that have been checked before and have not changed since then. Instead of each check having to do it's own bookkeeping this helper method provides the list of filenames that changed since the last time the check completed without any issues.

Tests: I've not written rspecs before, but if this PR is acceptable I can see if ChatGPT can come up with one
Documentation: One potential pitfall is that while you are modifying a check you can get confused if you've completed a run successfully, and then subsequently running the modified check will not show anything. We could invalidate the cache if a check is modified but that seems a lot of work for just this edge case.

### To do

* [ ] Tests
* [ ] Documentation

### Related issues

(Add issue IDs for related issues here.)
