### PR TITLE
Simplify filter duration recording

### DIFF
--- a/nanoc-cli/spec/nanoc/cli/compile_listeners/timing_recorder_spec.rb
+++ b/nanoc-cli/spec/nanoc/cli/compile_listeners/timing_recorder_spec.rb
@@ -104,45 +104,6 @@ describe Nanoc::CLI::CompileListeners::TimingRecorder, stdio: true do
     expect(listener.filters_summary.get(name: 'outer').count).to eq(1.00)
   end
 
-  it 'pauses outer stopwatch when suspended' do
-    mock_time(0)
-    Nanoc::Core::NotificationCenter.post(:compilation_started, rep).sync
-    Nanoc::Core::NotificationCenter.post(:filtering_started, rep, :outer).sync
-    mock_time(1)
-    Nanoc::Core::NotificationCenter.post(:filtering_started, rep, :inner).sync
-    mock_time(3)
-    Nanoc::Core::NotificationCenter.post(:compilation_suspended, rep).sync
-    mock_time(6)
-    Nanoc::Core::NotificationCenter.post(:compilation_started, rep).sync
-    mock_time(10)
-    Nanoc::Core::NotificationCenter.post(:filtering_ended, rep, :inner).sync
-    Nanoc::Core::NotificationCenter.post(:filtering_ended, rep, :outer).sync
-
-    expect(listener.filters_summary.get(name: 'outer').min).to eq(7.00)
-    expect(listener.filters_summary.get(name: 'outer').avg).to eq(7.00)
-    expect(listener.filters_summary.get(name: 'outer').max).to eq(7.00)
-    expect(listener.filters_summary.get(name: 'outer').sum).to eq(7.00)
-    expect(listener.filters_summary.get(name: 'outer').count).to eq(1.00)
-  end
-
-  it 'records single from filtering_started over compilation_{suspended,started} to filtering_ended' do
-    Nanoc::Core::NotificationCenter.post(:compilation_started, rep).sync
-    mock_time(0)
-    Nanoc::Core::NotificationCenter.post(:filtering_started, rep, :erb).sync
-    mock_time(1)
-    Nanoc::Core::NotificationCenter.post(:compilation_suspended, rep).sync
-    mock_time(3)
-    Nanoc::Core::NotificationCenter.post(:compilation_started, rep).sync
-    mock_time(7)
-    Nanoc::Core::NotificationCenter.post(:filtering_ended, rep, :erb).sync
-
-    expect(listener.filters_summary.get(name: 'erb').min).to eq(5.00)
-    expect(listener.filters_summary.get(name: 'erb').avg).to eq(5.00)
-    expect(listener.filters_summary.get(name: 'erb').max).to eq(5.00)
-    expect(listener.filters_summary.get(name: 'erb').sum).to eq(5.00)
-    expect(listener.filters_summary.get(name: 'erb').count).to eq(1.00)
-  end
-
   it 'records single phase start+stop' do
     mock_time(0)
     Nanoc::Core::NotificationCenter.post(:phase_started, 'donkey', rep).sync


### PR DESCRIPTION
### Detailed description

The code for measuring the filter durations is too complex for its own good.

Because filters always happen in pairs (start/stop) and can be nested, we can rely purely on `filtering_started` and `filtering_ended` events.

(This also appears to remove some odd unreproducible behavior where wrong timings are recorded, but I cannot reproduce it with the old code anymore either. Strange!)
