### PR TITLE
Make NotificationCenter synchronous

### DIFF
--- a/common/spec/spec_helper_foot_core.rb
+++ b/common/spec/spec_helper_foot_core.rb
@@ -96,7 +96,6 @@ RSpec::Matchers.define :send_notification do |name, *expected_args|
     end
 
     actual.call
-    Nanoc::Core::NotificationCenter.sync
 
     @actual_notifications.any? { |c| c == expected_args }
   end

--- a/guard-nanoc/lib/guard/nanoc.rb
+++ b/guard-nanoc/lib/guard/nanoc.rb
@@ -57,7 +57,7 @@ module Guard
 
     def recompile
       # Necessary, because forking and threading don’t work together.
-      ::Nanoc::Core::NotificationCenter.force_reset
+      ::Nanoc::Core::NotificationCenter.reset
 
       Dir.chdir(@dir) do
         site = ::Nanoc::Core::SiteLoader.new.new_from_cwd

--- a/nanoc-cli/lib/nanoc/cli/compile_listeners/abstract.rb
+++ b/nanoc-cli/lib/nanoc/cli/compile_listeners/abstract.rb
@@ -26,8 +26,6 @@ module Nanoc::CLI::CompileListeners
     def wrapped_stop
       stop
 
-      Nanoc::Core::NotificationCenter.sync
-
       @_notification_names.each do |name|
         Nanoc::Core::NotificationCenter.remove(name, self)
       end

--- a/nanoc-cli/spec/nanoc/cli/compile_listeners/debug_printer_spec.rb
+++ b/nanoc-cli/spec/nanoc/cli/compile_listeners/debug_printer_spec.rb
@@ -13,42 +13,42 @@ describe Nanoc::CLI::CompileListeners::DebugPrinter, stdio: true do
   it 'records snapshot_created' do
     listener.start_safely
 
-    expect { Nanoc::Core::NotificationCenter.post(:snapshot_created, rep, :last).sync }
+    expect { Nanoc::Core::NotificationCenter.post(:snapshot_created, rep, :last) }
       .to output(%r{Snapshot last created for /donkey.md \(rep name :latex\)}).to_stdout
   end
 
   it 'prints with timestamp' do
     listener.start_safely
 
-    expect { Nanoc::Core::NotificationCenter.post(:snapshot_created, rep, :last).sync }
+    expect { Nanoc::Core::NotificationCenter.post(:snapshot_created, rep, :last) }
       .to output(%r{^\*\*\* \d{2}:\d{2}:\d{2}\.\d{3} .*Snapshot last created for /donkey.md \(rep name :latex\)}).to_stdout
   end
 
   it 'records cached_content_used' do
     listener.start_safely
 
-    expect { Nanoc::Core::NotificationCenter.post(:cached_content_used, rep).sync }
+    expect { Nanoc::Core::NotificationCenter.post(:cached_content_used, rep) }
       .to output(%r{Used cached compiled content for /donkey.md \(rep name :latex\) instead of recompiling}).to_stdout
   end
 
   it 'records stage_started' do
     listener.start_safely
 
-    expect { Nanoc::Core::NotificationCenter.post(:stage_started, 'Moo').sync }
+    expect { Nanoc::Core::NotificationCenter.post(:stage_started, 'Moo') }
       .to output(/Stage started: Moo/).to_stdout
   end
 
   it 'records stage_ended' do
     listener.start_safely
 
-    expect { Nanoc::Core::NotificationCenter.post(:stage_ended, 'Moo').sync }
+    expect { Nanoc::Core::NotificationCenter.post(:stage_ended, 'Moo') }
       .to output(/Stage ended: Moo/).to_stdout
   end
 
   it 'records stage_aborted' do
     listener.start_safely
 
-    expect { Nanoc::Core::NotificationCenter.post(:stage_aborted, 'Moo').sync }
+    expect { Nanoc::Core::NotificationCenter.post(:stage_aborted, 'Moo') }
       .to output(/Stage aborted: Moo/).to_stdout
   end
 end

--- a/nanoc-cli/spec/nanoc/cli/compile_listeners/file_action_printer_spec.rb
+++ b/nanoc-cli/spec/nanoc/cli/compile_listeners/file_action_printer_spec.rb
@@ -31,10 +31,10 @@ describe Nanoc::CLI::CompileListeners::FileActionPrinter, stdio: true do
     listener.start_safely
 
     mock_time(0)
-    Nanoc::Core::NotificationCenter.post(:compilation_started, rep).sync
+    Nanoc::Core::NotificationCenter.post(:compilation_started, rep)
     mock_time(1)
 
-    expect { Nanoc::Core::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', true, true).sync }
+    expect { Nanoc::Core::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', true, true) }
       .to output(/create.*\[1\.00s\]/).to_stdout
   end
 
@@ -42,9 +42,9 @@ describe Nanoc::CLI::CompileListeners::FileActionPrinter, stdio: true do
     listener.start_safely
     listener.stop_safely
 
-    Nanoc::Core::NotificationCenter.post(:compilation_started, rep).sync
+    Nanoc::Core::NotificationCenter.post(:compilation_started, rep)
 
-    expect { Nanoc::Core::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', true, true).sync }
+    expect { Nanoc::Core::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', true, true) }
       .not_to output(/create/).to_stdout
   end
 
@@ -52,14 +52,14 @@ describe Nanoc::CLI::CompileListeners::FileActionPrinter, stdio: true do
     listener.start_safely
 
     mock_time(0)
-    Nanoc::Core::NotificationCenter.post(:compilation_started, rep).sync
+    Nanoc::Core::NotificationCenter.post(:compilation_started, rep)
     mock_time(1)
-    Nanoc::Core::NotificationCenter.post(:compilation_suspended, rep, :__irrelevant__).sync
+    Nanoc::Core::NotificationCenter.post(:compilation_suspended, rep, :__irrelevant__)
     mock_time(3)
-    Nanoc::Core::NotificationCenter.post(:compilation_started, rep).sync
+    Nanoc::Core::NotificationCenter.post(:compilation_started, rep)
     mock_time(6)
 
-    expect { Nanoc::Core::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', true, true).sync }
+    expect { Nanoc::Core::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', true, true) }
       .to output(/create.*\[4\.00s\]/).to_stdout
   end
 
@@ -67,14 +67,14 @@ describe Nanoc::CLI::CompileListeners::FileActionPrinter, stdio: true do
     listener.start_safely
 
     mock_time(0)
-    Nanoc::Core::NotificationCenter.post(:compilation_started, rep).sync
+    Nanoc::Core::NotificationCenter.post(:compilation_started, rep)
     mock_time(1)
-    Nanoc::Core::NotificationCenter.post(:rep_write_enqueued, rep).sync
+    Nanoc::Core::NotificationCenter.post(:rep_write_enqueued, rep)
     mock_time(3)
-    Nanoc::Core::NotificationCenter.post(:rep_write_started, rep).sync
+    Nanoc::Core::NotificationCenter.post(:rep_write_started, rep)
     mock_time(6)
 
-    expect { Nanoc::Core::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', true, true).sync }
+    expect { Nanoc::Core::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', true, true) }
       .to output(/create.*\[4\.00s\]/).to_stdout
   end
 
@@ -90,19 +90,19 @@ describe Nanoc::CLI::CompileListeners::FileActionPrinter, stdio: true do
     end
 
     it 'prints nothing' do
-      Nanoc::Core::NotificationCenter.post(:compilation_started, rep).sync
+      Nanoc::Core::NotificationCenter.post(:compilation_started, rep)
       mock_time(1)
 
-      expect { Nanoc::Core::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', false, false).sync }
+      expect { Nanoc::Core::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', false, false) }
         .not_to output(/identical/).to_stdout
     end
 
     it 'prints nothing' do
-      Nanoc::Core::NotificationCenter.post(:compilation_started, rep).sync
-      Nanoc::Core::NotificationCenter.post(:cached_content_used, rep).sync
+      Nanoc::Core::NotificationCenter.post(:compilation_started, rep)
+      Nanoc::Core::NotificationCenter.post(:cached_content_used, rep)
       mock_time(1)
 
-      expect { Nanoc::Core::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', false, false).sync }
+      expect { Nanoc::Core::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', false, false) }
         .not_to output(/cached/).to_stdout
     end
   end
@@ -119,19 +119,19 @@ describe Nanoc::CLI::CompileListeners::FileActionPrinter, stdio: true do
     end
 
     it 'prints “identical” if not cached' do
-      Nanoc::Core::NotificationCenter.post(:compilation_started, rep).sync
+      Nanoc::Core::NotificationCenter.post(:compilation_started, rep)
       mock_time(1)
 
-      expect { Nanoc::Core::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', false, false).sync }
+      expect { Nanoc::Core::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', false, false) }
         .to output(/identical/).to_stdout
     end
 
     it 'prints “cached” if cached' do
-      Nanoc::Core::NotificationCenter.post(:compilation_started, rep).sync
-      Nanoc::Core::NotificationCenter.post(:cached_content_used, rep).sync
+      Nanoc::Core::NotificationCenter.post(:compilation_started, rep)
+      Nanoc::Core::NotificationCenter.post(:cached_content_used, rep)
       mock_time(1)
 
-      expect { Nanoc::Core::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', false, false).sync }
+      expect { Nanoc::Core::NotificationCenter.post(:rep_write_ended, rep, false, '/foo.html', false, false) }
         .to output(/cached/).to_stdout
     end
   end

--- a/nanoc-cli/spec/nanoc/cli/compile_listeners/timing_recorder_spec.rb
+++ b/nanoc-cli/spec/nanoc/cli/compile_listeners/timing_recorder_spec.rb
@@ -39,13 +39,13 @@ describe Nanoc::CLI::CompileListeners::TimingRecorder, stdio: true do
 
   it 'prints filters table' do
     mock_time(0)
-    Nanoc::Core::NotificationCenter.post(:filtering_started, rep, :erb).sync
+    Nanoc::Core::NotificationCenter.post(:filtering_started, rep, :erb)
     mock_time(1)
-    Nanoc::Core::NotificationCenter.post(:filtering_ended, rep, :erb).sync
+    Nanoc::Core::NotificationCenter.post(:filtering_ended, rep, :erb)
     mock_time(100)
-    Nanoc::Core::NotificationCenter.post(:filtering_started, rep, :erb).sync
+    Nanoc::Core::NotificationCenter.post(:filtering_started, rep, :erb)
     mock_time(102)
-    Nanoc::Core::NotificationCenter.post(:filtering_ended, rep, :erb).sync
+    Nanoc::Core::NotificationCenter.post(:filtering_ended, rep, :erb)
 
     expect { listener.stop_safely }
       .to output(/^\s*erb │     2   1\.00s   1\.50s   1\.90s   1\.95s   2\.00s   3\.00s$/).to_stdout
@@ -53,9 +53,9 @@ describe Nanoc::CLI::CompileListeners::TimingRecorder, stdio: true do
 
   it 'records single from filtering_started to filtering_ended' do
     mock_time(0)
-    Nanoc::Core::NotificationCenter.post(:filtering_started, rep, :erb).sync
+    Nanoc::Core::NotificationCenter.post(:filtering_started, rep, :erb)
     mock_time(1)
-    Nanoc::Core::NotificationCenter.post(:filtering_ended, rep, :erb).sync
+    Nanoc::Core::NotificationCenter.post(:filtering_ended, rep, :erb)
 
     expect(listener.filters_summary.get(name: 'erb').min).to eq(1.00)
     expect(listener.filters_summary.get(name: 'erb').avg).to eq(1.00)
@@ -66,13 +66,13 @@ describe Nanoc::CLI::CompileListeners::TimingRecorder, stdio: true do
 
   it 'records multiple from filtering_started to filtering_ended' do
     mock_time(0)
-    Nanoc::Core::NotificationCenter.post(:filtering_started, rep, :erb).sync
+    Nanoc::Core::NotificationCenter.post(:filtering_started, rep, :erb)
     mock_time(1)
-    Nanoc::Core::NotificationCenter.post(:filtering_ended, rep, :erb).sync
+    Nanoc::Core::NotificationCenter.post(:filtering_ended, rep, :erb)
     mock_time(100)
-    Nanoc::Core::NotificationCenter.post(:filtering_started, rep, :erb).sync
+    Nanoc::Core::NotificationCenter.post(:filtering_started, rep, :erb)
     mock_time(102)
-    Nanoc::Core::NotificationCenter.post(:filtering_ended, rep, :erb).sync
+    Nanoc::Core::NotificationCenter.post(:filtering_ended, rep, :erb)
 
     expect(listener.filters_summary.get(name: 'erb').min).to eq(1.00)
     expect(listener.filters_summary.get(name: 'erb').avg).to eq(1.50)
@@ -83,13 +83,13 @@ describe Nanoc::CLI::CompileListeners::TimingRecorder, stdio: true do
 
   it 'records filters in nested filtering_started/filtering_ended' do
     mock_time(0)
-    Nanoc::Core::NotificationCenter.post(:filtering_started, rep, :outer).sync
+    Nanoc::Core::NotificationCenter.post(:filtering_started, rep, :outer)
     mock_time(1)
-    Nanoc::Core::NotificationCenter.post(:filtering_started, rep, :inner).sync
+    Nanoc::Core::NotificationCenter.post(:filtering_started, rep, :inner)
     mock_time(3)
-    Nanoc::Core::NotificationCenter.post(:filtering_ended, rep, :inner).sync
+    Nanoc::Core::NotificationCenter.post(:filtering_ended, rep, :inner)
     mock_time(6)
-    Nanoc::Core::NotificationCenter.post(:filtering_ended, rep, :outer).sync
+    Nanoc::Core::NotificationCenter.post(:filtering_ended, rep, :outer)
 
     expect(listener.filters_summary.get(name: 'inner').min).to eq(2.00)
     expect(listener.filters_summary.get(name: 'inner').avg).to eq(2.00)
@@ -106,9 +106,9 @@ describe Nanoc::CLI::CompileListeners::TimingRecorder, stdio: true do
 
   it 'records single phase start+stop' do
     mock_time(0)
-    Nanoc::Core::NotificationCenter.post(:phase_started, 'donkey', rep).sync
+    Nanoc::Core::NotificationCenter.post(:phase_started, 'donkey', rep)
     mock_time(1)
-    Nanoc::Core::NotificationCenter.post(:phase_ended, 'donkey', rep).sync
+    Nanoc::Core::NotificationCenter.post(:phase_ended, 'donkey', rep)
 
     expect(listener.phases_summary.get(name: 'donkey').min).to eq(1.00)
     expect(listener.phases_summary.get(name: 'donkey').avg).to eq(1.00)
@@ -119,13 +119,13 @@ describe Nanoc::CLI::CompileListeners::TimingRecorder, stdio: true do
 
   it 'records multiple phase start+stop' do
     mock_time(0)
-    Nanoc::Core::NotificationCenter.post(:phase_started, 'donkey', rep).sync
+    Nanoc::Core::NotificationCenter.post(:phase_started, 'donkey', rep)
     mock_time(1)
-    Nanoc::Core::NotificationCenter.post(:phase_ended, 'donkey', rep).sync
+    Nanoc::Core::NotificationCenter.post(:phase_ended, 'donkey', rep)
     mock_time(100)
-    Nanoc::Core::NotificationCenter.post(:phase_started, 'donkey', rep).sync
+    Nanoc::Core::NotificationCenter.post(:phase_started, 'donkey', rep)
     mock_time(102)
-    Nanoc::Core::NotificationCenter.post(:phase_ended, 'donkey', rep).sync
+    Nanoc::Core::NotificationCenter.post(:phase_ended, 'donkey', rep)
 
     expect(listener.phases_summary.get(name: 'donkey').min).to eq(1.00)
     expect(listener.phases_summary.get(name: 'donkey').avg).to eq(1.50)
@@ -136,13 +136,13 @@ describe Nanoc::CLI::CompileListeners::TimingRecorder, stdio: true do
 
   it 'records single phase start+yield+resume+stop' do
     mock_time(0)
-    Nanoc::Core::NotificationCenter.post(:phase_started, 'donkey', rep).sync
+    Nanoc::Core::NotificationCenter.post(:phase_started, 'donkey', rep)
     mock_time(1)
-    Nanoc::Core::NotificationCenter.post(:phase_yielded, 'donkey', rep).sync
+    Nanoc::Core::NotificationCenter.post(:phase_yielded, 'donkey', rep)
     mock_time(100)
-    Nanoc::Core::NotificationCenter.post(:phase_resumed, 'donkey', rep).sync
+    Nanoc::Core::NotificationCenter.post(:phase_resumed, 'donkey', rep)
     mock_time(102)
-    Nanoc::Core::NotificationCenter.post(:phase_ended, 'donkey', rep).sync
+    Nanoc::Core::NotificationCenter.post(:phase_ended, 'donkey', rep)
 
     expect(listener.phases_summary.get(name: 'donkey').min).to eq(3.00)
     expect(listener.phases_summary.get(name: 'donkey').avg).to eq(3.00)
@@ -153,15 +153,15 @@ describe Nanoc::CLI::CompileListeners::TimingRecorder, stdio: true do
 
   it 'records single phase start+yield+abort+start+stop' do
     mock_time(0)
-    Nanoc::Core::NotificationCenter.post(:phase_started, 'donkey', rep).sync
+    Nanoc::Core::NotificationCenter.post(:phase_started, 'donkey', rep)
     mock_time(1)
-    Nanoc::Core::NotificationCenter.post(:phase_yielded, 'donkey', rep).sync
+    Nanoc::Core::NotificationCenter.post(:phase_yielded, 'donkey', rep)
     mock_time(100)
-    Nanoc::Core::NotificationCenter.post(:phase_aborted, 'donkey', rep).sync
+    Nanoc::Core::NotificationCenter.post(:phase_aborted, 'donkey', rep)
     mock_time(200)
-    Nanoc::Core::NotificationCenter.post(:phase_started, 'donkey', rep).sync
+    Nanoc::Core::NotificationCenter.post(:phase_started, 'donkey', rep)
     mock_time(203)
-    Nanoc::Core::NotificationCenter.post(:phase_ended, 'donkey', rep).sync
+    Nanoc::Core::NotificationCenter.post(:phase_ended, 'donkey', rep)
 
     expect(listener.phases_summary.get(name: 'donkey').min).to eq(1.00)
     expect(listener.phases_summary.get(name: 'donkey').avg).to eq(2.00)
@@ -171,28 +171,28 @@ describe Nanoc::CLI::CompileListeners::TimingRecorder, stdio: true do
   end
 
   it 'records stage duration' do
-    Nanoc::Core::NotificationCenter.post(:stage_ran, 1.23, 'donkey_stage').sync
+    Nanoc::Core::NotificationCenter.post(:stage_ran, 1.23, 'donkey_stage')
 
     expect(listener.stages_summary.get(name: 'donkey_stage').sum).to eq(1.23)
     expect(listener.stages_summary.get(name: 'donkey_stage').count).to eq(1)
   end
 
   it 'prints stage durations' do
-    Nanoc::Core::NotificationCenter.post(:stage_ran, 1.23, 'donkey_stage').sync
+    Nanoc::Core::NotificationCenter.post(:stage_ran, 1.23, 'donkey_stage')
 
     expect { listener.stop_safely }
       .to output(/^\s*donkey_stage │ 1\.23s$/).to_stdout
   end
 
   it 'prints out outdatedness rule durations' do
-    Nanoc::Core::NotificationCenter.post(:outdatedness_rule_ran, 1.0, Nanoc::Core::OutdatednessRules::CodeSnippetsModified).sync
+    Nanoc::Core::NotificationCenter.post(:outdatedness_rule_ran, 1.0, Nanoc::Core::OutdatednessRules::CodeSnippetsModified)
 
     expect { listener.stop_safely }
       .to output(/^\s*CodeSnippetsModified │     1   1\.00s   1\.00s   1\.00s   1\.00s   1\.00s   1\.00s$/).to_stdout
   end
 
   it 'records single outdatedness rule duration' do
-    Nanoc::Core::NotificationCenter.post(:outdatedness_rule_ran, 1.0, Nanoc::Core::OutdatednessRules::CodeSnippetsModified).sync
+    Nanoc::Core::NotificationCenter.post(:outdatedness_rule_ran, 1.0, Nanoc::Core::OutdatednessRules::CodeSnippetsModified)
 
     expect(listener.outdatedness_rules_summary.get(name: 'CodeSnippetsModified').min).to eq(1.00)
     expect(listener.outdatedness_rules_summary.get(name: 'CodeSnippetsModified').avg).to eq(1.00)
@@ -202,8 +202,8 @@ describe Nanoc::CLI::CompileListeners::TimingRecorder, stdio: true do
   end
 
   it 'records multiple outdatedness rule duration' do
-    Nanoc::Core::NotificationCenter.post(:outdatedness_rule_ran, 1.0, Nanoc::Core::OutdatednessRules::CodeSnippetsModified).sync
-    Nanoc::Core::NotificationCenter.post(:outdatedness_rule_ran, 3.0, Nanoc::Core::OutdatednessRules::CodeSnippetsModified).sync
+    Nanoc::Core::NotificationCenter.post(:outdatedness_rule_ran, 1.0, Nanoc::Core::OutdatednessRules::CodeSnippetsModified)
+    Nanoc::Core::NotificationCenter.post(:outdatedness_rule_ran, 3.0, Nanoc::Core::OutdatednessRules::CodeSnippetsModified)
 
     expect(listener.outdatedness_rules_summary.get(name: 'CodeSnippetsModified').min).to eq(1.00)
     expect(listener.outdatedness_rules_summary.get(name: 'CodeSnippetsModified').avg).to eq(2.00)
@@ -213,14 +213,14 @@ describe Nanoc::CLI::CompileListeners::TimingRecorder, stdio: true do
   end
 
   it 'prints load store durations' do
-    Nanoc::Core::NotificationCenter.post(:store_loaded, 1.23, Nanoc::Core::ChecksumStore).sync
+    Nanoc::Core::NotificationCenter.post(:store_loaded, 1.23, Nanoc::Core::ChecksumStore)
 
     expect { listener.stop_safely }
       .to output(/^\s*Nanoc::Core::ChecksumStore │ 1\.23s$/).to_stdout
   end
 
   it 'prints store store durations' do
-    Nanoc::Core::NotificationCenter.post(:store_stored, 2.34, Nanoc::Core::ChecksumStore).sync
+    Nanoc::Core::NotificationCenter.post(:store_stored, 2.34, Nanoc::Core::ChecksumStore)
 
     expect { listener.stop_safely }
       .to output(/^\s*Nanoc::Core::ChecksumStore │ 2\.34s$/).to_stdout

--- a/nanoc-core/spec/nanoc/core/notification_center_spec.rb
+++ b/nanoc-core/spec/nanoc/core/notification_center_spec.rb
@@ -7,7 +7,7 @@ shared_examples 'a notification center' do
       res = true
     end
 
-    subject.post(:ping_received).sync
+    subject.post(:ping_received)
     expect(res).to be(true)
   end
 
@@ -19,7 +19,7 @@ shared_examples 'a notification center' do
 
     subject.remove :ping_received, :test
 
-    subject.post(:ping_received).sync
+    subject.post(:ping_received)
     expect(res).to be(false)
   end
 end

--- a/nanoc/test/orig_cli/commands/test_compile.rb
+++ b/nanoc/test/orig_cli/commands/test_compile.rb
@@ -139,8 +139,8 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
     # Listen
     listener = new_file_action_printer([rep])
     listener.start_safely
-    Nanoc::Core::NotificationCenter.post(:compilation_started, rep).sync
-    Nanoc::Core::NotificationCenter.post(:rep_write_ended, rep, false, rep.raw_path, false, true).sync
+    Nanoc::Core::NotificationCenter.post(:compilation_started, rep)
+    Nanoc::Core::NotificationCenter.post(:rep_write_ended, rep, false, rep.raw_path, false, true)
     listener.stop_safely
 
     # Check
@@ -160,7 +160,7 @@ class Nanoc::CLI::Commands::CompileTest < Nanoc::TestCase
     # Listen
     listener = new_file_action_printer([rep])
     listener.start_safely
-    Nanoc::Core::NotificationCenter.post(:compilation_started, rep).sync
+    Nanoc::Core::NotificationCenter.post(:compilation_started, rep)
     listener.stop_safely
 
     # Check


### PR DESCRIPTION
### Detailed description

There is no clear benefit in running the `NotificationCenter` in a thread, and adds overhead.

This also resolves an issue with filter timings (recorded with `--verbose --verbose`) not being accurate; I suspect inadvertent context switching to be the cause here.