### PR TITLE
Print rsync output for rsync deployer

### DIFF
--- a/nanoc-deploying/lib/nanoc/deploying/deployers/rsync.rb
+++ b/nanoc-deploying/lib/nanoc/deploying/deployers/rsync.rb
@@ -55,7 +55,7 @@ module Nanoc
           # Run
           if dry_run
             warn 'Performing a dry-run; no actions will actually be performed'
-            run_shell_cmd(['echo', 'rsync', options, src, dst].flatten)
+            run_shell_cmd(['rsync', '--dry-run', options, src, dst].flatten)
           else
             run_shell_cmd(['rsync', options, src, dst].flatten)
           end
@@ -64,7 +64,7 @@ module Nanoc
         private
 
         def run_shell_cmd(cmd)
-          TTY::Command.new(printer: :null).run(*cmd)
+          TTY::Command.new(uuid: false).run(*cmd)
         end
       end
     end

--- a/nanoc-deploying/spec/nanoc/deploying/deployers/rsync_spec.rb
+++ b/nanoc-deploying/spec/nanoc/deploying/deployers/rsync_spec.rb
@@ -51,7 +51,7 @@ describe Nanoc::Deploying::Deployers::Rsync, stdio: true do
 
       it 'runs' do
         opts = Nanoc::Deploying::Deployers::Rsync::DEFAULT_OPTIONS
-        args = ['echo', 'rsync', opts, 'output/', 'asdf'].flatten
+        args = ['rsync', '--dry-run', opts, 'output/', 'asdf'].flatten
         expect(deployer).to receive(:run_shell_cmd).with(args)
 
         deployer.run


### PR DESCRIPTION
### Detailed description

The `nanoc deploy` command with the `rsync` deployer is inadvertently quiet. This PR changes this, letting the `rsync` deployer print output.

In addition, this uses `--dry-run` for `rsync` so that even a dry run yields useful output.

Fixes #1709.