### PR TITLE
Reimplement dart-sass importer according to the specification

### DIFF
--- a/nanoc-dart-sass/nanoc-dart-sass.gemspec
+++ b/nanoc-dart-sass/nanoc-dart-sass.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.2'
 
   s.add_dependency('nanoc-core', '~> 4.13', '>= 4.13.1')
-  s.add_dependency('sass-embedded', '~> 1.56')
+  s.add_dependency('sass-embedded', '~> 1.80')
   s.metadata = {
     'rubygems_mfa_required' => 'true',
     'source_code_uri' => "https://github.com/nanoc/nanoc/tree/#{s.name}-v#{s.version}/#{s.name}",


### PR DESCRIPTION
The current nanoc dart-sass importer works to some degree but it is not compliant to the spec: https://github.com/sass/sass/blob/main/accepted/module-system.md#resolving-a-file-url

This PR reimplement the importer to be more close to the spec:

- Locate the file in `canonicalize` method and return `nil` if not found according to the spec. Let `sass-embedded` throw for non-exist imports instead of throwing ourselves in the custom importer.
- Handling `@import` and `@use` differently according to the spec.
- Properly handling deeply nested relative imports using `containing_url`, rather than always resolve relative to the entrypoint file.

Note, there is still one noncompliant detail that nanoc allows and resolves wildcard (`*`) in the url, which is kept as is.