### PR TITLE
Remove nanoc-rust support

### DIFF
--- a/nanoc/bin/nanoc
+++ b/nanoc/bin/nanoc
@@ -2,13 +2,6 @@
 # frozen_string_literal: true
 
 require 'nanoc'
-
-begin
-  require 'nanoc-rust'
-  NanocRust.activate!
-rescue LoadError
-end
-
 require 'nanoc/orig_cli'
 
 if File.file?('Gemfile') && !defined?(Bundler)


### PR DESCRIPTION
nanoc-rust has not made any progress and it is unclear if it ever will be used. Probaby won’t.