### PR TITLE
Optimize DependencyProps: Don’t convert to Set until needed

### DIFF
--- a/nanoc-cli/lib/nanoc/cli/commands/show-data.rb
+++ b/nanoc-cli/lib/nanoc/cli/commands/show-data.rb
@@ -139,7 +139,7 @@ module Nanoc::CLI::Commands
       case dep.props.raw_content
       when true
         outcome << 'matching any identifier'
-      when Set
+      when Set, Array
         dep.props.raw_content.sort.each do |x|
           outcome << "matching identifier #{x}"
         end
@@ -149,7 +149,7 @@ module Nanoc::CLI::Commands
         case dep.props.attributes
         when true
           outcome << 'matching any attribute'
-        when Set
+        when Set, Array
           dep.props.attributes.each do |elem|
             case elem
             when Symbol

--- a/nanoc-core/lib/nanoc/core/dependency_props.rb
+++ b/nanoc-core/lib/nanoc/core/dependency_props.rb
@@ -44,28 +44,10 @@ module Nanoc
 
       contract C_ARGS => C::Any
       def initialize(raw_content: false, attributes: false, compiled_content: false, path: false)
+        @raw_content = raw_content
+        @attributes = attributes
         @compiled_content = compiled_content
         @path = path
-
-        @attributes =
-          case attributes
-          when Set
-            attributes
-          when Array
-            Set.new(attributes)
-          else
-            attributes
-          end
-
-        @raw_content =
-          case raw_content
-          when Set
-            raw_content
-          when Array
-            Set.new(raw_content)
-          else
-            raw_content
-          end
       end
 
       contract C::None => String
@@ -77,7 +59,7 @@ module Nanoc
           s << (compiled_content? ? 'c' : '_')
           s << (path? ? 'p' : '_')
 
-          if @raw_content.is_a?(Set)
+          if @raw_content.is_a?(Set) || @raw_content.is_a?(Array)
             @raw_content.each do |elem|
               s << '; raw_content('
               s << elem.inspect
@@ -85,7 +67,7 @@ module Nanoc
             end
           end
 
-          if @attributes.is_a?(Set)
+          if @attributes.is_a?(Set) || @attributes.is_a?(Array)
             @attributes.each do |elem|
               s << '; attr('
               s << elem.inspect
@@ -110,7 +92,7 @@ module Nanoc
       contract C::None => C::Bool
       def raw_content?
         case @raw_content
-        when Set
+        when Array, Set
           !@raw_content.empty?
         else
           @raw_content
@@ -120,7 +102,7 @@ module Nanoc
       contract C::None => C::Bool
       def attributes?
         case @attributes
-        when Set
+        when Array, Set
           !@attributes.empty?
         else
           @attributes
@@ -168,7 +150,7 @@ module Nanoc
           when false
             own
           else
-            own + other
+            Set.new(own + other)
           end
         end
       end

--- a/nanoc-core/lib/nanoc/core/outdatedness_checker.rb
+++ b/nanoc-core/lib/nanoc/core/outdatedness_checker.rb
@@ -175,7 +175,7 @@ module Nanoc
       def attributes_prop_causes_outdatedness?(objects, attributes_prop)
         return false unless attributes_prop
 
-        unless attributes_prop.is_a?(Set)
+        unless attributes_prop.is_a?(Set) || attributes_prop.is_a?(Array)
           raise(
             Nanoc::Core::Errors::InternalInconsistency,
             'expected attributes_prop to be a Set',

--- a/nanoc-core/spec/nanoc/core/dependency_props_spec.rb
+++ b/nanoc-core/spec/nanoc/core/dependency_props_spec.rb
@@ -259,7 +259,7 @@ describe Nanoc::Core::DependencyProps do
       let(:props) { props_attrs_false }
       let(:other_props) { props_attrs_list_a }
 
-      it { is_expected.to be_a(Set) }
+      it { is_expected.to be_a(Array) }
       it { is_expected.to match_array(%i[donkey giraffe]) }
     end
 
@@ -288,7 +288,7 @@ describe Nanoc::Core::DependencyProps do
       let(:props) { props_attrs_list_a }
       let(:other_props) { props_attrs_false }
 
-      it { is_expected.to be_a(Set) }
+      it { is_expected.to be_a(Array) }
       it { is_expected.to match_array(%i[donkey giraffe]) }
     end
 
@@ -345,7 +345,7 @@ describe Nanoc::Core::DependencyProps do
       let(:props) { props_raw_content_false }
       let(:other_props) { props_raw_content_list_a }
 
-      it { is_expected.to be_a(Set) }
+      it { is_expected.to be_a(Array) }
       it { is_expected.to match_array(%w[donkey giraffe]) }
     end
 
@@ -374,7 +374,7 @@ describe Nanoc::Core::DependencyProps do
       let(:props) { props_raw_content_list_a }
       let(:other_props) { props_raw_content_false }
 
-      it { is_expected.to be_a(Set) }
+      it { is_expected.to be_a(Array) }
       it { is_expected.to match_array(%w[donkey giraffe]) }
     end
 


### PR DESCRIPTION
This changes `DependencyProps` to not eagerly convert its enumerable (`Array`) argument into a `Set` until it is necessary. This is faster.
