### PR TITLE
remove haml warnings related to :outvar and :disable_capture which are now invalid

### DIFF
--- a/nanoc/lib/nanoc/filters/haml.rb
+++ b/nanoc/lib/nanoc/filters/haml.rb
@@ -17,8 +17,6 @@ module Nanoc::Filters
       # Get options
       options = params.merge(
         filename:,
-        outvar: '_erbout',
-        disable_capture: true,
       )
 
       # Create context


### PR DESCRIPTION


### Detailed description

When using the Haml template format we have now the following warnings:
```
Haml::TempleEngine: Option :disable_capture is invalid
Haml::TempleEngine: Option :outvar is invalid
```
This PR is fixing this by removing those options from the Haml filter

### To do

I have tested this change on one of my site with success.
I have not found any test that would need to be modified for this (but I might have missed it).
I do not think that any documentation is necessary, but let me know if I am wrong.

* [ ] Tests
* [ ] Documentation

### Related issues

None
