### PR TITLE
Remove clonefile as a hard dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ end
 
 group :devel do
   gem 'addressable', '~> 2.8'
+  gem 'clonefile', '~> 0.5.3', platforms: :ruby
   gem 'contracts', '~> 0.17'
   gem 'debug', '~> 1.9'
   gem 'fuubar', '~> 2.5'

--- a/nanoc-core/lib/nanoc/core.rb
+++ b/nanoc-core/lib/nanoc/core.rb
@@ -10,7 +10,6 @@ require 'yaml'
 require 'zlib'
 
 # External gems
-require 'clonefile'
 require 'concurrent-ruby'
 require 'json_schema'
 require 'ddmetrics'
@@ -20,6 +19,13 @@ require 'memo_wise'
 require 'slow_enumerator_tools'
 require 'tty-platform'
 require 'zeitwerk'
+
+# External gems (optional)
+begin
+  require 'clonefile'
+rescue LoadError
+  # ignore
+end
 
 module Nanoc
   module Core

--- a/nanoc-core/lib/nanoc/core/binary_compiled_content_cache.rb
+++ b/nanoc-core/lib/nanoc/core/binary_compiled_content_cache.rb
@@ -92,6 +92,10 @@ module Nanoc
         end
       end
 
+      def use_clonefile?
+        defined?(Clonefile)
+      end
+
       private
 
       def dirname
@@ -132,11 +136,13 @@ module Nanoc
         # changed outside of Nanoc.
 
         # Try clonefile
-        FileUtils.rm_f(to)
-        begin
-          res = Clonefile.always(from, to)
-          return if res
-        rescue Clonefile::UnsupportedPlatform, Errno::ENOTSUP, Errno::EXDEV, Errno::EINVAL
+        if use_clonefile?
+          FileUtils.rm_f(to)
+          begin
+            res = Clonefile.always(from, to)
+            return if res
+          rescue Clonefile::UnsupportedPlatform, Errno::ENOTSUP, Errno::EXDEV, Errno::EINVAL
+          end
         end
 
         # Fall back to old-school copy

--- a/nanoc-core/lib/nanoc/core/item_rep_writer.rb
+++ b/nanoc-core/lib/nanoc/core/item_rep_writer.rb
@@ -79,11 +79,13 @@ module Nanoc
 
       def smart_cp(from, to)
         # Try clonefile
-        FileUtils.rm_f(to)
-        begin
-          res = Clonefile.always(from, to)
-          return if res
-        rescue Clonefile::UnsupportedPlatform, Errno::ENOTSUP, Errno::EXDEV, Errno::EINVAL
+        if defined?(Clonefile)
+          FileUtils.rm_f(to)
+          begin
+            res = Clonefile.always(from, to)
+            return if res
+          rescue Clonefile::UnsupportedPlatform, Errno::ENOTSUP, Errno::EXDEV, Errno::EINVAL
+          end
         end
 
         # Try with hardlink

--- a/nanoc-core/nanoc-core.gemspec
+++ b/nanoc-core/nanoc-core.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.1'
 
   s.add_dependency('base64', '~> 0.2')
-  s.add_dependency('clonefile', '~> 0.5.3')
   s.add_dependency('concurrent-ruby', '~> 1.1')
   s.add_dependency('ddmetrics', '~> 1.0')
   s.add_dependency('ddplugin', '~> 1.0')

--- a/nanoc/spec/nanoc/regressions/gh_1572_spec.rb
+++ b/nanoc/spec/nanoc/regressions/gh_1572_spec.rb
@@ -4,6 +4,10 @@ describe 'GH-1572', site: true, stdio: true do
   example do
     FileUtils.mkdir_p('content')
 
+    allow_any_instance_of(Nanoc::Core::BinaryCompiledContentCache)
+      .to receive(:use_clonefile?)
+      .and_return(false)
+
     File.write('content/repro.jpg', '<data>')
     File.chmod(0o400, 'content/repro.jpg')
     expect(File.stat('content/repro.jpg').mode).to eq(0o100400)


### PR DESCRIPTION
[clonefile](https://codeberg.org/da/ruby-clonefile) unfortunately cannot be installed on Windows, and Windows support is needed.

This reverts commit 982575af3edc26e4a87b40c721da6104a4cbaaa1, but adds clonefile to the Gemfile.

The clonefile gem can still be installed, but it can’t be a hard dependency.

Fixes #1744.
