### PR TITLE
Support TOML frontmatter and configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ group :devel do
   gem 'm', '~> 1.5'
   gem 'minitest', '~> 5.11'
   gem 'mocha', '~> 2.7'
+  gem 'perfect_toml', '~> 0.9.0'
   gem 'pry', '~> 0.15.2'
   gem 'rake', '~> 13.2'
   gem 'rdoc', '~> 6.0'

--- a/nanoc-cli/lib/nanoc/cli/error_handler.rb
+++ b/nanoc-cli/lib/nanoc/cli/error_handler.rb
@@ -203,6 +203,7 @@ module Nanoc::CLI
       'nanoc/live' => 'nanoc-live',
       'nokogiri' => 'nokogiri',
       'pandoc-ruby' => 'pandoc-ruby',
+      'perfect_toml' => 'perfect_toml',
       'pry' => 'pry',
       'rack' => 'rack',
       'rack/cache' => 'rack-cache',

--- a/nanoc-core/lib/nanoc/core/config_loader.rb
+++ b/nanoc-core/lib/nanoc/core/config_loader.rb
@@ -29,7 +29,11 @@ module Nanoc
 
       # @return [String]
       def self.config_filename_for_cwd
-        filenames = %w[nanoc.yaml config.yaml]
+        filenames = [
+          'nanoc.yaml',
+          'nanoc.toml',
+          'config.yaml',
+        ]
         candidate = filenames.find { |f| File.file?(f) }
         candidate && File.expand_path(candidate)
       end
@@ -54,7 +58,8 @@ module Nanoc
       end
 
       def load_file(filename)
-        YamlLoader.load_file(filename)
+        loader = StructuredDataLoader.for_extension(File.extname(filename))
+        loader.load_file(filename)
       end
 
       # @api private

--- a/nanoc-core/lib/nanoc/core/structured_data_loader.rb
+++ b/nanoc-core/lib/nanoc/core/structured_data_loader.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Nanoc
+  module Core
+    # @api private
+    module StructuredDataLoader
+      class UnknownLanguageError < StandardError
+        def initialize(lang)
+          super("cannot find loader for language: #{lang.inspect}")
+        end
+      end
+
+      def self.for_language(language)
+        case language
+        when :yaml
+          YamlLoader
+        when :toml
+          TomlLoader
+        else
+          raise UnknownLanguageError.enw(language)
+        end
+      end
+
+      def self.for_extension(ext)
+        case ext
+        when '.yaml'
+          YamlLoader
+        when '.toml'
+          TomlLoader
+        else
+          raise UnknownLanguageError.enw(language)
+        end
+      end
+    end
+  end
+end

--- a/nanoc-core/lib/nanoc/core/toml_loader.rb
+++ b/nanoc-core/lib/nanoc/core/toml_loader.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Nanoc
+  module Core
+    # @api private
+    module TomlLoader
+      def self.load(string)
+        require 'perfect_toml'
+        PerfectTOML.parse(string)
+      end
+
+      def self.load_file(filename)
+        require 'perfect_toml'
+        load(File.read(filename))
+      end
+    end
+  end
+end

--- a/nanoc-core/lib/nanoc/core/yaml_loader.rb
+++ b/nanoc-core/lib/nanoc/core/yaml_loader.rb
@@ -11,8 +11,8 @@ module Nanoc
 
       private_constant :OPTIONS
 
-      def self.load(yaml_string)
-        YAML.safe_load(yaml_string, **OPTIONS)
+      def self.load(string)
+        YAML.safe_load(string, **OPTIONS)
       end
 
       def self.load_file(filename)

--- a/nanoc-core/nanoc-core.manifest
+++ b/nanoc-core/nanoc-core.manifest
@@ -132,9 +132,11 @@ lib/nanoc/core/site.rb
 lib/nanoc/core/snapshot_def.rb
 lib/nanoc/core/store.rb
 lib/nanoc/core/string_pattern.rb
+lib/nanoc/core/structured_data_loader.rb
 lib/nanoc/core/temp_filename_factory.rb
 lib/nanoc/core/textual_compiled_content_cache.rb
 lib/nanoc/core/textual_content.rb
+lib/nanoc/core/toml_loader.rb
 lib/nanoc/core/trivial_error.rb
 lib/nanoc/core/utils.rb
 lib/nanoc/core/view_context_for_compilation.rb

--- a/nanoc-core/spec/nanoc/core/config_loader_spec.rb
+++ b/nanoc-core/spec/nanoc/core/config_loader_spec.rb
@@ -32,6 +32,24 @@ describe Nanoc::Core::ConfigLoader do
       end
     end
 
+    context 'TOML config file present' do
+      before do
+        File.write('nanoc.toml', 'foo = "bar"')
+      end
+
+      it 'returns a configuration' do
+        expect(subject).to be_a(Nanoc::Core::Configuration)
+      end
+
+      it 'has the defaults' do
+        expect(subject[:output_dir]).to eq('output')
+      end
+
+      it 'has the custom option' do
+        expect(subject[:foo]).to eq('bar')
+      end
+    end
+
     context 'YAML config file and YAML parent present' do
       before do
         File.write('nanoc.yaml', YAML.dump(parent_config_file: 'parent.yaml'))
@@ -52,6 +70,25 @@ describe Nanoc::Core::ConfigLoader do
 
       it 'does not include parent config option' do
         expect(subject[:parent_config_file]).to be_nil
+      end
+    end
+
+    context 'TOML config file present and TOML parent present' do
+      before do
+        File.write('nanoc.toml', 'parent_config_file = "parent.toml"')
+        File.write('parent.toml', 'foo = "bar"')
+      end
+
+      it 'returns a configuration' do
+        expect(subject).to be_a(Nanoc::Core::Configuration)
+      end
+
+      it 'has the defaults' do
+        expect(subject[:output_dir]).to eq('output')
+      end
+
+      it 'has the custom option' do
+        expect(subject[:foo]).to eq('bar')
       end
     end
 

--- a/nanoc-core/spec/nanoc/core/structured_data_loader_spec.rb
+++ b/nanoc-core/spec/nanoc/core/structured_data_loader_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+describe Nanoc::Core::StructuredDataLoader do
+  subject(:loader) { described_class }
+
+  describe '.for_language' do
+    it 'can handle YAML' do
+      expect(loader.for_language(:yaml).load('hello: world'))
+        .to eq({ 'hello' => 'world' })
+    end
+
+    it 'can handle TOML' do
+      expect(loader.for_language(:toml).load('hello = "world"'))
+        .to eq({ 'hello' => 'world' })
+    end
+  end
+
+  describe '.for_extension' do
+    it 'can handle YAML' do
+      expect(loader.for_extension('.yaml').load('hello: world'))
+        .to eq({ 'hello' => 'world' })
+    end
+
+    it 'can handle TOML' do
+      expect(loader.for_extension('.toml').load('hello = "world"'))
+        .to eq({ 'hello' => 'world' })
+    end
+  end
+end

--- a/nanoc-core/spec/nanoc/core/toml_loader_spec.rb
+++ b/nanoc-core/spec/nanoc/core/toml_loader_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe Nanoc::Core::TomlLoader do
+  subject(:loader) { described_class }
+
+  let(:input) do
+    <<~TOML
+      point.x = 42
+      point.y = 43
+    TOML
+  end
+
+  let(:expected_output) do
+    {
+      'point' => { 'x' => 42, 'y' => 43 },
+    }
+  end
+
+  describe 'load' do
+    it 'returns parsed TOML' do
+      expect(loader.load(input)).to eq expected_output
+    end
+  end
+end

--- a/nanoc-core/spec/nanoc/core/yaml_loader_spec.rb
+++ b/nanoc-core/spec/nanoc/core/yaml_loader_spec.rb
@@ -3,7 +3,7 @@
 describe Nanoc::Core::YamlLoader do
   subject(:loader) { described_class }
 
-  let(:yaml_input) do
+  let(:input) do
     <<~YAML
       point: &point_data
         x: 42
@@ -13,6 +13,7 @@ describe Nanoc::Core::YamlLoader do
         extent: {w: 10, h: 11}
     YAML
   end
+
   let(:expected_output) do
     {
       'point' => { 'x' => 42, 'y' => 43 },
@@ -25,7 +26,7 @@ describe Nanoc::Core::YamlLoader do
 
   describe 'load' do
     it 'accepts YAML aliases' do
-      expect(loader.load(yaml_input)).to eq expected_output
+      expect(loader.load(input)).to eq expected_output
     end
   end
 end

--- a/nanoc/lib/nanoc/data_sources/filesystem.rb
+++ b/nanoc/lib/nanoc/data_sources/filesystem.rb
@@ -152,6 +152,7 @@ module Nanoc::DataSources
       is_binary = content_filename && !@site_config[:text_extensions].include?(File.extname(content_filename)[1..])
 
       if is_binary && klass == Nanoc::Core::Item
+        # NOTE: TOML support is explicitly not added here, in case there are existing sites with `.toml` files.
         meta = (meta_filename && Nanoc::Core::YamlLoader.load_file(meta_filename)) || {}
 
         ProtoDocument.new(is_binary: true, filename: content_filename, attributes: meta)

--- a/nanoc/spec/nanoc/data_sources/filesystem/parser_spec.rb
+++ b/nanoc/spec/nanoc/data_sources/filesystem/parser_spec.rb
@@ -173,6 +173,18 @@ describe Nanoc::DataSources::Filesystem::Parser do
           end
         end
 
+        context 'three pluses (TOML)' do
+          let(:content) { "+++\ntitle = \"Welcome\"\n+++\nHello!\n" }
+
+          it 'has attributes' do
+            expect(subject.attributes).to eq('title' => 'Welcome')
+          end
+
+          it 'has content' do
+            expect(subject.content).to eq("Hello!\n")
+          end
+        end
+
         context 'separator not at beginning' do
           let(:content) { "foo\n---\ntitle: Welcome\n---\nStuff\n" }
 


### PR DESCRIPTION
### Detailed description

YAML is a pain to work with, with so many weird syntax gotchas.

TOML, on the other hand, is far simpler. It is supported by other SSGs, like Zola and Hugo, with a frontmatter that uses `+++` rather than `---` as the delimiter, like this:

```
+++
title = "Homepage"

[author]
name = "Denis"
email = "denis@example.com"
+++

Hic ipsam rerum. Accusantium mumblecore hic ut. Pitchfork disrupt umami
consequatur sint. Qui voluptatibus et phlogiston nam. Quod green juice
rerum hic selfies mollitia ea…
```

In addition to adding support for TOML frontmatter, it also allows the configuration file to be written in TOML.

One change that is deliberately missing is support for separate `.toml` files with metadata. The risk of this introducing backwards incompatibility is too high.

### To do

n/a

### Related issues

n/a