### PR TITLE
Lazily (de)compress textual content

### DIFF
--- a/nanoc-core/lib/nanoc/core/assertions.rb
+++ b/nanoc-core/lib/nanoc/core/assertions.rb
@@ -42,7 +42,7 @@ module Nanoc
         contract C::None => C::Bool
         def call
           @item_reps.all? do |rep|
-            @compiled_content_cache[rep]
+            @compiled_content_cache.include?(rep)
           end
         end
       end

--- a/nanoc-core/lib/nanoc/core/compiled_content_cache.rb
+++ b/nanoc-core/lib/nanoc/core/compiled_content_cache.rb
@@ -36,6 +36,10 @@ module Nanoc
         textual_content_map.merge(binary_content_map)
       end
 
+      def include?(rep)
+        @textual_cache.include?(rep) || @binary_cache.include?(rep)
+      end
+
       contract Nanoc::Core::ItemRep,
                C::HashOf[Symbol => Nanoc::Core::Content] => C::Any
       # Sets the compiled content for the given representation.

--- a/nanoc-core/lib/nanoc/core/textual_compiled_content_cache.rb
+++ b/nanoc-core/lib/nanoc/core/textual_compiled_content_cache.rb
@@ -9,6 +9,34 @@ module Nanoc
     class TextualCompiledContentCache < ::Nanoc::Core::Store
       include Nanoc::Core::ContractsSupport
 
+      class LazyCompressedValue
+        def initialize(uncompressed: nil, compressed: nil)
+          if uncompressed.nil? && compressed.nil?
+            raise ArgumentError, 'must specify at least uncompressed or compressed'
+          end
+
+          @_uncompressed = uncompressed
+          @_compressed = compressed
+        end
+
+        def compressed
+          @_compressed ||= Zlib::Deflate.deflate(Marshal.dump(@_uncompressed), Zlib::BEST_SPEED)
+        end
+
+        def uncompressed
+          @_uncompressed ||= Marshal.load(Zlib::Inflate.inflate(@_compressed))
+        end
+
+        def marshal_dump
+          [compressed]
+        end
+
+        def marshal_load(array)
+          @_compressed = array[0]
+          @_uncompressed = nil
+        end
+      end
+
       contract C::KeywordArgs[config: Nanoc::Core::Configuration] => C::Any
       def initialize(config:)
         super(
@@ -16,7 +44,7 @@ module Nanoc
             config:,
             store_name: 'compiled_content',
           ),
-          4,
+          5,
         )
 
         @cache = {}
@@ -30,7 +58,7 @@ module Nanoc
       # names, and the values the compiled content at the given snapshot.
       def [](rep)
         item_cache = @cache[rep.item.identifier] || {}
-        item_cache[rep.name]
+        item_cache[rep.name]&.uncompressed
       end
 
       contract Nanoc::Core::ItemRep => C::Bool
@@ -47,7 +75,7 @@ module Nanoc
       # names, and the values the compiled content at the given snapshot.
       def []=(rep, content)
         @cache[rep.item.identifier] ||= {}
-        @cache[rep.item.identifier][rep.name] = content
+        @cache[rep.item.identifier][rep.name] = LazyCompressedValue.new(uncompressed: content)
       end
 
       def prune(items:)
@@ -59,6 +87,25 @@ module Nanoc
 
           @cache.delete(key)
         end
+      end
+
+      # Similar to Store#load_data, but does not use zlib compression on the
+      # data itself (instead, values are compressed individually).
+      def load_data
+        raw_data = File.binread(data_filename)
+        self.data = Marshal.load(raw_data)
+      end
+
+      # Similar to Store#store_data, but does not use zlib compression on the
+      # data itself (instead, values are compressed individually).
+      def store_data
+        raw_data = Marshal.dump(data)
+        write_data_to_file(data_filename, raw_data)
+      end
+
+      # Identical to Store#store_data; replicated for clarity.
+      def reset_data
+        FileUtils.rm_f(data_filename)
       end
 
       protected


### PR DESCRIPTION
This avoids decompressing textual content until it is needed, which might be never. It also avoids (re)compressing textual content that hasn’t changed.

This is covered by existing tests.

On my own site, this reduces compilation time when nothing has changes by about 10%. Compare before and after:

```
┌──────────────────────────────────────────┬───────┐
│                              load_stores │   tot │
├──────────────────────────────────────────┼───────┤
...
│ Nanoc::Core::TextualCompiledContentCache │ 0.03s │
...

┌──────────────────────────────────────────┬───────┐
│                             store_stores │   tot │
├──────────────────────────────────────────┼───────┤
...
│ Nanoc::Core::TextualCompiledContentCache │ 0.11s │
...
```

```
┌──────────────────────────────────────────┬───────┐
│                              load_stores │   tot │
├──────────────────────────────────────────┼───────┤
...
│ Nanoc::Core::TextualCompiledContentCache │ 0.00s │
...

┌──────────────────────────────────────────┬───────┐
│                             store_stores │   tot │
├──────────────────────────────────────────┼───────┤
...
│ Nanoc::Core::TextualCompiledContentCache │ 0.01s │
...
```

The store version has been bumped because of backwards incompatibility.