### PR TITLE
external link check user agent configurable

### DIFF
--- a/nanoc-checking/lib/nanoc/checking/checks/external_links.rb
+++ b/nanoc-checking/lib/nanoc/checking/checks/external_links.rb
@@ -143,7 +143,7 @@ module Nanoc
 
         def request_url_once(url)
           req = Net::HTTP::Get.new(path_for_url(url))
-          req['User-Agent'] = "Mozilla/5.0 Nanoc/#{Nanoc::VERSION} (link rot checker)"
+          req['User-Agent'] = user_agent
           http = Net::HTTP.new(url.host, url.port)
           if url.instance_of? URI::HTTPS
             http.use_ssl = true
@@ -160,6 +160,20 @@ module Nanoc
         def excluded_file?(file)
           excludes = @config.fetch(:checks, {}).fetch(:external_links, {}).fetch(:exclude_files, [])
           excludes.any? { |pattern| Regexp.new(pattern).match(file) }
+        end
+
+        def user_agent
+          @_user_agent ||= custom_user_agent || default_user_agent
+        end
+
+        private
+
+        def custom_user_agent
+          @config.dig(:checks, :external_links, :user_agent)
+        end
+
+        def default_user_agent
+          "Mozilla/5.0 Nanoc/#{Nanoc::VERSION} (link rot checker)"
         end
       end
     end

--- a/nanoc-checking/spec/nanoc/checking/checks/external_links_spec.rb
+++ b/nanoc-checking/spec/nanoc/checking/checks/external_links_spec.rb
@@ -34,6 +34,30 @@ describe Nanoc::Checking::Checks::ExternalLinks do
     File.write('Rules', 'passthrough "/**/*"')
   end
 
+  describe '#user_agent' do
+    subject(:check) do
+      described_class.create(site)
+    end
+
+    context 'when none configured' do
+      it 'uses default' do
+        expect(check.user_agent).to eql "Mozilla/5.0 Nanoc/#{Nanoc::VERSION} (link rot checker)"
+      end
+    end
+
+    context 'when custom user agent configured' do
+      let(:config) do
+        super().merge(
+          checks: { external_links: { user_agent: 'my custom user agent' } },
+        )
+      end
+
+      it 'uses custom user agent' do
+        expect(check.user_agent).to eql 'my custom user agent'
+      end
+    end
+  end
+
   context 'found' do
     before do
       File.write('output/hi.html', '<a href="http://example.com/x">stuff</a>')

--- a/nanoc-core/lib/nanoc/core/configuration-schema.json
+++ b/nanoc-core/lib/nanoc/core/configuration-schema.json
@@ -106,6 +106,9 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
+            "user_agent" : {
+              "type": "string"
+            },
             "exclude": {
               "type": "array",
               "items": {


### PR DESCRIPTION
### Detailed description

- Makes user agent for external links check configurable
- This is to bypass servers that blacklist certain user agent strings

### To do

* [X] Tests
* [ ] Documentation
* [ ] Feature flags

### Related issues

n/a
